### PR TITLE
Make Railway observer diagnosable and deployment-ID first

### DIFF
--- a/docs/deployment/railway-observer.md
+++ b/docs/deployment/railway-observer.md
@@ -25,8 +25,10 @@ Automatic runs accept only GitHub `deployment_status` events whose deployment en
 exactly `production`. Manual runs also remain fixed to the production Railway environment and
 cannot override it. If a GitHub deployment payload contains a Railway deployment ID under
 `payload.railway_deployment_id`, `payload.railwayDeploymentId`, `payload.deployment_id`, or a
-nested `payload.railway` deployment ID, that ID is used. Otherwise the observer selects the
-latest ASA production deployment.
+nested `payload.railway` deployment ID, that ID is used. A Railway deployment ID in the `id`
+query parameter of the deployment status target URL is next. Only when none of those sources
+provides an ID does the observer list deployments and select the latest ASA production deployment.
+Resolved IDs fetch build and runtime logs directly without an unnecessary deployment-list call.
 
 ## Reading an artifact
 
@@ -36,8 +38,10 @@ bounded error cluster and likely build, pre-deploy, startup, healthcheck, or run
 quotes at most 80 redacted log lines. No external AI service is called.
 
 An empty log stream produces an empty JSONL file. If collection, parsing, or redaction fails,
-the collector deletes partial output, writes only a safe failure `summary.md`, and exits with a
-failure. Raw logs are never uploaded or committed.
+the collector deletes partial output and writes only `failure.json` and a safe `summary.md`.
+Railway command failures record only the command category, exit code, and redacted stdout/stderr,
+bounded together to 100 lines or 16 KiB. The token and process environment are never serialized.
+Raw logs are never uploaded or committed.
 
 ## Rollback
 

--- a/tests/deployment_observer/test_observer.py
+++ b/tests/deployment_observer/test_observer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -9,13 +10,16 @@ import pytest
 
 from tools.deployment_observer import collect as collect_entrypoint
 from tools.deployment_observer.observer import (
+    CommandFailure,
     MAX_SUMMARY_LINES,
     collect,
     first_error_cluster,
     parse_json_records,
     redact,
     redact_text,
+    railway_command,
     resolve_deployment,
+    resolve_known_deployment_id,
     validate_manifest,
 )
 
@@ -42,6 +46,28 @@ def test_resolves_payload_id_before_latest() -> None:
     event = {"deployment": {"payload": {"railway_deployment_id": "payload-id"}}}
     result = resolve_deployment(None, event, [deployment("latest")], "ASA", "production")
     assert result.deployment_id == "payload-id"
+
+
+def test_target_url_extracts_railway_deployment_id() -> None:
+    event = {
+        "deployment_status": {
+            "target_url": (
+                "https://railway.app/project/example/service/example?"
+                "id=e9030deb-31ac-4f13-83e3-a236989afb65"
+            )
+        }
+    }
+    assert resolve_known_deployment_id(None, event) == "e9030deb-31ac-4f13-83e3-a236989afb65"
+
+
+def test_payload_id_takes_precedence_over_target_url() -> None:
+    event = {
+        "deployment": {"payload": {"railway_deployment_id": "payload-id"}},
+        "deployment_status": {
+            "target_url": "https://railway.app/?id=e9030deb-31ac-4f13-83e3-a236989afb65"
+        },
+    }
+    assert resolve_known_deployment_id(None, event) == "payload-id"
 
 
 @pytest.mark.parametrize(
@@ -161,6 +187,73 @@ def test_uses_only_required_read_only_railway_commands(tmp_path: Path) -> None:
     ]
 
 
