### PR TITLE
ASA-OPS-007: publish Railway diagnostics to pull requests

### DIFF
--- a/.github/workflows/railway-deployment-observer.yml
+++ b/.github/workflows/railway-deployment-observer.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: railway-observer-${{ github.event.deployment.id || github.run_id }}
@@ -44,7 +45,15 @@ jobs:
         id: collect
         run: python tools/deployment_observer/collect.py
 
+      - name: Publish report to originating pull request
+        id: publish
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python tools/deployment_observer/publish.py
+
       - name: Upload bounded diagnostic snapshot
+        id: artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -52,3 +61,15 @@ jobs:
           path: .artifacts/railway-deployment
           retention-days: 14
           if-no-files-found: error
+
+      - name: Report observer channel outcomes
+        if: always()
+        env:
+          COLLECTION_OUTCOME: ${{ steps.collect.outcome }}
+          COMMENT_OUTCOME: ${{ steps.publish.outcome }}
+          ARTIFACT_OUTCOME: ${{ steps.artifact.outcome }}
+        run: |
+          echo "collection=${COLLECTION_OUTCOME} comment=${COMMENT_OUTCOME} artifact=${ARTIFACT_OUTCOME}"
+          test "${COLLECTION_OUTCOME}" = success
+          test "${COMMENT_OUTCOME}" = success
+          test "${ARTIFACT_OUTCOME}" = success

--- a/docs/deployment/railway-observer.md
+++ b/docs/deployment/railway-observer.md
@@ -1,9 +1,12 @@
 # Railway deployment observer
 
 The Railway Deployment Observer copies a bounded, redacted diagnostic snapshot into a
-14-day GitHub Actions artifact. Railway remains authoritative for deployment state and
-complete logs. The observer is read-only: it lists deployments and reads build/runtime logs;
-it cannot deploy, restart, roll back, change variables, or alter Railway resources.
+14-day GitHub Actions artifact and publishes a concise report to the pull request associated
+with the deployed commit. The artifact remains the immutable diagnostic archive; the marked
+pull request comment is the review surface and is updated on reruns. Railway remains
+authoritative for deployment state and complete logs. The observer is read-only: it lists
+deployments and reads build/runtime logs; it cannot deploy, restart, roll back, change
+variables, or alter Railway resources.
 
 ## Founder setup
 
@@ -21,14 +24,35 @@ it cannot deploy, restart, roll back, change variables, or alter Railway resourc
    confirm the artifact contains `[REDACTED]` rather than the seeded value. Never seed a real
    credential for this check.
 
-Automatic runs accept only GitHub `deployment_status` events whose deployment environment is
-exactly `production`. Manual runs also remain fixed to the production Railway environment and
-cannot override it. If a GitHub deployment payload contains a Railway deployment ID under
+Every `deployment_status` event starts the observer, including events with differently cased or
+missing GitHub environment metadata. Manual runs also remain fixed to the production Railway
+environment and cannot override it. If a GitHub deployment payload contains a Railway
+deployment ID under
 `payload.railway_deployment_id`, `payload.railwayDeploymentId`, `payload.deployment_id`, or a
 nested `payload.railway` deployment ID, that ID is used. A Railway deployment ID in the `id`
 query parameter of the deployment status target URL is next. Only when none of those sources
 provides an ID does the observer list deployments and select the latest ASA production deployment.
-Resolved IDs fetch build and runtime logs directly without an unnecessary deployment-list call.
+Resolved IDs are polled using the explicit production service and environment until Railway
+reaches a terminal state or the bounded deadline, then build and runtime logs are collected.
+
+## Pull request reports
+
+After collection, the observer resolves pull requests associated with the deployed commit SHA
+using GitHub commit metadata. It prefers an exact merge-commit match merged into the default
+branch and never guesses from a source branch name. One unambiguous association receives a
+`Railway Deployment Report` comment containing component statuses, the decisive root-cause
+excerpt, bounded collapsible logs, and links to the workflow run and its artifact area.
+
+The comment begins with `<!-- ASA_RAILWAY_DEPLOYMENT_OBSERVER -->`. Reruns search all issue
+comments for that marker and update the existing report instead of adding another. If GitHub
+reports no pull request or multiple ambiguous candidates, publication is skipped without
+failing artifact collection. Resolution and comment outcomes are stored in `manifest.json`.
+
+Comment text receives the same redaction as artifacts and tighter limits: 20 root-cause lines,
+100 build lines, 150 runtime lines, 100 health-check lines, and fewer than 50,000 total
+characters. Raw environment variables and complete GitHub event payloads are never included.
+Comment and artifact publication are independent `always()` steps; the final workflow step
+reports partial completion if collection, comment publication, or artifact upload fails.
 
 ## Reading an artifact
 

