### PR TITLE
Preserve safe Railway CLI failure diagnostics

### DIFF
--- a/tests/deployment_observer/test_observer.py
+++ b/tests/deployment_observer/test_observer.py
@@ -297,26 +297,62 @@ def test_called_process_error_output_is_redacted_and_bounded(
 ) -> None:
     token = "seeded-railway-token-value"
     monkeypatch.setenv("RAILWAY_TOKEN", token)
-    stdout = "\n".join([f"password=secret-{index} {token}" for index in range(200)])
+    stdout = "\n".join(
+        [f"line-{index} {token} {'x' * 1_000}" for index in range(200)]
+    )
+    stderr = "Authorization: Bearer hidden\n" + "\n".join(
+        [f"stderr-{index} {'y' * 1_000}" for index in range(200)]
+    )
 
     def fail(*_: Any, **__: Any) -> None:
         raise subprocess.CalledProcessError(
             17,
             ["railway", "logs"],
             output=stdout,
-            stderr=f"Authorization: Bearer {token}",
+            stderr=stderr,
         )
 
     monkeypatch.setattr(subprocess, "run", fail)
     with pytest.raises(CommandFailure) as raised:
         railway_command(["logs", "deployment-id", "--build", "--lines", "5000", "--json"])
     failure = raised.value
-    assert failure.category == "build-logs"
+    assert failure.command == [
+        "railway",
+        "logs",
+        "deployment-id",
+        "--build",
+        "--lines",
+        "5000",
+        "--json",
+    ]
     assert failure.exit_code == 17
     assert token not in failure.stdout + failure.stderr
