### PR TITLE
ASA-CORE-001: foundation scaffold, immutable domain model, ADR amendments

### DIFF
--- a/.github/workflows/validate-architecture.yml
+++ b/.github/workflows/validate-architecture.yml
@@ -1,0 +1,41 @@
+name: Validate Architecture
+
+on:
+  pull_request:
+    paths:
+      - 'providers/**'
+      - 'observation/**'
+      - 'facts/**'
+      - 'indicators/**'
+      - 'strategies/**'
+      - 'guardrails/**'
+      - 'ranking/**'
+      - 'presentation/**'
+      - 'domain/**'
+      - 'architecture/**'
+      - 'tests/architecture/**'
+      - 'tests/domain/**'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Architecture Validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: python -m pip install pytest
+
+      - name: Run architecture and domain tests
+        run: python -m pytest tests/architecture tests/domain -v
+
+# Mechanical checks only. A passing workflow does NOT constitute approval,
+# merge authorization, or deployment authorization.

--- a/architecture/ADR-001-observation-canonical-facts.md
+++ b/architecture/ADR-001-observation-canonical-facts.md
@@ -30,6 +30,16 @@ Every Observation carries, at minimum:
 
 **Provenance:** every Canonical Fact version references the specific Observation(s) that produced it, including their Provider identities. This is what makes reconciliation auditable.
 
+**Confidence is internal; Provenance is external.** The Confidence value a Canonical Fact version carries is an **internal attribute of reconciliation**: it is an input to downstream evidence-confidence aggregation (ADR-003) and to reconciliation itself, not a number ASA presents to users as a standalone quality claim. **Provenance, by contrast, is a first-class, externally visible concept.** Any API that exposes a Canonical Fact or a Recommendation must expose that record's complete provenance, with drill-down capability showing, at minimum:
+
+- the contributing Providers (every Provider whose Observations participated in reconciliation),
+- the selected Provider (whose Observation the resolved value was taken from, where applicable),
+- provider disagreements (which Providers reported conflicting values, and what they reported),
+- the relevant timestamps (effective time, recorded time, and reconciliation time),
+- reconciliation metadata (the priority/agreement/staleness inputs that drove the resolution).
+
+"Externally visible" here binds future API design without designing any API in this ADR: whatever surface eventually exposes Facts or Recommendations must be able to answer "where did this number come from, who disagreed, and when" from the stored record alone. The domain model must therefore carry complete provenance structurally on every Canonical Fact version — this is not an optional annotation.
+
 **Historical replay:** because both Observations and Canonical Fact versions are immutable and timestamped with both effective time and recorded time, ASA can reconstruct "what did we believe as of time T" for any past T. This is a required capability of the model, not an incidental byproduct — it is what makes Strategy evaluation reproducible over historical data (Constitution Law 7).
 
 **Determinism is a write-time guarantee, not a re-derivation guarantee.** "Same Observation set always reconciles to the same Canonical Fact version" describes the reconciliation function at the moment it runs, given whatever provider-priority configuration and confidence inputs are in effect at that time. It does not mean that re-running reconciliation *today*, against *yesterday's* Observation set, is guaranteed to reproduce *yesterday's* stored Canonical Fact version — provider priority and confidence-scoring configuration are not versioned by this ADR (see Open Questions and ADR-002), so they may differ between "then" and "now." Historical replay does not depend on this kind of re-derivation matching: replay is a **lookup** of the Canonical Fact version that was actually stored at the relevant time, not a **recomputation** of reconciliation against current configuration. An implementer should not build a test that reconciles historical Observations under today's configuration and asserts the result matches the historically stored version — that test would fail on any configuration change and would not indicate a defect.
@@ -59,6 +69,10 @@ Every Observation carries, at minimum:
 `ARCHITECTURE_VISION.md`'s Open Questions section currently asks: *"The precise mechanism by which the Canonical Fact Layer resolves disagreement between providers... has not been settled by an ADR."* This ADR settles it. Recommend removing that Open Question from `ARCHITECTURE_VISION.md` and replacing it with a reference to this ADR.
 
 Recommend a minor clarifying edit to `DOMAIN_GLOSSARY.md`'s **Observation** entry: "raw provider evidence" should be understood as raw in *content* (the reported value is never altered) but structurally normalized into ASA's schema at the point of recording (see ADR-002). The current Glossary wording does not contradict this, but a reader could plausibly misread "raw" as "untransformed in every sense." Recommend appending a one-clause parenthetical to the existing definition rather than rewriting it.
+
+## Revision note (ASA-CORE-001)
+
+This ADR originally described Confidence and Provenance side by side without distinguishing their visibility. This amendment clarifies that reconciliation confidence is an internal attribute (consumed by reconciliation and downstream evidence-confidence aggregation, not presented as a user-facing quality score), and elevates Provenance to a first-class, externally visible concept with a binding drill-down requirement on any future API exposing Canonical Facts or Recommendations. No reconciliation semantics changed; the amendment constrains what the stored record must be able to answer, and therefore what the domain model must carry.
 
 ## References
 

