### PR TITLE
ASA-PROD-006: fail fast on invalid database URL

### DIFF
--- a/backend/src/asa/config.py
+++ b/backend/src/asa/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
         env_file=".env",
         extra="ignore",
         populate_by_name=True,
+        hide_input_in_errors=True,
     )
 
     database_url: str = Field(
@@ -37,6 +38,13 @@ class Settings(BaseSettings):
     @field_validator("database_url")
     @classmethod
     def normalize_database_url(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("Database URL cannot be empty")
+        if "${{" in value and "}}" in value:
+            raise ValueError("Database URL contains an unresolved variable reference")
+        if "://" not in value or not value.partition("://")[0]:
+            raise ValueError("Database URL must include a URL scheme")
         if value.startswith("postgres://"):
             return value.replace("postgres://", "postgresql+psycopg://", 1)
         if value.startswith("postgresql://"):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -48,11 +48,59 @@ def test_robinhood_secrets_are_redacted_and_excluded_from_config_hash() -> None:
     [
         ("postgres://host/db", "postgresql+psycopg://host/db"),
         ("postgresql://host/db", "postgresql+psycopg://host/db"),
+        (
+            "postgresql://railway_user:railway_password@railway_host:5432/railway",
+            "postgresql+psycopg://railway_user:railway_password@railway_host:5432/railway",
+        ),
         ("postgresql+psycopg://host/db", "postgresql+psycopg://host/db"),
     ],
 )
 def test_railway_database_url_is_psycopg_compatible(provided: str, expected: str) -> None:
     assert Settings(_env_file=None, database_url=provided).database_url == expected
+
+
+def test_database_url_strips_surrounding_whitespace() -> None:
+    settings = Settings(_env_file=None, database_url="  postgresql://host/db  ")
+
+    assert settings.database_url == "postgresql+psycopg://host/db"
+
+
+@pytest.mark.parametrize(
+    ("provided", "expected_error"),
+    [
+        ("  ", "Database URL cannot be empty"),
+        ("${{Postgres.DATABASE_URL}}", "unresolved variable reference"),
+        ("database.internal/asa", "must include a URL scheme"),
+    ],
+)
+def test_invalid_database_url_fails_with_safe_actionable_error(
+    provided: str,
+    expected_error: str,
+) -> None:
+    with pytest.raises(ValidationError) as captured:
+        Settings(_env_file=None, database_url=provided)
+
+    message = str(captured.value)
+    assert expected_error in message
+    if provided.strip():
+        assert provided.strip() not in message
+
+
+def test_database_url_validation_never_discloses_url_components() -> None:
+    sensitive_url = "private-user:private-password@private-host/private-database"
+
+    with pytest.raises(ValidationError) as captured:
+        Settings(_env_file=None, database_url=sensitive_url)
+
+    message = str(captured.value)
+    for sensitive_value in (
+        sensitive_url,
+        "private-user",
+        "private-password",
+        "private-host",
+        "private-database",
+    ):
+        assert sensitive_value not in message
 
 
 def test_railway_port_is_loaded(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Fails fast during settings construction when `DATABASE_URL` is empty, contains an unresolved Railway reference, or has no URL scheme. Errors are actionable while redacting the entire supplied input.

## Scope

- **2 changed files, 56 additions**
- No migration, engine, Railway configuration, frontend, governance, or project-state changes.
- Strips surrounding whitespace before validation and normalization.
- Preserves exact `postgres://` and `postgresql://` normalization to `postgresql+psycopg://`.
- Enables Pydantic input hiding so exception text cannot disclose credentials, hosts, database names, or the full URL.
- Adds empty, unresolved-reference, malformed-value, whitespace, realistic Railway URL, and redaction regression tests.

## Local verification

Using uv with CPython 3.12.13 and the declared `dev` extra:

- `uv run ruff check .` — passed.
- `uv run mypy src` — passed for 27 source files.
- `uv run pytest` — **43 passed, 7 PostgreSQL-dependent skipped, 1 existing warning**.
- Final focused configuration suite — **15 passed**.
- Invalid Railway-reference Alembic probe — failed during `Settings()` construction with the safe actionable error and did not reach SQLAlchemy engine creation.
- Lean entrypoint, governance integrity, and `git diff --check` — passed.

The normal local `uv run python -m alembic upgrade head` passed configuration and normalization, then could not connect because no PostgreSQL server was listening locally.

## Product CI verification

Product CI run `29704102995` passed on Python 3.12.13:

- Backend — **passed in 49s**.
- Ruff — passed.
- Mypy — passed for 27 source files.
- PostgreSQL initial upgrade through migrations `0001`, `0002`, and `0003` — passed.
- Full PostgreSQL backend suite — **51 passed, 8 warnings in 2.00s**.
- PostgreSQL downgrade to base and re-upgrade through `0003` — passed.
- Frontend — **passed in 23s**; 2 tests passed and build completed in 912ms.

The valid Railway URL normalization and database-backed migration both pass; no escalation condition was met.

## Security

No diagnostic logging was added. Messages contain only the configuration category and corrective action. Tests assert malformed inputs, usernames, passwords, hosts, database names, and complete URLs do not appear in rendered validation errors.

## Risk

R1 configuration validation only. One focused commit; draft PR; Founder retains acceptance and merge authority.
