### PR TITLE
feat(lean-pos-03): add lean operational views and generate CLI

### DIFF
--- a/tests/pos/lean/fixtures/views/handoff-reconciliation.yaml
+++ b/tests/pos/lean/fixtures/views/handoff-reconciliation.yaml
@@ -1,0 +1,15 @@
+# Reconciliation fixture for worker-context tests (review state — PR open, checks passing)
+repository: jaiaFoster/ASA
+observed_at: "2026-07-18T10:00:00Z"
+sources:
+  - jaiaFoster/ASA
+derived_state: review
+facts:
+  - code: F004
+    source: pr#5
+    detail: PR is open and not draft
+  - code: F009
+    source: pr#5/check/validate-pos
+    detail: check 'validate-pos' passed (success)
+conflicts: []
+undetermined: []

--- a/tests/pos/lean/fixtures/views/project-reconciliation-accepted.yaml
+++ b/tests/pos/lean/fixtures/views/project-reconciliation-accepted.yaml
@@ -1,0 +1,18 @@
+# Reconciliation output fixture — accepted state (authorized merge)
+repository: jaiaFoster/ASA
+observed_at: "2026-07-18T12:00:00Z"
+sources:
+  - jaiaFoster/ASA
+derived_state: accepted
+facts:
+  - code: F001
+    source: issue#12
+    detail: issue is open
+  - code: F005
+    source: pr#4
+    detail: merged by jaiaFoster at 2026-07-18T11:55:00Z
+  - code: F007
+    source: pr#4/review/jaiaFoster
+    detail: jaiaFoster approved
+conflicts: []
+undetermined: []

--- a/tests/pos/lean/fixtures/views/project-reconciliation-blocked.yaml
+++ b/tests/pos/lean/fixtures/views/project-reconciliation-blocked.yaml
@@ -1,0 +1,18 @@
+# Reconciliation output fixture — blocked state (failing required check)
+repository: jaiaFoster/ASA
+observed_at: "2026-07-18T10:00:00Z"
+sources:
+  - jaiaFoster/ASA
+derived_state: blocked
+facts:
+  - code: F001
+    source: issue#12
+    detail: issue is open
+  - code: F004
+    source: pr#5
+    detail: PR is open and not draft
+  - code: F010
+    source: pr#5/check/validate-pos
+    detail: check 'validate-pos' failed (failure)
+conflicts: []
+undetermined: []

--- a/tests/pos/lean/fixtures/views/project-reconciliation-conflict.yaml
+++ b/tests/pos/lean/fixtures/views/project-reconciliation-conflict.yaml
@@ -1,0 +1,20 @@
+# Reconciliation output fixture — conflict state (unauthorized merge)
+repository: jaiaFoster/ASA
+observed_at: "2026-07-18T12:00:00Z"
+sources:
+  - jaiaFoster/ASA
+derived_state: conflict
+facts:
+  - code: F001
+    source: issue#12
+    detail: issue is open
+  - code: F005
+    source: pr#5
+    detail: merged by unauthorized-bot at 2026-07-18T11:55:00Z
+conflicts:
+  - code: G005
+    source: pr#5
+    detail: >-
+      PR merged by 'unauthorized-bot' who is not in authorized_mergers
+      ['jaiaFoster']
+undetermined: []

--- a/tests/pos/lean/fixtures/views/project-reconciliation-review.yaml
+++ b/tests/pos/lean/fixtures/views/project-reconciliation-review.yaml
@@ -1,0 +1,18 @@
+# Reconciliation output fixture — review state (open non-draft PR, checks passing)
+repository: jaiaFoster/ASA
+observed_at: "2026-07-18T10:00:00Z"
+sources:
+  - jaiaFoster/ASA
+derived_state: review
+facts:
+  - code: F001
+    source: issue#12
+    detail: issue is open
+  - code: F004
+    source: pr#5
+    detail: PR is open and not draft
+  - code: F009
+    source: pr#5/check/validate-pos
+    detail: check 'validate-pos' passed (success)
+conflicts: []
+undetermined: []

--- a/tests/pos/lean/fixtures/views/project-reconciliation-undetermined.yaml
+++ b/tests/pos/lean/fixtures/views/project-reconciliation-undetermined.yaml
@@ -1,0 +1,17 @@
+# Reconciliation output fixture — undetermined state (missing authority)
+repository: jaiaFoster/ASA
+observed_at: "2026-07-18T12:00:00Z"
+sources:
+  - jaiaFoster/ASA
+derived_state: undetermined
+facts:
+  - code: F005
+    source: pr#5
+    detail: merged by jaiaFoster at 2026-07-18T11:55:00Z
+conflicts: []
+undetermined:
+  - code: G004
+    source: pr#5
+    detail: >-
+      PR merged by 'jaiaFoster' but no authority configuration was provided;
+      cannot determine whether merger was authorized

--- a/tests/pos/lean/fixtures/views/project-reconciliation.yaml
+++ b/tests/pos/lean/fixtures/views/project-reconciliation.yaml
@@ -1,0 +1,12 @@
+# Reconciliation output fixture — planned state (open issue, no PR)
+repository: jaiaFoster/ASA
+observed_at: "2026-07-18T10:00:00Z"
+sources:
+  - jaiaFoster/ASA
+derived_state: planned
+facts:
+  - code: F001
+    source: issue#12
+    detail: issue is open
+conflicts: []
+undetermined: []

--- a/tests/pos/lean/fixtures/views/trial-rules.yaml
+++ b/tests/pos/lean/fixtures/views/trial-rules.yaml
@@ -1,0 +1,28 @@
+# List of trial rule records for view generation tests
+- v: 1
+  id: lean-tr-001
+  title: Workers must not modify frozen governance without Founder authorization
+  state: active_trial
+  rule: >
+    Any file under governance/frozen/ is immutable. Workers must stop and
+    report a blocker rather than modifying these files unilaterally.
+  github_issue: "jaiaFoster/asa#1"
+  created_at: "2026-07-18T00:00:00Z"
+- v: 1
+  id: lean-tr-002
+  title: Offline validator must never require network access
+  state: active_trial
+  rule: >
+    The offline validator (tools/pos/lean/validate.py) must complete
+    without any network call. Tests must fail if a network dependency
+    is introduced.
+  github_issue: null
+  created_at: "2026-07-18T00:00:00Z"
+- v: 1
+  id: lean-tr-003
+  title: Legacy generate.py retained without modification
+  state: adopted
+  rule: >
+    tools/pos/generate.py must not be modified by lean workers.
+  github_issue: null
+  created_at: "2026-07-18T00:00:00Z"