--- a/architecture/ADR-003-opportunity-model.md
+++ b/architecture/ADR-003-opportunity-model.md
@@ -18,9 +18,8 @@ An **Opportunity**, from the moment it is produced by the Strategy Layer through
 - **Supporting Indicators.** The specific Indicator values the Strategy relied on, each referencing the Canonical Fact version(s) (ADR-001) they were computed from — not just the final numbers, but a traceable path back to Evidence.
 - **Evidence.** The structured Observations and Canonical Facts underlying the above, per `DOMAIN_GLOSSARY.md`'s existing Evidence definition. This is what the Presentation Layer is permitted to summarize; anything not present here is not available for the Presentation Layer to reference.
 - **Assumptions.** Any modeling assumption the Strategy relied on that is not itself a Fact or Indicator (for example, an assumption about normal market conditions, or a simplification in how a spread's risk is modeled). Assumptions are recorded explicitly by the Strategy, not left implicit in code, so they can be surfaced as caveats.
-- **Confidence.** Two distinct values, kept separate rather than merged into one score:
-  - *Evidence confidence* — deterministically aggregated from the Confidence values of the underlying Canonical Facts and Indicators (ADR-001).
-  - *Strategy confidence* — an optional, separately labeled assessment the Strategy itself may attach, distinct from evidence confidence. These are never merged into a single number, because one reflects uncertainty in the underlying data and the other reflects the Strategy's own model judgment; conflating them would violate the Facts-before-opinions distinction (Constitution Law 1) at the Opportunity level.
+- **Confidence.** A single value: *evidence confidence* — deterministically aggregated from the Confidence values of the underlying Canonical Facts and Indicators (ADR-001). It reflects uncertainty in the underlying data only. A Strategy does not express subjective confidence of its own, at any level — see Expected Outcome Metrics below, which replace the concept formerly called "Strategy confidence" (see Revision note).
+- **Expected Outcome Metrics.** Standardized, objective financial characteristics that **every** Strategy produces for every Opportunity it emits — for example: expected return, maximum gain, maximum loss, capital required, probability of profit, and time horizon. These are deterministic outputs of the Strategy's model applied to the cited Evidence, expressed in a common, Strategy-independent vocabulary. They are not a judgment score and carry no subjective component: two Strategies of entirely different structure describe their Opportunities in the same financial terms. This common vocabulary is what makes the Ranking Layer possible — Ranking compares Opportunities produced by structurally different Strategies using these common financial metrics (together with evidence confidence and Guardrail outcomes), not by comparing Strategy-specific scores that have no shared meaning.
 - **Guardrail outcomes.** The result of every Guardrail evaluated against this Opportunity — not only the final pass/fail, but each individual Guardrail's outcome and reason. This holds even for Opportunities that are ultimately rejected: a rejected Opportunity's Guardrail trail is retained, not discarded, so "why wasn't this recommended" is answerable from the same structural record as "why was this recommended."
 - **Recommendation state.** An explicit lifecycle state (for example: discovered, guardrail-evaluated, ranked, presented, rejected) so any consumer of the record can tell where in the pipeline this Opportunity currently sits without inferring it from which fields happen to be populated.
 
@@ -38,18 +37,22 @@ An **Opportunity**, from the moment it is produced by the Strategy Layer through
 ## Consequences
 
 - Opportunity records are substantially larger than a "final score plus a label" model would produce, since they must carry a full evidence and Guardrail trail. This is treated as a direct, accepted cost of Constitution Law 6, not an inefficiency to be optimized away later.
-- Every Strategy author must explicitly emit Assumptions and a clearly separated Strategy confidence (if any) — this is a discipline requirement on Strategy implementation, not merely a data-model nicety.
+- Every Strategy author must explicitly emit Assumptions and the full set of Expected Outcome Metrics — this is a discipline requirement on Strategy implementation, not merely a data-model nicety. A Strategy that cannot state its Opportunity's expected financial characteristics in the standard vocabulary is not a complete Strategy.
 - Rejected Opportunities are retained with their full Guardrail trail rather than discarded, which has a storage-cost and retention-policy implication (see Open Questions), but directly enables future "why wasn't this recommended" functionality without further architectural work.
 - Because the Decision Journal is defined as the Opportunity record itself at presentation time, no separate persistence mechanism needs to be designed or maintained for it.
 
 ## Open Questions
 
 - Retention policy for full Opportunity records (including rejected ones and their Guardrail trails) is not decided here. Given the volume implied by tracking every Guardrail outcome for every discovered Opportunity, this may have cost implications material enough to warrant Founder input, not a purely architectural decision.
-- Whether "Strategy confidence" is required on every Opportunity or genuinely optional per Strategy is left to individual Strategy specifications; this ADR only requires that, when present, it is never merged with evidence confidence.
+- The exact standard field set of Expected Outcome Metrics (which metrics are mandatory for every Strategy versus applicable-when-meaningful) is fixed at the domain-model level, not in this ADR; extending the standard set is an engineering decision unless a new metric changes what Ranking is allowed to compare, in which case it warrants an ADR amendment.
 
 ## Documentation Impact
 
 Recommend updating `DOMAIN_GLOSSARY.md`'s **Decision Journal** entry to remove its "provisional" flag and reference this ADR as the settled definition (Decision Journal = the persisted Opportunity record at presentation time, per ADR-003). The Glossary's separate open question about the **Capability vs. Indicator boundary** is untouched by this ADR and remains open.
+
+## Revision note (ASA-CORE-001)
+
+This ADR originally defined a two-value Confidence model on the Opportunity: *evidence confidence* plus an optional, subjective *Strategy confidence*. That second value is removed by this amendment and replaced with **Expected Outcome Metrics**, as defined in the Decision section above. Rationale: a subjective per-Strategy confidence score has no shared meaning across structurally different Strategies and therefore cannot be compared by Ranking without conflating model judgment with data uncertainty — the same Facts/opinions conflation this ADR's Alternative 3 already rejected for a single merged score. Standardized financial characteristics are objective, Strategy-independent, and give Ranking a common basis of comparison. Alternative 3 in "Alternatives Considered" is retained as originally written for historical accuracy; its reasoning (never merge data uncertainty with model output into one number) continues to apply to the amended model.
 
 ## References
 

--- a/architecture/DECISION_LOG.md
+++ b/architecture/DECISION_LOG.md
@@ -8,6 +8,8 @@ Do not add substantive reasoning to this file. If an entry needs more than two s
 
 | Date | Summary | ADR |
 |---|---|---|
+| 2026-07-21 | "Strategy confidence" is removed and replaced by Expected Outcome Metrics — standardized, objective financial characteristics every Strategy must produce; Ranking compares Opportunities using these common metrics. | ADR-003 (amended) |
+| 2026-07-21 | Reconciliation confidence is clarified as an internal attribute; Provenance is elevated to a first-class externally visible concept with a binding drill-down requirement (contributing providers, selected provider, disagreements, timestamps, reconciliation metadata). | ADR-001 (amended) |
 | 2026-07-20 | Indicator values are versioned and immutable, mirroring the Canonical Fact model, closing a reproducibility gap between Facts and Strategies. | ADR-006 |
 | 2026-07-20 | Guardrails are defined as deterministic, versioned, single-Opportunity eligibility rules with no independent Confidence; cross-Opportunity guardrails are explicitly out of scope pending a future ADR. | ADR-005 |
 | 2026-07-20 | `presentation/`'s allowed dependencies are narrowed to `ranking/` and `domain/` only, correcting a contradiction with the Presentation Layer's evidence-only constraint. | ADR-004 (revised) |

--- a/domain/__init__.py
+++ b/domain/__init__.py
@@ -1,0 +1,33 @@
+"""Shared domain module (ADR-004 `domain/`).
+
+Cross-cutting, immutable value types referenced by multiple layers —
+defined once here, referenced everywhere (Constitution Law 3). Structural
+definitions only; no business logic lives in this package (ASA-CORE-001).
+
+Depends on nothing but itself and the standard library.
+"""
+from domain.canonical_fact import CanonicalFact
+from domain.guardrail import GuardrailOutcome
+from domain.indicator import Indicator
+from domain.observation import Observation
+from domain.opportunity import Opportunity, RecommendationState
+from domain.outcome_metrics import ExpectedOutcomeMetrics
+from domain.provenance import Provenance, ProviderDisagreement
+from domain.provider import Provider
+from domain.references import Confidence, EvidenceKind, EvidenceReference
+
+__all__ = [
+    "CanonicalFact",
+    "Confidence",
+    "EvidenceKind",
+    "EvidenceReference",
+    "ExpectedOutcomeMetrics",
+    "GuardrailOutcome",
+    "Indicator",
+    "Observation",
+    "Opportunity",
+    "Provenance",
+    "Provider",
+    "ProviderDisagreement",
+    "RecommendationState",
+]

--- a/domain/canonical_fact.py
+++ b/domain/canonical_fact.py
@@ -1,0 +1,32 @@
+"""Canonical Fact — versioned, immutable best understanding (ADR-001).
+
+Structural definitions only — no business logic (ASA-CORE-001).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from domain.provenance import Provenance
+from domain.references import Confidence
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalFact:
+    """One immutable version of ASA's resolved record for a data point.
+
+    Each reconciliation that changes the resolved value produces a new
+    version; prior versions are retained permanently and never recomputed
+    (ADR-001). ``confidence`` is an internal reconciliation attribute;
+    ``provenance`` is externally visible and mandatory (ADR-001 as amended
+    by ASA-CORE-001).
+    """
+
+    fact_id: str
+    version: int
+    fact_type: str
+    value: object
+    confidence: Confidence
+    provenance: Provenance
+    effective_time: datetime
+    created_time: datetime

--- a/domain/guardrail.py
+++ b/domain/guardrail.py
@@ -1,0 +1,28 @@
+"""Guardrail outcome — deterministic, versioned, evidence-citing (ADR-005).
+
+Structural definitions only — no business logic (ASA-CORE-001).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from domain.references import EvidenceReference
+
+
+@dataclass(frozen=True, slots=True)
+class GuardrailOutcome:
+    """The result of one versioned Guardrail against one Opportunity.
+
+    Retained even for rejected Opportunities (ADR-003). ``reason`` is not
+    free text alone: ``evidence`` cites the specific Fact and Indicator
+    versions that drove the pass/fail result (ADR-005). Guardrail outcomes
+    carry no independent Confidence value (ADR-005).
+    """
+
+    guardrail_id: str
+    guardrail_version: str
+    passed: bool
+    reason: str
+    evidence: tuple[EvidenceReference, ...]
+    evaluated_at: datetime

--- a/domain/indicator.py
+++ b/domain/indicator.py
@@ -1,0 +1,29 @@
+"""Indicator — versioned, immutable derived value (ADR-006).
+
+Structural definitions only — no business logic (ASA-CORE-001).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from domain.references import EvidenceReference
+
+
+@dataclass(frozen=True, slots=True)
+class Indicator:
+    """One immutable version of a derived Indicator value (ADR-006).
+
+    A new version is produced when an underlying Canonical Fact version
+    changes or the calculation logic changes. ``computed_from`` pins the
+    exact Canonical Fact version(s); ``logic_version`` pins the exact
+    calculation-logic version. Never mutated or silently recomputed.
+    """
+
+    indicator_id: str
+    version: int
+    logic_version: str
+    value: object
+    computed_from: tuple[EvidenceReference, ...]
+    effective_time: datetime
+    created_time: datetime

--- a/domain/observation.py
+++ b/domain/observation.py
@@ -1,0 +1,26 @@
+"""Observation — immutable, append-only provider evidence (ADR-001).
+
+Structural definitions only — no business logic (ASA-CORE-001).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True, slots=True)
+class Observation:
+    """What a specific Provider reported, at a specific time (ADR-001).
+
+    Never edited or deleted once written; a Provider correction is a new
+    Observation. ``value`` is already structurally normalized into ASA's
+    schema for ``observation_type`` (ADR-002) — normalization is a
+    structural transform, never an interpretive one.
+    """
+
+    observation_id: str
+    observation_type: str
+    provider_id: str
+    value: object
+    effective_time: datetime
+    recorded_time: datetime