+def test_explicit_id_performs_no_deployment_list_call(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def runner(args: list[str]) -> str:
+        calls.append(args)
+        return ""
+
+    collect(
+        output_dir=tmp_path / "artifacts",
+        service="ASA",
+        environment="production",
+        explicit_id="e9030deb-31ac-4f13-83e3-a236989afb65",
+        event={},
+        include_runtime_logs=True,
+        runner=runner,
+    )
+    assert calls == [
+        [
+            "logs",
+            "e9030deb-31ac-4f13-83e3-a236989afb65",
+            "--build",
+            "--lines",
+            "5000",
+            "--json",
+        ],
+        [
+            "logs",
+            "e9030deb-31ac-4f13-83e3-a236989afb65",
+            "--deployment",
+            "--lines",
+            "5000",
+            "--json",
+        ],
+    ]
+
+
+def test_deployment_list_is_used_only_as_fallback(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def runner(args: list[str]) -> str:
+        calls.append(args)
+        return json.dumps([deployment()]) if args[:2] == ["deployment", "list"] else ""
+
+    collect(
+        output_dir=tmp_path / "fallback",
+        service="ASA",
+        environment="production",
+        explicit_id=None,
+        event={},
+        include_runtime_logs=False,
+        runner=runner,
+    )
+    assert calls[0][:2] == ["deployment", "list"]
+
+    calls.clear()
+    collect(
+        output_dir=tmp_path / "known",
+        service="ASA",
+        environment="production",
+        explicit_id="known-id",
+        event={},
+        include_runtime_logs=False,
+        runner=runner,
+    )
+    assert all(call[:2] != ["deployment", "list"] for call in calls)
+
+
 def test_collection_writes_only_redacted_logs_and_schema(tmp_path: Path) -> None:
     output = tmp_path / "artifacts"
     _, manifest, summary = collect(
@@ -195,8 +288,58 @@ def test_redaction_failure_prevents_raw_artifact_output(
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
     monkeypatch.setattr(collect_entrypoint, "collect", lambda **_: (_ for _ in ()).throw(ValueError()))
     assert collect_entrypoint.main() == 1
-    assert [path.name for path in output.iterdir()] == ["summary.md"]
+    assert {path.name for path in output.iterdir()} == {"failure.json", "summary.md"}
     assert "logs were uploaded" in (output / "summary.md").read_text()
+
+
+def test_called_process_error_output_is_redacted_and_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = "seeded-railway-token-value"
+    monkeypatch.setenv("RAILWAY_TOKEN", token)
+    stdout = "\n".join([f"password=secret-{index} {token}" for index in range(200)])
+
+    def fail(*_: Any, **__: Any) -> None:
+        raise subprocess.CalledProcessError(
+            17,
+            ["railway", "logs"],
+            output=stdout,
+            stderr=f"Authorization: Bearer {token}",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    with pytest.raises(CommandFailure) as raised:
+        railway_command(["logs", "deployment-id", "--build", "--lines", "5000", "--json"])
+    failure = raised.value
+    assert failure.category == "build-logs"
+    assert failure.exit_code == 17
+    assert token not in failure.stdout + failure.stderr
+    assert "secret-" not in failure.stdout
+    assert len((failure.stderr + failure.stdout).encode()) <= 16 * 1024
+    assert len((failure.stderr + failure.stdout).splitlines()) <= 100
+
+
+def test_safe_failure_artifacts_include_category_and_exit_code_without_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "artifacts"
+    event_path = tmp_path / "event.json"
+    event_path.write_text("{}")
+    token = "never-serialize-this-token"
+    monkeypatch.setenv("RAILWAY_TOKEN", token)
+    monkeypatch.setenv("OBSERVER_OUTPUT_DIR", str(output))
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    failure = CommandFailure("runtime-logs", 23, "token=[REDACTED]", "password=[REDACTED]")
+    monkeypatch.setattr(
+        collect_entrypoint, "collect", lambda **_: (_ for _ in ()).throw(failure)
+    )
+    assert collect_entrypoint.main() == 1
+    assert {path.name for path in output.iterdir()} == {"failure.json", "summary.md"}
+    combined = "".join(path.read_text() for path in output.iterdir())
+    data = json.loads((output / "failure.json").read_text())
+    assert data["command_category"] == "runtime-logs"
+    assert data["exit_code"] == 23
+    assert token not in combined
 
 
 def test_manifest_never_contains_prohibited_fields() -> None:

--- a/tools/deployment_observer/collect.py
+++ b/tools/deployment_observer/collect.py
@@ -12,7 +12,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from tools.deployment_observer.observer import collect
+from tools.deployment_observer.observer import CommandFailure, collect
 
 
 def _event() -> dict[str, Any]:
@@ -49,10 +49,30 @@ def main() -> int:
         # Never retain partially written log artifacts after an unexpected failure.
         shutil.rmtree(output_dir, ignore_errors=True)
         output_dir.mkdir(parents=True, exist_ok=True)
+        if isinstance(error, CommandFailure):
+            failure = {
+                "version": 1,
+                "collection_status": "failed",
+                "command_category": error.category,
+                "exit_code": error.exit_code,
+                "stderr": error.stderr,
+                "stdout": error.stdout,
+            }
+        else:
+            failure = {
+                "version": 1,
+                "collection_status": "failed",
+                "command_category": "observer",
+                "exit_code": None,
+                "stderr": "",
+                "stdout": "",
+            }
+        (output_dir / "failure.json").write_text(json.dumps(failure, indent=2) + "\n")
         safe_summary = (
             "## Railway deployment observer\n\n"
             "Collection failed safely. No deployment logs were uploaded. "
-            f"Error type: `{type(error).__name__}`.\n"
+            f"Command category: `{failure['command_category']}`. "
+            f"Exit code: `{failure['exit_code']}`.\n"
         )
         (output_dir / "summary.md").write_text(safe_summary)
         if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):

--- a/tools/deployment_observer/observer.py
+++ b/tools/deployment_observer/observer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 from collections.abc import Callable, Iterable, Mapping
@@ -10,10 +11,13 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 REDACTED = "[REDACTED]"
 MAX_LOG_LINES = 5_000
 MAX_SUMMARY_LINES = 80
+MAX_FAILURE_LINES = 100
+MAX_FAILURE_BYTES = 16 * 1024
 PROHIBITED_MANIFEST_FIELDS = {
     "railway_token",
     "environment_variables",
@@ -27,7 +31,7 @@ _PATTERNS = (
     re.compile(r"(?i)(\bAuthorization\s*[:=]\s*Bearer\s+)([^\s,;]+)"),
     re.compile(
         r"(?i)(\b(?:access[_-]?token|refresh[_-]?token|session(?:[_-]?(?:cookie|token))?|"
-        r"password|pgpassword|database_url|robinhood[_-]?(?:username|password|totp|cookie|"
+        r"password|pgpassword|database_url|railway_token|robinhood[_-]?(?:username|password|totp|cookie|"
         r"cookies|token|access_token|refresh_token))\b\s*[:=]\s*)([^\s,;]+|\"[^\"]*\"|'[^']*')"
     ),
     re.compile(r"(?i)(\b(?:Cookie|Set-Cookie)\s*:\s*)([^\r\n]+)"),
@@ -48,6 +52,16 @@ class Deployment:
     service: str
     environment: str
     source_commit_sha: str
+
+
+@dataclass(frozen=True)
+class CommandFailure(Exception):
+    """A bounded, already-redacted Railway CLI failure."""
+
+    category: str
+    exit_code: int
+    stdout: str
+    stderr: str
 
 
 def redact_text(value: str) -> tuple[str, int]:
@@ -146,6 +160,34 @@ def _payload_deployment_id(event: Mapping[str, Any]) -> str | None:
     return None
 
 
+def _target_url_deployment_id(event: Mapping[str, Any]) -> str | None:
+    status = event.get("deployment_status")
+    if not isinstance(status, Mapping):
+        return None
+    target_url = status.get("target_url")
+    if not isinstance(target_url, str):
+        return None
+    parsed = urlparse(target_url)
+    hostname = (parsed.hostname or "").lower()
+    if hostname not in {"railway.app", "railway.com"} and not hostname.endswith(
+        (".railway.app", ".railway.com")
+    ):
+        return None
+    candidate = parse_qs(parsed.query).get("id", [""])[0]
+    if re.fullmatch(r"[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}", candidate):
+        return candidate
+    return None
+
+
+def resolve_known_deployment_id(
+    explicit_id: str | None, event: Mapping[str, Any]
+) -> str | None:
+    """Resolve an ID without contacting Railway."""
+    return (explicit_id or "").strip() or _payload_deployment_id(event) or _target_url_deployment_id(
+        event
+    )
+
+
 def resolve_deployment(
     explicit_id: str | None,
     event: Mapping[str, Any],
@@ -153,14 +195,23 @@ def resolve_deployment(
     service: str,
     environment: str,
 ) -> Deployment:
-    """Resolve explicit, payload-derived, then latest Railway deployment."""
-    wanted = (explicit_id or "").strip() or _payload_deployment_id(event)
+    """Resolve explicit, payload-derived, target-URL, then latest deployment."""
+    wanted = resolve_known_deployment_id(explicit_id, event)
     record: dict[str, Any] | None = None
     if wanted:
         record = next(
             (item for item in deployments if _first(item, "id", "deploymentId") == wanted), None
         )
-        record = record or {"id": wanted}
+        status = event.get("deployment_status")
+        status_record = status if isinstance(status, Mapping) else {}
+        github_deployment = event.get("deployment")
+        github_record = github_deployment if isinstance(github_deployment, Mapping) else {}
+        record = record or {
+            "id": wanted,
+            "status": status_record.get("state", "unknown"),
+            "createdAt": status_record.get("created_at", ""),
+            "commitHash": github_record.get("sha", ""),
+        }
     elif deployments:
         record = max(
             deployments,
@@ -239,10 +290,55 @@ def validate_manifest(manifest: Mapping[str, Any]) -> None:
         raise ValueError("Manifest contains a prohibited field")
 
 
+def _command_category(args: list[str]) -> str:
+    if args[:2] == ["deployment", "list"]:
+        return "deployment-list"
+    if "--build" in args:
+        return "build-logs"
+    if "--deployment" in args:
+        return "runtime-logs"
+    return "railway-read"
+
+
+def _redact_secret(value: str) -> str:
+    token = os.environ.get("RAILWAY_TOKEN", "")
+    without_token = value.replace(token, REDACTED) if token else value
+    return redact_text(without_token)[0]
+
+
+def _bounded_outputs(stderr: str, stdout: str) -> tuple[str, str]:
+    """Bound combined captured output to 100 lines and 16 KiB, prioritizing stderr."""
+    remaining_lines = MAX_FAILURE_LINES
+    remaining_bytes = MAX_FAILURE_BYTES
+
+    def take(value: str) -> str:
+        nonlocal remaining_lines, remaining_bytes
+        lines = value.splitlines()[:remaining_lines]
+        candidate = "\n".join(lines)
+        encoded = candidate.encode()[:remaining_bytes]
+        bounded = encoded.decode(errors="ignore")
+        remaining_lines -= len(bounded.splitlines())
+        remaining_bytes -= len(bounded.encode())
+        return bounded
+
+    safe_stderr = take(_redact_secret(stderr))
+    safe_stdout = take(_redact_secret(stdout))
+    return safe_stderr, safe_stdout
+
+
 def railway_command(args: list[str]) -> str:
-    completed = subprocess.run(
-        ["railway", *args], check=True, capture_output=True, text=True, timeout=120
-    )
+    try:
+        completed = subprocess.run(
+            ["railway", *args], check=True, capture_output=True, text=True, timeout=120
+        )
+    except subprocess.CalledProcessError as error:
+        stderr, stdout = _bounded_outputs(error.stderr or "", error.stdout or "")
+        raise CommandFailure(
+            category=_command_category(args),
+            exit_code=error.returncode,
+            stdout=stdout,
+            stderr=stderr,
+        ) from None
     return completed.stdout
 
 
@@ -258,10 +354,23 @@ def collect(
     now: Callable[[], datetime] = lambda: datetime.now(UTC),
 ) -> tuple[Deployment, dict[str, Any], str]:
     """Collect all content in memory, redact it, then atomically expose safe files."""
-    deployments = parse_json_records(
-        runner(["deployment", "list", "--service", service, "--environment", environment, "--json"])
-    )
-    deployment = resolve_deployment(explicit_id, event, deployments, service, environment)
+    known_id = resolve_known_deployment_id(explicit_id, event)
+    deployments: list[dict[str, Any]] = []
+    if known_id is None:
+        deployments = parse_json_records(
+            runner(
+                [
+                    "deployment",
+                    "list",
+                    "--service",
+                    service,
+                    "--environment",
+                    environment,
+                    "--json",
+                ]
+            )
+        )
+    deployment = resolve_deployment(known_id, event, deployments, service, environment)
     build_raw = parse_json_records(
         runner(["logs", deployment.deployment_id, "--build", "--lines", "5000", "--json"])
     )[:MAX_LOG_LINES]


### PR DESCRIPTION
## Objective

Implement ASA-OPS-002 and ASA-OPS-003 by making the Railway observer deployment-ID first while preserving exact, safe CLI failure diagnostics.

## Work Item

ASA-OPS-002, ASA-OPS-003

## Scope

- Resolves an explicit workflow input before making any Railway CLI request.
- Applies ID priority: explicit input, GitHub deployment payload, Railway status target URL `id`, then deployment-list fallback.
- Fetches build and runtime logs directly when an ID is already known.
- Converts `CalledProcessError` into bounded, already-redacted diagnostics containing the exact sanitized command, exit code, stderr, and stdout.
- Removes Authorization headers, bearer values, and the Railway token before serialization; stdout and stderr are each limited to 100 lines and 16 KiB.
- Produces only `failure.json` and `summary.md` on collection failure while preserving raw-log fail-closed behavior.
- Documents ID-first resolution and safe failure artifacts.
- Makes no runtime, Railway configuration, frozen governance, or project-state changes.

## Files changed

- `tools/deployment_observer/observer.py`: ID-first resolution, target-URL parsing, command categorization, redaction, and output bounds.
- `tools/deployment_observer/collect.py`: safe `failure.json` and summary generation.
- `tests/deployment_observer/test_observer.py`: resolution, bypass, failure-diagnostic, bounding, and regression tests.
- `docs/deployment/railway-observer.md`: updated operation and failure behavior.

## Verification

```text
$ uv run ruff check tools/deployment_observer tests/deployment_observer
All checks passed!

$ uv run mypy tools/deployment_observer
Success: no issues found in 3 source files

$ uv run pytest tests/deployment_observer
45 passed in 0.08s

$ git diff --check
(no output)
```

## Safety evidence

- Explicit ID `e9030deb-31ac-4f13-83e3-a236989afb65` is tested to call only direct build/runtime log commands.
- Payload IDs are tested to precede target-URL IDs.
- Deployment listing is tested as fallback-only.
- Seeded token, password, Authorization header, and bearer values are absent from captured failure output.
- Captured stderr and stdout are each bounded to 100 lines and 16 KiB.
- An end-to-end `CalledProcessError` test proves `failure.json` is written, raw log files remain absent, and the observer returns non-zero.
- Successful collection still produces the original four files.

## Risk classification

R1. Acceptance authority: Founder.

## Known limitations

- Live manual acceptance still requires the Founder-configured project-scoped `RAILWAY_TOKEN`.
- No merge or deployment is included in this PR.

## Required review

Founder acceptance is required before merge.

## Founder decision required

Yes. Confirm the manual run bypasses deployment listing and safely diagnoses any remaining CLI failure.
