### PR TITLE
ASA-PROD-004: correct portfolio freshness and provider-neutral logging

### DIFF
--- a/backend/src/asa/application/portfolio_use_cases.py
+++ b/backend/src/asa/application/portfolio_use_cases.py
@@ -69,17 +69,25 @@ class RunPortfolioIntelligence:
             requested_at.astimezone(UTC), release_sha, effective_config_hash
         )
         current_step = RunStepName.ACQUIRE_PORTFOLIO
+        provider_name = self._provider.name
         self._repository.start_run(run.id, self._clock())
         try:
             accounts, positions = self._acquire(run.id)
+            provider_name = accounts.provider
             current_step = RunStepName.NORMALIZE_PORTFOLIO
             snapshot = self._run_step(
                 run.id,
                 current_step,
+                provider_name,
                 lambda: self._normalize(accounts, positions),
             )
             current_step = RunStepName.VALIDATE_PUBLICATION
-            self._run_step(run.id, current_step, lambda: validate_snapshot(snapshot))
+            self._run_step(
+                run.id,
+                current_step,
+                provider_name,
+                lambda: validate_snapshot(snapshot),
+            )
             current_step = RunStepName.PUBLISH
             publication = self._repository.publish_portfolio(run.id, snapshot, self._clock())
             self._log_step(run.id, current_step, snapshot.provider, None)
@@ -93,7 +101,7 @@ class RunPortfolioIntelligence:
                 "portfolio_run_failed",
                 detail,
             )
-            self._log_step(run.id, current_step, "deterministic_fake_broker", None)
+            self._log_step(run.id, current_step, provider_name, None)
             return RunPortfolioResult(run.id, RunStatus.FAILED, None)
 
     def _acquire(self, run_id: UUID) -> tuple[BrokerAccountsResult, BrokerPositionsResult]:
@@ -108,11 +116,17 @@ class RunPortfolioIntelligence:
         self._log_step(run_id, step, accounts.provider, account_id)
         return accounts, positions
 
-    def _run_step(self, run_id: UUID, step: RunStepName, operation: Callable[[], T]) -> T:
+    def _run_step(
+        self,
+        run_id: UUID,
+        step: RunStepName,
+        provider: str,
+        operation: Callable[[], T],
+    ) -> T:
         self._repository.start_step(run_id, step, self._clock())
         result = operation()
         self._repository.complete_step(run_id, step, self._clock())
-        self._log_step(run_id, step, "deterministic_fake_broker", None)
+        self._log_step(run_id, step, provider, None)
         return result
 
     @staticmethod
@@ -161,7 +175,10 @@ class RunPortfolioIntelligence:
             )
             for item in positions_result.option_legs
         )