--- a/tests/deployment_observer/test_observer.py
+++ b/tests/deployment_observer/test_observer.py
@@ -502,6 +502,11 @@ def test_manifest_never_contains_prohibited_fields() -> None:
         "build_log_line_count": 0,
         "runtime_log_line_count": 0,
         "redaction_count": 0,
+        "pull_request_resolution_status": "not_found",
+        "pull_request_number": None,
+        "pull_request_url": None,
+        "pull_request_comment_status": "skipped",
+        "pull_request_comment_url": None,
     }
     validate_manifest(valid)
     for field in ("railway_token", "environment_variables", "database_url", "credentials"):

--- a/tests/deployment_observer/test_publish.py
+++ b/tests/deployment_observer/test_publish.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tools.deployment_observer.publish import (
+    COMMENT_MARKER,
+    MAX_COMMENT_CHARACTERS,
+    GitHubApiError,
+    publish,
+    render_comment,
+    resolve_pull_request,
+)
+
+
+def pr(
+    number: int, *, merge_sha: str = "sha", base: str = "main", merged: bool = True
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "html_url": f"https://github.test/owner/repo/pull/{number}",
+        "merge_commit_sha": merge_sha,
+        "merged_at": "2026-07-20T00:00:00Z" if merged else None,
+        "base": {"ref": base},
+    }
+
+
+def resolver_api(candidates: list[dict[str, Any]]):
+    def call(method: str, path: str, payload: Mapping[str, Any] | None) -> Any:
+        assert method == "GET"
+        assert payload is None
+        if path == "/repos/owner/repo":
+            return {"default_branch": "main"}
+        assert path.startswith("/repos/owner/repo/commits/")
+        return candidates
+
+    return call
+
+
+def manifest() -> dict[str, Any]:
+    return {
+        "version": 1,
+        "collected_at": "2026-07-20T00:00:00+00:00",
+        "deployment_id": "deployment-id",
+        "service": "ASA",
+        "environment": "production",
+        "deployment_status": "FAILED",
+        "collection_status": "complete",
+        "classification": "startup_or_packaging",
+        "phase": "startup",
+        "source_commit_sha": "sha",
+        "build_log_line_count": 1,
+        "runtime_log_line_count": 2,
+        "redaction_count": 0,
+        "pull_request_resolution_status": "not_found",
+        "pull_request_number": None,
+        "pull_request_url": None,
+        "pull_request_comment_status": "skipped",
+        "pull_request_comment_url": None,
+    }
+
+
+def write_artifacts(output: Path, data: dict[str, Any] | None = None) -> None:
+    output.mkdir()
+    (output / "manifest.json").write_text(json.dumps(data or manifest()))
+    (output / "build-log.jsonl").write_text('{"message":"build complete"}\n')
+    (output / "runtime-log.jsonl").write_text(
+        '{"message":"No module named asa"}\n{"message":"healthcheck failed"}\n'
+    )
+
+
+def test_exact_merge_commit_resolves_merged_default_branch_pull_request() -> None:
+    result = resolve_pull_request(
+        "owner/repo",
+        "sha",
+        resolver_api([pr(10, merge_sha="other"), pr(11, merge_sha="sha")]),
+    )
+    assert result.status == "resolved"
+    assert result.pull_request is not None
+    assert result.pull_request.number == 11
+
+
+def test_single_associated_pull_request_is_selected() -> None:
+    result = resolve_pull_request(
+        "owner/repo", "sha", resolver_api([pr(12, merge_sha="other", merged=False)])
+    )
+    assert result.status == "resolved"
+    assert result.pull_request is not None
+    assert result.pull_request.number == 12
+
+
+def test_no_associated_pull_request_is_not_found() -> None:
+    assert resolve_pull_request("owner/repo", "sha", resolver_api([])).status == "not_found"
+
+
+def test_multiple_associated_pull_requests_are_ambiguous() -> None:
+    candidates = [
+        pr(12, merge_sha="other", merged=False),
+        pr(13, merge_sha="another", merged=False),
+    ]
+    assert resolve_pull_request("owner/repo", "sha", resolver_api(candidates)).status == "ambiguous"
+
+
+class FakeApi:
+    def __init__(
+        self, comments: list[dict[str, Any]] | None = None, *, fail_comment: bool = False
+    ) -> None:
+        self.comments = comments or []
+        self.fail_comment = fail_comment
+        self.calls: list[tuple[str, str, Mapping[str, Any] | None]] = []
+
+    def __call__(self, method: str, path: str, payload: Mapping[str, Any] | None) -> Any:
+        self.calls.append((method, path, payload))
+        if path == "/repos/owner/repo":
+            return {"default_branch": "main"}
+        if "/commits/" in path:
+            return [pr(21)]
+        if path.endswith("/comments?per_page=100&page=1"):
+            return self.comments
+        if self.fail_comment:
+            raise GitHubApiError("seeded failure")
+        if method == "POST":
+            self.comments.append({"id": 91, "body": payload["body"] if payload else ""})
+            return {"html_url": "https://github.test/comment/91"}
+        if method == "PATCH":
+            assert payload is not None
+            self.comments[0]["body"] = payload["body"]
+            return {"html_url": "https://github.test/comment/91"}
+        raise AssertionError((method, path))
+
+
+def test_rerun_updates_one_marked_comment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    output = tmp_path / "artifacts"
+    write_artifacts(output)
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+    api = FakeApi()
+    assert publish(output, "owner/repo", api) == 0
+    assert publish(output, "owner/repo", api) == 0
+    assert len(api.comments) == 1
+    assert [method for method, _, _ in api.calls].count("POST") == 1
+    assert [method for method, _, _ in api.calls].count("PATCH") == 1
+    saved = json.loads((output / "manifest.json").read_text())
+    assert saved["pull_request_resolution_status"] == "resolved"
+    assert saved["pull_request_comment_status"] == "updated"
+    assert saved["pull_request_comment_url"] == "https://github.test/comment/91"
+
+
+@pytest.mark.parametrize(
+    ("candidates", "expected"),
+    [
+        ([], "not_found"),
+        ([pr(1, merge_sha="a", merged=False), pr(2, merge_sha="b", merged=False)], "ambiguous"),
+    ],
+)
+def test_unresolved_pull_request_skips_comment_and_preserves_artifact(
+    tmp_path: Path, candidates: list[dict[str, Any]], expected: str
+) -> None:
+    output = tmp_path / expected
+    write_artifacts(output)
+    calls: list[str] = []
+
+    def api(method: str, path: str, payload: Mapping[str, Any] | None) -> Any:
+        calls.append(path)
+        return {"default_branch": "main"} if path == "/repos/owner/repo" else candidates
+
+    assert publish(output, "owner/repo", api) == 0
+    saved = json.loads((output / "manifest.json").read_text())
+    assert saved["pull_request_resolution_status"] == expected
+    assert saved["pull_request_comment_status"] == "skipped"
+    assert (output / "build-log.jsonl").exists()
+    assert not any("/comments" in path for path in calls)
+
+
+def test_decisive_runtime_error_precedes_healthcheck_symptom_in_report(tmp_path: Path) -> None:
+    output = tmp_path / "report"
+    write_artifacts(output)
+    report = render_comment(
+        manifest(), output, "https://github.test/run", "https://github.test/artifact"
+    )
+    assert "`import` / `startup`" in report
+    assert "No module named asa" in report
+    assert "Health check | `failed`" in report
+
+
+def test_secrets_are_redacted_and_oversized_logs_remain_bounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "bounded"
+    write_artifacts(output)
+    monkeypatch.setenv("RAILWAY_TOKEN", "bare-railway-secret")
+    secret_line = json.dumps(
+        {
+            "message": (
+                "Authorization: Bearer token password=hunter2 bare-railway-secret " + ("x" * 20_000)
+            )
+        }
+    )
+    (output / "runtime-log.jsonl").write_text((secret_line + "\n") * 500)
+    report = render_comment(
+        manifest(), output, "https://github.test/run", "https://github.test/artifact"
+    )
+    assert "token" not in report
+    assert "hunter2" not in report
+    assert "bare-railway-secret" not in report
+    assert "[REDACTED]" in report
+    assert len(report) <= MAX_COMMENT_CHARACTERS
+
+
+def test_comment_api_failure_records_failure_without_removing_artifact(tmp_path: Path) -> None:
+    output = tmp_path / "failed"
+    write_artifacts(output)
+    api = FakeApi(fail_comment=True)
+    assert publish(output, "owner/repo", api) == 1
+    saved = json.loads((output / "manifest.json").read_text())
+    assert saved["pull_request_resolution_status"] == "resolved"
+    assert saved["pull_request_comment_status"] == "failed"
+    assert (output / "runtime-log.jsonl").exists()
+
+
+def test_comment_marker_and_hidden_metadata_are_stable(tmp_path: Path) -> None:
+    output = tmp_path / "metadata"
+    write_artifacts(output)
+    report = render_comment(
+        manifest(), output, "https://github.test/run", "https://github.test/artifact"
+    )
+    assert report.startswith(COMMENT_MARKER)
+    assert report.count(COMMENT_MARKER) == 1
+    assert "\nASA_RAILWAY_DEPLOYMENT_OBSERVER\n" in report
+    assert "deployment_id=deployment-id" in report
+    assert "workflow_run_id=" in report