--- a/domain/opportunity.py
+++ b/domain/opportunity.py
@@ -1,0 +1,51 @@
+"""Opportunity — explainable, evidence-carrying record (ADR-003 as amended).
+
+Structural definitions only — no business logic (ASA-CORE-001).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+from domain.guardrail import GuardrailOutcome
+from domain.outcome_metrics import ExpectedOutcomeMetrics
+from domain.references import Confidence, EvidenceReference
+
+
+class RecommendationState(str, Enum):
+    """Explicit lifecycle state of an Opportunity (ADR-003)."""
+
+    DISCOVERED = "discovered"
+    GUARDRAIL_EVALUATED = "guardrail_evaluated"
+    RANKED = "ranked"
+    PRESENTED = "presented"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True, slots=True)
+class Opportunity:
+    """One immutable version of an Opportunity record (ADR-003 as amended).
+
+    Carries the full minimum structural content: pinned Strategy version,
+    supporting Indicator versions, Evidence, Assumptions, evidence
+    confidence, Expected Outcome Metrics, Guardrail outcomes, and an
+    explicit lifecycle state. The Decision Journal entry for a presented
+    Recommendation is this record frozen at presentation time — no separate
+    structure exists (ADR-003). State progression yields a new version;
+    ``opportunity_id`` is stable across the lifecycle.
+    """
+
+    opportunity_id: str
+    version: int
+    strategy_id: str
+    strategy_version: str
+    supporting_indicators: tuple[EvidenceReference, ...]
+    evidence: tuple[EvidenceReference, ...]
+    assumptions: tuple[str, ...]
+    evidence_confidence: Confidence
+    expected_outcome_metrics: ExpectedOutcomeMetrics
+    state: RecommendationState
+    effective_time: datetime
+    created_time: datetime
+    guardrail_outcomes: tuple[GuardrailOutcome, ...] = field(default=())

--- a/domain/outcome_metrics.py
+++ b/domain/outcome_metrics.py
@@ -1,0 +1,28 @@
+"""Expected Outcome Metrics (ADR-003 as amended by ASA-CORE-001).
+
+Structural definitions only — no business logic (ASA-CORE-001).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectedOutcomeMetrics:
+    """Standardized financial characteristics of an Opportunity.
+
+    Every Strategy produces these for every Opportunity it emits, in this
+    common Strategy-independent vocabulary; Ranking compares Opportunities
+    using these metrics (ADR-003 as amended). They are objective outputs of
+    the Strategy's model applied to cited Evidence — never a subjective
+    confidence score. A metric that is not meaningful for a given Strategy
+    is None, never a fabricated value.
+    """
+
+    expected_return: Decimal | None
+    maximum_gain: Decimal | None
+    maximum_loss: Decimal | None
+    capital_required: Decimal | None
+    probability_of_profit: Decimal | None
+    time_horizon_days: int | None