-        observed_at = min(account.observed_at for account in accounts)
+        evidence_observed_at = [account.observed_at for account in accounts]
+        evidence_observed_at.extend(position.observed_at for position in equities)
+        evidence_observed_at.extend(leg.observed_at for leg in option_legs)
+        observed_at = min(evidence_observed_at)
         return PortfolioSnapshot(
             observed_at=observed_at,
             provider=accounts_result.provider,

--- a/backend/src/asa/application/ports/brokers.py
+++ b/backend/src/asa/application/ports/brokers.py
@@ -56,6 +56,8 @@ class BrokerPositionsResult:
 
 
 class BrokerPortfolioProvider(Protocol):
+    name: str
+
     def fetch_accounts(self) -> BrokerAccountsResult: ...
 
     def fetch_positions(self) -> BrokerPositionsResult: ...

--- a/backend/tests/test_logging.py
+++ b/backend/tests/test_logging.py
@@ -1,6 +1,17 @@
 import json
 import logging
+from pathlib import Path
+from unittest.mock import Mock
+from uuid import uuid4
 
+import pytest
+
+from asa.application.portfolio_use_cases import RunPortfolioIntelligence
+from asa.application.ports.runs import RunPublicationRepository
+from asa.domain.runs import RunStepName
+from asa.integrations.providers.deterministic_fake_broker import (
+    DeterministicFakeBrokerPortfolioProvider,
+)
 from asa.logging import JsonFormatter, request_id_context
 
 
@@ -33,3 +44,26 @@ def test_structured_market_log_contains_required_correlation_fields() -> None:
     assert payload["run_id"] == "run-123"
     assert payload["run_step"] == "acquire_portfolio"
     assert payload["account_id"] == "taxable-001"
+
+
+def test_run_step_log_uses_provider_supplied_by_port(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    provider.name = "provider_selected_at_composition"
+    repository = Mock(spec=RunPublicationRepository)
+    runner = RunPortfolioIntelligence(provider, repository)
+
+    with caplog.at_level(logging.INFO, logger="asa.portfolio_run"):
+        runner._run_step(
+            uuid4(),
+            RunStepName.NORMALIZE_PORTFOLIO,
+            provider.name,
+            lambda: None,
+        )
+
+    assert caplog.records[-1].provider == "provider_selected_at_composition"
+    application_source = (
+        Path(__file__).parents[1] / "src" / "asa" / "application" / "portfolio_use_cases.py"
+    ).read_text()
+    assert "deterministic_fake_broker" not in application_source

--- a/backend/tests/test_portfolio_acceptance.py
+++ b/backend/tests/test_portfolio_acceptance.py
@@ -114,3 +114,24 @@ def test_failed_run_preserves_publication_and_discloses_last_success(
     assert failed["publication_id"] is None
     assert portfolio["run"]["id"] == successful["id"]
     assert portfolio["freshness"]["serving_last_success"] is True
+
+
+def test_account_only_portfolio_can_be_published(portfolio_client: TestClient) -> None:
+    provider = portfolio_client.app.state.dependencies["broker_provider"]
+    positions = provider.fetch_positions()
+    provider.fetch_positions = lambda: replace(positions, equities=(), option_legs=())
+
+    run = portfolio_client.post(
+        "/api/v1/runs",
+        json={
+            "requested_at": datetime.now(UTC).isoformat(),
+            "release_sha": "release-account-only",
+            "effective_config_hash": "config-account-only",
+        },
+    ).json()
+    portfolio = portfolio_client.get("/api/v1/portfolio").json()
+
+    assert run["status"] == "succeeded"
+    assert portfolio["data"]["account_count"] == 1
+    assert portfolio["data"]["equity_position_count"] == 0
+    assert portfolio["data"]["option_leg_count"] == 0

--- a/backend/tests/test_portfolio_domain.py
+++ b/backend/tests/test_portfolio_domain.py
@@ -13,6 +13,40 @@ from asa.integrations.providers.deterministic_fake_broker import (
 )
 
 
+def publication_view_for_snapshot(snapshot: object, now: datetime):
+    published_run = RunRecord(
+        uuid4(),
+        RunStatus.SUCCEEDED,
+        snapshot.observed_at,
+        snapshot.observed_at,
+        snapshot.observed_at,
+        "release-a",
+        "config-a",
+        None,
+        None,
+        (),
+    )
+    publication = PublishedPortfolio(
+        uuid4(), published_run.id, uuid4(), snapshot.observed_at, snapshot
+    )
+
+    class QueryRepository:
+        def current_portfolio(self) -> PublishedPortfolio:
+            return publication
+
+        def get_run(self, run_id: object) -> RunRecord:
+            return published_run
+
+        def latest_run(self) -> RunRecord:
+            return published_run
+
+    return PublishedPortfolioQuery(
+        QueryRepository(),  # type: ignore[arg-type]
+        timedelta(minutes=5),
+        clock=lambda: now,
+    ).current()
+
+
 def test_fake_broker_normalizes_one_account_equity_and_two_option_legs() -> None:
     provider = DeterministicFakeBrokerPortfolioProvider()
     snapshot = RunPortfolioIntelligence._normalize(
@@ -34,6 +68,56 @@ def test_option_leg_validation_rejects_missing_symbol() -> None:
     invalid_leg = replace(snapshot.option_legs[0], option_symbol="")
     with pytest.raises(ValueError, match="option legs require"):
         validate_snapshot(replace(snapshot, option_legs=(invalid_leg,)))
+
+
+def test_stale_equity_evidence_makes_portfolio_stale() -> None:
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    accounts = provider.fetch_accounts()
+    positions = provider.fetch_positions()
+    stale_at = provider.observed_at - timedelta(hours=1)
+    stale_equity = replace(positions.equities[0], observed_at=stale_at)
+    snapshot = RunPortfolioIntelligence._normalize(
+        accounts,
+        replace(positions, equities=(stale_equity,)),
+    )
+
+    view = publication_view_for_snapshot(snapshot, provider.observed_at)
+    assert snapshot.observed_at == stale_at
+    assert view is not None
+    assert view.freshness_status is FreshnessStatus.STALE
+
+
+def test_stale_option_leg_evidence_makes_portfolio_stale() -> None:
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    accounts = provider.fetch_accounts()
+    positions = provider.fetch_positions()
+    stale_at = provider.observed_at - timedelta(hours=1)
+    stale_leg = replace(positions.option_legs[0], observed_at=stale_at)
+    snapshot = RunPortfolioIntelligence._normalize(
+        accounts,
+        replace(positions, option_legs=(stale_leg, positions.option_legs[1])),
+    )
+
+    view = publication_view_for_snapshot(snapshot, provider.observed_at)
+    assert snapshot.observed_at == stale_at
+    assert view is not None
+    assert view.freshness_status is FreshnessStatus.STALE
+
+
+def test_account_only_publication_uses_account_observation() -> None:
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    accounts = provider.fetch_accounts()
+    positions = replace(provider.fetch_positions(), equities=(), option_legs=())
+    snapshot = RunPortfolioIntelligence._normalize(accounts, positions)
+
+    validate_snapshot(snapshot)
+    view = publication_view_for_snapshot(
+        snapshot,
+        provider.observed_at + timedelta(minutes=1),
+    )
+    assert snapshot.observed_at == provider.observed_at
+    assert view is not None
+    assert view.freshness_status is FreshnessStatus.FRESH
 
 
 def test_publication_freshness_and_last_success_are_application_fields() -> None:


### PR DESCRIPTION
## Summary

Correct portfolio freshness so the canonical snapshot `observed_at` is the oldest timestamp across every included account, equity position, and option leg. Account-only publications continue to derive freshness from account evidence.

Run-step logging now obtains the provider identity from the `BrokerPortfolioProvider` port and provider results. The application layer contains no deterministic-provider name.

## Regression evidence

- stale equity evidence makes the published portfolio stale
- stale option-leg evidence makes the published portfolio stale
- account-only normalization remains valid and fresh when the account evidence is fresh
- PostgreSQL acceptance publishes an account-only snapshot
- run-step logs contain the provider selected at composition
- existing run/publication and quote suites remain green

## Scope

Five backend application/test files changed. No schema, migration, API, OpenAPI, frontend, provider mode, valuation, or strategy changes.

## Verification

- Python 3.12.10
- Ruff: pass
- strict mypy: pass
- local pytest: 21 passed, 6 PostgreSQL-gated tests
- frontend OpenAPI drift, lint, typecheck, tests, and build: pass
- Lean entrypoint and governance integrity: pass
- `git diff --check`: pass

Risk class: R1. Founder-only merge authority is unchanged; this PR is draft and unmerged.