--- a/tests/deployment_observer/test_workflow.py
+++ b/tests/deployment_observer/test_workflow.py
@@ -23,8 +23,8 @@ def workflow() -> dict[str, Any]:
     return cast(dict[str, Any], parsed)
 
 
-def test_workflow_has_contents_read_only() -> None:
-    assert workflow()["permissions"] == {"contents": "read"}
+def test_workflow_has_minimum_comment_permissions() -> None:
+    assert workflow()["permissions"] == {"contents": "read", "pull-requests": "write"}
 
 
 def test_workflow_never_uses_pull_request_target() -> None:
@@ -50,6 +50,19 @@ def test_workflow_uploads_only_observer_artifact_directory() -> None:
     assert len(uploads) == 1
     assert uploads[0]["if"] == "always()"
     assert uploads[0]["with"]["path"] == ".artifacts/railway-deployment"
+
+
+def test_comment_publication_and_artifact_are_independent_channels() -> None:
+    steps = workflow()["jobs"]["observe"]["steps"]
+    publish = next(step for step in steps if step.get("id") == "publish")
+    artifact = next(step for step in steps if step.get("id") == "artifact")
+    outcome = next(step for step in steps if step.get("name") == "Report observer channel outcomes")
+    assert publish["if"] == "always()"
+    assert artifact["if"] == "always()"
+    assert steps.index(publish) < steps.index(artifact)
+    assert outcome["if"] == "always()"
+    assert "steps.publish.outcome" in outcome["env"]["COMMENT_OUTCOME"]
+    assert "steps.artifact.outcome" in outcome["env"]["ARTIFACT_OUTCOME"]
 
 
 def test_workflow_cli_context_is_explicit_and_pinned() -> None:

--- a/tools/deployment_observer/observer.py
+++ b/tools/deployment_observer/observer.py
@@ -22,6 +22,8 @@ MAX_FAILURE_BYTES = 16 * 1024
 POLL_INTERVAL_SECONDS = 10.0
 MAX_POLL_SECONDS = 600.0
 TERMINAL_DEPLOYMENT_STATES = frozenset({"SUCCESS", "FAILED", "CRASHED", "REMOVED", "CANCELLED"})
+PULL_REQUEST_RESOLUTION_STATUSES = frozenset({"resolved", "not_found", "ambiguous", "error"})
+PULL_REQUEST_COMMENT_STATUSES = frozenset({"created", "updated", "skipped", "failed"})
 PROHIBITED_MANIFEST_FIELDS = {
     "railway_token",
     "environment_variables",
@@ -305,11 +307,30 @@ def validate_manifest(manifest: Mapping[str, Any]) -> None:
         "build_log_line_count",
         "runtime_log_line_count",
         "redaction_count",
+        "pull_request_resolution_status",
+        "pull_request_number",
+        "pull_request_url",
+        "pull_request_comment_status",
+        "pull_request_comment_url",
     }
     if manifest.get("version") != 1 or not required.issubset(manifest):
         raise ValueError("Manifest does not satisfy schema version 1")
     if PROHIBITED_MANIFEST_FIELDS.intersection(key.lower() for key in manifest):
         raise ValueError("Manifest contains a prohibited field")
+    if manifest["pull_request_resolution_status"] not in PULL_REQUEST_RESOLUTION_STATUSES:
+        raise ValueError("Manifest has an invalid pull request resolution status")
+    if manifest["pull_request_comment_status"] not in PULL_REQUEST_COMMENT_STATUSES:
+        raise ValueError("Manifest has an invalid pull request comment status")
+
+
+def _pull_request_manifest_defaults() -> dict[str, Any]:
+    return {
+        "pull_request_resolution_status": "not_found",
+        "pull_request_number": None,
+        "pull_request_url": None,
+        "pull_request_comment_status": "skipped",
+        "pull_request_comment_url": None,
+    }
 
 
 def _redact_failure_text(value: str) -> str:
@@ -434,6 +455,7 @@ def _write_timeout_artifacts(
         "build_log_line_count": 0,
         "runtime_log_line_count": 0,
         "redaction_count": 0,
+        **_pull_request_manifest_defaults(),
     }
     validate_manifest(manifest)
     failure = {
@@ -555,6 +577,9 @@ def collect(
         "build_log_line_count": len(build_logs),
         "runtime_log_line_count": len(runtime_logs),
         "redaction_count": redacted_build.count + redacted_runtime.count,
+        "classification": classification,
+        "phase": phase,
+        **_pull_request_manifest_defaults(),
     }
     validate_manifest(manifest)
     quoted = "\n".join(f"    {line}" for line in cluster) or "    No error cluster found."

--- a/tools/deployment_observer/publish.py
+++ b/tools/deployment_observer/publish.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Publish a bounded Railway report to the pull request for the deployed commit."""
+
+from __future__ import annotations
+
+import html
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.deployment_observer.observer import (
+    REDACTED,
+    first_error_cluster,
+    redact_text,
+    validate_manifest,
+)
+
+COMMENT_MARKER = "<!-- ASA_RAILWAY_DEPLOYMENT_OBSERVER -->"
+MAX_COMMENT_CHARACTERS = 50_000
+MAX_ROOT_CAUSE_LINES = 20
+MAX_BUILD_LOG_LINES = 100
+MAX_RUNTIME_LOG_LINES = 150
+MAX_HEALTHCHECK_LOG_LINES = 100
+SUPPORTED_CLASSIFICATIONS = frozenset(
+    {
+        "build",
+        "startup",
+        "import",
+        "migration",
+        "healthcheck",
+        "crash",
+        "timeout",
+        "infrastructure",
+        "unknown",
+    }
+)
+
+
+class GitHubApiError(RuntimeError):
+    """A safe GitHub API failure without response content or credentials."""
+
+
+@dataclass(frozen=True)
+class PullRequest:
+    number: int
+    url: str
+
+
+@dataclass(frozen=True)
+class Resolution:
+    status: str
+    pull_request: PullRequest | None = None
+
+
+ApiCall = Callable[[str, str, Mapping[str, Any] | None], Any]
+
+
+class GitHubClient:
+    def __init__(
+        self, repository: str, token: str, api_url: str = "https://api.github.com"
+    ) -> None:
+        self.repository = repository
+        self._token = token
+        self._api_url = api_url.rstrip("/")
+
+    def call(self, method: str, path: str, payload: Mapping[str, Any] | None = None) -> Any:
+        body = json.dumps(payload).encode() if payload is not None else None
+        request = Request(
+            f"{self._api_url}{path}",
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self._token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "asa-railway-deployment-observer",
+            },
+        )
+        try:
+            with urlopen(request, timeout=30) as response:  # noqa: S310 -- fixed GitHub API origin
+                raw = response.read()
+        except (HTTPError, URLError, TimeoutError) as error:
+            raise GitHubApiError(f"GitHub API request failed ({type(error).__name__})") from None
+        return json.loads(raw) if raw else None
+
+
+def resolve_pull_request(repository: str, commit_sha: str, api_call: ApiCall) -> Resolution:
+    """Resolve one PR without branch-name inference, preferring exact merge commits."""
+    encoded_repository = quote(repository, safe="/")
+    encoded_sha = quote(commit_sha, safe="")
+    try:
+        repository_data = api_call("GET", f"/repos/{encoded_repository}", None)
+        candidates = api_call(
+            "GET", f"/repos/{encoded_repository}/commits/{encoded_sha}/pulls?per_page=100", None
+        )
+    except GitHubApiError:
+        return Resolution("error")
+    if not isinstance(repository_data, Mapping) or not isinstance(candidates, list):
+        return Resolution("error")
+    default_branch = str(repository_data.get("default_branch", ""))
+    records = [item for item in candidates if isinstance(item, Mapping)]
+    exact = [item for item in records if item.get("merge_commit_sha") == commit_sha]
+    selected = _select_one(exact, default_branch)
+    if selected is None and not exact:
+        selected = _select_one(records, default_branch)
+    if selected is not None:
+        number = selected.get("number")
+        url = selected.get("html_url")
+        if isinstance(number, int) and isinstance(url, str):
+            return Resolution("resolved", PullRequest(number, url))
+        return Resolution("error")
+    return Resolution("not_found" if not records else "ambiguous")
+
+
+def _select_one(records: list[Mapping[str, Any]], default_branch: str) -> Mapping[str, Any] | None:
+    merged_to_default = [
+        item
+        for item in records
+        if item.get("merged_at")
+        and isinstance(item.get("base"), Mapping)
+        and item["base"].get("ref") == default_branch
+    ]
+    if len(merged_to_default) == 1:
+        return merged_to_default[0]
+    if len(merged_to_default) > 1:
+        return None
+    return records[0] if len(records) == 1 else None
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line in path.read_text().splitlines():
+        parsed = json.loads(line)
+        if isinstance(parsed, dict):
+            records.append(parsed)
+    return records
+
+
+def _safe_inline(value: Any) -> str:
+    redacted = _redact_for_comment(str(value or "unknown"))
+    single_line = " ".join(redacted.splitlines())
+    return html.escape(single_line, quote=False).replace("|", "\\|").replace("`", "'")
+
+
+def _redact_for_comment(value: str) -> str:
+    safe = value
+    for variable in ("RAILWAY_TOKEN", "GITHUB_TOKEN"):
+        secret = os.environ.get(variable, "")
+        if secret:
+            safe = safe.replace(secret, REDACTED)
+    return redact_text(safe)[0]
+
+
+def _bounded_code(lines: list[str], maximum_lines: int, maximum_characters: int) -> str:
+    safe_lines: list[str] = []
+    used = 0
+    for line in lines[:maximum_lines]:
+        redacted = _redact_for_comment(line)
+        safe = html.escape(redacted, quote=False).replace("```", "` ` `")
+        remaining = maximum_characters - used
+        if remaining <= 0:
+            break
+        safe_lines.append(safe[:remaining])
+        used += len(safe_lines[-1]) + 1
+    return "\n".join(safe_lines) or "No relevant log lines were collected."
+
+
+def _message_lines(records: list[dict[str, Any]]) -> list[str]:
+    return [json.dumps(record, sort_keys=True, ensure_ascii=False) for record in records]
+
+
+def _public_classification(manifest: Mapping[str, Any], root_lines: list[str]) -> str:
+    raw = str(manifest.get("classification", "unknown"))
+    text = "\n".join(root_lines).lower()
+    if raw in SUPPORTED_CLASSIFICATIONS:
+        return raw
+    if raw == "observer-timeout":
+        return "timeout"
+    if raw == "startup_or_packaging":
+        return "import" if "no module named" in text else "startup"
+    if raw in {"configuration", "database_connectivity"}:
+        return "startup"
+    return "unknown"
+
+
+def render_comment(
+    manifest: Mapping[str, Any], output_dir: Path, workflow_run_url: str, artifact_url: str
+) -> str:
+    """Render a redacted report whose fixed budgets remain below GitHub's comment limit."""
+    build_logs = _read_jsonl(output_dir / "build-log.jsonl")
+    runtime_logs = _read_jsonl(output_dir / "runtime-log.jsonl")
+    root_cluster, _, phase = first_error_cluster(build_logs, runtime_logs)
+    classification = _public_classification(manifest, root_cluster)
+    status = str(manifest.get("deployment_status", "unknown")).upper()
+    failed = status not in {"SUCCESS", "SUCCEEDED"}
+    build_status = (
+        "failed" if classification == "build" else ("completed" if build_logs else "not detected")
+    )
+    migration_seen = any(
+        "alembic" in line.lower() for line in _message_lines(runtime_logs + build_logs)
+    )
+    migration_status = (
+        "failed"
+        if classification == "migration"
+        else ("detected" if migration_seen else "not detected")
+    )
+    runtime_status = (
+        "failed"
+        if classification in {"startup", "import", "crash"}
+        else ("collected" if runtime_logs else "not collected")
+    )
+    health_lines = [line for line in _message_lines(runtime_logs) if "health" in line.lower()]
+    health_status = (
+        "failed" if health_lines and failed else ("passed" if health_lines else "not detected")
+    )
+    root = root_cluster[:MAX_ROOT_CAUSE_LINES]
+    root_excerpt = _bounded_code(root, MAX_ROOT_CAUSE_LINES, 4_000)
+    build_excerpt = _bounded_code(_message_lines(build_logs), MAX_BUILD_LOG_LINES, 8_000)
+    runtime_excerpt = _bounded_code(_message_lines(runtime_logs), MAX_RUNTIME_LOG_LINES, 12_000)
+    health_excerpt = _bounded_code(health_lines, MAX_HEALTHCHECK_LOG_LINES, 8_000)
+    report = f"""{COMMENT_MARKER}
+## Railway Deployment Report
+
+| Field | Result |
+| --- | --- |
+| Deployment | `{_safe_inline(manifest.get("deployment_id"))}` |
+| Environment / service | `{_safe_inline(manifest.get("environment"))}` / `{_safe_inline(manifest.get("service"))}` |
+| Commit | `{_safe_inline(manifest.get("source_commit_sha"))}` |
+| Railway terminal status | **{_safe_inline(status)}** |
+| Observer collection | `{_safe_inline(manifest.get("collection_status"))}` |
+| Classification / phase | `{_safe_inline(classification)}` / `{_safe_inline(phase)}` |
+| Build | `{build_status}` |
+| Migration | `{migration_status}` |
+| Runtime | `{runtime_status}` |
+| Health check | `{health_status}` |
+
+### Root cause
+
+```text
+{root_excerpt}
+```
+
+[Observer workflow run]({workflow_run_url}) · [Diagnostic artifact details]({artifact_url})
+
+<details><summary>Bounded build logs (up to {MAX_BUILD_LOG_LINES} lines)</summary>
+
+```text
+{build_excerpt}
+```
+</details>
+
+<details><summary>Bounded runtime logs (up to {MAX_RUNTIME_LOG_LINES} lines)</summary>
+
+```text
+{runtime_excerpt}
+```
+</details>
+
+<details><summary>Bounded health-check logs (up to {MAX_HEALTHCHECK_LOG_LINES} lines)</summary>
+
+```text
+{health_excerpt}
+```
+</details>
+
+<!--
+ASA_RAILWAY_DEPLOYMENT_OBSERVER
+deployment_id={_safe_inline(manifest.get("deployment_id"))}
+deployment_status={_safe_inline(status)}
+classification={_safe_inline(classification)}
+commit_sha={_safe_inline(manifest.get("source_commit_sha"))}
+service={_safe_inline(manifest.get("service"))}
+environment={_safe_inline(manifest.get("environment"))}
+workflow_run_id={_safe_inline(os.environ.get("GITHUB_RUN_ID"))}
+-->
+"""
+    if len(report) > MAX_COMMENT_CHARACTERS:
+        raise ValueError("Rendered observer comment exceeds its fixed size bound")
+    if REDACTED not in report and any(
+        secret in report.lower()
+        for secret in ("authorization: bearer", "password=", "database_url=")
+    ):
+        raise ValueError("Rendered observer comment contains an unredacted secret form")
+    return report
+
+
+def _find_marked_comment(
+    repository: str, number: int, api_call: ApiCall
+) -> Mapping[str, Any] | None:
+    page = 1
+    while True:
+        comments = api_call(
+            "GET", f"/repos/{repository}/issues/{number}/comments?per_page=100&page={page}", None
+        )
+        if not isinstance(comments, list):
+            raise GitHubApiError("GitHub comments response was invalid")
+        for comment in comments:
+            if isinstance(comment, Mapping) and COMMENT_MARKER in str(comment.get("body", "")):
+                return comment
+        if len(comments) < 100:
+            return None
+        page += 1
+
+
+def _write_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    validate_manifest(manifest)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(manifest, indent=2) + "\n")
+    temporary.replace(path)
+
+
+def publish(output_dir: Path, repository: str, api_call: ApiCall) -> int:
+    manifest_path = output_dir / "manifest.json"
+    if not manifest_path.exists():
+        print("No observer manifest exists; pull request publication was skipped.")
+        return 0
+    parsed = json.loads(manifest_path.read_text())
+    if not isinstance(parsed, dict):
+        print("Observer manifest is invalid; pull request publication failed.", file=sys.stderr)
+        return 1
+    manifest: dict[str, Any] = parsed
+    sha = str(manifest.get("source_commit_sha", "")).strip()
+    resolution = resolve_pull_request(repository, sha, api_call) if sha else Resolution("not_found")
+    manifest.update(
+        pull_request_resolution_status=resolution.status,
+        pull_request_number=None,
+        pull_request_url=None,
+        pull_request_comment_status="skipped",
+        pull_request_comment_url=None,
+    )
+    if resolution.pull_request is None:
+        _write_manifest(manifest_path, manifest)
+        print(f"Pull request publication skipped: resolution status is {resolution.status}.")
+        return 0 if resolution.status != "error" else 1
+    pull_request = resolution.pull_request
+    manifest["pull_request_number"] = pull_request.number
+    manifest["pull_request_url"] = pull_request.url
+    server = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip("/")
+    run_id = os.environ.get("GITHUB_RUN_ID", "unknown")
+    run_url = f"{server}/{repository}/actions/runs/{run_id}"
+    artifact_url = f"{run_url}#artifacts"
+    try:
+        body = render_comment(manifest, output_dir, run_url, artifact_url)
+        existing = _find_marked_comment(repository, pull_request.number, api_call)
+        if existing is None:
+            response = api_call(
+                "POST", f"/repos/{repository}/issues/{pull_request.number}/comments", {"body": body}
+            )
+            comment_status = "created"
+        else:
+            comment_id = existing.get("id")
+            if not isinstance(comment_id, int):
+                raise GitHubApiError("Marked comment has no valid ID")
+            response = api_call(
+                "PATCH", f"/repos/{repository}/issues/comments/{comment_id}", {"body": body}
+            )
+            comment_status = "updated"
+        if not isinstance(response, Mapping) or not isinstance(response.get("html_url"), str):
+            raise GitHubApiError("GitHub comment response was invalid")
+        manifest["pull_request_comment_status"] = comment_status
+        manifest["pull_request_comment_url"] = response["html_url"]
+        _write_manifest(manifest_path, manifest)
+        print(f"Pull request observer comment {comment_status}: {response['html_url']}")
+        return 0
+    except (GitHubApiError, ValueError, OSError, json.JSONDecodeError) as error:
+        manifest["pull_request_comment_status"] = "failed"
+        _write_manifest(manifest_path, manifest)
+        print(
+            f"Pull request comment publication failed safely: {type(error).__name__}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+def main() -> int:
+    output_dir = Path(os.environ.get("OBSERVER_OUTPUT_DIR", ".artifacts/railway-deployment"))
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not repository or not token:
+        print(
+            "GitHub repository context is incomplete; comment publication failed.", file=sys.stderr
+        )
+        return 1
+    client = GitHubClient(
+        repository, token, os.environ.get("GITHUB_API_URL", "https://api.github.com")
+    )
+    return publish(output_dir, repository, client.call)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- resolves the pull request associated with the deployed commit, preferring an exact merge-commit match on the default branch
- creates or updates one marker-identified Railway report comment
- preserves bounded artifact upload as an independent output channel
- records PR resolution and comment publication outcomes in `manifest.json`
- adds concise component status, decisive root cause, bounded collapsible logs, workflow links, and artifact details

## Pull request resolution strategy

The publisher queries GitHub's commit-to-pull-request association. It prefers an exact merge commit merged into the default branch, then one unambiguous associated pull request. It never infers from a source branch. Missing and ambiguous associations are recorded and skipped without failing artifact collection.

## Comment idempotency

Comments use the stable `<!-- ASA_RAILWAY_DEPLOYMENT_OBSERVER -->` marker and a hidden metadata block. The publisher searches marked issue comments across pages, creates a report when none exists, and updates the existing marked report on reruns.

## Security and log bounds

The existing redaction rules are reapplied before publication, with explicit Railway and GitHub token removal. External values are HTML/Markdown-safe and single-line metadata is normalized. Reports are capped below 50,000 characters with limits of 20 root-cause, 100 build, 150 runtime, and 100 health-check lines. No environment serialization or complete GitHub event payload is added.

## Test evidence

- `.venv/bin/python -m ruff check tools/deployment_observer tests/deployment_observer` — passed
- `.venv/bin/python -m mypy tools/deployment_observer` — passed, 4 source files
- `.venv/bin/python -m pytest -q` — passed, 70 tests
- `.venv/bin/python tools/pos/lean/pre_push_check.py` — passed all 5 checks
- `git diff --check` — passed

Coverage includes exact merge commits, single association, no association, ambiguity, idempotent updates, decisive runtime errors over health-check symptoms, redaction, size bounds, GitHub API failure, and independent comment/artifact outcomes.

## Operational fallback behavior

Collection, comment publication, and artifact upload are separately identified steps. Comment publication and artifact upload both use `if: always()`. A final outcome step reports all three statuses and marks partial completion without allowing one failed output channel to erase the other.

## Sample success report

```markdown
## Railway Deployment Report
| Railway terminal status | **SUCCESS** |
| Observer collection | `complete` |
| Build | `completed` |
| Migration | `detected` |
| Runtime | `collected` |
| Health check | `passed` |
```

## Sample failure report

```markdown
## Railway Deployment Report
| Railway terminal status | **FAILED** |
| Classification / phase | `import` / `startup` |
| Runtime | `failed` |
| Health check | `failed` |

### Root cause
No module named asa
```

## Scope confirmation

Seven files changed: 733 insertions, 9 deletions. No backend or frontend application behavior changed. No Railway resource was changed, no deployment was triggered, and no merge was performed.
