### PR TITLE
ASA-FEAT-002: establish published portfolio foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,7 @@ POSTGRES_PASSWORD=asa
 ASA_DATABASE_URL=postgresql+psycopg://asa:asa@localhost:5432/asa
 ASA_ENVIRONMENT=development
 ASA_QUOTE_PROVIDER=deterministic_fake
+ASA_BROKER_PORTFOLIO_PROVIDER=deterministic_fake_broker
 ASA_FRESH_FOR_SECONDS=300
+ASA_PORTFOLIO_FRESH_FOR_SECONDS=3600
 ASA_CORS_ORIGINS=http://localhost:5173

--- a/backend/migrations/versions/0002_runs_and_publications.py
+++ b/backend/migrations/versions/0002_runs_and_publications.py
@@ -1,0 +1,121 @@
+"""Create persisted runs and atomic publication pointer.
+
+Revision ID: 0002
+Revises: 0001
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+RUN_STATUSES = ("requested", "running", "succeeded", "failed")
+STEP_STATUSES = ("pending", "running", "succeeded", "failed")
+STEP_NAMES = ("acquire_portfolio", "normalize_portfolio", "validate_publication", "publish")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "runs",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("requested_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("release_sha", sa.String(length=64), nullable=False),
+        sa.Column("effective_config_hash", sa.String(length=128), nullable=False),
+        sa.Column("failure_code", sa.String(length=64), nullable=True),
+        sa.Column("failure_detail", sa.Text(), nullable=True),
+        sa.CheckConstraint(
+            f"status IN {RUN_STATUSES}",
+            name="ck_runs_status",
+        ),
+        sa.CheckConstraint(
+            "status <> 'succeeded' OR completed_at IS NOT NULL",
+            name="ck_runs_succeeded_completed",
+        ),
+    )
+    op.create_table(
+        "run_steps",
+        sa.Column("id", sa.BigInteger(), sa.Identity(), primary_key=True),
+        sa.Column(
+            "run_id",
+            sa.Uuid(),
+            sa.ForeignKey("runs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("step_name", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("failure_detail", sa.Text(), nullable=True),
+        sa.CheckConstraint(f"step_name IN {STEP_NAMES}", name="ck_run_steps_name"),
+        sa.CheckConstraint(f"status IN {STEP_STATUSES}", name="ck_run_steps_status"),
+        sa.UniqueConstraint("run_id", "step_name", name="uq_run_steps_run_name"),
+    )
+    op.create_table(
+        "portfolio_snapshots",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("run_id", sa.Uuid(), sa.ForeignKey("runs.id"), nullable=False, unique=True),
+        sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("provider", sa.String(length=64), nullable=False),
+        sa.Column("provider_request_id", sa.String(length=128), nullable=False),
+    )
+    op.create_table(
+        "publications",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("run_id", sa.Uuid(), sa.ForeignKey("runs.id"), nullable=False, unique=True),
+        sa.Column(
+            "snapshot_id",
+            sa.Uuid(),
+            sa.ForeignKey("portfolio_snapshots.id"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_table(
+        "publication_pointer",
+        sa.Column("id", sa.SmallInteger(), primary_key=True),
+        sa.Column(
+            "publication_id",
+            sa.Uuid(),
+            sa.ForeignKey("publications.id"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.CheckConstraint("id = 1", name="ck_publication_pointer_singleton"),
+    )
+    op.execute("""
+        CREATE FUNCTION validate_publication_succeeded_run() RETURNS trigger AS $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM runs WHERE id = NEW.run_id AND status = 'succeeded'
+            ) THEN
+                RAISE EXCEPTION 'publication requires a succeeded run';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+    """)
+    op.execute("""
+        CREATE CONSTRAINT TRIGGER publication_succeeded_run
+        AFTER INSERT OR UPDATE ON publications
+        DEFERRABLE INITIALLY DEFERRED
+        FOR EACH ROW EXECUTE FUNCTION validate_publication_succeeded_run()
+    """)
+
+
+def downgrade() -> None:
+    op.drop_table("publication_pointer")
+    op.execute("DROP TRIGGER publication_succeeded_run ON publications")
+    op.execute("DROP FUNCTION validate_publication_succeeded_run")
+    op.drop_table("publications")
+    op.drop_table("portfolio_snapshots")
+    op.drop_table("run_steps")
+    op.drop_table("runs")

--- a/backend/migrations/versions/0003_portfolio_positions.py
+++ b/backend/migrations/versions/0003_portfolio_positions.py
@@ -1,0 +1,83 @@
+"""Create normalized broker accounts and positions.
+
+Revision ID: 0003
+Revises: 0002
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "broker_accounts",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "snapshot_id",
+            sa.Uuid(),
+            sa.ForeignKey("portfolio_snapshots.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("connection_id", sa.String(length=128), nullable=False),
+        sa.Column("external_account_id", sa.String(length=128), nullable=False),
+        sa.Column("provider", sa.String(length=64), nullable=False),
+        sa.Column("account_type", sa.String(length=64), nullable=False),
+        sa.Column("display_name", sa.String(length=128), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint(
+            "snapshot_id",
+            "external_account_id",
+            name="uq_broker_accounts_snapshot_external",
+        ),
+    )
+    op.create_table(
+        "equity_positions",
+        sa.Column("id", sa.BigInteger(), sa.Identity(), primary_key=True),
+        sa.Column(
+            "account_id",
+            sa.Uuid(),
+            sa.ForeignKey("broker_accounts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("symbol", sa.String(length=16), nullable=False),
+        sa.Column("quantity", sa.Numeric(precision=24, scale=8), nullable=False),
+        sa.Column("average_cost", sa.Numeric(precision=24, scale=8), nullable=True),
+        sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("original_provider", sa.String(length=64), nullable=False),
+    )
+    op.create_table(
+        "option_legs",
+        sa.Column("id", sa.BigInteger(), sa.Identity(), primary_key=True),
+        sa.Column(
+            "account_id",
+            sa.Uuid(),
+            sa.ForeignKey("broker_accounts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("underlying_symbol", sa.String(length=16), nullable=False),
+        sa.Column("option_symbol", sa.String(length=64), nullable=False),
+        sa.Column("option_type", sa.String(length=8), nullable=False),
+        sa.Column("strike", sa.Numeric(precision=24, scale=8), nullable=False),
+        sa.Column("expiration", sa.Date(), nullable=False),
+        sa.Column("quantity", sa.Numeric(precision=24, scale=8), nullable=False),
+        sa.Column("side", sa.String(length=8), nullable=False),
+        sa.Column("average_price", sa.Numeric(precision=24, scale=8), nullable=True),
+        sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("original_provider", sa.String(length=64), nullable=False),
+        sa.CheckConstraint("option_type IN ('call', 'put')", name="ck_option_legs_type"),
+        sa.CheckConstraint("side IN ('long', 'short')", name="ck_option_legs_side"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("option_legs")
+    op.drop_table("equity_positions")
+    op.drop_table("broker_accounts")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "asa-backend"
 version = "0.1.0"
-requires-python = ">=3.11"
+requires-python = ">=3.12,<3.13"
 dependencies = [
   "alembic>=1.13,<2",
   "fastapi>=0.115,<1",
@@ -36,7 +36,7 @@ target-version = "py311"
 select = ["E", "F", "I", "UP", "B", "SIM"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 strict = true
 packages = ["asa"]
 mypy_path = "src"

--- a/backend/src/asa/api/models.py
+++ b/backend/src/asa/api/models.py
@@ -1,9 +1,12 @@
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
+from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+from asa.application.portfolio_use_cases import PublishedPortfolioView
 from asa.domain.market import MarketObservation
+from asa.domain.runs import PublicationRecord, RunRecord
 
 
 class IngestQuotesRequest(BaseModel):
@@ -53,3 +56,206 @@ class IngestQuotesResponse(BaseModel):
 
 class HealthResponse(BaseModel):
     status: str
+
+
+class StartRunRequest(BaseModel):
+    requested_at: datetime
+    release_sha: str = Field(min_length=1, max_length=64)
+    effective_config_hash: str = Field(min_length=1, max_length=128)
+
+
+class RunStepResponse(BaseModel):
+    name: str
+    status: str
+    started_at: datetime | None
+    completed_at: datetime | None
+    failure_detail: str | None
+
+
+class RunResponse(BaseModel):
+    id: UUID
+    status: str
+    started_at: datetime | None
+    completed_at: datetime | None
+    release_sha: str
+    effective_config_hash: str
+    failure_code: str | None
+    failure_detail: str | None
+    publication_id: UUID | None
+    steps: list[RunStepResponse]
+
+    @classmethod
+    def from_domain(
+        cls,
+        run: RunRecord,
+        publication: PublicationRecord | None,
+    ) -> "RunResponse":
+        return cls(
+            id=run.id,
+            status=run.status.value,
+            started_at=run.started_at,
+            completed_at=run.completed_at,
+            release_sha=run.release_sha,
+            effective_config_hash=run.effective_config_hash,
+            failure_code=run.failure_code,
+            failure_detail=run.failure_detail,
+            publication_id=None if publication is None else publication.id,
+            steps=[
+                RunStepResponse(
+                    name=step.name.value,
+                    status=step.status.value,
+                    started_at=step.started_at,
+                    completed_at=step.completed_at,
+                    failure_detail=step.failure_detail,
+                )
+                for step in run.steps
+            ],
+        )
+
+
+class FreshnessResponse(BaseModel):
+    as_of: datetime
+    status: str
+    serving_last_success: bool
+
+
+class AccountResponse(BaseModel):
+    id: UUID
+    external_account_id: str
+    provider: str
+    account_type: str
+    display_name: str
+    currency: str
+    observed_at: datetime
+
+
+class EquityPositionResponse(BaseModel):
+    account_id: UUID
+    symbol: str
+    quantity: Decimal
+    average_cost: Decimal | None
+    observed_at: datetime
+    original_provider: str
+
+
+class OptionLegResponse(BaseModel):
+    account_id: UUID
+    underlying_symbol: str
+    option_symbol: str
+    option_type: str
+    strike: Decimal
+    expiration: date
+    quantity: Decimal
+    side: str
+    average_price: Decimal | None
+    observed_at: datetime
+    original_provider: str
+
+
+class PortfolioDataResponse(BaseModel):
+    publication_id: UUID
+    snapshot_id: UUID
+    provider: str
+    account_count: int
+    equity_position_count: int
+    option_leg_count: int
+    accounts: list[AccountResponse]
+
+
+class PositionsDataResponse(BaseModel):
+    publication_id: UUID
+    snapshot_id: UUID
+    equity_positions: list[EquityPositionResponse]
+    option_legs: list[OptionLegResponse]
+
+
+class PortfolioEnvelope(BaseModel):
+    run: RunResponse
+    freshness: FreshnessResponse
+    data: PortfolioDataResponse
+
+    @classmethod
+    def from_view(cls, view: PublishedPortfolioView) -> "PortfolioEnvelope":
+        publication = view.publication
+        snapshot = publication.snapshot
+        return cls(
+            run=RunResponse.from_domain(
+                view.run,
+                PublicationRecord(
+                    publication.publication_id,
+                    publication.run_id,
+                    publication.snapshot_id,
+                    publication.published_at,
+                ),
+            ),
+            freshness=FreshnessResponse(
+                as_of=snapshot.observed_at,
+                status=view.freshness_status.value,
+                serving_last_success=view.serving_last_success,
+            ),
+            data=PortfolioDataResponse(
+                publication_id=publication.publication_id,
+                snapshot_id=publication.snapshot_id,
+                provider=snapshot.provider,
+                account_count=view.account_count,
+                equity_position_count=view.equity_position_count,
+                option_leg_count=view.option_leg_count,
+                accounts=[
+                    AccountResponse.model_validate(account, from_attributes=True)
+                    for account in snapshot.accounts
+                ],
+            ),
+        )
+
+
+class PositionsEnvelope(BaseModel):
+    run: RunResponse
+    freshness: FreshnessResponse
+    data: PositionsDataResponse
+
+    @classmethod
+    def from_view(cls, view: PublishedPortfolioView) -> "PositionsEnvelope":
+        publication = view.publication
+        snapshot = publication.snapshot
+        run_response = RunResponse.from_domain(
+            view.run,
+            PublicationRecord(
+                publication.publication_id,
+                publication.run_id,
+                publication.snapshot_id,
+                publication.published_at,
+            ),
+        )
+        freshness = FreshnessResponse(
+            as_of=snapshot.observed_at,
+            status=view.freshness_status.value,
+            serving_last_success=view.serving_last_success,
+        )
+        return cls(
+            run=run_response,
+            freshness=freshness,
+            data=PositionsDataResponse(
+                publication_id=publication.publication_id,
+                snapshot_id=publication.snapshot_id,
+                equity_positions=[
+                    EquityPositionResponse.model_validate(item, from_attributes=True)
+                    for item in snapshot.equity_positions
+                ],
+                option_legs=[
+                    OptionLegResponse(
+                        account_id=item.account_id,
+                        underlying_symbol=item.underlying_symbol,
+                        option_symbol=item.option_symbol,
+                        option_type=item.option_type.value,
+                        strike=item.strike,
+                        expiration=item.expiration,
+                        quantity=item.quantity,
+                        side=item.side.value,
+                        average_price=item.average_price,
+                        observed_at=item.observed_at,
+                        original_provider=item.original_provider,
+                    )
+                    for item in snapshot.option_legs
+                ],
+            ),
+        )

--- a/backend/src/asa/api/routes.py
+++ b/backend/src/asa/api/routes.py
@@ -1,6 +1,22 @@
+from uuid import UUID
+
 from fastapi import APIRouter, HTTPException, Request, status
 
-from asa.api.models import HealthResponse, IngestQuotesRequest, IngestQuotesResponse, QuoteResponse
+from asa.api.models import (
+    HealthResponse,
+    IngestQuotesRequest,
+    IngestQuotesResponse,
+    PortfolioEnvelope,
+    PositionsEnvelope,
+    QuoteResponse,
+    RunResponse,
+    StartRunRequest,
+)
+from asa.application.portfolio_use_cases import (
+    PublishedPortfolioQuery,
+    RunPortfolioIntelligence,
+    RunQueryService,
+)
 from asa.application.ports.repositories import MarketObservationRepository
 from asa.application.use_cases import MarketQuoteService
 
@@ -9,6 +25,9 @@ def build_router(
     quote_service: MarketQuoteService,
     repository: MarketObservationRepository,
     development_ingest_enabled: bool,
+    portfolio_runner: RunPortfolioIntelligence,
+    portfolio_query: PublishedPortfolioQuery,
+    run_query: RunQueryService,
 ) -> APIRouter:
     router = APIRouter(prefix="/api/v1")
 
@@ -50,5 +69,45 @@ def build_router(
         if observation is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="quote unavailable")
         return QuoteResponse.from_domain(observation)
+
+    @router.post("/runs", response_model=RunResponse)
+    def start_run(payload: StartRunRequest) -> RunResponse:
+        result = portfolio_runner.execute(
+            payload.requested_at,
+            payload.release_sha,
+            payload.effective_config_hash,
+        )
+        run = run_query.get(result.run_id)
+        if run is None:
+            raise HTTPException(status_code=500, detail="persisted run unavailable")
+        return RunResponse.from_domain(run, run_query.publication_for(run.id))
+
+    @router.get("/runs/current", response_model=RunResponse)
+    def current_run() -> RunResponse:
+        run = run_query.latest()
+        if run is None:
+            raise HTTPException(status_code=404, detail="run unavailable")
+        return RunResponse.from_domain(run, run_query.publication_for(run.id))
+
+    @router.get("/runs/{run_id}", response_model=RunResponse)
+    def get_run(run_id: UUID) -> RunResponse:
+        run = run_query.get(run_id)
+        if run is None:
+            raise HTTPException(status_code=404, detail="run unavailable")
+        return RunResponse.from_domain(run, run_query.publication_for(run.id))
+
+    @router.get("/portfolio", response_model=PortfolioEnvelope, operation_id="getPortfolio")
+    def get_portfolio() -> PortfolioEnvelope:
+        view = portfolio_query.current()
+        if view is None:
+            raise HTTPException(status_code=404, detail="portfolio unavailable")
+        return PortfolioEnvelope.from_view(view)
+
+    @router.get("/positions", response_model=PositionsEnvelope, operation_id="getPositions")
+    def get_positions() -> PositionsEnvelope:
+        view = portfolio_query.current()
+        if view is None:
+            raise HTTPException(status_code=404, detail="positions unavailable")
+        return PositionsEnvelope.from_view(view)
 
     return router

--- a/backend/src/asa/application/portfolio_use_cases.py
+++ b/backend/src/asa/application/portfolio_use_cases.py
@@ -1,0 +1,244 @@
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TypeVar
+from uuid import UUID, uuid4
+
+from asa.application.ports.brokers import (
+    BrokerAccountsResult,
+    BrokerPortfolioProvider,
+    BrokerPositionsResult,
+)
+from asa.application.ports.runs import RunPublicationRepository
+from asa.domain.market import FreshnessStatus
+from asa.domain.portfolio import (
+    BrokerAccount,
+    EquityPosition,
+    OptionPositionLeg,
+    OptionType,
+    PortfolioSnapshot,
+    PositionSide,
+    PublishedPortfolio,
+    validate_snapshot,
+)
+from asa.domain.runs import PublicationRecord, RunRecord, RunStatus, RunStepName
+
+Clock = Callable[[], datetime]
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class RunPortfolioResult:
+    run_id: UUID
+    status: RunStatus
+    publication_id: UUID | None
+
+
+@dataclass(frozen=True, slots=True)
+class PublishedPortfolioView:
+    publication: PublishedPortfolio
+    run: RunRecord
+    latest_run: RunRecord
+    freshness_status: FreshnessStatus
+    serving_last_success: bool
+    account_count: int
+    equity_position_count: int
+    option_leg_count: int
+
+
+class RunPortfolioIntelligence:
+    def __init__(
+        self,
+        provider: BrokerPortfolioProvider,
+        repository: RunPublicationRepository,
+        clock: Clock = lambda: datetime.now(UTC),
+    ) -> None:
+        self._provider = provider
+        self._repository = repository
+        self._clock = clock
+        self._logger = logging.getLogger("asa.portfolio_run")
+
+    def execute(
+        self,
+        requested_at: datetime,
+        release_sha: str,
+        effective_config_hash: str,
+    ) -> RunPortfolioResult:
+        run = self._repository.create_run(
+            requested_at.astimezone(UTC), release_sha, effective_config_hash
+        )
+        current_step = RunStepName.ACQUIRE_PORTFOLIO
+        self._repository.start_run(run.id, self._clock())
+        try:
+            accounts, positions = self._acquire(run.id)
+            current_step = RunStepName.NORMALIZE_PORTFOLIO
+            snapshot = self._run_step(
+                run.id,
+                current_step,
+                lambda: self._normalize(accounts, positions),
+            )
+            current_step = RunStepName.VALIDATE_PUBLICATION
+            self._run_step(run.id, current_step, lambda: validate_snapshot(snapshot))
+            current_step = RunStepName.PUBLISH
+            publication = self._repository.publish_portfolio(run.id, snapshot, self._clock())
+            self._log_step(run.id, current_step, snapshot.provider, None)
+            return RunPortfolioResult(run.id, RunStatus.SUCCEEDED, publication.id)
+        except Exception as exc:
+            detail = str(exc)[:500] or exc.__class__.__name__
+            self._repository.fail_run(
+                run.id,
+                current_step,
+                self._clock(),
+                "portfolio_run_failed",
+                detail,
+            )
+            self._log_step(run.id, current_step, "deterministic_fake_broker", None)
+            return RunPortfolioResult(run.id, RunStatus.FAILED, None)
+
+    def _acquire(self, run_id: UUID) -> tuple[BrokerAccountsResult, BrokerPositionsResult]:
+        step = RunStepName.ACQUIRE_PORTFOLIO
+        self._repository.start_step(run_id, step, self._clock())
+        accounts = self._provider.fetch_accounts()
+        positions = self._provider.fetch_positions()
+        if accounts.provider != positions.provider:
+            raise ValueError("broker account and position providers must match")
+        self._repository.complete_step(run_id, step, self._clock())
+        account_id = accounts.accounts[0].external_account_id if accounts.accounts else None
+        self._log_step(run_id, step, accounts.provider, account_id)
+        return accounts, positions
+
+    def _run_step(self, run_id: UUID, step: RunStepName, operation: Callable[[], T]) -> T:
+        self._repository.start_step(run_id, step, self._clock())
+        result = operation()
+        self._repository.complete_step(run_id, step, self._clock())
+        self._log_step(run_id, step, "deterministic_fake_broker", None)
+        return result
+
+    @staticmethod
+    def _normalize(
+        accounts_result: BrokerAccountsResult,
+        positions_result: BrokerPositionsResult,
+    ) -> PortfolioSnapshot:
+        accounts = tuple(
+            BrokerAccount(
+                id=uuid4(),
+                connection_id=item.connection_id,
+                external_account_id=item.external_account_id.strip(),
+                provider=item.provider,
+                account_type=item.account_type.strip().lower(),
+                display_name=item.display_name.strip(),
+                currency=item.currency.strip().upper(),
+                observed_at=item.observed_at.astimezone(UTC),
+            )
+            for item in accounts_result.accounts
+        )
+        account_ids = {item.external_account_id: item.id for item in accounts}
+        equities = tuple(
+            EquityPosition(
+                account_id=account_ids[item.external_account_id],
+                symbol=item.symbol.strip().upper(),
+                quantity=item.quantity,
+                average_cost=item.average_cost,
+                observed_at=item.observed_at.astimezone(UTC),
+                original_provider=item.original_provider,
+            )
+            for item in positions_result.equities
+        )
+        option_legs = tuple(
+            OptionPositionLeg(
+                account_id=account_ids[item.external_account_id],
+                underlying_symbol=item.underlying_symbol.strip().upper(),
+                option_symbol=item.option_symbol.strip().upper(),
+                option_type=OptionType(item.option_type.lower()),
+                strike=item.strike,
+                expiration=item.expiration,
+                quantity=item.quantity,
+                side=PositionSide(item.side.lower()),
+                average_price=item.average_price,
+                observed_at=item.observed_at.astimezone(UTC),
+                original_provider=item.original_provider,
+            )
+            for item in positions_result.option_legs
+        )
+        observed_at = min(account.observed_at for account in accounts)
+        return PortfolioSnapshot(
+            observed_at=observed_at,
+            provider=accounts_result.provider,
+            provider_request_id=(
+                f"{accounts_result.provider_request_id}:{positions_result.provider_request_id}"
+            ),
+            accounts=accounts,
+            equity_positions=equities,
+            option_legs=option_legs,
+        )
+
+    def _log_step(
+        self,
+        run_id: UUID,
+        step: RunStepName,
+        provider: str,
+        account_id: str | None,
+    ) -> None:
+        self._logger.info(
+            "portfolio_run_step",
+            extra={
+                "run_id": str(run_id),
+                "run_step": step.value,
+                "provider": provider,
+                "account_id": account_id,
+            },
+        )
+
+
+class PublishedPortfolioQuery:
+    def __init__(
+        self,
+        repository: RunPublicationRepository,
+        fresh_for: timedelta,
+        clock: Clock = lambda: datetime.now(UTC),
+    ) -> None:
+        self._repository = repository
+        self._fresh_for = fresh_for
+        self._clock = clock
+
+    def current(self) -> PublishedPortfolioView | None:
+        publication = self._repository.current_portfolio()
+        if publication is None:
+            return None
+        run = self._repository.get_run(publication.run_id)
+        latest_run = self._repository.latest_run()
+        if run is None or latest_run is None:
+            raise RuntimeError("published portfolio has incomplete run provenance")
+        freshness = (
+            FreshnessStatus.FRESH
+            if publication.snapshot.observed_at >= self._clock() - self._fresh_for
+            else FreshnessStatus.STALE
+        )
+        return PublishedPortfolioView(
+            publication=publication,
+            run=run,
+            latest_run=latest_run,
+            freshness_status=freshness,
+            serving_last_success=(
+                latest_run.id != run.id and latest_run.status is RunStatus.FAILED
+            ),
+            account_count=len(publication.snapshot.accounts),
+            equity_position_count=len(publication.snapshot.equity_positions),
+            option_leg_count=len(publication.snapshot.option_legs),
+        )
+
+
+class RunQueryService:
+    def __init__(self, repository: RunPublicationRepository) -> None:
+        self._repository = repository
+
+    def get(self, run_id: UUID) -> RunRecord | None:
+        return self._repository.get_run(run_id)
+
+    def latest(self) -> RunRecord | None:
+        return self._repository.latest_run()
+
+    def publication_for(self, run_id: UUID) -> PublicationRecord | None:
+        publication = self._repository.current_publication()
+        return publication if publication is not None and publication.run_id == run_id else None

--- a/backend/src/asa/application/ports/brokers.py
+++ b/backend/src/asa/application/ports/brokers.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAccount:
+    external_account_id: str
+    connection_id: str
+    provider: str
+    account_type: str
+    display_name: str
+    currency: str
+    observed_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderEquityPosition:
+    external_account_id: str
+    symbol: str
+    quantity: Decimal
+    average_cost: Decimal | None
+    observed_at: datetime
+    original_provider: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderOptionLeg:
+    external_account_id: str
+    underlying_symbol: str
+    option_symbol: str
+    option_type: str
+    strike: Decimal
+    expiration: date
+    quantity: Decimal
+    side: str
+    average_price: Decimal | None
+    observed_at: datetime
+    original_provider: str
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerAccountsResult:
+    provider: str
+    provider_request_id: str
+    accounts: tuple[ProviderAccount, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerPositionsResult:
+    provider: str
+    provider_request_id: str
+    equities: tuple[ProviderEquityPosition, ...]
+    option_legs: tuple[ProviderOptionLeg, ...]
+
+
+class BrokerPortfolioProvider(Protocol):
+    def fetch_accounts(self) -> BrokerAccountsResult: ...
+
+    def fetch_positions(self) -> BrokerPositionsResult: ...

--- a/backend/src/asa/application/ports/runs.py
+++ b/backend/src/asa/application/ports/runs.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from typing import Protocol
+from uuid import UUID
+
+from asa.domain.runs import PublicationRecord, RunRecord, RunStepName
+
+
+class RunPublicationRepository(Protocol):
+    def create_run(
+        self,
+        requested_at: datetime,
+        release_sha: str,
+        effective_config_hash: str,
+    ) -> RunRecord: ...
+
+    def start_run(self, run_id: UUID, started_at: datetime) -> None: ...
+
+    def start_step(self, run_id: UUID, step: RunStepName, started_at: datetime) -> None: ...
+
+    def complete_step(self, run_id: UUID, step: RunStepName, completed_at: datetime) -> None: ...
+
+    def fail_run(
+        self,
+        run_id: UUID,
+        failed_step: RunStepName,
+        completed_at: datetime,
+        failure_code: str,
+        failure_detail: str,
+    ) -> None: ...
+
+    def get_run(self, run_id: UUID) -> RunRecord | None: ...
+
+    def latest_run(self) -> RunRecord | None: ...
+
+    def current_publication(self) -> PublicationRecord | None: ...
+
+    def publish_snapshot(
+        self,
+        run_id: UUID,
+        observed_at: datetime,
+        provider: str,
+        provider_request_id: str,
+        published_at: datetime,
+    ) -> PublicationRecord: ...

--- a/backend/src/asa/application/ports/runs.py
+++ b/backend/src/asa/application/ports/runs.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Protocol
 from uuid import UUID
 
+from asa.domain.portfolio import PortfolioSnapshot, PublishedPortfolio
 from asa.domain.runs import PublicationRecord, RunRecord, RunStepName
 
 
@@ -42,3 +43,12 @@ class RunPublicationRepository(Protocol):
         provider_request_id: str,
         published_at: datetime,
     ) -> PublicationRecord: ...
+
+    def publish_portfolio(
+        self,
+        run_id: UUID,
+        snapshot: PortfolioSnapshot,
+        published_at: datetime,
+    ) -> PublicationRecord: ...
+
+    def current_portfolio(self) -> PublishedPortfolio | None: ...

--- a/backend/src/asa/bootstrap.py
+++ b/backend/src/asa/bootstrap.py
@@ -8,12 +8,23 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import Engine
 
 from asa.api.routes import build_router
+from asa.application.portfolio_use_cases import (
+    PublishedPortfolioQuery,
+    RunPortfolioIntelligence,
+    RunQueryService,
+)
+from asa.application.ports.brokers import BrokerPortfolioProvider
 from asa.application.ports.quotes import QuoteProvider
 from asa.application.ports.repositories import MarketObservationRepository
+from asa.application.ports.runs import RunPublicationRepository
 from asa.application.use_cases import MarketQuoteService
 from asa.config import Settings
 from asa.integrations.postgres import PostgresMarketObservationRepository, create_postgres_engine
 from asa.integrations.providers.deterministic_fake import DeterministicFakeQuoteProvider
+from asa.integrations.providers.deterministic_fake_broker import (
+    DeterministicFakeBrokerPortfolioProvider,
+)
+from asa.integrations.runs_postgres import PostgresRunPublicationRepository
 from asa.logging import configure_logging, request_id_context
 
 
@@ -21,6 +32,8 @@ from asa.logging import configure_logging, request_id_context
 class DependencyOverrides:
     quote_provider: QuoteProvider | None = None
     repository: MarketObservationRepository | None = None
+    run_repository: RunPublicationRepository | None = None
+    broker_provider: BrokerPortfolioProvider | None = None
     engine_factory: Callable[[str], Engine] | None = None
 
 
@@ -36,11 +49,21 @@ def build_application(
         engine_factory(settings.database_url)
     )
     provider = selected.quote_provider or _build_provider(settings)
+    run_repository = selected.run_repository or PostgresRunPublicationRepository(
+        engine_factory(settings.database_url)
+    )
+    broker_provider = selected.broker_provider or _build_broker_provider(settings)
     quote_service = MarketQuoteService(
         provider=provider,
         repository=repository,
         fresh_for=timedelta(seconds=settings.fresh_for_seconds),
     )
+    portfolio_runner = RunPortfolioIntelligence(broker_provider, run_repository)
+    portfolio_query = PublishedPortfolioQuery(
+        run_repository,
+        timedelta(seconds=settings.portfolio_fresh_for_seconds),
+    )
+    run_query = RunQueryService(run_repository)
 
     app = FastAPI(title="ASA Market Quote API", version="1.0.0")
     app.add_middleware(
@@ -54,6 +77,9 @@ def build_application(
             quote_service=quote_service,
             repository=repository,
             development_ingest_enabled=settings.environment == "development",
+            portfolio_runner=portfolio_runner,
+            portfolio_query=portfolio_query,
+            run_query=run_query,
         )
     )
 
@@ -75,6 +101,10 @@ def build_application(
         "quote_provider": provider,
         "repository": repository,
         "quote_service": quote_service,
+        "run_repository": run_repository,
+        "broker_provider": broker_provider,
+        "portfolio_runner": portfolio_runner,
+        "portfolio_query": portfolio_query,
     }
     return app
 
@@ -83,3 +113,11 @@ def _build_provider(settings: Settings) -> QuoteProvider:
     if settings.quote_provider != "deterministic_fake":
         raise ValueError(f"unsupported quote provider: {settings.quote_provider}")
     return DeterministicFakeQuoteProvider()
+
+
+def _build_broker_provider(settings: Settings) -> BrokerPortfolioProvider:
+    if settings.broker_portfolio_provider != "deterministic_fake_broker":
+        raise ValueError(
+            f"unsupported broker portfolio provider: {settings.broker_portfolio_provider}"
+        )
+    return DeterministicFakeBrokerPortfolioProvider()

--- a/backend/src/asa/config.py
+++ b/backend/src/asa/config.py
@@ -8,5 +8,7 @@ class Settings(BaseSettings):
     database_url: str = "postgresql+psycopg://asa:asa@localhost:5432/asa"
     environment: str = "development"
     quote_provider: str = "deterministic_fake"
+    broker_portfolio_provider: str = "deterministic_fake_broker"
     fresh_for_seconds: int = Field(default=300, ge=1)
+    portfolio_fresh_for_seconds: int = Field(default=3600, ge=1)
     cors_origins: str = "http://localhost:5173"

--- a/backend/src/asa/domain/portfolio.py
+++ b/backend/src/asa/domain/portfolio.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from enum import StrEnum
+from uuid import UUID
+
+
+class OptionType(StrEnum):
+    CALL = "call"
+    PUT = "put"
+
+
+class PositionSide(StrEnum):
+    LONG = "long"
+    SHORT = "short"
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerAccount:
+    id: UUID
+    connection_id: str
+    external_account_id: str
+    provider: str
+    account_type: str
+    display_name: str
+    currency: str
+    observed_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class EquityPosition:
+    account_id: UUID
+    symbol: str
+    quantity: Decimal
+    average_cost: Decimal | None
+    observed_at: datetime
+    original_provider: str
+
+
+@dataclass(frozen=True, slots=True)
+class OptionPositionLeg:
+    account_id: UUID
+    underlying_symbol: str
+    option_symbol: str
+    option_type: OptionType
+    strike: Decimal
+    expiration: date
+    quantity: Decimal
+    side: PositionSide
+    average_price: Decimal | None
+    observed_at: datetime
+    original_provider: str
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioSnapshot:
+    observed_at: datetime
+    provider: str
+    provider_request_id: str
+    accounts: tuple[BrokerAccount, ...]
+    equity_positions: tuple[EquityPosition, ...]
+    option_legs: tuple[OptionPositionLeg, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PublishedPortfolio:
+    publication_id: UUID
+    run_id: UUID
+    snapshot_id: UUID
+    published_at: datetime
+    snapshot: PortfolioSnapshot
+
+
+def validate_snapshot(snapshot: PortfolioSnapshot) -> None:
+    if not snapshot.accounts:
+        raise ValueError("portfolio requires at least one account")
+    account_ids = {account.id for account in snapshot.accounts}
+    if len(account_ids) != len(snapshot.accounts):
+        raise ValueError("portfolio account identifiers must be unique")
+    for equity in snapshot.equity_positions:
+        if equity.account_id not in account_ids:
+            raise ValueError("every position must reference one snapshot account")
+    for option_leg in snapshot.option_legs:
+        if option_leg.account_id not in account_ids:
+            raise ValueError("every position must reference one snapshot account")
+    for leg in snapshot.option_legs:
+        if not leg.option_symbol or leg.expiration is None:
+            raise ValueError("option legs require symbol and expiration")

--- a/backend/src/asa/domain/runs.py
+++ b/backend/src/asa/domain/runs.py
@@ -1,0 +1,67 @@
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+
+class RunStatus(StrEnum):
+    REQUESTED = "requested"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class RunStepName(StrEnum):
+    ACQUIRE_PORTFOLIO = "acquire_portfolio"
+    NORMALIZE_PORTFOLIO = "normalize_portfolio"
+    VALIDATE_PUBLICATION = "validate_publication"
+    PUBLISH = "publish"
+
+
+class RunStepStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class RunStep:
+    name: RunStepName
+    status: RunStepStatus
+    started_at: datetime | None
+    completed_at: datetime | None
+    failure_detail: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RunRecord:
+    id: UUID
+    status: RunStatus
+    requested_at: datetime
+    started_at: datetime | None
+    completed_at: datetime | None
+    release_sha: str
+    effective_config_hash: str
+    failure_code: str | None
+    failure_detail: str | None
+    steps: tuple[RunStep, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationRecord:
+    id: UUID
+    run_id: UUID
+    snapshot_id: UUID
+    published_at: datetime
+
+
+def validate_status_transition(current: RunStatus, target: RunStatus) -> None:
+    allowed = {
+        RunStatus.REQUESTED: {RunStatus.RUNNING, RunStatus.FAILED},
+        RunStatus.RUNNING: {RunStatus.SUCCEEDED, RunStatus.FAILED},
+        RunStatus.SUCCEEDED: set(),
+        RunStatus.FAILED: set(),
+    }
+    if target not in allowed[current]:
+        raise ValueError(f"invalid run status transition: {current} -> {target}")

--- a/backend/src/asa/integrations/providers/deterministic_fake_broker.py
+++ b/backend/src/asa/integrations/providers/deterministic_fake_broker.py
@@ -1,0 +1,76 @@
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from asa.application.ports.brokers import (
+    BrokerAccountsResult,
+    BrokerPositionsResult,
+    ProviderAccount,
+    ProviderEquityPosition,
+    ProviderOptionLeg,
+)
+
+
+class DeterministicFakeBrokerPortfolioProvider:
+    name = "deterministic_fake_broker"
+    observed_at = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+
+    def fetch_accounts(self) -> BrokerAccountsResult:
+        return BrokerAccountsResult(
+            provider=self.name,
+            provider_request_id="fake-broker-accounts-001",
+            accounts=(
+                ProviderAccount(
+                    external_account_id="taxable-001",
+                    connection_id="fake-connection-primary",
+                    provider=self.name,
+                    account_type="taxable",
+                    display_name="Primary Taxable",
+                    currency="USD",
+                    observed_at=self.observed_at,
+                ),
+            ),
+        )
+
+    def fetch_positions(self) -> BrokerPositionsResult:
+        return BrokerPositionsResult(
+            provider=self.name,
+            provider_request_id="fake-broker-positions-001",
+            equities=(
+                ProviderEquityPosition(
+                    external_account_id="taxable-001",
+                    symbol="AAPL",
+                    quantity=Decimal("12"),
+                    average_cost=Decimal("172.50"),
+                    observed_at=self.observed_at,
+                    original_provider=self.name,
+                ),
+            ),
+            option_legs=(
+                ProviderOptionLeg(
+                    external_account_id="taxable-001",
+                    underlying_symbol="AAPL",
+                    option_symbol="AAPL260918C00200000",
+                    option_type="call",
+                    strike=Decimal("200"),
+                    expiration=date(2026, 9, 18),
+                    quantity=Decimal("1"),
+                    side="long",
+                    average_price=Decimal("8.40"),
+                    observed_at=self.observed_at,
+                    original_provider=self.name,
+                ),
+                ProviderOptionLeg(
+                    external_account_id="taxable-001",
+                    underlying_symbol="AAPL",
+                    option_symbol="AAPL260918C00210000",
+                    option_type="call",
+                    strike=Decimal("210"),
+                    expiration=date(2026, 9, 18),
+                    quantity=Decimal("1"),
+                    side="short",
+                    average_price=Decimal("5.10"),
+                    observed_at=self.observed_at,
+                    original_provider=self.name,
+                ),
+            ),
+        )

--- a/backend/src/asa/integrations/runs_postgres.py
+++ b/backend/src/asa/integrations/runs_postgres.py
@@ -1,9 +1,20 @@
+from dataclasses import asdict
 from datetime import datetime
+from decimal import Decimal
 from uuid import UUID, uuid4
 
 from sqlalchemy import Engine, text
 from sqlalchemy.engine import Connection, RowMapping
 
+from asa.domain.portfolio import (
+    BrokerAccount,
+    EquityPosition,
+    OptionPositionLeg,
+    OptionType,
+    PortfolioSnapshot,
+    PositionSide,
+    PublishedPortfolio,
+)
 from asa.domain.runs import (
     PublicationRecord,
     RunRecord,
@@ -221,6 +232,121 @@ class PostgresRunPublicationRepository:
             published_at=published_at,
         )
 
+    def publish_portfolio(
+        self,
+        run_id: UUID,
+        snapshot: PortfolioSnapshot,
+        published_at: datetime,
+    ) -> PublicationRecord:
+        publication_id, snapshot_id = new_publication_ids()
+        with self._engine.begin() as connection:
+            self._begin_publish_step(connection, run_id, published_at)
+            connection.execute(
+                text("""
+                    INSERT INTO portfolio_snapshots (
+                        id, run_id, observed_at, provider, provider_request_id
+                    ) VALUES (
+                        :id, :run_id, :observed_at, :provider, :provider_request_id
+                    )
+                """),
+                {
+                    "id": snapshot_id,
+                    "run_id": run_id,
+                    "observed_at": snapshot.observed_at,
+                    "provider": snapshot.provider,
+                    "provider_request_id": snapshot.provider_request_id,
+                },
+            )
+            self._insert_portfolio_rows(connection, snapshot_id, snapshot)
+            run_result = connection.execute(
+                text("""
+                    UPDATE runs SET status = 'succeeded', completed_at = :published_at
+                    WHERE id = :run_id AND status = 'running'
+                """),
+                {"run_id": run_id, "published_at": published_at},
+            )
+            if run_result.rowcount != 1:
+                raise ValueError("only a running run can publish")
+            connection.execute(
+                text("""
+                    INSERT INTO publications (id, run_id, snapshot_id, published_at)
+                    VALUES (:id, :run_id, :snapshot_id, :published_at)
+                """),
+                {
+                    "id": publication_id,
+                    "run_id": run_id,
+                    "snapshot_id": snapshot_id,
+                    "published_at": published_at,
+                },
+            )
+            connection.execute(
+                text("""
+                    INSERT INTO publication_pointer (id, publication_id)
+                    VALUES (1, :publication_id)
+                    ON CONFLICT (id) DO UPDATE
+                    SET publication_id = EXCLUDED.publication_id
+                """),
+                {"publication_id": publication_id},
+            )
+            step_result = connection.execute(
+                text("""
+                    UPDATE run_steps SET status = 'succeeded', completed_at = :published_at
+                    WHERE run_id = :run_id AND step_name = 'publish' AND status = 'running'
+                """),
+                {"run_id": run_id, "published_at": published_at},
+            )
+            if step_result.rowcount != 1:
+                raise ValueError("publish step was not running")
+        return PublicationRecord(publication_id, run_id, snapshot_id, published_at)
+
+    def current_portfolio(self) -> PublishedPortfolio | None:
+        with self._engine.connect() as connection:
+            row = (
+                connection.execute(
+                    text("""
+                    SELECT p.id AS publication_id, p.run_id, p.snapshot_id,
+                           p.published_at, s.observed_at, s.provider,
+                           s.provider_request_id
+                    FROM publication_pointer pp
+                    JOIN publications p ON p.id = pp.publication_id
+                    JOIN portfolio_snapshots s ON s.id = p.snapshot_id
+                    WHERE pp.id = 1
+                """)
+                )
+                .mappings()
+                .first()
+            )
+            if row is None:
+                return None
+            account_rows = (
+                connection.execute(
+                    text(
+                        "SELECT * FROM broker_accounts WHERE snapshot_id = :snapshot_id ORDER BY id"
+                    ),
+                    {"snapshot_id": row["snapshot_id"]},
+                )
+                .mappings()
+                .all()
+            )
+            account_ids = [item["id"] for item in account_rows]
+            equity_rows = self._position_rows(connection, "equity_positions", account_ids)
+            option_rows = self._position_rows(connection, "option_legs", account_ids)
+        snapshot = PortfolioSnapshot(
+            observed_at=row["observed_at"],
+            provider=row["provider"],
+            provider_request_id=row["provider_request_id"],
+            accounts=tuple(self._to_account(item) for item in account_rows),
+            equity_positions=tuple(self._to_equity(item) for item in equity_rows),
+            option_legs=tuple(self._to_option_leg(item) for item in option_rows),
+        )
+        return PublishedPortfolio(
+            publication_id=row["publication_id"],
+            run_id=row["run_id"],
+            snapshot_id=row["snapshot_id"],
+            published_at=row["published_at"],
+            snapshot=snapshot,
+        )
+
     def _transition_run(
         self,
         run_id: UUID,
@@ -286,6 +412,110 @@ class PostgresRunPublicationRepository:
         )
         if result.rowcount != 1:
             raise ValueError("publish step cannot start")
+
+    @staticmethod
+    def _insert_portfolio_rows(
+        connection: Connection,
+        snapshot_id: UUID,
+        snapshot: PortfolioSnapshot,
+    ) -> None:
+        for account in snapshot.accounts:
+            connection.execute(
+                text("""
+                    INSERT INTO broker_accounts (
+                        id, snapshot_id, connection_id, external_account_id, provider,
+                        account_type, display_name, currency, observed_at
+                    ) VALUES (
+                        :id, :snapshot_id, :connection_id, :external_account_id, :provider,
+                        :account_type, :display_name, :currency, :observed_at
+                    )
+                """),
+                {**asdict(account), "snapshot_id": snapshot_id},
+            )
+        for position in snapshot.equity_positions:
+            connection.execute(
+                text("""
+                    INSERT INTO equity_positions (
+                        account_id, symbol, quantity, average_cost, observed_at, original_provider
+                    ) VALUES (
+                        :account_id, :symbol, :quantity, :average_cost,
+                        :observed_at, :original_provider
+                    )
+                """),
+                asdict(position),
+            )
+        for leg in snapshot.option_legs:
+            values = {**asdict(leg), "option_type": leg.option_type.value, "side": leg.side.value}
+            connection.execute(
+                text("""
+                    INSERT INTO option_legs (
+                        account_id, underlying_symbol, option_symbol, option_type, strike,
+                        expiration, quantity, side, average_price, observed_at, original_provider
+                    ) VALUES (
+                        :account_id, :underlying_symbol, :option_symbol, :option_type, :strike,
+                        :expiration, :quantity, :side, :average_price, :observed_at,
+                        :original_provider
+                    )
+                """),
+                values,
+            )
+
+    @staticmethod
+    def _position_rows(
+        connection: Connection,
+        table: str,
+        account_ids: list[UUID],
+    ) -> list[RowMapping]:
+        if not account_ids:
+            return []
+        return list(
+            connection.execute(
+                text(f"SELECT * FROM {table} WHERE account_id = ANY(:account_ids) ORDER BY id"),
+                {"account_ids": account_ids},
+            ).mappings()
+        )
+
+    @staticmethod
+    def _to_account(row: RowMapping) -> BrokerAccount:
+        return BrokerAccount(
+            id=row["id"],
+            connection_id=row["connection_id"],
+            external_account_id=row["external_account_id"],
+            provider=row["provider"],
+            account_type=row["account_type"],
+            display_name=row["display_name"],
+            currency=row["currency"],
+            observed_at=row["observed_at"],
+        )
+
+    @staticmethod
+    def _to_equity(row: RowMapping) -> EquityPosition:
+        return EquityPosition(
+            account_id=row["account_id"],
+            symbol=row["symbol"],
+            quantity=Decimal(str(row["quantity"])),
+            average_cost=None if row["average_cost"] is None else Decimal(str(row["average_cost"])),
+            observed_at=row["observed_at"],
+            original_provider=row["original_provider"],
+        )
+
+    @staticmethod
+    def _to_option_leg(row: RowMapping) -> OptionPositionLeg:
+        return OptionPositionLeg(
+            account_id=row["account_id"],
+            underlying_symbol=row["underlying_symbol"],
+            option_symbol=row["option_symbol"],
+            option_type=OptionType(row["option_type"]),
+            strike=Decimal(str(row["strike"])),
+            expiration=row["expiration"],
+            quantity=Decimal(str(row["quantity"])),
+            side=PositionSide(row["side"]),
+            average_price=(
+                None if row["average_price"] is None else Decimal(str(row["average_price"]))
+            ),
+            observed_at=row["observed_at"],
+            original_provider=row["original_provider"],
+        )
 
     @staticmethod
     def _to_run(connection: Connection, row: RowMapping) -> RunRecord:

--- a/backend/src/asa/integrations/runs_postgres.py
+++ b/backend/src/asa/integrations/runs_postgres.py
@@ -1,0 +1,332 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import Engine, text
+from sqlalchemy.engine import Connection, RowMapping
+
+from asa.domain.runs import (
+    PublicationRecord,
+    RunRecord,
+    RunStatus,
+    RunStep,
+    RunStepName,
+    RunStepStatus,
+)
+
+
+class PostgresRunPublicationRepository:
+    def __init__(self, engine: Engine) -> None:
+        self._engine = engine
+
+    def create_run(
+        self,
+        requested_at: datetime,
+        release_sha: str,
+        effective_config_hash: str,
+    ) -> RunRecord:
+        run_id = uuid4()
+        with self._engine.begin() as connection:
+            connection.execute(
+                text("""
+                    INSERT INTO runs (
+                        id, status, requested_at, release_sha, effective_config_hash
+                    ) VALUES (
+                        :id, 'requested', :requested_at, :release_sha, :config_hash
+                    )
+                """),
+                {
+                    "id": run_id,
+                    "requested_at": requested_at,
+                    "release_sha": release_sha,
+                    "config_hash": effective_config_hash,
+                },
+            )
+            connection.execute(
+                text("""
+                    INSERT INTO run_steps (run_id, step_name, status)
+                    SELECT :run_id, step_name, 'pending'
+                    FROM unnest(CAST(:steps AS text[])) AS step_name
+                """),
+                {"run_id": run_id, "steps": [step.value for step in RunStepName]},
+            )
+        created = self.get_run(run_id)
+        if created is None:
+            raise RuntimeError("created run could not be read")
+        return created
+
+    def start_run(self, run_id: UUID, started_at: datetime) -> None:
+        self._transition_run(run_id, RunStatus.REQUESTED, RunStatus.RUNNING, started_at)
+
+    def start_step(self, run_id: UUID, step: RunStepName, started_at: datetime) -> None:
+        self._update_step(run_id, step, RunStepStatus.PENDING, RunStepStatus.RUNNING, started_at)
+
+    def complete_step(self, run_id: UUID, step: RunStepName, completed_at: datetime) -> None:
+        self._update_step(
+            run_id,
+            step,
+            RunStepStatus.RUNNING,
+            RunStepStatus.SUCCEEDED,
+            completed_at,
+        )
+
+    def fail_run(
+        self,
+        run_id: UUID,
+        failed_step: RunStepName,
+        completed_at: datetime,
+        failure_code: str,
+        failure_detail: str,
+    ) -> None:
+        with self._engine.begin() as connection:
+            connection.execute(
+                text("""
+                    UPDATE run_steps
+                    SET status = 'failed', completed_at = :completed_at,
+                        failure_detail = :failure_detail
+                    WHERE run_id = :run_id AND step_name = :step_name
+                      AND status IN ('pending', 'running')
+                """),
+                {
+                    "run_id": run_id,
+                    "step_name": failed_step.value,
+                    "completed_at": completed_at,
+                    "failure_detail": failure_detail,
+                },
+            )
+            result = connection.execute(
+                text("""
+                    UPDATE runs
+                    SET status = 'failed', completed_at = :completed_at,
+                        failure_code = :failure_code, failure_detail = :failure_detail
+                    WHERE id = :run_id AND status IN ('requested', 'running')
+                """),
+                {
+                    "run_id": run_id,
+                    "completed_at": completed_at,
+                    "failure_code": failure_code,
+                    "failure_detail": failure_detail,
+                },
+            )
+            if result.rowcount != 1:
+                raise ValueError("run cannot transition to failed")
+
+    def get_run(self, run_id: UUID) -> RunRecord | None:
+        with self._engine.connect() as connection:
+            row = (
+                connection.execute(
+                    text("SELECT * FROM runs WHERE id = :run_id"), {"run_id": run_id}
+                )
+                .mappings()
+                .first()
+            )
+            return None if row is None else self._to_run(connection, row)
+
+    def latest_run(self) -> RunRecord | None:
+        with self._engine.connect() as connection:
+            row = (
+                connection.execute(
+                    text("SELECT * FROM runs ORDER BY requested_at DESC, id DESC LIMIT 1")
+                )
+                .mappings()
+                .first()
+            )
+            return None if row is None else self._to_run(connection, row)
+
+    def current_publication(self) -> PublicationRecord | None:
+        with self._engine.connect() as connection:
+            row = (
+                connection.execute(
+                    text("""
+                    SELECT p.id, p.run_id, p.snapshot_id, p.published_at
+                    FROM publication_pointer pp
+                    JOIN publications p ON p.id = pp.publication_id
+                    WHERE pp.id = 1
+                """)
+                )
+                .mappings()
+                .first()
+            )
+        return None if row is None else self._to_publication(row)
+
+    def publish_snapshot(
+        self,
+        run_id: UUID,
+        observed_at: datetime,
+        provider: str,
+        provider_request_id: str,
+        published_at: datetime,
+    ) -> PublicationRecord:
+        publication_id, snapshot_id = new_publication_ids()
+        with self._engine.begin() as connection:
+            self._begin_publish_step(connection, run_id, published_at)
+            connection.execute(
+                text("""
+                    INSERT INTO portfolio_snapshots (
+                        id, run_id, observed_at, provider, provider_request_id
+                    ) VALUES (
+                        :id, :run_id, :observed_at, :provider, :provider_request_id
+                    )
+                """),
+                {
+                    "id": snapshot_id,
+                    "run_id": run_id,
+                    "observed_at": observed_at,
+                    "provider": provider,
+                    "provider_request_id": provider_request_id,
+                },
+            )
+            run_result = connection.execute(
+                text("""
+                    UPDATE runs SET status = 'succeeded', completed_at = :published_at
+                    WHERE id = :run_id AND status = 'running'
+                """),
+                {"run_id": run_id, "published_at": published_at},
+            )
+            if run_result.rowcount != 1:
+                raise ValueError("only a running run can publish")
+            connection.execute(
+                text("""
+                    INSERT INTO publications (id, run_id, snapshot_id, published_at)
+                    VALUES (:id, :run_id, :snapshot_id, :published_at)
+                """),
+                {
+                    "id": publication_id,
+                    "run_id": run_id,
+                    "snapshot_id": snapshot_id,
+                    "published_at": published_at,
+                },
+            )
+            connection.execute(
+                text("""
+                    INSERT INTO publication_pointer (id, publication_id)
+                    VALUES (1, :publication_id)
+                    ON CONFLICT (id) DO UPDATE
+                    SET publication_id = EXCLUDED.publication_id
+                """),
+                {"publication_id": publication_id},
+            )
+            step_result = connection.execute(
+                text("""
+                    UPDATE run_steps SET status = 'succeeded', completed_at = :published_at
+                    WHERE run_id = :run_id AND step_name = 'publish' AND status = 'running'
+                """),
+                {"run_id": run_id, "published_at": published_at},
+            )
+            if step_result.rowcount != 1:
+                raise ValueError("publish step was not running")
+        return PublicationRecord(
+            id=publication_id,
+            run_id=run_id,
+            snapshot_id=snapshot_id,
+            published_at=published_at,
+        )
+
+    def _transition_run(
+        self,
+        run_id: UUID,
+        current: RunStatus,
+        target: RunStatus,
+        changed_at: datetime,
+    ) -> None:
+        timestamp_column = "started_at" if target is RunStatus.RUNNING else "completed_at"
+        with self._engine.begin() as connection:
+            result = connection.execute(
+                text(f"""
+                    UPDATE runs SET status = :target, {timestamp_column} = :changed_at
+                    WHERE id = :run_id AND status = :current
+                """),
+                {
+                    "run_id": run_id,
+                    "target": target.value,
+                    "current": current.value,
+                    "changed_at": changed_at,
+                },
+            )
+            if result.rowcount != 1:
+                raise ValueError(f"run cannot transition from {current} to {target}")
+
+    def _update_step(
+        self,
+        run_id: UUID,
+        step: RunStepName,
+        current: RunStepStatus,
+        target: RunStepStatus,
+        changed_at: datetime,
+    ) -> None:
+        timestamp_column = "started_at" if target is RunStepStatus.RUNNING else "completed_at"
+        with self._engine.begin() as connection:
+            result = connection.execute(
+                text(f"""
+                    UPDATE run_steps SET status = :target, {timestamp_column} = :changed_at
+                    WHERE run_id = :run_id AND step_name = :step AND status = :current
+                """),
+                {
+                    "run_id": run_id,
+                    "step": step.value,
+                    "target": target.value,
+                    "current": current.value,
+                    "changed_at": changed_at,
+                },
+            )
+            if result.rowcount != 1:
+                raise ValueError(f"step {step} cannot transition from {current} to {target}")
+
+    @staticmethod
+    def _begin_publish_step(
+        connection: Connection,
+        run_id: UUID,
+        started_at: datetime,
+    ) -> None:
+        result = connection.execute(
+            text("""
+                UPDATE run_steps SET status = 'running', started_at = :started_at
+                WHERE run_id = :run_id AND step_name = 'publish' AND status = 'pending'
+            """),
+            {"run_id": run_id, "started_at": started_at},
+        )
+        if result.rowcount != 1:
+            raise ValueError("publish step cannot start")
+
+    @staticmethod
+    def _to_run(connection: Connection, row: RowMapping) -> RunRecord:
+        step_rows = connection.execute(
+            text("""
+                SELECT step_name, status, started_at, completed_at, failure_detail
+                FROM run_steps WHERE run_id = :run_id ORDER BY id
+            """),
+            {"run_id": row["id"]},
+        ).mappings()
+        return RunRecord(
+            id=row["id"],
+            status=RunStatus(row["status"]),
+            requested_at=row["requested_at"],
+            started_at=row["started_at"],
+            completed_at=row["completed_at"],
+            release_sha=row["release_sha"],
+            effective_config_hash=row["effective_config_hash"],
+            failure_code=row["failure_code"],
+            failure_detail=row["failure_detail"],
+            steps=tuple(
+                RunStep(
+                    name=RunStepName(item["step_name"]),
+                    status=RunStepStatus(item["status"]),
+                    started_at=item["started_at"],
+                    completed_at=item["completed_at"],
+                    failure_detail=item["failure_detail"],
+                )
+                for item in step_rows
+            ),
+        )
+
+    @staticmethod
+    def _to_publication(row: RowMapping) -> PublicationRecord:
+        return PublicationRecord(
+            id=row["id"],
+            run_id=row["run_id"],
+            snapshot_id=row["snapshot_id"],
+            published_at=row["published_at"],
+        )
+
+
+def new_publication_ids() -> tuple[UUID, UUID]:
+    return uuid4(), uuid4()

--- a/backend/src/asa/logging.py
+++ b/backend/src/asa/logging.py
@@ -15,7 +15,14 @@ class JsonFormatter(logging.Formatter):
             "event": record.getMessage(),
             "request_id": request_id_context.get(),
         }
-        for key in ("provider_request_id", "symbol", "provider"):
+        for key in (
+            "provider_request_id",
+            "symbol",
+            "provider",
+            "run_id",
+            "run_step",
+            "account_id",
+        ):
             value = getattr(record, key, None)
             if value is not None:
                 payload[key] = value

--- a/backend/tests/test_boundaries.py
+++ b/backend/tests/test_boundaries.py
@@ -48,3 +48,14 @@ def test_exactly_one_build_application_composition_root_exists() -> None:
             and node.name == "build_application"
         )
     assert len(definitions) == 1, definitions
+
+
+def test_broker_provider_contract_is_read_only() -> None:
+    from asa.application.ports.brokers import BrokerPortfolioProvider
+
+    operations = {
+        name
+        for name, value in vars(BrokerPortfolioProvider).items()
+        if callable(value) and not name.startswith("_")
+    }
+    assert operations == {"fetch_accounts", "fetch_positions"}

--- a/backend/tests/test_composition.py
+++ b/backend/tests/test_composition.py
@@ -3,17 +3,27 @@ from fastapi.testclient import TestClient
 from asa.bootstrap import DependencyOverrides, build_application
 from asa.config import Settings
 from asa.integrations.providers.deterministic_fake import DeterministicFakeQuoteProvider
+from asa.integrations.providers.deterministic_fake_broker import (
+    DeterministicFakeBrokerPortfolioProvider,
+)
 from tests.fakes import InMemoryObservationRepository
 
 
 def test_build_application_activates_injected_dependencies() -> None:
     provider = DeterministicFakeQuoteProvider()
+    broker_provider = DeterministicFakeBrokerPortfolioProvider()
     repository = InMemoryObservationRepository()
     app = build_application(
         Settings(),
-        DependencyOverrides(quote_provider=provider, repository=repository),
+        DependencyOverrides(
+            quote_provider=provider,
+            repository=repository,
+            broker_provider=broker_provider,
+        ),
     )
 
     assert app.state.dependencies["quote_provider"] is provider
     assert app.state.dependencies["repository"] is repository
+    assert app.state.dependencies["broker_provider"] is broker_provider
+    assert app.state.dependencies["portfolio_runner"]._provider is broker_provider
     assert TestClient(app).get("/api/v1/health").json() == {"status": "ok"}

--- a/backend/tests/test_logging.py
+++ b/backend/tests/test_logging.py
@@ -17,6 +17,9 @@ def test_structured_market_log_contains_required_correlation_fields() -> None:
     record.provider_request_id = "fake-provider-request"
     record.symbol = "AAPL"
     record.provider = "deterministic_fake"
+    record.run_id = "run-123"
+    record.run_step = "acquire_portfolio"
+    record.account_id = "taxable-001"
     token = request_id_context.set("http-request")
     try:
         payload = json.loads(JsonFormatter().format(record))
@@ -27,3 +30,6 @@ def test_structured_market_log_contains_required_correlation_fields() -> None:
     assert payload["provider_request_id"] == "fake-provider-request"
     assert payload["symbol"] == "AAPL"
     assert payload["provider"] == "deterministic_fake"
+    assert payload["run_id"] == "run-123"
+    assert payload["run_step"] == "acquire_portfolio"
+    assert payload["account_id"] == "taxable-001"

--- a/backend/tests/test_portfolio_acceptance.py
+++ b/backend/tests/test_portfolio_acceptance.py
@@ -1,0 +1,116 @@
+import os
+from dataclasses import replace
+from datetime import UTC, datetime
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+from asa.bootstrap import DependencyOverrides, build_application
+from asa.config import Settings
+from asa.integrations.providers.deterministic_fake_broker import (
+    DeterministicFakeBrokerPortfolioProvider,
+)
+from asa.integrations.runs_postgres import PostgresRunPublicationRepository
+from tests.fakes import InMemoryObservationRepository
+
+pytestmark = [
+    pytest.mark.postgres,
+    pytest.mark.skipif(
+        not os.getenv("ASA_TEST_DATABASE_URL"),
+        reason="ASA_TEST_DATABASE_URL not set",
+    ),
+]
+
+
+@pytest.fixture
+def portfolio_client() -> TestClient:
+    database_url = os.environ["ASA_TEST_DATABASE_URL"]
+    os.environ["ASA_DATABASE_URL"] = database_url
+    command.upgrade(Config("alembic.ini"), "head")
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "TRUNCATE publication_pointer, publications, option_legs, equity_positions, "
+                "broker_accounts, portfolio_snapshots, run_steps, runs CASCADE"
+            )
+        )
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    app = build_application(
+        Settings(database_url=database_url),
+        DependencyOverrides(
+            repository=InMemoryObservationRepository(),
+            run_repository=PostgresRunPublicationRepository(engine),
+            broker_provider=provider,
+        ),
+    )
+    return TestClient(app)
+
+
+def test_successful_run_publishes_portfolio_and_provider_free_reads(
+    portfolio_client: TestClient,
+) -> None:
+    response = portfolio_client.post(
+        "/api/v1/runs",
+        json={
+            "requested_at": datetime.now(UTC).isoformat(),
+            "release_sha": "release-success",
+            "effective_config_hash": "config-success",
+        },
+    )
+    assert response.status_code == 200
+    run = response.json()
+    assert run["status"] == "succeeded"
+    assert [step["status"] for step in run["steps"]] == ["succeeded"] * 4
+
+    provider = portfolio_client.app.state.dependencies["broker_provider"]
+    provider.fetch_accounts = lambda: (_ for _ in ()).throw(AssertionError("provider called"))
+    provider.fetch_positions = lambda: (_ for _ in ()).throw(AssertionError("provider called"))
+    portfolio = portfolio_client.get("/api/v1/portfolio")
+    positions = portfolio_client.get("/api/v1/positions")
+
+    assert portfolio.status_code == positions.status_code == 200
+    portfolio_body = portfolio.json()
+    positions_body = positions.json()
+    assert portfolio_body["run"]["id"] == positions_body["run"]["id"] == run["id"]
+    assert portfolio_body["data"]["publication_id"] == positions_body["data"]["publication_id"]
+    assert portfolio_body["data"]["account_count"] == 1
+    assert portfolio_body["data"]["equity_position_count"] == 1
+    assert portfolio_body["data"]["option_leg_count"] == 2
+    assert len(positions_body["data"]["equity_positions"]) == 1
+    assert len(positions_body["data"]["option_legs"]) == 2
+
+
+def test_failed_run_preserves_publication_and_discloses_last_success(
+    portfolio_client: TestClient,
+) -> None:
+    successful = portfolio_client.post(
+        "/api/v1/runs",
+        json={
+            "requested_at": datetime.now(UTC).isoformat(),
+            "release_sha": "release-a",
+            "effective_config_hash": "config-a",
+        },
+    ).json()
+    provider = portfolio_client.app.state.dependencies["broker_provider"]
+    positions = provider.fetch_positions()
+    invalid_leg = replace(positions.option_legs[0], option_symbol="")
+    provider.fetch_positions = lambda: replace(positions, option_legs=(invalid_leg,))
+    failed = portfolio_client.post(
+        "/api/v1/runs",
+        json={
+            "requested_at": datetime.now(UTC).isoformat(),
+            "release_sha": "release-b",
+            "effective_config_hash": "config-b",
+        },
+    ).json()
+
+    portfolio = portfolio_client.get("/api/v1/portfolio").json()
+    assert failed["status"] == "failed"
+    assert failed["steps"][2]["status"] == "failed"
+    assert failed["publication_id"] is None
+    assert portfolio["run"]["id"] == successful["id"]
+    assert portfolio["freshness"]["serving_last_success"] is True

--- a/backend/tests/test_portfolio_domain.py
+++ b/backend/tests/test_portfolio_domain.py
@@ -1,0 +1,83 @@
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from asa.application.portfolio_use_cases import PublishedPortfolioQuery, RunPortfolioIntelligence
+from asa.domain.market import FreshnessStatus
+from asa.domain.portfolio import PublishedPortfolio, validate_snapshot
+from asa.domain.runs import RunRecord, RunStatus
+from asa.integrations.providers.deterministic_fake_broker import (
+    DeterministicFakeBrokerPortfolioProvider,
+)
+
+
+def test_fake_broker_normalizes_one_account_equity_and_two_option_legs() -> None:
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    snapshot = RunPortfolioIntelligence._normalize(
+        provider.fetch_accounts(), provider.fetch_positions()
+    )
+
+    validate_snapshot(snapshot)
+    assert len(snapshot.accounts) == 1
+    assert snapshot.accounts[0].external_account_id == "taxable-001"
+    assert [item.symbol for item in snapshot.equity_positions] == ["AAPL"]
+    assert [item.side.value for item in snapshot.option_legs] == ["long", "short"]
+
+
+def test_option_leg_validation_rejects_missing_symbol() -> None:
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    snapshot = RunPortfolioIntelligence._normalize(
+        provider.fetch_accounts(), provider.fetch_positions()
+    )
+    invalid_leg = replace(snapshot.option_legs[0], option_symbol="")
+    with pytest.raises(ValueError, match="option legs require"):
+        validate_snapshot(replace(snapshot, option_legs=(invalid_leg,)))
+
+
+def test_publication_freshness_and_last_success_are_application_fields() -> None:
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    snapshot = RunPortfolioIntelligence._normalize(
+        provider.fetch_accounts(), provider.fetch_positions()
+    )
+    published_run = RunRecord(
+        uuid4(),
+        RunStatus.SUCCEEDED,
+        snapshot.observed_at,
+        snapshot.observed_at,
+        snapshot.observed_at,
+        "release-a",
+        "config-a",
+        None,
+        None,
+        (),
+    )
+    failed_run = replace(
+        published_run,
+        id=uuid4(),
+        status=RunStatus.FAILED,
+        release_sha="release-b",
+    )
+    publication = PublishedPortfolio(
+        uuid4(), published_run.id, uuid4(), snapshot.observed_at, snapshot
+    )
+
+    class QueryRepository:
+        def current_portfolio(self) -> PublishedPortfolio:
+            return publication
+
+        def get_run(self, run_id: object) -> RunRecord:
+            return published_run
+
+        def latest_run(self) -> RunRecord:
+            return failed_run
+
+    view = PublishedPortfolioQuery(
+        QueryRepository(),  # type: ignore[arg-type]
+        timedelta(minutes=5),
+        clock=lambda: datetime(2026, 7, 20, tzinfo=UTC),
+    ).current()
+    assert view is not None
+    assert view.freshness_status is FreshnessStatus.STALE
+    assert view.serving_last_success is True

--- a/backend/tests/test_runs.py
+++ b/backend/tests/test_runs.py
@@ -1,0 +1,17 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from asa.domain.runs import RunStatus, validate_status_transition
+
+
+def test_run_status_transitions_are_explicit() -> None:
+    validate_status_transition(RunStatus.REQUESTED, RunStatus.RUNNING)
+    validate_status_transition(RunStatus.RUNNING, RunStatus.SUCCEEDED)
+    with pytest.raises(ValueError):
+        validate_status_transition(RunStatus.SUCCEEDED, RunStatus.RUNNING)
+
+
+def test_run_terminal_timestamp_contract() -> None:
+    now = datetime.now(UTC)
+    assert now.tzinfo is UTC

--- a/backend/tests/test_runs_postgres.py
+++ b/backend/tests/test_runs_postgres.py
@@ -1,0 +1,88 @@
+import os
+from datetime import UTC, datetime
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from asa.domain.runs import RunStatus, RunStepName, RunStepStatus
+from asa.integrations.runs_postgres import PostgresRunPublicationRepository
+
+
+@pytest.fixture
+def run_repository() -> PostgresRunPublicationRepository:
+    database_url = os.environ["ASA_TEST_DATABASE_URL"]
+    os.environ["ASA_DATABASE_URL"] = database_url
+    command.upgrade(Config("alembic.ini"), "head")
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "TRUNCATE publication_pointer, publications, portfolio_snapshots, "
+                "run_steps, runs CASCADE"
+            )
+        )
+    return PostgresRunPublicationRepository(engine)
+
+
+pytestmark = [
+    pytest.mark.postgres,
+    pytest.mark.skipif(
+        not os.getenv("ASA_TEST_DATABASE_URL"),
+        reason="ASA_TEST_DATABASE_URL not set",
+    ),
+]
+
+
+def test_run_steps_and_atomic_publication(run_repository: PostgresRunPublicationRepository) -> None:
+    now = datetime.now(UTC)
+    run = run_repository.create_run(now, "release-a", "config-a")
+    run_repository.start_run(run.id, now)
+    for step in (
+        RunStepName.ACQUIRE_PORTFOLIO,
+        RunStepName.NORMALIZE_PORTFOLIO,
+        RunStepName.VALIDATE_PUBLICATION,
+    ):
+        run_repository.start_step(run.id, step, now)
+        run_repository.complete_step(run.id, step, now)
+    publication = run_repository.publish_snapshot(
+        run.id, now, "deterministic_fake", "broker-request-a", now
+    )
+
+    persisted = run_repository.get_run(run.id)
+    assert persisted is not None
+    assert persisted.status is RunStatus.SUCCEEDED
+    assert all(step.status is RunStepStatus.SUCCEEDED for step in persisted.steps)
+    assert run_repository.current_publication() == publication
+
+
+def test_failed_run_preserves_current_publication(
+    run_repository: PostgresRunPublicationRepository,
+) -> None:
+    now = datetime.now(UTC)
+    successful = run_repository.create_run(now, "release-a", "config-a")
+    run_repository.start_run(successful.id, now)
+    for step in (
+        RunStepName.ACQUIRE_PORTFOLIO,
+        RunStepName.NORMALIZE_PORTFOLIO,
+        RunStepName.VALIDATE_PUBLICATION,
+    ):
+        run_repository.start_step(successful.id, step, now)
+        run_repository.complete_step(successful.id, step, now)
+    publication = run_repository.publish_snapshot(
+        successful.id, now, "deterministic_fake", "broker-request-a", now
+    )
+
+    failed = run_repository.create_run(now, "release-b", "config-b")
+    run_repository.start_run(failed.id, now)
+    run_repository.start_step(failed.id, RunStepName.ACQUIRE_PORTFOLIO, now)
+    run_repository.fail_run(
+        failed.id,
+        RunStepName.ACQUIRE_PORTFOLIO,
+        now,
+        "provider_failed",
+        "sanitized failure",
+    )
+
+    assert run_repository.current_publication() == publication

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,6 +24,7 @@ services:
       ASA_DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-asa}:${POSTGRES_PASSWORD:-asa}@postgres:5432/${POSTGRES_DB:-asa}
       ASA_ENVIRONMENT: development
       ASA_QUOTE_PROVIDER: deterministic_fake
+      ASA_BROKER_PORTFOLIO_PROVIDER: deterministic_fake_broker
       ASA_CORS_ORIGINS: http://localhost:5173
     command: >-
       sh -c "pip install -e . && alembic upgrade head && python -m asa"

--- a/docs/architecture/ADR-003-published-portfolio.md
+++ b/docs/architecture/ADR-003-published-portfolio.md
@@ -1,0 +1,28 @@
+# ADR-003: Persisted runs and atomic portfolio publication
+
+Status: Accepted for ASA-FEAT-002 (2026-07-19)
+
+## Context
+
+Portfolio reads must never expose a partially written run or lose the last known successful result when a later synchronous run fails. The runtime remains Python 3.12, FastAPI, SQLAlchemy, Alembic, PostgreSQL, and React/TypeScript/Vite.
+
+## Decision
+
+Persist every execution in `runs` and its four ordered facts in `run_steps`. A successful execution normalizes one immutable `portfolio_snapshot` with broker accounts and positions. In one PostgreSQL transaction ASA inserts the snapshot graph, marks the run and publish step successful, creates a publication, and upserts the singleton row `publication_pointer(id = 1)`.
+
+The pointer is the only canonical current-publication authority. Failed acquisition, normalization, or validation marks its run failed outside the publication transaction and never modifies the pointer. Portfolio reads join through the pointer; they do not infer currency from timestamps or the latest run.
+
+`RunPortfolioIntelligence` executes synchronously. No worker, job registry, thread, queue, scheduler, retry framework, event bus, or alternate composition path is introduced.
+
+## Canonical ownership
+
+- `runs` and `run_steps`: execution history and failure evidence.
+- `portfolio_snapshots`, `broker_accounts`, `equity_positions`, `option_legs`: immutable normalized portfolio facts.
+- `publications`: successful run-to-snapshot publication history.
+- singleton `publication_pointer`: current published portfolio.
+
+The database constrains statuses, terminal completion, account ownership, option shape, and the one-row pointer. A deferred PostgreSQL constraint trigger rejects a publication whose run is not successful at transaction commit.
+
+## Recovery
+
+The migrations downgrade in reverse dependency order. A failed publication transaction rolls back all candidate snapshot rows and preserves the prior pointer. Operators can inspect the failed persisted run without changing served data.

--- a/docs/contracts/published-portfolio.md
+++ b/docs/contracts/published-portfolio.md
@@ -1,0 +1,42 @@
+# Published portfolio contract
+
+Version: v1
+
+## Runtime and provider
+
+The local and CI runtime is Python 3.12. `BrokerPortfolioProvider` exposes only `fetch_accounts` and `fetch_positions`. Slice 2 statically selects `DeterministicFakeBrokerPortfolioProvider`; it has no credentials or broker write operations.
+
+The sanitized fixture always supplies one taxable USD account, one AAPL equity position, one long AAPL call leg, and one short AAPL call leg. Values and provider request identifiers are stable across executions.
+
+## Run lifecycle
+
+Statuses are `requested`, `running`, `succeeded`, and `failed`. Each run persists these steps:
+
+1. `acquire_portfolio`
+2. `normalize_portfolio`
+3. `validate_publication`
+4. `publish`
+
+A run records request/start/completion timestamps, release SHA, effective configuration hash, and sanitized failure details. Execution is synchronous within `POST /api/v1/runs`.
+
+## Publication invariant
+
+A publication references exactly one successful run and its one snapshot. Snapshot insertion, normalized child insertion, successful run completion, publication insertion, and singleton pointer advancement share one transaction. Failure never changes the pointer.
+
+`GET /api/v1/portfolio` and `GET /api/v1/positions` query only through that pointer. Their envelopes identify the same published run, publication, snapshot, freshness `as_of`, freshness status, and `serving_last_success` disclosure. If the latest run failed after the current successful run, `serving_last_success` is true.
+
+## Normalized facts
+
+Accounts retain external account identity, connection identity, provider, account type, display name, currency, and observation time. Equities retain symbol, quantity, optional average cost, observation time, and original provider. Option legs retain underlying/option symbols, call/put, strike, expiration, quantity, long/short side, optional average price, observation time, and original provider.
+
+No valuation, options-chain data, lifecycle advice, strategy result, trade entry, position entry, or order operation is part of this contract.
+
+## HTTP endpoints
+
+- `POST /api/v1/runs`
+- `GET /api/v1/runs/{run_id}`
+- `GET /api/v1/runs/current`
+- `GET /api/v1/portfolio`
+- `GET /api/v1/positions`
+
+Existing quote, health, and readiness endpoints retain their v1 behavior.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,21 +1,27 @@
 import { useEffect, useState } from 'react'
 
-import { marketQuoteClient, type MarketQuoteClient, type QuoteResponse } from './api/market'
+import {
+  publishedPortfolioClient,
+  type PortfolioEnvelope,
+  type PositionsEnvelope,
+  type PublishedPortfolioClient,
+} from './api/portfolio'
 import './styles.css'
 
+type DashboardData = { portfolio: PortfolioEnvelope; positions: PositionsEnvelope }
 type ViewState =
   | { kind: 'loading' }
-  | { kind: 'success'; quote: QuoteResponse }
+  | { kind: 'success'; value: DashboardData }
   | { kind: 'unavailable' }
   | { kind: 'error' }
 
-export function App({ client = marketQuoteClient }: { client?: MarketQuoteClient }) {
+export function App({ client = publishedPortfolioClient }: { client?: PublishedPortfolioClient }) {
   const [state, setState] = useState<ViewState>({ kind: 'loading' })
 
   useEffect(() => {
     let active = true
-    client.getLatestQuote('AAPL').then(
-      (quote) => active && setState({ kind: 'success', quote }),
+    Promise.all([client.getPortfolio(), client.getPositions()]).then(
+      ([portfolio, positions]) => active && setState({ kind: 'success', value: { portfolio, positions } }),
       (error: { status?: number }) => {
         if (active) setState(error.status === 404 ? { kind: 'unavailable' } : { kind: 'error' })
       },
@@ -25,30 +31,73 @@ export function App({ client = marketQuoteClient }: { client?: MarketQuoteClient
 
   return (
     <main>
-      <p className="eyebrow">ASA · canonical market data</p>
-      <h1>Market observation</h1>
-      {state.kind === 'loading' && <p role="status">Loading latest quote…</p>}
-      {state.kind === 'unavailable' && <p role="status">AAPL quote unavailable.</p>}
-      {state.kind === 'error' && <p role="alert">Unable to reach the market data service.</p>}
-      {state.kind === 'success' && <QuoteCard quote={state.quote} />}
+      <p className="eyebrow">ASA · published portfolio</p>
+      <h1>Portfolio foundation</h1>
+      {state.kind === 'loading' && <p role="status">Loading current publication…</p>}
+      {state.kind === 'unavailable' && <p role="status">No published portfolio is available.</p>}
+      {state.kind === 'error' && <p role="alert">Unable to reach the portfolio service.</p>}
+      {state.kind === 'success' && <PortfolioDashboard {...state.value} />}
     </main>
   )
 }
 
-function QuoteCard({ quote }: { quote: QuoteResponse }) {
+function PortfolioDashboard({ portfolio, positions }: DashboardData) {
   return (
-    <article aria-label={`${quote.symbol} quote`}>
-      <div className="quote-heading">
-        <span className="symbol">{quote.symbol}</span>
-        <span className={`freshness ${quote.provenance.freshness_status}`}>
-          {quote.provenance.freshness_status}
-        </span>
-      </div>
-      <p className="price">{quote.price} <span>{quote.currency}</span></p>
-      <dl>
-        <div><dt>Observed</dt><dd>{quote.observed_at}</dd></div>
-        <div><dt>Provider</dt><dd>{quote.provenance.selected_provider}</dd></div>
-      </dl>
-    </article>
+    <div className="dashboard">
+      <section className="run-banner" aria-label="Canonical run">
+        <div><span>Canonical run</span><strong>{portfolio.run.id}</strong></div>
+        <span className={`freshness ${portfolio.freshness.status}`}>{portfolio.freshness.status}</span>
+        <div><span>As of</span><strong>{portfolio.freshness.as_of}</strong></div>
+        {portfolio.freshness.serving_last_success && (
+          <p className="last-success">Serving last successful publication</p>
+        )}
+      </section>
+
+      <section className="summary" aria-label="Portfolio summary">
+        <Metric label="Accounts" value={portfolio.data.account_count} />
+        <Metric label="Equities" value={portfolio.data.equity_position_count} />
+        <Metric label="Option legs" value={portfolio.data.option_leg_count} />
+      </section>
+
+      <section>
+        <h2>Accounts</h2>
+        {portfolio.data.accounts.map((account) => (
+          <article key={account.id} className="account-card">
+            <strong>{account.display_name}</strong>
+            <span>{account.account_type} · {account.currency}</span>
+            <small>{account.provider} · {account.external_account_id}</small>
+          </article>
+        ))}
+      </section>
+
+      <section>
+        <h2>Equity positions</h2>
+        <div className="position-list">
+          {positions.data.equity_positions.map((position) => (
+            <article key={`${position.account_id}-${position.symbol}`}>
+              <strong>{position.symbol}</strong><span>{position.quantity} shares</span>
+              <small>Average cost {position.average_cost ?? 'unavailable'} · {position.original_provider}</small>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2>Option legs</h2>
+        <div className="position-list">
+          {positions.data.option_legs.map((leg) => (
+            <article key={leg.option_symbol}>
+              <strong>{leg.underlying_symbol} {leg.option_type}</strong>
+              <span>{leg.side} · {leg.quantity} · strike {leg.strike}</span>
+              <small>{leg.expiration} · {leg.option_symbol} · {leg.original_provider}</small>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
   )
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return <div><span>{label}</span><strong>{value}</strong></div>
 }

--- a/frontend/src/api/generated/index.ts
+++ b/frontend/src/api/generated/index.ts
@@ -7,7 +7,23 @@ export { CancelablePromise, CancelError } from './core/CancelablePromise';
 export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
+export type { AccountResponse } from './models/AccountResponse';
+export type { EquityPositionResponse } from './models/EquityPositionResponse';
+export type { FreshnessResponse } from './models/FreshnessResponse';
+export type { HealthResponse } from './models/HealthResponse';
+export type { HTTPValidationError } from './models/HTTPValidationError';
+export type { IngestQuotesRequest } from './models/IngestQuotesRequest';
+export type { IngestQuotesResponse } from './models/IngestQuotesResponse';
+export type { OptionLegResponse } from './models/OptionLegResponse';
+export type { PortfolioDataResponse } from './models/PortfolioDataResponse';
+export type { PortfolioEnvelope } from './models/PortfolioEnvelope';
+export type { PositionsDataResponse } from './models/PositionsDataResponse';
+export type { PositionsEnvelope } from './models/PositionsEnvelope';
 export type { ProvenanceResponse } from './models/ProvenanceResponse';
 export type { QuoteResponse } from './models/QuoteResponse';
+export type { RunResponse } from './models/RunResponse';
+export type { RunStepResponse } from './models/RunStepResponse';
+export type { StartRunRequest } from './models/StartRunRequest';
+export type { ValidationError } from './models/ValidationError';
 
 export { DefaultService } from './services/DefaultService';

--- a/frontend/src/api/generated/models/AccountResponse.ts
+++ b/frontend/src/api/generated/models/AccountResponse.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type AccountResponse = {
+    id: string;
+    external_account_id: string;
+    provider: string;
+    account_type: string;
+    display_name: string;
+    currency: string;
+    observed_at: string;
+};

--- a/frontend/src/api/generated/models/EquityPositionResponse.ts
+++ b/frontend/src/api/generated/models/EquityPositionResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type EquityPositionResponse = {
+    account_id: string;
+    symbol: string;
+    quantity: string;
+    average_cost: (string | null);
+    observed_at: string;
+    original_provider: string;
+};

--- a/frontend/src/api/generated/models/FreshnessResponse.ts
+++ b/frontend/src/api/generated/models/FreshnessResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type FreshnessResponse = {
+    as_of: string;
+    status: string;
+    serving_last_success: boolean;
+};

--- a/frontend/src/api/generated/models/HTTPValidationError.ts
+++ b/frontend/src/api/generated/models/HTTPValidationError.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ValidationError } from './ValidationError';
+export type HTTPValidationError = {
+    detail?: Array<ValidationError>;
+};

--- a/frontend/src/api/generated/models/HealthResponse.ts
+++ b/frontend/src/api/generated/models/HealthResponse.ts
@@ -1,0 +1,7 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type HealthResponse = {
+    status: string;
+};

--- a/frontend/src/api/generated/models/IngestQuotesRequest.ts
+++ b/frontend/src/api/generated/models/IngestQuotesRequest.ts
@@ -1,0 +1,7 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type IngestQuotesRequest = {
+    symbols: Array<string>;
+};

--- a/frontend/src/api/generated/models/IngestQuotesResponse.ts
+++ b/frontend/src/api/generated/models/IngestQuotesResponse.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { QuoteResponse } from './QuoteResponse';
+export type IngestQuotesResponse = {
+    observations: Array<QuoteResponse>;
+};

--- a/frontend/src/api/generated/models/OptionLegResponse.ts
+++ b/frontend/src/api/generated/models/OptionLegResponse.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type OptionLegResponse = {
+    account_id: string;
+    underlying_symbol: string;
+    option_symbol: string;
+    option_type: string;
+    strike: string;
+    expiration: string;
+    quantity: string;
+    side: string;
+    average_price: (string | null);
+    observed_at: string;
+    original_provider: string;
+};

--- a/frontend/src/api/generated/models/PortfolioDataResponse.ts
+++ b/frontend/src/api/generated/models/PortfolioDataResponse.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { AccountResponse } from './AccountResponse';
+export type PortfolioDataResponse = {
+    publication_id: string;
+    snapshot_id: string;
+    provider: string;
+    account_count: number;
+    equity_position_count: number;
+    option_leg_count: number;
+    accounts: Array<AccountResponse>;
+};

--- a/frontend/src/api/generated/models/PortfolioEnvelope.ts
+++ b/frontend/src/api/generated/models/PortfolioEnvelope.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { FreshnessResponse } from './FreshnessResponse';
+import type { PortfolioDataResponse } from './PortfolioDataResponse';
+import type { RunResponse } from './RunResponse';
+export type PortfolioEnvelope = {
+    run: RunResponse;
+    freshness: FreshnessResponse;
+    data: PortfolioDataResponse;
+};

--- a/frontend/src/api/generated/models/PositionsDataResponse.ts
+++ b/frontend/src/api/generated/models/PositionsDataResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { EquityPositionResponse } from './EquityPositionResponse';
+import type { OptionLegResponse } from './OptionLegResponse';
+export type PositionsDataResponse = {
+    publication_id: string;
+    snapshot_id: string;
+    equity_positions: Array<EquityPositionResponse>;
+    option_legs: Array<OptionLegResponse>;
+};

--- a/frontend/src/api/generated/models/PositionsEnvelope.ts
+++ b/frontend/src/api/generated/models/PositionsEnvelope.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { FreshnessResponse } from './FreshnessResponse';
+import type { PositionsDataResponse } from './PositionsDataResponse';
+import type { RunResponse } from './RunResponse';
+export type PositionsEnvelope = {
+    run: RunResponse;
+    freshness: FreshnessResponse;
+    data: PositionsDataResponse;
+};

--- a/frontend/src/api/generated/models/ProvenanceResponse.ts
+++ b/frontend/src/api/generated/models/ProvenanceResponse.ts
@@ -7,6 +7,6 @@ export type ProvenanceResponse = {
     original_provider: string;
     cache_status: string;
     freshness_status: string;
-    fallback_reason: string | null;
+    fallback_reason: (string | null);
     provider_request_id: string;
 };

--- a/frontend/src/api/generated/models/QuoteResponse.ts
+++ b/frontend/src/api/generated/models/QuoteResponse.ts
@@ -5,7 +5,7 @@
 import type { ProvenanceResponse } from './ProvenanceResponse';
 export type QuoteResponse = {
     symbol: string;
-    price: number | string;
+    price: string;
     currency: string;
     observed_at: string;
     received_at: string;

--- a/frontend/src/api/generated/models/RunResponse.ts
+++ b/frontend/src/api/generated/models/RunResponse.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { RunStepResponse } from './RunStepResponse';
+export type RunResponse = {
+    id: string;
+    status: string;
+    started_at: (string | null);
+    completed_at: (string | null);
+    release_sha: string;
+    effective_config_hash: string;
+    failure_code: (string | null);
+    failure_detail: (string | null);
+    publication_id: (string | null);
+    steps: Array<RunStepResponse>;
+};

--- a/frontend/src/api/generated/models/RunStepResponse.ts
+++ b/frontend/src/api/generated/models/RunStepResponse.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type RunStepResponse = {
+    name: string;
+    status: string;
+    started_at: (string | null);
+    completed_at: (string | null);
+    failure_detail: (string | null);
+};

--- a/frontend/src/api/generated/models/StartRunRequest.ts
+++ b/frontend/src/api/generated/models/StartRunRequest.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type StartRunRequest = {
+    requested_at: string;
+    release_sha: string;
+    effective_config_hash: string;
+};

--- a/frontend/src/api/generated/models/ValidationError.ts
+++ b/frontend/src/api/generated/models/ValidationError.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ValidationError = {
+    loc: Array<(string | number)>;
+    msg: string;
+    type: string;
+    input?: any;
+    ctx?: Record<string, any>;
+};

--- a/frontend/src/api/generated/services/DefaultService.ts
+++ b/frontend/src/api/generated/services/DefaultService.ts
@@ -2,14 +2,63 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { HealthResponse } from '../models/HealthResponse';
+import type { IngestQuotesRequest } from '../models/IngestQuotesRequest';
+import type { IngestQuotesResponse } from '../models/IngestQuotesResponse';
+import type { PortfolioEnvelope } from '../models/PortfolioEnvelope';
+import type { PositionsEnvelope } from '../models/PositionsEnvelope';
 import type { QuoteResponse } from '../models/QuoteResponse';
+import type { RunResponse } from '../models/RunResponse';
+import type { StartRunRequest } from '../models/StartRunRequest';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 export class DefaultService {
     /**
+     * Health
+     * @returns HealthResponse Successful Response
+     * @throws ApiError
+     */
+    public static healthApiV1HealthGet(): CancelablePromise<HealthResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/health',
+        });
+    }
+    /**
+     * Readiness
+     * @returns HealthResponse Successful Response
+     * @throws ApiError
+     */
+    public static readinessApiV1ReadinessGet(): CancelablePromise<HealthResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/readiness',
+        });
+    }
+    /**
+     * Ingest Quotes
+     * @param requestBody
+     * @returns IngestQuotesResponse Successful Response
+     * @throws ApiError
+     */
+    public static ingestQuotesApiV1MarketQuotesIngestPost(
+        requestBody: IngestQuotesRequest,
+    ): CancelablePromise<IngestQuotesResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/market/quotes/ingest',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Latest Quote
      * @param symbol
-     * @returns QuoteResponse Latest canonical observation
+     * @returns QuoteResponse Successful Response
      * @throws ApiError
      */
     public static getLatestQuote(
@@ -22,8 +71,80 @@ export class DefaultService {
                 'symbol': symbol,
             },
             errors: {
-                404: `Unavailable`,
+                422: `Validation Error`,
             },
+        });
+    }
+    /**
+     * Start Run
+     * @param requestBody
+     * @returns RunResponse Successful Response
+     * @throws ApiError
+     */
+    public static startRunApiV1RunsPost(
+        requestBody: StartRunRequest,
+    ): CancelablePromise<RunResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/runs',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Current Run
+     * @returns RunResponse Successful Response
+     * @throws ApiError
+     */
+    public static currentRunApiV1RunsCurrentGet(): CancelablePromise<RunResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/runs/current',
+        });
+    }
+    /**
+     * Get Run
+     * @param runId
+     * @returns RunResponse Successful Response
+     * @throws ApiError
+     */
+    public static getRunApiV1RunsRunIdGet(
+        runId: string,
+    ): CancelablePromise<RunResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/runs/{run_id}',
+            path: {
+                'run_id': runId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Get Portfolio
+     * @returns PortfolioEnvelope Successful Response
+     * @throws ApiError
+     */
+    public static getPortfolio(): CancelablePromise<PortfolioEnvelope> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/portfolio',
+        });
+    }
+    /**
+     * Get Positions
+     * @returns PositionsEnvelope Successful Response
+     * @throws ApiError
+     */
+    public static getPositions(): CancelablePromise<PositionsEnvelope> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/positions',
         });
     }
 }

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -1,43 +1,944 @@
 {
   "openapi": "3.1.0",
-  "info": { "title": "ASA Market Quote API", "version": "1.0.0" },
+  "info": {
+    "title": "ASA Market Quote API",
+    "version": "1.0.0"
+  },
   "paths": {
+    "/api/v1/health": {
+      "get": {
+        "summary": "Health",
+        "operationId": "health_api_v1_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/readiness": {
+      "get": {
+        "summary": "Readiness",
+        "operationId": "readiness_api_v1_readiness_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/market/quotes/ingest": {
+      "post": {
+        "summary": "Ingest Quotes",
+        "operationId": "ingest_quotes_api_v1_market_quotes_ingest_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngestQuotesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestQuotesResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/market/quotes/{symbol}": {
       "get": {
+        "summary": "Latest Quote",
         "operationId": "getLatestQuote",
-        "parameters": [{ "name": "symbol", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Symbol"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Latest canonical observation", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/QuoteResponse" } } } },
-          "404": { "description": "Unavailable" }
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuoteResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/runs": {
+      "post": {
+        "summary": "Start Run",
+        "operationId": "start_run_api_v1_runs_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/runs/current": {
+      "get": {
+        "summary": "Current Run",
+        "operationId": "current_run_api_v1_runs_current_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/runs/{run_id}": {
+      "get": {
+        "summary": "Get Run",
+        "operationId": "get_run_api_v1_runs__run_id__get",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Run Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/portfolio": {
+      "get": {
+        "summary": "Get Portfolio",
+        "operationId": "getPortfolio",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/positions": {
+      "get": {
+        "summary": "Get Positions",
+        "operationId": "getPositions",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PositionsEnvelope"
+                }
+              }
+            }
+          }
         }
       }
     }
   },
   "components": {
     "schemas": {
-      "ProvenanceResponse": {
-        "type": "object",
-        "required": ["selected_provider", "original_provider", "cache_status", "freshness_status", "fallback_reason", "provider_request_id"],
+      "AccountResponse": {
         "properties": {
-          "selected_provider": { "type": "string" },
-          "original_provider": { "type": "string" },
-          "cache_status": { "type": "string" },
-          "freshness_status": { "type": "string" },
-          "fallback_reason": { "type": ["string", "null"] },
-          "provider_request_id": { "type": "string" }
-        }
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "external_account_id": {
+            "type": "string",
+            "title": "External Account Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
+          "account_type": {
+            "type": "string",
+            "title": "Account Type"
+          },
+          "display_name": {
+            "type": "string",
+            "title": "Display Name"
+          },
+          "currency": {
+            "type": "string",
+            "title": "Currency"
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Observed At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "external_account_id",
+          "provider",
+          "account_type",
+          "display_name",
+          "currency",
+          "observed_at"
+        ],
+        "title": "AccountResponse"
+      },
+      "EquityPositionResponse": {
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Account Id"
+          },
+          "symbol": {
+            "type": "string",
+            "title": "Symbol"
+          },
+          "quantity": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Quantity"
+          },
+          "average_cost": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Cost"
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Observed At"
+          },
+          "original_provider": {
+            "type": "string",
+            "title": "Original Provider"
+          }
+        },
+        "type": "object",
+        "required": [
+          "account_id",
+          "symbol",
+          "quantity",
+          "average_cost",
+          "observed_at",
+          "original_provider"
+        ],
+        "title": "EquityPositionResponse"
+      },
+      "FreshnessResponse": {
+        "properties": {
+          "as_of": {
+            "type": "string",
+            "format": "date-time",
+            "title": "As Of"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "serving_last_success": {
+            "type": "boolean",
+            "title": "Serving Last Success"
+          }
+        },
+        "type": "object",
+        "required": [
+          "as_of",
+          "status",
+          "serving_last_success"
+        ],
+        "title": "FreshnessResponse"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "HealthResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "HealthResponse"
+      },
+      "IngestQuotesRequest": {
+        "properties": {
+          "symbols": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "title": "Symbols"
+          }
+        },
+        "type": "object",
+        "required": [
+          "symbols"
+        ],
+        "title": "IngestQuotesRequest"
+      },
+      "IngestQuotesResponse": {
+        "properties": {
+          "observations": {
+            "items": {
+              "$ref": "#/components/schemas/QuoteResponse"
+            },
+            "type": "array",
+            "title": "Observations"
+          }
+        },
+        "type": "object",
+        "required": [
+          "observations"
+        ],
+        "title": "IngestQuotesResponse"
+      },
+      "OptionLegResponse": {
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Account Id"
+          },
+          "underlying_symbol": {
+            "type": "string",
+            "title": "Underlying Symbol"
+          },
+          "option_symbol": {
+            "type": "string",
+            "title": "Option Symbol"
+          },
+          "option_type": {
+            "type": "string",
+            "title": "Option Type"
+          },
+          "strike": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Strike"
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date",
+            "title": "Expiration"
+          },
+          "quantity": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Quantity"
+          },
+          "side": {
+            "type": "string",
+            "title": "Side"
+          },
+          "average_price": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Price"
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Observed At"
+          },
+          "original_provider": {
+            "type": "string",
+            "title": "Original Provider"
+          }
+        },
+        "type": "object",
+        "required": [
+          "account_id",
+          "underlying_symbol",
+          "option_symbol",
+          "option_type",
+          "strike",
+          "expiration",
+          "quantity",
+          "side",
+          "average_price",
+          "observed_at",
+          "original_provider"
+        ],
+        "title": "OptionLegResponse"
+      },
+      "PortfolioDataResponse": {
+        "properties": {
+          "publication_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Publication Id"
+          },
+          "snapshot_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Snapshot Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
+          "account_count": {
+            "type": "integer",
+            "title": "Account Count"
+          },
+          "equity_position_count": {
+            "type": "integer",
+            "title": "Equity Position Count"
+          },
+          "option_leg_count": {
+            "type": "integer",
+            "title": "Option Leg Count"
+          },
+          "accounts": {
+            "items": {
+              "$ref": "#/components/schemas/AccountResponse"
+            },
+            "type": "array",
+            "title": "Accounts"
+          }
+        },
+        "type": "object",
+        "required": [
+          "publication_id",
+          "snapshot_id",
+          "provider",
+          "account_count",
+          "equity_position_count",
+          "option_leg_count",
+          "accounts"
+        ],
+        "title": "PortfolioDataResponse"
+      },
+      "PortfolioEnvelope": {
+        "properties": {
+          "run": {
+            "$ref": "#/components/schemas/RunResponse"
+          },
+          "freshness": {
+            "$ref": "#/components/schemas/FreshnessResponse"
+          },
+          "data": {
+            "$ref": "#/components/schemas/PortfolioDataResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "run",
+          "freshness",
+          "data"
+        ],
+        "title": "PortfolioEnvelope"
+      },
+      "PositionsDataResponse": {
+        "properties": {
+          "publication_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Publication Id"
+          },
+          "snapshot_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Snapshot Id"
+          },
+          "equity_positions": {
+            "items": {
+              "$ref": "#/components/schemas/EquityPositionResponse"
+            },
+            "type": "array",
+            "title": "Equity Positions"
+          },
+          "option_legs": {
+            "items": {
+              "$ref": "#/components/schemas/OptionLegResponse"
+            },
+            "type": "array",
+            "title": "Option Legs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "publication_id",
+          "snapshot_id",
+          "equity_positions",
+          "option_legs"
+        ],
+        "title": "PositionsDataResponse"
+      },
+      "PositionsEnvelope": {
+        "properties": {
+          "run": {
+            "$ref": "#/components/schemas/RunResponse"
+          },
+          "freshness": {
+            "$ref": "#/components/schemas/FreshnessResponse"
+          },
+          "data": {
+            "$ref": "#/components/schemas/PositionsDataResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "run",
+          "freshness",
+          "data"
+        ],
+        "title": "PositionsEnvelope"
+      },
+      "ProvenanceResponse": {
+        "properties": {
+          "selected_provider": {
+            "type": "string",
+            "title": "Selected Provider"
+          },
+          "original_provider": {
+            "type": "string",
+            "title": "Original Provider"
+          },
+          "cache_status": {
+            "type": "string",
+            "title": "Cache Status"
+          },
+          "freshness_status": {
+            "type": "string",
+            "title": "Freshness Status"
+          },
+          "fallback_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fallback Reason"
+          },
+          "provider_request_id": {
+            "type": "string",
+            "title": "Provider Request Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "selected_provider",
+          "original_provider",
+          "cache_status",
+          "freshness_status",
+          "fallback_reason",
+          "provider_request_id"
+        ],
+        "title": "ProvenanceResponse"
       },
       "QuoteResponse": {
-        "type": "object",
-        "required": ["symbol", "price", "currency", "observed_at", "received_at", "provenance"],
         "properties": {
-          "symbol": { "type": "string" },
-          "price": { "type": ["number", "string"] },
-          "currency": { "type": "string" },
-          "observed_at": { "type": "string", "format": "date-time" },
-          "received_at": { "type": "string", "format": "date-time" },
-          "provenance": { "$ref": "#/components/schemas/ProvenanceResponse" }
-        }
+          "symbol": {
+            "type": "string",
+            "title": "Symbol"
+          },
+          "price": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Price"
+          },
+          "currency": {
+            "type": "string",
+            "title": "Currency"
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Observed At"
+          },
+          "received_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Received At"
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/ProvenanceResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "symbol",
+          "price",
+          "currency",
+          "observed_at",
+          "received_at",
+          "provenance"
+        ],
+        "title": "QuoteResponse"
+      },
+      "RunResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At"
+          },
+          "release_sha": {
+            "type": "string",
+            "title": "Release Sha"
+          },
+          "effective_config_hash": {
+            "type": "string",
+            "title": "Effective Config Hash"
+          },
+          "failure_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Failure Code"
+          },
+          "failure_detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Failure Detail"
+          },
+          "publication_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Publication Id"
+          },
+          "steps": {
+            "items": {
+              "$ref": "#/components/schemas/RunStepResponse"
+            },
+            "type": "array",
+            "title": "Steps"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "status",
+          "started_at",
+          "completed_at",
+          "release_sha",
+          "effective_config_hash",
+          "failure_code",
+          "failure_detail",
+          "publication_id",
+          "steps"
+        ],
+        "title": "RunResponse"
+      },
+      "RunStepResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At"
+          },
+          "failure_detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Failure Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "status",
+          "started_at",
+          "completed_at",
+          "failure_detail"
+        ],
+        "title": "RunStepResponse"
+      },
+      "StartRunRequest": {
+        "properties": {
+          "requested_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Requested At"
+          },
+          "release_sha": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Release Sha"
+          },
+          "effective_config_hash": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Effective Config Hash"
+          }
+        },
+        "type": "object",
+        "required": [
+          "requested_at",
+          "release_sha",
+          "effective_config_hash"
+        ],
+        "title": "StartRunRequest"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
       }
     }
   }