--- a/tests/pos/lean/test_generate.py
+++ b/tests/pos/lean/test_generate.py
@@ -1,0 +1,462 @@
+"""
+Tests for tools/pos/lean/views.py and tools/pos/lean/generate.py.
+
+Groups:
+  1. current-state rendering
+  2. worker-context rendering
+  3. token budgets
+  4. atomic write
+  5. safety (no network, no writes, legacy mtime)
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Ensure repo root is on sys.path
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.pos.lean.views import (
+    render_current_state,
+    render_worker_context,
+    estimate_worker_context_tokens,
+)
+from tools.pos.lean.generate import atomic_write
+from tools.pos.lean.schemas import (
+    TOKEN_BUDGET_CURRENT_STATE,
+    TOKEN_BUDGET_WORKER_CONTEXT_NORMAL,
+    TOKEN_BUDGET_WORKER_CONTEXT_ELEVATED,
+    estimate_tokens,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture paths
+# ---------------------------------------------------------------------------
+
+FIXTURES_VIEWS = REPO_ROOT / "tests" / "pos" / "lean" / "fixtures" / "views"
+FIXTURES_VALID = REPO_ROOT / "project" / "lean" / "fixtures" / "valid"
+LEAN_GENERATED = REPO_ROOT / "project" / "lean" / "generated"
+LEGACY_GENERATED = REPO_ROOT / "project" / "generated"
+
+
+def _load(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _load_rules() -> list[dict]:
+    data = _load(FIXTURES_VIEWS / "trial-rules.yaml")
+    return data if isinstance(data, list) else data.get("rules", [])
+
+
+def _project_state() -> dict:
+    return _load(FIXTURES_VALID / "project-state.yaml")
+
+
+def _handoff() -> dict:
+    return _load(FIXTURES_VALID / "worker-handoff.yaml")
+
+
+GENERATED_AT = "2026-07-18T12:00:00Z"
+
+
+# ===========================================================================
+# 1. current-state rendering
+# ===========================================================================
+
+class TestCurrentState:
+    def _render(self, recon_name: str | None = None, **kw) -> str:
+        recon = _load(FIXTURES_VIEWS / recon_name) if recon_name else None
+        return render_current_state(
+            project_state=_project_state(),
+            reconciliation=recon,
+            trial_rules=_load_rules(),
+            generated_at=GENERATED_AT,
+            **kw,
+        )
+
+    def test_planned_issue(self):
+        md = self._render("project-reconciliation.yaml")
+        assert "planned" in md
+        assert "issue#12" in md
+
+    def test_active_draft_pr(self):
+        md = self._render("project-reconciliation-review.yaml")
+        # review state should appear in the Active Work section
+        assert "review" in md
+
+    def test_review_ready_pr(self):
+        md = self._render("project-reconciliation-review.yaml")
+        assert "## Active Work" in md
+
+    def test_blocked_failed_checks(self):
+        md = self._render("project-reconciliation-blocked.yaml")
+        assert "## Blocked" in md
+        assert "validate-pos" in md
+
+    def test_unauthorized_merge_conflict(self):
+        md = self._render("project-reconciliation-conflict.yaml")
+        assert "## Conflicts" in md
+        assert "unauthorized-bot" in md
+
+    def test_missing_authority_undetermined(self):
+        md = self._render("project-reconciliation-undetermined.yaml")
+        assert "## Undetermined" in md
+        assert "G004" in md
+
+    def test_accepted_work_bounded_history(self):
+        md = self._render("project-reconciliation-accepted.yaml", recently_accepted_limit=2)
+        assert "## Recently Accepted" in md
+        # Should show at most 2 merged items
+        assert md.count("merged by") <= 2
+
+    def test_active_trial_rules(self):
+        md = self._render("project-reconciliation.yaml")
+        assert "## Active Trial Rules" in md
+        assert "lean-tr-001" in md
+        assert "lean-tr-002" in md
+        # lean-tr-003 is 'adopted', should not appear in Active Trial Rules
+        active_section = md.split("## Active Trial Rules")[1].split("##")[0]
+        assert "lean-tr-003" not in active_section
+
+    def test_empty_optional_sections_no_crash(self):
+        md = render_current_state(
+            project_state={"id": "ps-empty", "objective": "Nothing"},
+            reconciliation=None,
+            trial_rules=[],
+            generated_at=GENERATED_AT,
+        )
+        assert "## Current Objective" in md
+        assert "Nothing" in md
+
+    def test_non_canonical_warning_present(self):
+        md = self._render("project-reconciliation.yaml")
+        assert "DO NOT EDIT MANUALLY" in md
+
+    def test_generated_at_present(self):
+        md = self._render("project-reconciliation.yaml")
+        assert GENERATED_AT in md
+
+    def test_sources_section_present(self):
+        md = self._render("project-reconciliation.yaml")
+        assert "## Sources" in md
+
+    def test_deterministic(self):
+        md1 = self._render("project-reconciliation.yaml")
+        md2 = self._render("project-reconciliation.yaml")
+        assert md1 == md2
+
+
+# ===========================================================================
+# 2. worker-context rendering
+# ===========================================================================
+
+class TestWorkerContext:
+    def _render(self, recon_name: str | None = "handoff-reconciliation.yaml", **kw) -> dict:
+        recon = _load(FIXTURES_VIEWS / recon_name) if recon_name else None
+        return render_worker_context(
+            handoff=_handoff(),
+            reconciliation=recon,
+            trial_rules=_load_rules(),
+            generated_at=GENERATED_AT,
+            **kw,
+        )
+
+    def test_normal_R2_handoff(self):
+        ctx = self._render()
+        assert ctx["handoff"]["id"] == "lean-wh-001"
+        assert ctx["handoff"]["risk"] == "R2"
+        assert "scope" in ctx["handoff"]
+
+    def test_R3_handoff_with_extra_budget(self):
+        h = dict(_handoff())
+        h["risk"] = "R3"
+        ctx = render_worker_context(
+            handoff=h,
+            reconciliation=_load(FIXTURES_VIEWS / "handoff-reconciliation.yaml"),
+            trial_rules=_load_rules(),
+            generated_at=GENERATED_AT,
+        )
+        assert ctx["handoff"]["risk"] == "R3"
+
+    def test_active_trial_rule_included(self):
+        ctx = self._render()
+        rule_ids = [r["id"] for r in ctx["relevant_constraints"]["active_trial_rules"]]
+        assert "lean-tr-001" in rule_ids
+        assert "lean-tr-002" in rule_ids
+
+    def test_adopted_rule_excluded(self):
+        ctx = self._render()
+        rule_ids = [r["id"] for r in ctx["relevant_constraints"]["active_trial_rules"]]
+        assert "lean-tr-003" not in rule_ids
+
+    def test_github_blocker_included_when_blocked(self):
+        ctx = render_worker_context(
+            handoff=_handoff(),
+            reconciliation=_load(FIXTURES_VIEWS / "project-reconciliation-blocked.yaml"),
+            trial_rules=[],
+            generated_at=GENERATED_AT,
+        )
+        obs = ctx["observed_github_state"]
+        assert obs["derived_state"] == "blocked"
+        assert "blockers" in obs
+
+    def test_accepted_github_state(self):
+        ctx = render_worker_context(
+            handoff=_handoff(),
+            reconciliation=_load(FIXTURES_VIEWS / "project-reconciliation-accepted.yaml"),
+            trial_rules=[],
+            generated_at=GENERATED_AT,
+        )
+        assert ctx["observed_github_state"]["derived_state"] == "accepted"
+
+    def test_missing_reconciliation_data(self):
+        ctx = render_worker_context(
+            handoff=_handoff(),
+            reconciliation=None,
+            trial_rules=[],
+            generated_at=GENERATED_AT,
+        )
+        assert ctx["observed_github_state"]["derived_state"] == "undetermined"
+        assert "note" in ctx["observed_github_state"]
+
+    def test_locked_fields_not_truncated(self):
+        """Execution fields must be embedded verbatim, not summarized."""
+        ctx = self._render()
+        hf = ctx["handoff"]
+        original = _handoff()
+        for field in ("scope", "lock", "accept"):
+            assert hf[field] == original[field]
+
+    def test_invalid_handoff_rejected(self):
+        """generate.py CLI must exit 2 for missing required fields."""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "tools/pos/lean/generate.py", "worker-context",
+             "--handoff", "tests/pos/lean/fixtures/views/trial-rules.yaml",  # not a handoff
+             "--generated-at", GENERATED_AT],
+            capture_output=True, text=True, cwd=REPO_ROOT,
+        )
+        assert result.returncode == 2
+
+    def test_deterministic_key_order(self):
+        ctx1 = self._render()
+        ctx2 = self._render()
+        assert list(ctx1.keys()) == list(ctx2.keys())
+
+    def test_non_canonical_note_present(self):
+        ctx = self._render()
+        assert "NOT CANONICAL" in ctx.get("generated_note", "")
+
+    def test_sources_include_handoff(self):
+        ctx = self._render()
+        types = [s["type"] for s in ctx["sources"]]
+        assert "handoff" in types
+
+    def test_stop_conditions_present(self):
+        ctx = self._render()
+        assert len(ctx["stop_conditions"]) > 0
+
+    def test_verification_from_accept(self):
+        ctx = self._render()
+        assert len(ctx["verification"]) > 0
+
+
+# ===========================================================================
+# 3. Token budget
+# ===========================================================================
+
+class TestTokenBudget:
+    def test_current_state_within_budget_for_simple_input(self):
+        md = render_current_state(
+            project_state={"id": "ps-1", "objective": "Small objective"},
+            reconciliation=None,
+            trial_rules=[],
+            generated_at=GENERATED_AT,
+        )
+        assert estimate_tokens(md) < TOKEN_BUDGET_CURRENT_STATE
+
+    def test_token_warning_added_when_over_budget(self):
+        # Craft a huge objective that blows the budget
+        big_text = "x " * 20000
+        md = render_current_state(
+            project_state={"id": "ps-1", "objective": big_text},
+            reconciliation=None,
+            trial_rules=[],
+            generated_at=GENERATED_AT,
+        )
+        assert "WARNING: estimated token count" in md
+
+    def test_worker_context_token_estimate_returns_int(self):
+        ctx = render_worker_context(
+            handoff=_handoff(),
+            reconciliation=None,
+            trial_rules=[],
+            generated_at=GENERATED_AT,
+        )
+        est = estimate_worker_context_tokens(ctx)
+        assert isinstance(est, int) and est > 0
+
+    def test_R2_budget_is_normal(self):
+        assert TOKEN_BUDGET_WORKER_CONTEXT_NORMAL == 2000
+
+    def test_R3_budget_is_elevated(self):
+        assert TOKEN_BUDGET_WORKER_CONTEXT_ELEVATED == 3500
+
+
+# ===========================================================================
+# 4. Atomic write
+# ===========================================================================
+
+class TestAtomicWrite:
+    def test_atomic_write_success(self, tmp_path):
+        out = tmp_path / "output.md"
+        atomic_write(out, "hello world")
+        assert out.read_text() == "hello world"
+
+    def test_atomic_write_creates_parent_dirs(self, tmp_path):
+        out = tmp_path / "deep" / "dir" / "file.txt"
+        atomic_write(out, "content")
+        assert out.read_text() == "content"
+
+    def test_atomic_write_failure_preserves_old_file(self, tmp_path):
+        out = tmp_path / "output.md"
+        out.write_text("original content")
+
+        # Make a write that fails by passing an object that can't be serialised
+        with pytest.raises(Exception):
+            atomic_write(out, None)  # type: ignore[arg-type]
+
+        # Old file must be intact
+        assert out.read_text() == "original content"
+
+    def test_atomic_write_no_temp_file_left_on_success(self, tmp_path):
+        out = tmp_path / "output.md"
+        atomic_write(out, "data")
+        temp_files = list(tmp_path.glob(".lean-gen-*.tmp"))
+        assert temp_files == []
+
+    def test_atomic_write_no_temp_file_left_on_failure(self, tmp_path):
+        out = tmp_path / "output.md"
+        with pytest.raises(Exception):
+            atomic_write(out, None)  # type: ignore[arg-type]
+        temp_files = list(tmp_path.glob(".lean-gen-*.tmp"))
+        assert temp_files == []
+
+
+# ===========================================================================
+# 5. Safety
+# ===========================================================================
+
+class TestSafety:
+    def test_fixture_mode_has_no_network(self, tmp_path):
+        """generate.py current-state with --reconciliation must not import requests."""
+        import subprocess
+        out = tmp_path / "CURRENT_STATE.md"
+        result = subprocess.run(
+            [sys.executable, "-c",
+             "import sys; "
+             "sys.path.insert(0, '.'); "
+             "import tools.pos.lean.generate as g; "
+             "import tools.pos.lean.views as v; "
+             "assert 'requests' not in sys.modules, 'requests imported at import time'"],
+            capture_output=True, text=True, cwd=REPO_ROOT,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_live_adapter_has_no_write_methods(self):
+        from tools.pos.lean.github import LiveAdapter, WriteAttemptError
+        adapter = LiveAdapter.__new__(LiveAdapter)
+        with pytest.raises(WriteAttemptError):
+            adapter._write("anything")  # type: ignore[attr-defined]
+
+    def test_legacy_generated_mtimes_unchanged(self, tmp_path):
+        """generate.py must not touch project/generated/ (legacy files)."""
+        if not LEGACY_GENERATED.exists():
+            pytest.skip("project/generated/ does not exist in this environment")
+        legacy_files = list(LEGACY_GENERATED.rglob("*"))
+        if not legacy_files:
+            pytest.skip("No legacy files to check")
+        before = {f: f.stat().st_mtime for f in legacy_files if f.is_file()}
+
+        # Run the generator for current-state
+        import subprocess
+        out = tmp_path / "CURRENT_STATE.md"
+        subprocess.run(
+            [sys.executable, "tools/pos/lean/generate.py", "current-state",
+             "--project-state", str(FIXTURES_VALID / "project-state.yaml"),
+             "--reconciliation", str(FIXTURES_VIEWS / "project-reconciliation.yaml"),
+             "--output", str(out),
+             "--generated-at", GENERATED_AT],
+            capture_output=True, cwd=REPO_ROOT,
+        )
+
+        after = {f: f.stat().st_mtime for f in legacy_files if f.is_file()}
+        for f in before:
+            assert before[f] == after.get(f, before[f]), f"mtime changed: {f}"
+
+    def test_raw_token_not_in_worker_context_output(self, tmp_path):
+        """GITHUB_TOKEN env var must not appear in generated WORKER_CONTEXT.yaml."""
+        os.environ.setdefault("GITHUB_TOKEN", "ghp_testtesttest")
+        import subprocess
+        out = tmp_path / "WORKER_CONTEXT.yaml"
+        subprocess.run(
+            [sys.executable, "tools/pos/lean/generate.py", "worker-context",
+             "--handoff", str(FIXTURES_VALID / "worker-handoff.yaml"),
+             "--reconciliation", str(FIXTURES_VIEWS / "handoff-reconciliation.yaml"),
+             "--output", str(out),
+             "--generated-at", GENERATED_AT],
+            capture_output=True, cwd=REPO_ROOT,
+        )
+        if out.exists():
+            content = out.read_text()
+            assert "ghp_testtesttest" not in content
+
+    def test_generate_current_state_cli_exit_0(self, tmp_path):
+        import subprocess
+        out = tmp_path / "CURRENT_STATE.md"
+        result = subprocess.run(
+            [sys.executable, "tools/pos/lean/generate.py", "current-state",
+             "--project-state", str(FIXTURES_VALID / "project-state.yaml"),
+             "--reconciliation", str(FIXTURES_VIEWS / "project-reconciliation.yaml"),
+             "--output", str(out),
+             "--generated-at", GENERATED_AT],
+            capture_output=True, text=True, cwd=REPO_ROOT,
+        )
+        assert result.returncode == 0
+        assert out.exists()
+
+    def test_generate_worker_context_cli_exit_0(self, tmp_path):
+        import subprocess
+        out = tmp_path / "WORKER_CONTEXT.yaml"
+        result = subprocess.run(
+            [sys.executable, "tools/pos/lean/generate.py", "worker-context",
+             "--handoff", str(FIXTURES_VALID / "worker-handoff.yaml"),
+             "--reconciliation", str(FIXTURES_VIEWS / "handoff-reconciliation.yaml"),
+             "--output", str(out),
+             "--generated-at", GENERATED_AT],
+            capture_output=True, text=True, cwd=REPO_ROOT,
+        )
+        assert result.returncode == 0
+        assert out.exists()
+
+    def test_generate_missing_project_state_exits_2(self, tmp_path):
+        import subprocess
+        out = tmp_path / "CURRENT_STATE.md"
+        result = subprocess.run(
+            [sys.executable, "tools/pos/lean/generate.py", "current-state",
+             "--project-state", "/nonexistent/path.yaml",
+             "--output", str(out),
+             "--generated-at", GENERATED_AT],
+            capture_output=True, text=True, cwd=REPO_ROOT,
+        )
+        assert result.returncode == 2

--- a/tools/pos/lean/generate.py
+++ b/tools/pos/lean/generate.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""
+Lean POS view generator.
+
+Generates two non-canonical operational views from lean canonical records
+and GitHub reconciliation output. No GitHub writes. No canonical mutations.
+
+Subcommands:
+  current-state   Generate project/lean/generated/CURRENT_STATE.md
+  worker-context  Generate project/lean/generated/WORKER_CONTEXT.yaml
+
+Exit codes:
+  0  generation succeeded
+  1  generation failed (previous output preserved)
+  2  invalid input or configuration
+
+Usage examples:
+  python tools/pos/lean/generate.py current-state \\
+    --project-state project/lean/fixtures/valid/project-state.yaml \\
+    --reconciliation tests/pos/lean/fixtures/views/project-reconciliation.yaml \\
+    --output project/lean/generated/CURRENT_STATE.md \\
+    --generated-at 2026-07-18T18:00:00Z
+
+  python tools/pos/lean/generate.py worker-context \\
+    --handoff project/lean/fixtures/valid/worker-handoff.yaml \\
+    --reconciliation tests/pos/lean/fixtures/views/handoff-reconciliation.yaml \\
+    --output project/lean/generated/WORKER_CONTEXT.yaml \\
+    --generated-at 2026-07-18T18:00:00Z
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+import yaml
+
+from tools.pos.lean.schemas import (
+    REPO_ROOT,
+    LEAN_GENERATED_DIR,
+    TOKEN_BUDGET_WORKER_CONTEXT_NORMAL,
+    TOKEN_BUDGET_WORKER_CONTEXT_ELEVATED,
+    load_yaml,
+)
+from tools.pos.lean.views import (
+    render_current_state,
+    render_worker_context,
+    estimate_worker_context_tokens,
+)
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+def atomic_write(path: Path, content: str | bytes) -> None:
+    """Write content atomically: write to temp, rename. Failure preserves old file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    mode = "wb" if isinstance(content, bytes) else "w"
+    encoding = None if isinstance(content, bytes) else "utf-8"
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".lean-gen-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, mode, encoding=encoding) as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Input loading
+# ---------------------------------------------------------------------------
+
+def _load_yaml_arg(path_str: str | None, label: str) -> dict | None:
+    if not path_str:
+        return None
+    p = Path(path_str)
+    if not p.exists():
+        print(f"[ERROR] {label} not found: {p}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        data = load_yaml(p)
+    except Exception as exc:
+        print(f"[ERROR] {label} YAML parse error in {p}: {exc}", file=sys.stderr)
+        sys.exit(2)
+    if not isinstance(data, dict):
+        print(f"[ERROR] {label} must be a YAML mapping: {p}", file=sys.stderr)
+        sys.exit(2)
+    return data
+
+
+def _load_trial_rules(path_str: str | None) -> list[dict]:
+    if not path_str:
+        return []
+    p = Path(path_str)
+    if not p.exists():
+        return []
+    try:
+        data = load_yaml(p)
+    except Exception:
+        return []
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and "rules" in data:
+        return data["rules"]
+    return []
+
+
+def _load_reconciliation_live(
+    repo: str,
+    issue: int | None,
+    pr: int | None,
+    token: str | None,
+    observed_at: str | None,
+) -> dict:
+    """Fetch live reconciliation; return as dict matching reconcile output format."""
+    from tools.pos.lean.github import LiveAdapter
+    from tools.pos.lean.derived import derive
+    adapter = LiveAdapter(repo, token=token)
+    snapshot = adapter.fetch(issue_number=issue, pr_number=pr, observed_at=observed_at)
+    result = derive(snapshot)
+    return result.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: current-state
+# ---------------------------------------------------------------------------
+
+def cmd_current_state(args: argparse.Namespace) -> int:
+    project_state = _load_yaml_arg(args.project_state, "project-state")
+    if project_state is None:
+        print("[ERROR] --project-state is required", file=sys.stderr)
+        return 2
+
+    reconciliation: dict | None = None
+    if args.reconciliation:
+        reconciliation = _load_yaml_arg(args.reconciliation, "reconciliation")
+    elif args.repo:
+        token = args.token or os.environ.get("GITHUB_TOKEN")
+        reconciliation = _load_reconciliation_live(
+            args.repo, args.issue, args.pr, token, args.generated_at
+        )
+
+    trial_rules = _load_trial_rules(args.trial_rules)
+    generated_at = args.generated_at or _derive_timestamp()
+
+    content = render_current_state(
+        project_state=project_state,
+        reconciliation=reconciliation,
+        trial_rules=trial_rules,
+        generated_at=generated_at,
+        recently_accepted_limit=getattr(args, "accepted_limit", 5),
+    )
+
+    out_path = Path(args.output) if args.output else LEAN_GENERATED_DIR / "CURRENT_STATE.md"
+
+    try:
+        atomic_write(out_path, content)
+    except Exception as exc:
+        print(f"[ERROR] Failed to write {out_path}: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Generated: {out_path}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: worker-context
+# ---------------------------------------------------------------------------
+
+def cmd_worker_context(args: argparse.Namespace) -> int:
+    handoff = _load_yaml_arg(args.handoff, "handoff")
+    if handoff is None:
+        print("[ERROR] --handoff is required", file=sys.stderr)
+        return 2
+
+    # Validate handoff has required fields
+    required = ("v", "id", "goal", "scope", "lock", "accept", "risk", "deliver")
+    missing = [f for f in required if f not in handoff]
+    if missing:
+        print(f"[ERROR] handoff is missing required fields: {missing}", file=sys.stderr)
+        return 2
+
+    reconciliation: dict | None = None
+    if args.reconciliation:
+        reconciliation = _load_yaml_arg(args.reconciliation, "reconciliation")
+    elif args.repo:
+        token = args.token or os.environ.get("GITHUB_TOKEN")
+        reconciliation = _load_reconciliation_live(
+            args.repo, args.issue, args.pr, token, args.generated_at
+        )
+
+    trial_rules = _load_trial_rules(args.trial_rules)
+    generated_at = args.generated_at or _derive_timestamp()
+    repository = args.repo or (reconciliation or {}).get("repository", "")
+    base_ref = getattr(args, "base_ref", None) or "main"
+
+    ctx = render_worker_context(
+        handoff=handoff,
+        reconciliation=reconciliation,
+        trial_rules=trial_rules,
+        generated_at=generated_at,
+        repository=repository,
+        base_ref=base_ref,
+    )
+
+    # Token budget check
+    estimated = estimate_worker_context_tokens(ctx)
+    risk = handoff.get("risk", "R2")
+    budget = TOKEN_BUDGET_WORKER_CONTEXT_ELEVATED if risk in ("R3", "R4", "R5") else TOKEN_BUDGET_WORKER_CONTEXT_NORMAL
+    if estimated > budget:
+        print(
+            f"[WARNING] Estimated token count ({estimated}) exceeds budget ({budget}) for risk={risk}",
+            file=sys.stderr,
+        )
+
+    content_str = yaml.dump(
+        ctx,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=False,
+    )
+
+    out_path = Path(args.output) if args.output else LEAN_GENERATED_DIR / "WORKER_CONTEXT.yaml"
+
+    try:
+        atomic_write(out_path, content_str)
+    except Exception as exc:
+        print(f"[ERROR] Failed to write {out_path}: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Generated: {out_path} (~{estimated} tokens)")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _derive_timestamp() -> str:
+    import datetime
+    return datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Lean POS view generator. No GitHub writes. No canonical mutations.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    # --- current-state ---
+    cs = sub.add_parser("current-state", help="Generate CURRENT_STATE.md")
+    cs.add_argument("--project-state", metavar="PATH", required=True,
+                    help="project_state YAML file")
+    cs.add_argument("--trial-rules", metavar="PATH",
+                    help="YAML file with a list of trial rule records")
+    _add_reconciliation_args(cs)
+    cs.add_argument("--output", metavar="PATH",
+                    help="Output path (default: project/lean/generated/CURRENT_STATE.md)")
+    cs.add_argument("--generated-at", metavar="ISO8601",
+                    help="Override generation timestamp")
+    cs.add_argument("--accepted-limit", type=int, default=5, metavar="N",
+                    help="Max recently-accepted items to render (default: 5)")
+
+    # --- worker-context ---
+    wc = sub.add_parser("worker-context", help="Generate WORKER_CONTEXT.yaml")
+    wc.add_argument("--handoff", metavar="PATH", required=True,
+                    help="worker_handoff YAML file")
+    wc.add_argument("--trial-rules", metavar="PATH",
+                    help="YAML file with a list of trial rule records")
+    wc.add_argument("--base-ref", metavar="REF", default="main",
+                    help="Base git ref for this handoff (default: main)")
+    _add_reconciliation_args(wc)
+    wc.add_argument("--output", metavar="PATH",
+                    help="Output path (default: project/lean/generated/WORKER_CONTEXT.yaml)")
+    wc.add_argument("--generated-at", metavar="ISO8601",
+                    help="Override generation timestamp")
+
+    return p
+
+
+def _add_reconciliation_args(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--reconciliation", metavar="PATH",
+                       help="Pre-computed reconciliation YAML (no network)")
+    group.add_argument("--repo", metavar="OWNER/REPO",
+                       help="GitHub repository for live reconciliation")
+    parser.add_argument("--issue", type=int, metavar="N", help="Issue number (live mode)")
+    parser.add_argument("--pr", type=int, metavar="N", help="PR number (live mode)")
+    parser.add_argument("--token", metavar="TOKEN",
+                        help="GitHub token (or set GITHUB_TOKEN env var)")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "current-state":
+        return cmd_current_state(args)
+    if args.command == "worker-context":
+        return cmd_worker_context(args)
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pos/lean/schemas.py
+++ b/tools/pos/lean/schemas.py
@@ -63,6 +63,25 @@ DERIVED_STATES = (
 )
 
 
+LEAN_GENERATED_DIR = REPO_ROOT / "project" / "lean" / "generated"
+
+LEAN_GENERATED_HEADER = (
+    "<!-- THIS FILE IS GENERATED. DO NOT EDIT MANUALLY.\n"
+    "     Regenerate with: python tools/pos/lean/generate.py\n"
+    "     This file is not a canonical record. -->\n"
+)
+
+# Estimated token budget thresholds (1 token ≈ 4 chars)
+TOKEN_BUDGET_CURRENT_STATE = 3500
+TOKEN_BUDGET_WORKER_CONTEXT_NORMAL = 2000
+TOKEN_BUDGET_WORKER_CONTEXT_ELEVATED = 3500  # R3+
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimate: 1 token ≈ 4 characters."""
+    return max(1, len(text) // 4)
+
+
 def load_yaml(path: Path):
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)

--- a/tools/pos/lean/views.py
+++ b/tools/pos/lean/views.py
@@ -1,0 +1,282 @@
+"""
+Pure view rendering for the Lean POS generator.
+
+No I/O. No network. Fully deterministic given identical inputs.
+Two entry points:
+  render_current_state(...)  -> str   (Markdown)
+  render_worker_context(...) -> dict  (YAML-serialisable)
+
+Generated output is never canonical. Each call must embed the
+non-canonical warning.
+"""
+
+from __future__ import annotations
+
+from tools.pos.lean.schemas import (
+    LEAN_GENERATED_HEADER,
+    TOKEN_BUDGET_CURRENT_STATE,
+    TOKEN_BUDGET_WORKER_CONTEXT_NORMAL,
+    TOKEN_BUDGET_WORKER_CONTEXT_ELEVATED,
+    VALID_RISK_CLASSES,
+    estimate_tokens,
+)
+
+
+# ---------------------------------------------------------------------------
+# CURRENT_STATE.md
+# ---------------------------------------------------------------------------
+
+def render_current_state(
+    project_state: dict,
+    reconciliation: dict | None,
+    trial_rules: list[dict],
+    generated_at: str,
+    recently_accepted_limit: int = 5,
+) -> str:
+    """Render CURRENT_STATE.md from canonical + derived inputs."""
+    parts: list[str] = [LEAN_GENERATED_HEADER]
+    parts.append(f"# Lean POS — Current State\n")
+    parts.append(f"**Generated:** {generated_at}  \n")
+
+    repo = (reconciliation or {}).get("repository", "")
+    if repo:
+        parts.append(f"**Repository:** {repo}  \n")
+    parts.append("\n")
+
+    # --- Current Objective ---
+    objective = project_state.get("objective", "").strip()
+    ps_id = project_state.get("id", "")
+    constraints = project_state.get("constraints") or []
+    parts.append("## Current Objective\n\n")
+    parts.append(f"{objective}  \n")
+    if ps_id:
+        parts.append(f"*(source: project_state:{ps_id})*\n\n")
+    if constraints:
+        parts.append("**Active constraints:**\n")
+        for c in sorted(constraints):
+            parts.append(f"- {c}\n")
+        parts.append("\n")
+
+    # --- Active Work (from reconciliation) ---
+    derived = (reconciliation or {}).get("derived_state", "undetermined")
+    facts = (reconciliation or {}).get("facts", [])
+    conflicts = (reconciliation or {}).get("conflicts", [])
+    undetermined = (reconciliation or {}).get("undetermined", [])
+
+    if derived in ("active", "review", "planned") and reconciliation:
+        parts.append("## Active Work\n\n")
+        pr_facts = [f for f in facts if f["code"] in ("F003", "F004", "F005")]
+        issue_facts = [f for f in facts if f["code"] == "F001"]
+        if pr_facts or issue_facts:
+            for f in sorted(issue_facts + pr_facts, key=lambda x: (x["code"], x["source"])):
+                parts.append(f"- **{f['source']}**: {f['detail']}\n")
+        else:
+            parts.append("- State: `" + derived + "`\n")
+        parts.append(f"- Derived state: `{derived}`\n")
+        if reconciliation:
+            obs = reconciliation.get("observed_at", "")
+            if obs:
+                parts.append(f"- Observed: {obs}\n")
+        parts.append("\n")
+
+    # --- Blocked / Conflicted ---
+    blocker_facts = [f for f in facts if f["code"] in ("F008", "F010", "F011")]
+    if derived == "blocked" and reconciliation:
+        parts.append("## Blocked\n\n")
+        for f in sorted(blocker_facts, key=lambda x: (x["code"], x["source"])):
+            parts.append(f"- [{f['code']}] **{f['source']}**: {f['detail']}\n")
+        if not blocker_facts:
+            parts.append(f"- Derived state: `blocked`\n")
+        parts.append("\n")
+
+    if derived == "conflict" or conflicts:
+        parts.append("## Conflicts\n\n")
+        for c in sorted(conflicts, key=lambda x: (x["code"], x["source"])):
+            parts.append(f"- [{c['code']}] **{c['source']}**: {c['detail']}\n")
+        if not conflicts:
+            parts.append(f"- Derived state: `conflict` (no conflict detail available)\n")
+        parts.append("\n")
+
+    # --- Undetermined ---
+    if undetermined:
+        parts.append("## Undetermined\n\n")
+        for u in sorted(undetermined, key=lambda x: (x["code"], x["source"])):
+            parts.append(f"- [{u['code']}] **{u['source']}**: {u['detail']}\n")
+        parts.append("\n")
+
+    # --- Recently Accepted ---
+    if derived == "accepted" and reconciliation:
+        parts.append("## Recently Accepted\n\n")
+        merged_facts = [f for f in facts if f["code"] == "F005"]
+        for f in merged_facts[:recently_accepted_limit]:
+            parts.append(f"- {f['detail']} *(source: {f['source']})*\n")
+        parts.append("\n")
+
+    # --- Active Trial Rules ---
+    active_rules = [r for r in trial_rules if r.get("state") == "active_trial"]
+    if active_rules:
+        parts.append("## Active Trial Rules\n\n")
+        for r in sorted(active_rules, key=lambda x: x.get("id", "")):
+            ref = f" — issue: {r['github_issue']}" if r.get("github_issue") else ""
+            parts.append(f"- **{r['id']}**: {r.get('title', '')} [`{r['state']}`]{ref}\n")
+        parts.append("\n")
+
+    # --- Unresolved Governance Conflicts ---
+    if conflicts:
+        parts.append("## Unresolved Governance Conflicts\n\n")
+        for c in sorted(conflicts, key=lambda x: (x["code"], x["source"])):
+            parts.append(f"- [{c['code']}] {c['detail']} *(source: {c['source']})*\n")
+        parts.append("\n")
+
+    # --- Next Action ---
+    notes = project_state.get("notes", "").strip()
+    if notes:
+        parts.append("## Next Action\n\n")
+        parts.append(f"{notes}\n\n")
+
+    # --- Sources ---
+    parts.append("## Sources\n\n")
+    parts.append(f"- project_state: `{ps_id}`\n")
+    if reconciliation:
+        recon_sources = sorted(reconciliation.get("sources", []))
+        for s in recon_sources:
+            parts.append(f"- reconciliation: `{s}`\n")
+        recon_obs = reconciliation.get("observed_at", "")
+        if recon_obs:
+            parts.append(f"- observed_at: `{recon_obs}`\n")
+
+    content = "".join(parts)
+
+    # Token budget check
+    est = estimate_tokens(content)
+    if est > TOKEN_BUDGET_CURRENT_STATE:
+        content += (
+            f"\n<!-- WARNING: estimated token count ({est}) exceeds budget "
+            f"({TOKEN_BUDGET_CURRENT_STATE}). Consider reducing context. -->\n"
+        )
+
+    return content
+
+
+# ---------------------------------------------------------------------------
+# WORKER_CONTEXT.yaml
+# ---------------------------------------------------------------------------
+
+_EXECUTION_FIELDS = ("id", "goal", "scope", "lock", "accept", "risk", "deliver", "execute", "depends")
+
+
+def render_worker_context(
+    handoff: dict,
+    reconciliation: dict | None,
+    trial_rules: list[dict],
+    generated_at: str,
+    repository: str = "",
+    base_ref: str = "main",
+) -> dict:
+    """Render WORKER_CONTEXT.yaml content as a Python dict (YAML-serialisable)."""
+    # Embed handoff — only execution-relevant fields, no semantic rewriting
+    embedded_handoff: dict = {}
+    for key in _EXECUTION_FIELDS:
+        if key in handoff:
+            embedded_handoff[key] = handoff[key]
+
+    # Risk class → choose token budget
+    risk = handoff.get("risk", "R2")
+    try:
+        risk_rank = list(VALID_RISK_CLASSES)[list(VALID_RISK_CLASSES).index(risk)]
+        elevated = risk in ("R3", "R4", "R5")
+    except (ValueError, AttributeError):
+        elevated = False
+
+    # Relevant trial rules: those relevant to handoff scope/lock
+    scope_paths = set(handoff.get("scope") or [])
+    lock_paths = set(handoff.get("lock") or [])
+    all_paths = scope_paths | lock_paths
+    active_rules = [
+        {"id": r["id"], "rule": r["rule"], "state": r["state"]}
+        for r in sorted(trial_rules, key=lambda x: x.get("id", ""))
+        if r.get("state") == "active_trial"
+    ]
+
+    # Relevant refs from handoff
+    relevant_refs = sorted(handoff.get("refs") or [])
+
+    # Observed GitHub state — compact summary only
+    obs_github: dict = {}
+    if reconciliation:
+        obs_github = {
+            "derived_state": reconciliation.get("derived_state", "undetermined"),
+            "observed_at": reconciliation.get("observed_at", ""),
+        }
+        # Summarise blockers
+        blocker_facts = [
+            f for f in (reconciliation.get("facts") or [])
+            if f["code"] in ("F008", "F010", "F011")
+        ]
+        if blocker_facts:
+            obs_github["blockers"] = [
+                {"code": f["code"], "source": f["source"], "detail": f["detail"]}
+                for f in sorted(blocker_facts, key=lambda x: (x["code"], x["source"]))
+            ]
+        # Conflicts and undetermined
+        if reconciliation.get("conflicts"):
+            obs_github["conflicts"] = [
+                {"code": c["code"], "source": c["source"], "detail": c["detail"]}
+                for c in sorted(reconciliation["conflicts"], key=lambda x: (x["code"], x["source"]))
+            ]
+        if reconciliation.get("undetermined"):
+            obs_github["undetermined"] = [
+                {"code": u["code"], "source": u["source"], "detail": u["detail"]}
+                for u in sorted(reconciliation["undetermined"], key=lambda x: (x["code"], x["source"]))
+            ]
+    else:
+        obs_github["derived_state"] = "undetermined"
+        obs_github["note"] = "No reconciliation data provided"
+
+    # Verification: synthesise from handoff deliver/accept + risk
+    verification: list[dict] = []
+    for item in handoff.get("accept") or []:
+        verification.append({"criterion": item})
+
+    # Stop conditions derived from lock
+    stop_conditions: list[str] = [
+        "Required change would modify a locked path",
+    ]
+    for path in sorted(lock_paths)[:3]:  # show up to 3 examples to keep it compact
+        stop_conditions.append(f"  locked: {path}")
+    stop_conditions.append("Failed generation must not destroy previous output")
+
+    # Sources
+    sources: list[dict] = [
+        {"type": "handoff", "id": handoff.get("id", "")},
+    ]
+    if reconciliation:
+        recon_sources = sorted(reconciliation.get("sources") or [])
+        for s in recon_sources:
+            sources.append({"type": "reconciliation", "source": s})
+
+    result = {
+        "v": 1,
+        "generated_at": generated_at,
+        "generated_note": "NOT CANONICAL — do not treat as a canonical record",
+        "repository": repository or (reconciliation or {}).get("repository", ""),
+        "base_ref": base_ref,
+        "handoff": embedded_handoff,
+        "relevant_constraints": {
+            "risk_class": risk,
+            "active_trial_rules": active_rules,
+        },
+        "relevant_refs": relevant_refs,
+        "observed_github_state": obs_github,
+        "verification": verification,
+        "stop_conditions": stop_conditions,
+        "sources": sources,
+    }
+
+    return result
+
+
+def estimate_worker_context_tokens(ctx: dict) -> int:
+    import yaml
+    text = yaml.dump(ctx, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    return estimate_tokens(text)


### PR DESCRIPTION
## Summary

- **`tools/pos/lean/views.py`** — pure rendering: `render_current_state()` (Markdown, ≤3500 tokens) and `render_worker_context()` (YAML dict, ≤2000/3500 tokens for R1-R2/R3+); no I/O, no network; non-canonical warning embedded in all outputs
- **`tools/pos/lean/generate.py`** — CLI with `current-state` and `worker-context` subcommands; `--reconciliation` (fixture, offline) or `--repo` (live) modes; atomic write via `tempfile.mkstemp` + `os.replace`; exit 0/1/2
- **`tools/pos/lean/schemas.py`** — added `LEAN_GENERATED_DIR`, `LEAN_GENERATED_HEADER`, `TOKEN_BUDGET_*` constants, `estimate_tokens()`
- **`tests/pos/lean/fixtures/views/`** — 8 reconciliation + trial-rule fixtures covering planned/review/blocked/conflict/undetermined/accepted states
- **`tests/pos/lean/test_generate.py`** — 44 tests across 5 groups: current-state rendering, worker-context rendering, token budgets, atomic write, and safety invariants

## Test plan

- [x] All 44 new tests pass (`pytest tests/pos/lean/test_generate.py -v`)
- [x] Full lean suite passes: 171 tests (`pytest tests/pos/lean -v`)
- [x] `project/generated/` (legacy) mtime unchanged — verified by test `test_legacy_generated_mtimes_unchanged`
- [x] Fixture mode never imports `requests` — verified by `test_fixture_mode_has_no_network`
- [x] Atomic write leaves no temp file on failure — verified by `test_atomic_write_no_temp_file_left_on_failure`
- [x] `WriteAttemptError` raised on any write attempt via `LiveAdapter` — verified by `test_live_adapter_has_no_write_methods`
- [x] 3 pre-existing governance hash failures unchanged (not introduced by this PR)

## Constraints respected

- Does not modify `project/generated/**`, `tools/pos/generate.py`, or any locked path
- Writes only to `project/lean/generated/` (created by generator, not committed)
- No canonical record mutation; no GitHub writes

---
_Generated by [Claude Code](https://claude.ai/code/session_0171U6QSQe39nnsDLYLbmbG1)_