--- a/domain/provenance.py
+++ b/domain/provenance.py
@@ -1,0 +1,35 @@
+"""Provenance — first-class, externally visible (ADR-001 as amended).
+
+Structural definitions only — no business logic (ASA-CORE-001).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderDisagreement:
+    """One Provider's conflicting report, retained for drill-down (ADR-001)."""
+
+    provider_id: str
+    observation_id: str
+    reported_value: object
+
+
+@dataclass(frozen=True, slots=True)
+class Provenance:
+    """Complete provenance for a reconciled record (ADR-001 as amended).
+
+    Carries everything the amended ADR-001 drill-down requirement demands:
+    contributing providers, selected provider, provider disagreements,
+    timestamps, and reconciliation metadata. Every Canonical Fact version
+    must carry one of these structurally — it is not an optional annotation.
+    """
+
+    contributing_observation_ids: tuple[str, ...]
+    contributing_provider_ids: tuple[str, ...]
+    selected_provider_id: str | None
+    disagreements: tuple[ProviderDisagreement, ...]
+    reconciled_at: datetime
+    reconciliation_metadata: tuple[tuple[str, str], ...] = field(default=())

--- a/domain/provider.py
+++ b/domain/provider.py
@@ -1,0 +1,19 @@
+"""Provider identity value type (ADR-002).
+
+Structural definitions only — no business logic (ASA-CORE-001).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Provider:
+    """A stable, ASA-internal Provider identity (ADR-002).
+
+    ``provider_id`` is distinct from any vendor-specific account or API-key
+    identifier and must not change when keys rotate or vendors rename tiers.
+    """
+
+    provider_id: str
+    name: str

--- a/domain/references.py
+++ b/domain/references.py
@@ -1,0 +1,43 @@
+"""Cross-cutting reference and confidence value types (ADR-004 `domain/`).
+
+Structural definitions only — no business logic (ASA-CORE-001).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class EvidenceKind(str, Enum):
+    """The kind of record an EvidenceReference points at."""
+
+    OBSERVATION = "observation"
+    CANONICAL_FACT = "canonical_fact"
+    INDICATOR = "indicator"
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceReference:
+    """A pinned reference to a specific version of an evidence record.
+
+    ADR-003 requires every Opportunity to carry a traceable path back to
+    Evidence; ADR-006 requires that path to pin versions, not names.
+    ``version`` is None only for Observations, which are unversioned
+    append-only records (ADR-001).
+    """
+
+    kind: EvidenceKind
+    referenced_id: str
+    version: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Confidence:
+    """A deterministic confidence value in [0.0, 1.0] (ADR-001).
+
+    On a Canonical Fact this is an internal reconciliation attribute
+    (ADR-001 as amended by ASA-CORE-001); on an Opportunity it appears
+    only as deterministically aggregated evidence confidence (ADR-003).
+    """
+
+    score: float