--- a/frontend/src/api/portfolio.ts
+++ b/frontend/src/api/portfolio.ts
@@ -1,0 +1,15 @@
+import type { PortfolioEnvelope } from './generated/models/PortfolioEnvelope'
+import type { PositionsEnvelope } from './generated/models/PositionsEnvelope'
+import { DefaultService } from './generated/services/DefaultService'
+
+export type { PortfolioEnvelope, PositionsEnvelope }
+
+export interface PublishedPortfolioClient {
+  getPortfolio(): Promise<PortfolioEnvelope>
+  getPositions(): Promise<PositionsEnvelope>
+}
+
+export const publishedPortfolioClient: PublishedPortfolioClient = {
+  getPortfolio: () => DefaultService.getPortfolio(),
+  getPositions: () => DefaultService.getPositions(),
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,17 +1,23 @@
 :root { font-family: Inter, ui-sans-serif, system-ui, sans-serif; color: #172023; background: #edf1ed; }
 body { margin: 0; min-width: 320px; min-height: 100vh; }
-main { width: min(680px, calc(100% - 40px)); margin: 0 auto; padding: 12vh 0; }
+main { width: min(960px, calc(100% - 40px)); margin: 0 auto; padding: 8vh 0; }
 .eyebrow { color: #476457; font-size: .75rem; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
-h1 { margin: .4rem 0 2rem; font-family: Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 400; }
-article { background: #fff; border: 1px solid #ccd7cf; border-radius: 18px; box-shadow: 0 18px 60px #23382b12; padding: clamp(1.5rem, 5vw, 3rem); }
-.quote-heading, dl div { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
-.symbol { font-size: 1.4rem; font-weight: 750; letter-spacing: .08em; }
-.freshness { border-radius: 999px; padding: .4rem .7rem; font-size: .72rem; font-weight: 700; text-transform: uppercase; }
+h1 { margin: .4rem 0 2rem; font-family: Georgia, serif; font-size: clamp(2.5rem, 7vw, 5rem); font-weight: 400; }
+h2 { margin-top: 2.5rem; font-family: Georgia, serif; font-size: 1.7rem; font-weight: 400; }
+.dashboard { display: grid; gap: 1rem; }
+.run-banner, .summary, .account-card, .position-list article { background: #fff; border: 1px solid #ccd7cf; border-radius: 16px; padding: 1.25rem; }
+.run-banner { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 1rem; }
+.run-banner div { display: grid; gap: .35rem; }
+.run-banner div:nth-of-type(2) { text-align: right; }
+.run-banner span, .summary span, small { color: #64736b; font-size: .78rem; }
+.run-banner strong { font-size: .82rem; overflow-wrap: anywhere; }
+.freshness { border-radius: 999px; padding: .4rem .7rem; font-weight: 700; text-transform: uppercase; }
 .freshness.fresh { background: #dcefe2; color: #195d34; }
 .freshness.stale { background: #f6e8c9; color: #77520b; }
-.price { margin: 2rem 0; font-family: Georgia, serif; font-size: clamp(3rem, 12vw, 6rem); line-height: 1; }
-.price span { color: #64736b; font-family: Inter, sans-serif; font-size: 1rem; }
-dl { margin: 0; border-top: 1px solid #e3e8e4; }
-dl div { padding-top: 1rem; }
-dt { color: #64736b; }
-dd { margin: 0; text-align: right; }
+.last-success { grid-column: 1 / -1; margin: 0; border-top: 1px solid #e3e8e4; padding-top: 1rem; color: #77520b; font-weight: 700; }
+.summary { display: grid; grid-template-columns: repeat(3, 1fr); }
+.summary div { display: grid; gap: .4rem; text-align: center; }
+.summary strong { font-family: Georgia, serif; font-size: 2.4rem; }
+.account-card, .position-list article { display: grid; gap: .45rem; }
+.position-list { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: .75rem; }
+@media (max-width: 640px) { .run-banner { grid-template-columns: 1fr; } .run-banner div:nth-of-type(2) { text-align: left; } }

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -2,43 +2,68 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import { App } from '../src/App'
-import type { MarketQuoteClient } from '../src/api/market'
+import type { PublishedPortfolioClient } from '../src/api/portfolio'
 
-const quote = {
-  symbol: 'AAPL',
-  price: '189.42',
-  currency: 'USD',
-  observed_at: '2026-07-19T12:00:00Z',
-  received_at: '2026-07-19T12:00:01Z',
-  provenance: {
-    selected_provider: 'deterministic_fake',
-    original_provider: 'deterministic_fake',
-    cache_status: 'miss',
-    freshness_status: 'fresh',
-    fallback_reason: null,
-    provider_request_id: 'fake-123',
-  },
+const run = {
+  id: 'run-success-a', status: 'succeeded', started_at: '2026-07-19T12:00:00Z',
+  completed_at: '2026-07-19T12:00:01Z', release_sha: 'release-a',
+  effective_config_hash: 'config-a', failure_code: null, failure_detail: null,
+  publication_id: 'publication-a', steps: [],
+}
+const freshness = { as_of: '2026-07-19T12:00:00Z', status: 'stale', serving_last_success: true }
+const client: PublishedPortfolioClient = {
+  getPortfolio: async () => ({
+    run, freshness,
+    data: {
+      publication_id: 'publication-a', snapshot_id: 'snapshot-a',
+      provider: 'deterministic_fake_broker', account_count: 1,
+      equity_position_count: 1, option_leg_count: 2,
+      accounts: [{
+        id: 'account-a', external_account_id: 'taxable-001',
+        provider: 'deterministic_fake_broker', account_type: 'taxable',
+        display_name: 'Primary Taxable', currency: 'USD', observed_at: freshness.as_of,
+      }],
+    },
+  }),
+  getPositions: async () => ({
+    run, freshness,
+    data: {
+      publication_id: 'publication-a', snapshot_id: 'snapshot-a',
+      equity_positions: [{
+        account_id: 'account-a', symbol: 'AAPL', quantity: '12', average_cost: '172.50',
+        observed_at: freshness.as_of, original_provider: 'deterministic_fake_broker',
+      }],
+      option_legs: [
+        { account_id: 'account-a', underlying_symbol: 'AAPL', option_symbol: 'AAPL-LONG', option_type: 'call', strike: '200', expiration: '2026-09-18', quantity: '1', side: 'long', average_price: '8.40', observed_at: freshness.as_of, original_provider: 'deterministic_fake_broker' },
+        { account_id: 'account-a', underlying_symbol: 'AAPL', option_symbol: 'AAPL-SHORT', option_type: 'call', strike: '210', expiration: '2026-09-18', quantity: '1', side: 'short', average_price: '5.10', observed_at: freshness.as_of, original_provider: 'deterministic_fake_broker' },
+      ],
+    },
+  }),
 }
 
 describe('App', () => {
-  it('renders every required API field without recalculating it', async () => {
-    const client: MarketQuoteClient = { getLatestQuote: async () => quote }
+  it('renders the published run, freshness, accounts, equities, and option legs', async () => {
     render(<App client={client} />)
     expect(screen.getByRole('status')).toHaveTextContent('Loading')
-    expect(await screen.findByText('AAPL')).toBeInTheDocument()
-    expect(screen.getByText('189.42')).toBeInTheDocument()
-    expect(screen.getByText('USD')).toBeInTheDocument()
-    expect(screen.getByText('2026-07-19T12:00:00Z')).toBeInTheDocument()
-    expect(screen.getByText('deterministic_fake')).toBeInTheDocument()
-    expect(screen.getByText('fresh')).toBeInTheDocument()
+    expect(await screen.findByText('run-success-a')).toBeInTheDocument()
+    expect(screen.getByText('stale')).toBeInTheDocument()
+    expect(screen.getByText('Serving last successful publication')).toBeInTheDocument()
+    expect(screen.getByText('Primary Taxable')).toBeInTheDocument()
+    expect(screen.getByText('12 shares')).toBeInTheDocument()
+    expect(screen.getByText('long · 1 · strike 200')).toBeInTheDocument()
+    expect(screen.getByText('short · 1 · strike 210')).toBeInTheDocument()
   })
 
   it('renders unavailable and error states', async () => {
-    const unavailable: MarketQuoteClient = { getLatestQuote: async () => Promise.reject({ status: 404 }) }
+    const unavailable: PublishedPortfolioClient = {
+      getPortfolio: async () => Promise.reject({ status: 404 }), getPositions: client.getPositions,
+    }
     const { unmount } = render(<App client={unavailable} />)
-    expect(await screen.findByText('AAPL quote unavailable.')).toBeInTheDocument()
+    expect(await screen.findByText('No published portfolio is available.')).toBeInTheDocument()
     unmount()
-    const failed: MarketQuoteClient = { getLatestQuote: async () => Promise.reject(new Error('down')) }
+    const failed: PublishedPortfolioClient = {
+      getPortfolio: async () => Promise.reject(new Error('down')), getPositions: client.getPositions,
+    }
     render(<App client={failed} />)
     expect(await screen.findByRole('alert')).toBeInTheDocument()
   })


### PR DESCRIPTION
## Runtime path

`POST /api/v1/runs` executes the synchronous `RunPortfolioIntelligence` use case through the sole `build_application` composition root: deterministic fake broker -> acquire -> normalize -> validate -> atomic PostgreSQL publication. `GET /api/v1/portfolio` and `GET /api/v1/positions` read only through the canonical publication pointer; React renders those generated-client responses. Python 3.12 is enforced in `pyproject.toml`, Compose, and Product CI.

## Canonical ownership

PostgreSQL remains the only product store. `runs`/`run_steps` own execution evidence; immutable snapshots, accounts, equities, and option legs own normalized portfolio facts; `publications` owns successful publication history; singleton `publication_pointer(id = 1)` alone selects current data. Existing market observation ownership and quote endpoints are unchanged.

## Publication transaction

One transaction inserts the snapshot graph, marks the run succeeded, creates the publication, advances the singleton pointer, and completes the publish step. A deferred constraint trigger rejects publications whose run is not succeeded at commit. Reads never use latest timestamps, dual-read, or mutable booleans.

## Failure preservation evidence

The acceptance path publishes run A, executes run B with an invalid option leg so validation fails, and proves the pointer still serves A with `serving_last_success=true`. Candidate publication rows are rolled back and the failed run/step details remain persisted.

## Broker contract

`BrokerPortfolioProvider` exposes only `fetch_accounts` and `fetch_positions`; a boundary test rejects any added public operation. `DeterministicFakeBrokerPortfolioProvider` has stable sanitized facts and no SDK, credentials, write, order, or transfer capability.

## Normalized data model

The fixture normalizes one taxable USD account, one 12-share AAPL equity position, one long AAPL call, and one short AAPL call. Accounts retain connection/external identity and provider provenance. Positions retain account ownership, observation time, original provider, quantities, optional costs/prices, and required option shape.

## API contract

- `POST /api/v1/runs`
- `GET /api/v1/runs/{run_id}`
- `GET /api/v1/runs/current`
- `GET /api/v1/portfolio`
- `GET /api/v1/positions`

Published envelopes contain required run provenance, freshness (`as_of`, status, `serving_last_success`), publication/snapshot identity, and typed data. Existing quote/health/readiness behavior is preserved.

## Frontend evidence

The React dashboard renders the canonical run banner, freshness, last-success disclosure, portfolio counts, account summary, AAPL equity, and both option legs. Vitest covers success, stale last-success, unavailable, and error states using the generated client boundary. No valuation or business calculation is present in React.

## Composition and acceptance evidence

Composition tests prove one `build_application`, the existing quote provider, and the same injected broker provider instance used by the run use case. Backend acceptance covers synchronous POST, four persisted successful steps, canonical portfolio/position identity, provider-free reads, deterministic counts, and failed-validation pointer preservation.

## Migration round trip

Alembic adds `0002` (runs/publications/singleton pointer) then `0003` (accounts/positions). Local offline upgrade/downgrade/re-upgrade SQL generation passes. Product CI executes the full upgrade -> downgrade base -> upgrade cycle against PostgreSQL 17.

## Verification

- Python 3.12.10 local runtime
- Ruff: pass
- strict mypy: pass
- local pytest: 17 passed, 5 PostgreSQL-gated tests awaiting CI
- frontend OpenAPI regeneration/drift, lint, typecheck, 2 Vitest tests, and build: pass
- Lean entrypoint and frozen governance integrity: pass
- `git diff --check`: pass

## Complexity delta

51 files changed: 3,478 additions, 94 deletions. The largest changes are the generated OpenAPI schema/client and the explicit PostgreSQL adapter. No generic repository, event bus, job framework, compatibility layer, or plugin system was introduced.

## New abstractions

- `BrokerPortfolioProvider`
- `RunPublicationRepository`
- `RunPortfolioIntelligence`
- `PublishedPortfolioQuery` and `RunQueryService`
- canonical run, publication, account, equity, and option-leg domain records

Each has an active endpoint, transaction, or test consumer in this feature.

## New configuration

- `ASA_BROKER_PORTFOLIO_PROVIDER=deterministic_fake_broker`
- `ASA_PORTFOLIO_FRESH_FOR_SECONDS=3600`
- Python requirement changed to `>=3.12,<3.13`

No live credential configuration was added.

## Exclusions confirmed

No live broker, auth, background worker/thread, Redis, scheduler, options-chain market data, valuation, lifecycle advice, strategies, discovery, manual entry, order execution, fallback, multi-user scope, or legacy migration.

## Follow-up findings

Docker is unavailable on the implementation host, so real PostgreSQL and Compose runtime evidence is delegated to Product CI. `npm audit` reports one low-severity development dependency advisory; there are no high or critical findings. Live providers, auth, async execution, valuation, and deployment require separate tickets.

Risk class: R2. Founder-only merge authority remains unchanged; this PR is draft and was not merged.