-    assert "secret-" not in failure.stdout
-    assert len((failure.stderr + failure.stdout).encode()) <= 16 * 1024
-    assert len((failure.stderr + failure.stdout).splitlines()) <= 100
+    assert "Authorization" not in failure.stderr
+    assert len(failure.stdout.encode()) <= 16 * 1024
+    assert len(failure.stderr.encode()) <= 16 * 1024
+    assert len(failure.stdout.splitlines()) <= 100
+    assert len(failure.stderr.splitlines()) <= 100
+
+
+def test_command_and_bearer_values_are_redacted(monkeypatch: pytest.MonkeyPatch) -> None:
+    token = "command-secret-token"
+    monkeypatch.setenv("RAILWAY_TOKEN", token)
+
+    def fail(*_: Any, **__: Any) -> None:
+        raise subprocess.CalledProcessError(
+            1,
+            ["railway", "logs"],
+            output="Bearer other-secret",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    with pytest.raises(CommandFailure) as raised:
+        railway_command(["logs", "deployment-id", "--filter", f"token={token}"])
+    serialized = json.dumps(raised.value.command) + raised.value.stdout
+    assert token not in serialized
+    assert "other-secret" not in serialized
+    assert "[REDACTED]" in serialized
 
 
 def test_safe_failure_artifacts_include_category_and_exit_code_without_token(
@@ -329,7 +365,8 @@ def test_safe_failure_artifacts_include_category_and_exit_code_without_token(
     monkeypatch.setenv("RAILWAY_TOKEN", token)
     monkeypatch.setenv("OBSERVER_OUTPUT_DIR", str(output))
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
-    failure = CommandFailure("runtime-logs", 23, "token=[REDACTED]", "password=[REDACTED]")
+    command = ["railway", "logs", "deployment-id", "--deployment", "--json"]
+    failure = CommandFailure(command, 23, "token=[REDACTED]", "password=[REDACTED]")
     monkeypatch.setattr(
         collect_entrypoint, "collect", lambda **_: (_ for _ in ()).throw(failure)
     )
@@ -337,9 +374,55 @@ def test_safe_failure_artifacts_include_category_and_exit_code_without_token(
     assert {path.name for path in output.iterdir()} == {"failure.json", "summary.md"}
     combined = "".join(path.read_text() for path in output.iterdir())
     data = json.loads((output / "failure.json").read_text())
-    assert data["command_category"] == "runtime-logs"
+    assert data["command"] == command
     assert data["exit_code"] == 23
+    assert data["stdout"] == "token=[REDACTED]"
+    assert data["stderr"] == "password=[REDACTED]"
     assert token not in combined
+    summary = (output / "summary.md").read_text()
+    assert "Failed command" in summary
+    assert "failure.json" in summary
+
+
+def test_called_process_error_produces_failure_json_and_nonzero_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "artifacts"
+    token = "integration-railway-token"
+    monkeypatch.setenv("RAILWAY_TOKEN", token)
+    monkeypatch.setenv("OBSERVER_OUTPUT_DIR", str(output))
+    monkeypatch.setenv("INPUT_DEPLOYMENT_ID", "e9030deb-31ac-4f13-83e3-a236989afb65")
+
+    def fail(*_: Any, **__: Any) -> None:
+        raise subprocess.CalledProcessError(
+            9,
+            ["railway", "logs"],
+            output=f"password=stdout-secret {token}",
+            stderr=f"Authorization: Bearer {token}",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    assert collect_entrypoint.main() == 1
+    data = json.loads((output / "failure.json").read_text())
+    assert data == {
+        "command": [
+            "railway",
+            "logs",
+            "e9030deb-31ac-4f13-83e3-a236989afb65",
+            "--build",
+            "--lines",
+            "5000",
+            "--json",
+        ],
+        "exit_code": 9,
+        "stdout": "password=[REDACTED] [REDACTED]",
+        "stderr": "[REDACTED]",
+    }
+    combined = (output / "failure.json").read_text() + (output / "summary.md").read_text()
+    assert token not in combined
+    assert "Authorization" not in combined
+    assert not (output / "build-log.jsonl").exists()
+    assert not (output / "runtime-log.jsonl").exists()
 
 
 def test_manifest_never_contains_prohibited_fields() -> None:

--- a/tools/deployment_observer/collect.py
+++ b/tools/deployment_observer/collect.py
@@ -51,28 +51,25 @@ def main() -> int:
         output_dir.mkdir(parents=True, exist_ok=True)
         if isinstance(error, CommandFailure):
             failure = {
-                "version": 1,
-                "collection_status": "failed",
-                "command_category": error.category,
+                "command": error.command,
                 "exit_code": error.exit_code,
-                "stderr": error.stderr,
                 "stdout": error.stdout,
+                "stderr": error.stderr,
             }
         else:
             failure = {
-                "version": 1,
-                "collection_status": "failed",
-                "command_category": "observer",
+                "command": [],
                 "exit_code": None,
-                "stderr": "",
                 "stdout": "",
+                "stderr": "",
             }
         (output_dir / "failure.json").write_text(json.dumps(failure, indent=2) + "\n")
         safe_summary = (
             "## Railway deployment observer\n\n"
-            "Collection failed safely. No deployment logs were uploaded. "
-            f"Command category: `{failure['command_category']}`. "
-            f"Exit code: `{failure['exit_code']}`.\n"
+            "Collection failed safely. No deployment logs were uploaded.\n\n"
+            f"- Failed command: `{json.dumps(failure['command'])}`\n"
+            f"- Exit code: `{failure['exit_code']}`\n"
+            "- Sanitized diagnostics: `failure.json`\n"
         )
         (output_dir / "summary.md").write_text(safe_summary)
         if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):

--- a/tools/deployment_observer/observer.py
+++ b/tools/deployment_observer/observer.py
@@ -58,7 +58,7 @@ class Deployment:
 class CommandFailure(Exception):
     """A bounded, already-redacted Railway CLI failure."""
 
-    category: str
+    command: list[str]
     exit_code: int
     stdout: str
     stderr: str
@@ -290,40 +290,26 @@ def validate_manifest(manifest: Mapping[str, Any]) -> None:
         raise ValueError("Manifest contains a prohibited field")
 
 
-def _command_category(args: list[str]) -> str:
-    if args[:2] == ["deployment", "list"]:
-        return "deployment-list"
-    if "--build" in args:
-        return "build-logs"
-    if "--deployment" in args:
-        return "runtime-logs"
-    return "railway-read"
-
-
-def _redact_secret(value: str) -> str:
+def _redact_failure_text(value: str) -> str:
+    """Remove authorization headers and redact known secret forms and the Railway token."""
     token = os.environ.get("RAILWAY_TOKEN", "")
     without_token = value.replace(token, REDACTED) if token else value
-    return redact_text(without_token)[0]
+    without_authorization = re.sub(
+        r"(?i)\bAuthorization\s*[:=]\s*(?:Bearer\s+)?[^\r\n]*",
+        REDACTED,
+        without_token,
+    )
+    without_bearer_token = re.sub(
+        r"(?i)(\bBearer\s+)[^\s,;]+", r"\1[REDACTED]", without_authorization
+    )
+    return redact_text(without_bearer_token)[0]
 
 
-def _bounded_outputs(stderr: str, stdout: str) -> tuple[str, str]:
-    """Bound combined captured output to 100 lines and 16 KiB, prioritizing stderr."""
-    remaining_lines = MAX_FAILURE_LINES
-    remaining_bytes = MAX_FAILURE_BYTES
-
-    def take(value: str) -> str:
-        nonlocal remaining_lines, remaining_bytes
-        lines = value.splitlines()[:remaining_lines]
-        candidate = "\n".join(lines)
-        encoded = candidate.encode()[:remaining_bytes]
-        bounded = encoded.decode(errors="ignore")
-        remaining_lines -= len(bounded.splitlines())
-        remaining_bytes -= len(bounded.encode())
-        return bounded
-
-    safe_stderr = take(_redact_secret(stderr))
-    safe_stdout = take(_redact_secret(stdout))
-    return safe_stderr, safe_stdout
+def _bounded_output(value: str) -> str:
+    """Redact output, then retain its first 100 lines and at most 16 KiB."""
+    lines = _redact_failure_text(value).splitlines()[:MAX_FAILURE_LINES]
+    encoded = "\n".join(lines).encode()[:MAX_FAILURE_BYTES]
+    return encoded.decode(errors="ignore")
 
 
 def railway_command(args: list[str]) -> str:
@@ -332,12 +318,11 @@ def railway_command(args: list[str]) -> str:
             ["railway", *args], check=True, capture_output=True, text=True, timeout=120
         )
     except subprocess.CalledProcessError as error:
-        stderr, stdout = _bounded_outputs(error.stderr or "", error.stdout or "")
         raise CommandFailure(
-            category=_command_category(args),
+            command=[_redact_failure_text(part) for part in ["railway", *args]],
             exit_code=error.returncode,
-            stdout=stdout,
-            stderr=stderr,
+            stdout=_bounded_output(error.stdout or ""),
+            stderr=_bounded_output(error.stderr or ""),
         ) from None
     return completed.stdout
 


### PR DESCRIPTION
## Objective

Implement ASA-OPS-003 by preserving exact, redacted Railway CLI failure diagnostics without weakening fail-closed artifact handling.

## Work Item

ASA-OPS-003

## Scope

- Captures the exact sanitized Railway command, exit code, stdout, and stderr after `CalledProcessError`.
- Removes Authorization headers and redacts bearer values, known credential forms, and the exact Railway token before serialization.
- Bounds stdout and stderr independently to their first 100 lines and 16 KiB.
- Writes `failure.json` and a summary identifying the failed command, exit code, and diagnostic artifact.
- Continues returning non-zero and removes all partial/raw log files on failure.
- Changes only the two observer modules and observer tests.

## Failure artifact shape

```json
{
  "command": [
    "railway",
    "logs",
    "e9030deb-31ac-4f13-83e3-a236989afb65",
    "--build",
    "--lines",
    "5000",
    "--json"
  ],
  "exit_code": 1,
  "stdout": "[REDACTED]",
  "stderr": "[REDACTED]"
}
```

## Verification

```text
$ uv run ruff check tools/deployment_observer tests/deployment_observer
All checks passed!

$ uv run mypy tools/deployment_observer
Success: no issues found in 3 source files

$ uv run pytest tests/deployment_observer
45 passed in 0.08s

$ git diff --check
(no output)
```

## Safety evidence

- An end-to-end `CalledProcessError` test proves `failure.json` is written and the observer returns non-zero.
- The same test proves build/runtime raw-log artifacts remain absent.
- Seeded Railway token, password, Authorization header, and bearer values do not appear in artifacts.
- Command arguments are redacted before serialization.
- Existing successful collection tests remain unchanged and pass.

## Risk classification

R1. Acceptance authority: Founder.

## Founder decision required

Yes. Review the sanitized failure artifact before merge. No deployment or Railway mutation is included.