--- a/facts/__init__.py
+++ b/facts/__init__.py
@@ -1,0 +1,5 @@
+"""Canonical Fact Layer (ADR-001).
+
+Owns reconciliation and Canonical Fact versioning.
+May depend on: facts, observation, providers, domain (ADR-004).
+"""

--- a/guardrails/__init__.py
+++ b/guardrails/__init__.py
@@ -1,0 +1,7 @@
+"""Guardrail Layer (ADR-005).
+
+Owns platform-wide risk and eligibility rules, shared across all Strategies
+(Constitution Law 8).
+May depend on: guardrails, strategies, indicators, facts, observation,
+providers, domain (ADR-004).
+"""

--- a/indicators/__init__.py
+++ b/indicators/__init__.py
@@ -1,0 +1,5 @@
+"""Derived Indicator Layer (ADR-006).
+
+Owns shared, reusable indicator calculations.
+May depend on: indicators, facts, observation, providers, domain (ADR-004).
+"""

--- a/observation/__init__.py
+++ b/observation/__init__.py
@@ -1,0 +1,5 @@
+"""Observation Layer (ADR-001).
+
+Owns Observation storage and identity.
+May depend on: observation, providers, domain (ADR-004).
+"""

--- a/presentation/__init__.py
+++ b/presentation/__init__.py
@@ -1,0 +1,7 @@
+"""Presentation Layer (ADR-003, ADR-004).
+
+Owns summarization and user-facing output; the only module permitted to
+invoke a language model. NARROWED dependency rule (ADR-004): may depend
+ONLY on ranking and domain — never on guardrails, strategies, indicators,
+facts, observation, or providers.
+"""

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,0 +1,5 @@
+"""Provider adapters (ADR-002).
+
+Owns all Provider-specific fetching, normalization, and retry logic.
+May depend on: providers, domain. Nothing above (ADR-004).
+"""

--- a/ranking/__init__.py
+++ b/ranking/__init__.py
@@ -1,0 +1,7 @@
+"""Ranking Layer (ADR-004).
+
+Owns ordering of Guardrail-evaluated Opportunities, compared via the common
+Expected Outcome Metrics vocabulary (ADR-003 as amended).
+May depend on: ranking, guardrails, strategies, indicators, facts,
+observation, providers, domain (ADR-004).
+"""

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,0 +1,5 @@
+"""Strategy Layer (ADR-003).
+
+Owns deterministic Strategy evaluation and Opportunity production.
+May depend on: strategies, indicators, facts, observation, providers, domain (ADR-004).
+"""

--- a/strategies/capabilities/__init__.py
+++ b/strategies/capabilities/__init__.py
@@ -1,0 +1,4 @@
+"""Capabilities sub-package of the Strategy Layer (ADR-004, DOMAIN_GLOSSARY).
+
+Inherits the Strategy Layer's dependency boundary.
+"""

--- a/tests/architecture/test_dependency_boundaries.py
+++ b/tests/architecture/test_dependency_boundaries.py
@@ -1,0 +1,100 @@
+"""ASA-CORE-001: enforce ADR-004's one-way dependency rule via import analysis.
+
+Scans every Python file in each layer package with the AST module and asserts
+that no module imports a module above it in the pipeline order:
+
+    providers -> observation -> facts -> indicators -> strategies
+        -> guardrails -> ranking -> presentation
+
+Each module may import itself, `domain`, and modules strictly below it.
+`presentation` is narrower: only `ranking` and `domain` (ADR-004 revision).
+`domain` imports nothing but itself.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PIPELINE_ORDER = [
+    "providers",
+    "observation",
+    "facts",
+    "indicators",
+    "strategies",
+    "guardrails",
+    "ranking",
+    "presentation",
+]
+
+ALL_LAYERS = set(PIPELINE_ORDER) | {"domain"}
+
+
+def _allowed_imports(layer: str) -> set[str]:
+    if layer == "domain":
+        return {"domain"}
+    if layer == "presentation":
+        # Narrowed rule (ADR-004): ranking and domain only.
+        return {"presentation", "ranking", "domain"}
+    idx = PIPELINE_ORDER.index(layer)
+    return set(PIPELINE_ORDER[: idx + 1]) | {"domain"}
+
+
+def _imported_roots(py_file: Path) -> set[str]:
+    """Top-level module names imported by a Python file."""
+    tree = ast.parse(py_file.read_text())
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:
+                roots.add(node.module.split(".")[0])
+    return roots
+
+
+def _layer_files(layer: str) -> list[Path]:
+    return sorted((REPO_ROOT / layer).rglob("*.py"))
+
+
+@pytest.mark.parametrize("layer", sorted(ALL_LAYERS))
+def test_layer_respects_dependency_boundary(layer):
+    allowed = _allowed_imports(layer)
+    violations = []
+    for py_file in _layer_files(layer):
+        forbidden = (_imported_roots(py_file) & ALL_LAYERS) - allowed
+        if forbidden:
+            violations.append(f"{py_file.relative_to(REPO_ROOT)} imports {sorted(forbidden)}")
+    assert not violations, (
+        f"{layer}/ violates ADR-004 dependency rule "
+        f"(allowed: {sorted(allowed)}):\n" + "\n".join(violations)
+    )
+
+
+def test_presentation_allowed_set_is_narrowed():
+    """Guard the guard: the narrowed rule must not regress to the general rule."""
+    assert _allowed_imports("presentation") == {"presentation", "ranking", "domain"}
+
+
+def test_nothing_imports_presentation():
+    """presentation/ is terminal — no other layer may depend on it (ADR-004)."""
+    violations = []
+    for layer in sorted(ALL_LAYERS - {"presentation"}):
+        for py_file in _layer_files(layer):
+            if "presentation" in _imported_roots(py_file):
+                violations.append(str(py_file.relative_to(REPO_ROOT)))
+    assert not violations, f"Modules import terminal layer presentation/: {violations}"
+
+
+def test_domain_imports_no_layer():
+    """domain/ is shared and must not depend on any pipeline layer."""
+    violations = []
+    for py_file in _layer_files("domain"):
+        forbidden = _imported_roots(py_file) & set(PIPELINE_ORDER)
+        if forbidden:
+            violations.append(f"{py_file.relative_to(REPO_ROOT)} imports {sorted(forbidden)}")
+    assert not violations, "domain/ must not import pipeline layers:\n" + "\n".join(violations)

--- a/tests/architecture/test_scaffold.py
+++ b/tests/architecture/test_scaffold.py
@@ -1,0 +1,42 @@
+"""ASA-CORE-001: repository scaffold matches ADR-004."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+ADR_004_PACKAGES = [
+    "providers",
+    "observation",
+    "facts",
+    "indicators",
+    "strategies",
+    "strategies/capabilities",
+    "guardrails",
+    "ranking",
+    "presentation",
+    "domain",
+]
+
+
+@pytest.mark.parametrize("pkg", ADR_004_PACKAGES)
+def test_package_exists(pkg):
+    path = REPO_ROOT / pkg
+    assert path.is_dir(), f"ADR-004 package missing: {pkg}/"
+    assert (path / "__init__.py").is_file(), f"{pkg}/ is not a package (no __init__.py)"
+
+
+@pytest.mark.parametrize("pkg", ADR_004_PACKAGES)
+def test_package_documents_its_boundary(pkg):
+    """Each package's __init__ docstring states what it owns (ADR-004)."""
+    content = (REPO_ROOT / pkg / "__init__.py").read_text()
+    assert '"""' in content, f"{pkg}/__init__.py has no docstring"
+
+
+def test_presentation_docstring_states_narrowed_rule():
+    content = (REPO_ROOT / "presentation" / "__init__.py").read_text()
+    assert "ranking" in content and "domain" in content, (
+        "presentation/__init__.py must document its narrowed dependency rule (ADR-004)"
+    )

--- a/tests/domain/test_domain_model.py
+++ b/tests/domain/test_domain_model.py
@@ -1,0 +1,289 @@
+"""ASA-CORE-001: immutable domain model tests.
+
+Verifies:
+- every domain object is a frozen dataclass (immutable, raises on mutation)
+- identity, version, and timestamp fields exist where the ticket requires
+- provenance is represented in all required entities
+- ExpectedOutcomeMetrics exists and no Strategy-confidence field exists
+- no business logic: domain classes define no public methods of their own
+"""
+from __future__ import annotations
+
+import dataclasses
+import inspect
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+import domain
+from domain import (
+    CanonicalFact,
+    Confidence,
+    EvidenceKind,
+    EvidenceReference,
+    ExpectedOutcomeMetrics,
+    GuardrailOutcome,
+    Indicator,
+    Observation,
+    Opportunity,
+    Provenance,
+    Provider,
+    ProviderDisagreement,
+    RecommendationState,
+)
+
+NOW = datetime(2026, 7, 21, tzinfo=timezone.utc)
+
+DOMAIN_CLASSES = [
+    CanonicalFact,
+    Confidence,
+    EvidenceReference,
+    ExpectedOutcomeMetrics,
+    GuardrailOutcome,
+    Indicator,
+    Observation,
+    Opportunity,
+    Provenance,
+    Provider,
+    ProviderDisagreement,
+]
+
+
+def _sample_provenance() -> Provenance:
+    return Provenance(
+        contributing_observation_ids=("obs-1", "obs-2"),
+        contributing_provider_ids=("prov-a", "prov-b"),
+        selected_provider_id="prov-a",
+        disagreements=(
+            ProviderDisagreement(provider_id="prov-b", observation_id="obs-2",
+                                 reported_value=101.5),
+        ),
+        reconciled_at=NOW,
+        reconciliation_metadata=(("priority_winner", "prov-a"),),
+    )
+
+
+def _sample_fact() -> CanonicalFact:
+    return CanonicalFact(
+        fact_id="fact-1", version=1, fact_type="price", value=100.0,
+        confidence=Confidence(score=0.9), provenance=_sample_provenance(),
+        effective_time=NOW, created_time=NOW,
+    )
+
+
+def _sample_metrics() -> ExpectedOutcomeMetrics:
+    return ExpectedOutcomeMetrics(
+        expected_return=Decimal("0.12"), maximum_gain=Decimal("500"),
+        maximum_loss=Decimal("-200"), capital_required=Decimal("2000"),
+        probability_of_profit=Decimal("0.65"), time_horizon_days=30,
+    )
+
+
+def _sample_opportunity() -> Opportunity:
+    ref = EvidenceReference(kind=EvidenceKind.CANONICAL_FACT,
+                            referenced_id="fact-1", version=1)
+    return Opportunity(
+        opportunity_id="opp-1", version=1,
+        strategy_id="strat-1", strategy_version="1.0.0",
+        supporting_indicators=(EvidenceReference(
+            kind=EvidenceKind.INDICATOR, referenced_id="ind-1", version=3),),
+        evidence=(ref,), assumptions=("normal market conditions",),
+        evidence_confidence=Confidence(score=0.8),
+        expected_outcome_metrics=_sample_metrics(),
+        state=RecommendationState.DISCOVERED,
+        effective_time=NOW, created_time=NOW,
+        guardrail_outcomes=(GuardrailOutcome(
+            guardrail_id="gr-1", guardrail_version="1.0.0", passed=True,
+            reason="DTE above minimum", evidence=(ref,), evaluated_at=NOW),),
+    )
+
+
+SAMPLES = {
+    Provider: lambda: Provider(provider_id="prov-a", name="Alpha"),
+    Confidence: lambda: Confidence(score=0.5),
+    EvidenceReference: lambda: EvidenceReference(
+        kind=EvidenceKind.OBSERVATION, referenced_id="obs-1"),
+    ProviderDisagreement: lambda: ProviderDisagreement(
+        provider_id="p", observation_id="o", reported_value=1),
+    Provenance: _sample_provenance,
+    Observation: lambda: Observation(
+        observation_id="obs-1", observation_type="price", provider_id="prov-a",
+        value=100.0, effective_time=NOW, recorded_time=NOW),
+    CanonicalFact: _sample_fact,
+    Indicator: lambda: Indicator(
+        indicator_id="ind-1", version=3, logic_version="2.0.0", value=1.5,
+        computed_from=(EvidenceReference(
+            kind=EvidenceKind.CANONICAL_FACT, referenced_id="fact-1", version=1),),
+        effective_time=NOW, created_time=NOW),
+    ExpectedOutcomeMetrics: _sample_metrics,
+    GuardrailOutcome: lambda: GuardrailOutcome(
+        guardrail_id="gr-1", guardrail_version="1.0.0", passed=False,
+        reason="capital limit exceeded", evidence=(), evaluated_at=NOW),
+    Opportunity: _sample_opportunity,
+}
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("cls", DOMAIN_CLASSES, ids=lambda c: c.__name__)
+def test_is_frozen_dataclass(cls):
+    assert dataclasses.is_dataclass(cls), f"{cls.__name__} is not a dataclass"
+    assert cls.__dataclass_params__.frozen, f"{cls.__name__} is not frozen"
+
+
+@pytest.mark.parametrize("cls", DOMAIN_CLASSES, ids=lambda c: c.__name__)
+def test_mutation_raises(cls):
+    instance = SAMPLES[cls]()
+    first_field = dataclasses.fields(cls)[0].name
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(instance, first_field, "mutated")
+
+
+@pytest.mark.parametrize("cls", DOMAIN_CLASSES, ids=lambda c: c.__name__)
+def test_collection_fields_are_tuples_not_lists(cls):
+    """Collection-typed fields must be tuples so instances are deeply immutable."""
+    instance = SAMPLES[cls]()
+    for f in dataclasses.fields(cls):
+        value = getattr(instance, f.name)
+        assert not isinstance(value, (list, dict, set)), (
+            f"{cls.__name__}.{f.name} holds a mutable collection"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Identity, versioning, timestamps
+# ---------------------------------------------------------------------------
+
+VERSIONED = {CanonicalFact: "version", Indicator: "version", Opportunity: "version"}
+TIMESTAMPED = {
+    Observation: ("effective_time", "recorded_time"),
+    CanonicalFact: ("effective_time", "created_time"),
+    Indicator: ("effective_time", "created_time"),
+    Opportunity: ("effective_time", "created_time"),
+}
+IDENTIFIED = {
+    Provider: "provider_id",
+    Observation: "observation_id",
+    CanonicalFact: "fact_id",
+    Indicator: "indicator_id",
+    Opportunity: "opportunity_id",
+    GuardrailOutcome: "guardrail_id",
+}
+
+
+@pytest.mark.parametrize("cls,field_name", VERSIONED.items(), ids=lambda x: getattr(x, "__name__", x))
+def test_versioned_entities_have_version_field(cls, field_name):
+    assert field_name in {f.name for f in dataclasses.fields(cls)}
+
+
+@pytest.mark.parametrize("cls,fields", TIMESTAMPED.items(), ids=lambda x: getattr(x, "__name__", x))
+def test_timestamps_present(cls, fields):
+    names = {f.name for f in dataclasses.fields(cls)}
+    for fname in fields:
+        assert fname in names, f"{cls.__name__} missing timestamp field {fname}"
+
+
+@pytest.mark.parametrize("cls,field_name", IDENTIFIED.items(), ids=lambda x: getattr(x, "__name__", x))
+def test_identifier_fields_present(cls, field_name):
+    assert field_name in {f.name for f in dataclasses.fields(cls)}
+
+
+def test_indicator_pins_logic_version():
+    names = {f.name for f in dataclasses.fields(Indicator)}
+    assert "logic_version" in names, "ADR-006: Indicator must pin its calculation-logic version"
+
+
+def test_opportunity_pins_strategy_version():
+    names = {f.name for f in dataclasses.fields(Opportunity)}
+    assert "strategy_version" in names, "ADR-003: Opportunity must pin its Strategy version"
+
+
+def test_guardrail_outcome_pins_guardrail_version():
+    names = {f.name for f in dataclasses.fields(GuardrailOutcome)}
+    assert "guardrail_version" in names, "ADR-005: GuardrailOutcome must pin its Guardrail version"
+
+
+# ---------------------------------------------------------------------------
+# Provenance representation (ADR-001 as amended)
+# ---------------------------------------------------------------------------
+
+def test_canonical_fact_carries_full_provenance():
+    fact = _sample_fact()
+    prov = fact.provenance
+    assert prov.contributing_provider_ids
+    assert prov.selected_provider_id is not None
+    assert prov.disagreements is not None
+    assert prov.reconciled_at is not None
+    assert prov.reconciliation_metadata is not None
+
+
+def test_indicator_references_fact_versions():
+    ind = SAMPLES[Indicator]()
+    assert all(r.kind is EvidenceKind.CANONICAL_FACT and r.version is not None
+               for r in ind.computed_from)
+
+
+def test_opportunity_carries_evidence_references():
+    opp = _sample_opportunity()
+    assert opp.evidence and opp.supporting_indicators
+
+
+def test_guardrail_outcome_cites_evidence():
+    names = {f.name for f in dataclasses.fields(GuardrailOutcome)}
+    assert "evidence" in names and "reason" in names
+
+
+# ---------------------------------------------------------------------------
+# ExpectedOutcomeMetrics replaces Strategy Confidence (ADR-003 as amended)
+# ---------------------------------------------------------------------------
+
+def test_opportunity_has_expected_outcome_metrics():
+    names = {f.name for f in dataclasses.fields(Opportunity)}
+    assert "expected_outcome_metrics" in names
+
+
+def test_no_strategy_confidence_anywhere():
+    for cls in DOMAIN_CLASSES:
+        names = {f.name for f in dataclasses.fields(cls)}
+        assert "strategy_confidence" not in names, (
+            f"{cls.__name__} carries strategy_confidence — removed by ADR-003 amendment"
+        )
+
+
+def test_metrics_fields_are_standardized():
+    names = {f.name for f in dataclasses.fields(ExpectedOutcomeMetrics)}
+    assert {"expected_return", "maximum_gain", "maximum_loss",
+            "capital_required", "probability_of_profit",
+            "time_horizon_days"} <= names
+
+
+def test_recommendation_state_covers_lifecycle():
+    values = {s.value for s in RecommendationState}
+    assert {"discovered", "guardrail_evaluated", "ranked",
+            "presented", "rejected"} <= values
+
+
+# ---------------------------------------------------------------------------
+# No business logic
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("cls", DOMAIN_CLASSES, ids=lambda c: c.__name__)
+def test_no_public_methods_defined(cls):
+    """Domain objects are data only — no methods beyond dataclass machinery."""
+    own = [
+        name for name, member in vars(cls).items()
+        if inspect.isfunction(member)
+        and not name.startswith("__")
+    ]
+    assert own == [], f"{cls.__name__} defines business logic methods: {own}"
+
+
+def test_domain_package_exports_all_required_objects():
+    for name in ("Observation", "CanonicalFact", "Indicator", "Opportunity",
+                 "Provider", "Provenance", "EvidenceReference",
+                 "GuardrailOutcome", "ExpectedOutcomeMetrics",
+                 "RecommendationState"):
+        assert hasattr(domain, name), f"domain package does not export {name}"


### PR DESCRIPTION
## Summary

Implements ticket ASA-CORE-001 (Foundation Scaffold, ROLE-ARCH, P0). Branched from `origin/main` at `4fbfcc8`.

### ADR amendments
- **ADR-003**: "Strategy confidence" removed and replaced with **Expected Outcome Metrics** — standardized, objective financial characteristics (expected return, max gain/loss, capital required, probability of profit, time horizon) every Strategy must produce. No subjective confidence remains at the Strategy level; Ranking compares Opportunities using these common financial metrics. Revision note documents the change; Alternatives section kept as historical record.
- **ADR-001**: reconciliation confidence clarified as an **internal attribute**; **Provenance elevated to first-class, externally visible** with a binding drill-down requirement — contributing providers, selected provider, provider disagreements, timestamps (effective/recorded/reconciled), and reconciliation metadata must be answerable from the stored record for every Canonical Fact and Recommendation. Revision note added.
- **DECISION_LOG.md**: two dated amendment entries added (newest-first, two-sentence limit respected).

### Repository scaffold (ADR-004)
Nine top-level packages: `providers/`, `observation/`, `facts/`, `indicators/`, `strategies/` (with `capabilities/`), `guardrails/`, `ranking/`, `presentation/`, `domain/`. Each `__init__.py` documents what the module owns and its allowed dependencies, including `presentation/`'s narrowed rule (ranking + domain only).

### Immutable domain model (`domain/`)
Frozen, slotted dataclasses — data only, zero business logic: `Provider`, `Observation`, `Provenance` + `ProviderDisagreement`, `EvidenceReference` + `EvidenceKind`, `Confidence`, `CanonicalFact`, `Indicator`, `ExpectedOutcomeMetrics`, `GuardrailOutcome`, `Opportunity`, `RecommendationState`. All entities carry immutable identifiers; `CanonicalFact`/`Indicator`/`Opportunity` carry `version`; effective + created/recorded timestamps throughout; `Indicator` pins `logic_version` and Fact versions (ADR-006); `Opportunity` pins `strategy_version` and `GuardrailOutcome` pins `guardrail_version` (ADR-003/005); `Provenance` carries the full amended ADR-001 drill-down set. Collections are tuples — no mutable fields.

### Tests (102 passing)
- `tests/architecture/test_scaffold.py` — packages match ADR-004
- `tests/architecture/test_dependency_boundaries.py` — AST-based enforcement of the one-way dependency rule, the `presentation/` narrowed set specifically (per ADR-004's explicit warning), terminal-layer rule, and domain-imports-no-layer rule
- `tests/domain/test_domain_model.py` — frozen/mutation-raises for every class, versioning, timestamps, provenance representation, `ExpectedOutcomeMetrics` present, `strategy_confidence` absent everywhere, no public methods on domain classes

### CI
New `.github/workflows/validate-architecture.yml` runs the architecture and domain tests on PRs touching layer packages or `architecture/`. The existing POS workflow is untouched; POS entrypoint/integrity checks verified still green.

### Explicitly not implemented (ticket constraints)
Databases, APIs, UI, Robinhood/Tradier integration, strategies, indicators, calculations, LLM functionality.

## Acceptance criteria
- [x] Repository matches ADR-004 (enforced by test)
- [x] Architecture tests pass (102/102)
- [x] Domain objects are immutable (frozen + slots + tuple collections, enforced by test)
- [x] Versioning exists where required (Fact, Indicator, Opportunity + pinned logic/strategy/guardrail versions)
- [x] Provenance represented in all required entities (enforced by test)
- [x] ExpectedOutcomeMetrics replaces Strategy Confidence (ADR amended + enforced by test)
- [x] No business logic implemented (enforced by test)

---
_Generated by [Claude Code](https://claude.ai/code/session_0171U6QSQe39nnsDLYLbmbG1)_