### PR TITLE
ASA-CORE-001A: foundation invariant hardening

### DIFF
--- a/.github/workflows/validate-architecture.yml
+++ b/.github/workflows/validate-architecture.yml
@@ -1,6 +1,8 @@
 name: Validate Architecture
 
 on:
+  push:
+    branches: [main]
   pull_request:
     paths:
       - 'providers/**'

--- a/architecture/ADR-001-observation-canonical-facts.md
+++ b/architecture/ADR-001-observation-canonical-facts.md
@@ -1,4 +1,4 @@
-<!-- Repository path: docs/architecture/decisions/ADR-001-observation-canonical-facts.md -->
+<!-- Repository path: architecture/ADR-001-observation-canonical-facts.md -->
 
 # ADR-001: Observation & Canonical Fact Model
 

--- a/architecture/ADR-002-provider-interface.md
+++ b/architecture/ADR-002-provider-interface.md
@@ -1,4 +1,4 @@
-<!-- Repository path: docs/architecture/decisions/ADR-002-provider-interface.md -->
+<!-- Repository path: architecture/ADR-002-provider-interface.md -->
 
 # ADR-002: Provider Interface Contract
 

--- a/architecture/ADR-003-opportunity-model.md
+++ b/architecture/ADR-003-opportunity-model.md
@@ -1,4 +1,4 @@
-<!-- Repository path: docs/architecture/decisions/ADR-003-opportunity-model.md -->
+<!-- Repository path: architecture/ADR-003-opportunity-model.md -->
 
 # ADR-003: Explainable Opportunity Model
 

--- a/architecture/ADR-004-repository-organization.md
+++ b/architecture/ADR-004-repository-organization.md
@@ -1,4 +1,4 @@
-<!-- Repository path: docs/architecture/decisions/ADR-004-repository-organization.md -->
+<!-- Repository path: architecture/ADR-004-repository-organization.md -->
 
 # ADR-004: Repository Organization
 

--- a/architecture/ADR-005-guardrail-model.md
+++ b/architecture/ADR-005-guardrail-model.md
@@ -1,4 +1,4 @@
-<!-- Repository path: docs/architecture/decisions/ADR-005-guardrail-model.md -->
+<!-- Repository path: architecture/ADR-005-guardrail-model.md -->
 
 # ADR-005: Guardrail Model
 

--- a/architecture/ADR-006-indicator-versioning.md
+++ b/architecture/ADR-006-indicator-versioning.md
@@ -1,4 +1,4 @@
-<!-- Repository path: docs/architecture/decisions/ADR-006-indicator-versioning.md -->
+<!-- Repository path: architecture/ADR-006-indicator-versioning.md -->
 
 # ADR-006: Indicator Versioning and Immutability
 

--- a/architecture/ARCHITECTURE_VISION.md
+++ b/architecture/ARCHITECTURE_VISION.md
@@ -1,4 +1,4 @@
-<!-- Repository path: docs/architecture/ARCHITECTURE_VISION.md -->
+<!-- Repository path: architecture/ARCHITECTURE_VISION.md -->
 
 # ASA Architecture Vision
 

--- a/architecture/CONSTITUTION.md
+++ b/architecture/CONSTITUTION.md
@@ -1,4 +1,4 @@
-<!-- Repository path: docs/architecture/CONSTITUTION.md -->
+<!-- Repository path: architecture/CONSTITUTION.md -->
 
 # ASA Constitution
 

--- a/architecture/DECISION_LOG.md
+++ b/architecture/DECISION_LOG.md
@@ -1,4 +1,4 @@
-<!-- Repository path: docs/architecture/DECISION_LOG.md -->
+<!-- Repository path: architecture/DECISION_LOG.md -->
 
 # ASA Architecture Decision Log
 
@@ -8,15 +8,13 @@ Do not add substantive reasoning to this file. If an entry needs more than two s
 
 | Date | Summary | ADR |
 |---|---|---|
+| 2026-07-21 | Expected Outcome Metrics units fixed at the domain level (decimal-fraction return, USD amounts, [0,1] probability); expected_return, maximum_loss, and capital_required are mandatory. Domain primitives enforce normalized immutable values, legal ranges, positive versions, and timezone-aware timestamps. | ADR-003 (domain level, ASA-CORE-001A) |
 | 2026-07-21 | "Strategy confidence" is removed and replaced by Expected Outcome Metrics — standardized, objective financial characteristics every Strategy must produce; Ranking compares Opportunities using these common metrics. | ADR-003 (amended) |
 | 2026-07-21 | Reconciliation confidence is clarified as an internal attribute; Provenance is elevated to a first-class externally visible concept with a binding drill-down requirement (contributing providers, selected provider, disagreements, timestamps, reconciliation metadata). | ADR-001 (amended) |
 | 2026-07-20 | Indicator values are versioned and immutable, mirroring the Canonical Fact model, closing a reproducibility gap between Facts and Strategies. | ADR-006 |
 | 2026-07-20 | Guardrails are defined as deterministic, versioned, single-Opportunity eligibility rules with no independent Confidence; cross-Opportunity guardrails are explicitly out of scope pending a future ADR. | ADR-005 |
 | 2026-07-20 | `presentation/`'s allowed dependencies are narrowed to `ranking/` and `domain/` only, correcting a contradiction with the Presentation Layer's evidence-only constraint. | ADR-004 (revised) |
-| _pending_ | Providers are not assumed to agree; Canonical Facts are reconciled from potentially conflicting Observations using provider priority, confidence, and provenance. | ADR-001 |
-| _pending_ | Guardrails are platform-owned and shared across all Strategies; Strategies do not implement independent risk logic. | ADR-005 |
-| _pending_ | Strategy evaluation, and everything feeding it, is deterministic; language models are confined to the Presentation Layer. | ADR-004 |
-| _pending_ | Observation and Canonical Fact are established as distinct, non-interchangeable architectural concepts. | ADR-001 |
+| 2026-07-20 | Providers are not assumed to agree; Canonical Facts are reconciled from potentially conflicting Observations using provider priority, confidence, and provenance. Observation and Canonical Fact are distinct, non-interchangeable concepts. | ADR-001 |
 
 ## Open Questions / Requires ADR
 

--- a/architecture/DOMAIN_GLOSSARY.md
+++ b/architecture/DOMAIN_GLOSSARY.md
@@ -1,4 +1,4 @@
-<!-- Repository path: docs/architecture/DOMAIN_GLOSSARY.md -->
+<!-- Repository path: architecture/DOMAIN_GLOSSARY.md -->
 
 # ASA Domain Glossary
 

--- a/architecture/README.md
+++ b/architecture/README.md
@@ -1,4 +1,4 @@
-<!-- Repository path: docs/architecture/README.md -->
+<!-- Repository path: architecture/README.md -->
 
 # ASA Architecture Documentation
 
@@ -11,7 +11,7 @@ This directory is the authoritative architecture documentation for ASA (Algo Sto
 | [`CONSTITUTION.md`](./CONSTITUTION.md) | What must never change? |
 | [`ARCHITECTURE_VISION.md`](./ARCHITECTURE_VISION.md) | What kind of system are we building, and why? |
 | [`DOMAIN_GLOSSARY.md`](./DOMAIN_GLOSSARY.md) | What does this term mean? |
-| ADRs (`docs/architecture/decisions/`) | Why was this specific decision made? |
+| ADRs (`architecture/`) | Why was this specific decision made? |
 | [`DECISION_LOG.md`](./DECISION_LOG.md) | What has been decided, and where is the reasoning? |
 
 Each document has exactly one job. If you find the same explanation in two places, that is a defect — file an issue.
@@ -67,4 +67,4 @@ Deployment decisions, database technology choices, CI implementation, secrets ma
 
 ## Open Questions / Requires ADR
 
-- No ADR index or numbering convention has been formally adopted yet. This README assumes ADRs live at `docs/architecture/decisions/` and are individually numbered; that convention itself should be confirmed by an ADR rather than assumed here.
+- No ADR index or numbering convention has been formally adopted yet. This README assumes ADRs live at `architecture/` and are individually numbered (the repository's actual location); that convention itself should be confirmed by an ADR rather than assumed here.

--- a/domain/__init__.py
+++ b/domain/__init__.py
@@ -15,10 +15,13 @@ from domain.outcome_metrics import ExpectedOutcomeMetrics
 from domain.provenance import Provenance, ProviderDisagreement
 from domain.provider import Provider
 from domain.references import Confidence, EvidenceKind, EvidenceReference
+from domain.values import DomainInvariantError, is_normalized_value
 
 __all__ = [
     "CanonicalFact",
     "Confidence",
+    "DomainInvariantError",
+    "is_normalized_value",
     "EvidenceKind",
     "EvidenceReference",
     "ExpectedOutcomeMetrics",

--- a/domain/canonical_fact.py
+++ b/domain/canonical_fact.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 from domain.provenance import Provenance
 from domain.references import Confidence
+from domain.values import require_normalized, require_positive, require_tz_aware
 
 
 @dataclass(frozen=True, slots=True)
@@ -30,3 +31,9 @@ class CanonicalFact:
     provenance: Provenance
     effective_time: datetime
     created_time: datetime
+
+    def __post_init__(self) -> None:
+        require_positive(self.version, "CanonicalFact", "version")
+        require_normalized(self.value, "CanonicalFact", "value")
+        require_tz_aware(self.effective_time, "CanonicalFact", "effective_time")
+        require_tz_aware(self.created_time, "CanonicalFact", "created_time")

--- a/domain/guardrail.py
+++ b/domain/guardrail.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from domain.references import EvidenceReference
+from domain.values import require_tz_aware
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,3 +27,6 @@ class GuardrailOutcome:
     reason: str
     evidence: tuple[EvidenceReference, ...]
     evaluated_at: datetime
+
+    def __post_init__(self) -> None:
+        require_tz_aware(self.evaluated_at, "GuardrailOutcome", "evaluated_at")

--- a/domain/indicator.py
+++ b/domain/indicator.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from domain.references import EvidenceReference
+from domain.values import require_normalized, require_positive, require_tz_aware
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,3 +28,9 @@ class Indicator:
     computed_from: tuple[EvidenceReference, ...]
     effective_time: datetime
     created_time: datetime
+
+    def __post_init__(self) -> None:
+        require_positive(self.version, "Indicator", "version")
+        require_normalized(self.value, "Indicator", "value")
+        require_tz_aware(self.effective_time, "Indicator", "effective_time")
+        require_tz_aware(self.created_time, "Indicator", "created_time")

--- a/domain/observation.py
+++ b/domain/observation.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
+from domain.values import require_normalized, require_tz_aware
+
 
 @dataclass(frozen=True, slots=True)
 class Observation:
@@ -24,3 +26,8 @@ class Observation:
     value: object
     effective_time: datetime
     recorded_time: datetime
+
+    def __post_init__(self) -> None:
+        require_normalized(self.value, "Observation", "value")
+        require_tz_aware(self.effective_time, "Observation", "effective_time")
+        require_tz_aware(self.recorded_time, "Observation", "recorded_time")

--- a/domain/opportunity.py
+++ b/domain/opportunity.py
@@ -11,6 +11,7 @@ from enum import Enum
 from domain.guardrail import GuardrailOutcome
 from domain.outcome_metrics import ExpectedOutcomeMetrics
 from domain.references import Confidence, EvidenceReference
+from domain.values import require_positive, require_tz_aware
 
 
 class RecommendationState(str, Enum):
@@ -49,3 +50,8 @@ class Opportunity:
     effective_time: datetime
     created_time: datetime
     guardrail_outcomes: tuple[GuardrailOutcome, ...] = field(default=())
+
+    def __post_init__(self) -> None:
+        require_positive(self.version, "Opportunity", "version")
+        require_tz_aware(self.effective_time, "Opportunity", "effective_time")
+        require_tz_aware(self.created_time, "Opportunity", "created_time")

--- a/domain/outcome_metrics.py
+++ b/domain/outcome_metrics.py
@@ -1,11 +1,15 @@
 """Expected Outcome Metrics (ADR-003 as amended by ASA-CORE-001).
 
-Structural definitions only — no business logic (ASA-CORE-001).
+Units, semantics, and the mandatory/optional split are fixed here at the
+domain-model level, per the amended ADR-003 (ASA-CORE-001A). Structural
+definitions and identity invariants only — no calculations.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
 from decimal import Decimal
+
+from domain.values import DomainInvariantError, require_unit_interval
 
 
 @dataclass(frozen=True, slots=True)
@@ -16,13 +20,59 @@ class ExpectedOutcomeMetrics:
     common Strategy-independent vocabulary; Ranking compares Opportunities
     using these metrics (ADR-003 as amended). They are objective outputs of
     the Strategy's model applied to cited Evidence — never a subjective
-    confidence score. A metric that is not meaningful for a given Strategy
-    is None, never a fabricated value.
+    confidence score.
+
+    Units and semantics (ASA-CORE-001A):
+
+    - ``expected_return`` — **mandatory**. Expected profit or loss over the
+      Opportunity's horizon, as a signed decimal fraction of
+      ``capital_required`` (``Decimal("0.12")`` = +12%). Not annualized.
+    - ``maximum_loss`` — **mandatory**. Worst-case loss in account currency
+      (USD), expressed as a **non-positive** amount (``Decimal("-200")`` =
+      $200 at risk). ``0`` means no capital can be lost.
+    - ``capital_required`` — **mandatory**. Capital in USD that must be
+      committed or reserved to enter the position; **non-negative**.
+    - ``maximum_gain`` — optional (None where unbounded or not meaningful).
+      Best-case profit in USD; **non-negative**.
+    - ``probability_of_profit`` — optional. Model-derived probability the
+      position closes profitable, in **[0, 1]**.
+    - ``time_horizon_days`` — optional. Expected holding period in whole
+      calendar days; **positive** when present.
+
+    A metric that is not meaningful for a given Strategy is None — never a
+    fabricated value. Mandatory metrics can never be None: an Opportunity
+    with an empty comparison payload cannot be ranked and is structurally
+    invalid (see also ADR-003's "complete Strategy" discipline note).
     """
 
-    expected_return: Decimal | None
-    maximum_gain: Decimal | None
-    maximum_loss: Decimal | None
-    capital_required: Decimal | None
-    probability_of_profit: Decimal | None
-    time_horizon_days: int | None
+    expected_return: Decimal
+    maximum_loss: Decimal
+    capital_required: Decimal
+    maximum_gain: Decimal | None = None
+    probability_of_profit: Decimal | None = None
+    time_horizon_days: int | None = None
+
+    def __post_init__(self) -> None:
+        owner = "ExpectedOutcomeMetrics"
+        for name in ("expected_return", "maximum_loss", "capital_required"):
+            if getattr(self, name) is None:
+                raise DomainInvariantError(f"{owner}.{name} is mandatory and cannot be None")
+        if self.maximum_loss > 0:
+            raise DomainInvariantError(
+                f"{owner}.maximum_loss is a loss and must be <= 0; got {self.maximum_loss!r}"
+            )
+        if self.capital_required < 0:
+            raise DomainInvariantError(
+                f"{owner}.capital_required must be >= 0; got {self.capital_required!r}"
+            )
+        if self.maximum_gain is not None and self.maximum_gain < 0:
+            raise DomainInvariantError(
+                f"{owner}.maximum_gain must be >= 0 when present; got {self.maximum_gain!r}"
+            )
+        if self.probability_of_profit is not None:
+            require_unit_interval(self.probability_of_profit, owner, "probability_of_profit")
+        if self.time_horizon_days is not None and self.time_horizon_days < 1:
+            raise DomainInvariantError(
+                f"{owner}.time_horizon_days must be positive when present; "
+                f"got {self.time_horizon_days!r}"
+            )

--- a/domain/provenance.py
+++ b/domain/provenance.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 
+from domain.values import require_normalized, require_tz_aware
+
 
 @dataclass(frozen=True, slots=True)
 class ProviderDisagreement:
@@ -15,6 +17,9 @@ class ProviderDisagreement:
     provider_id: str
     observation_id: str
     reported_value: object
+
+    def __post_init__(self) -> None:
+        require_normalized(self.reported_value, "ProviderDisagreement", "reported_value")
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,3 +38,6 @@ class Provenance:
     disagreements: tuple[ProviderDisagreement, ...]
     reconciled_at: datetime
     reconciliation_metadata: tuple[tuple[str, str], ...] = field(default=())
+
+    def __post_init__(self) -> None:
+        require_tz_aware(self.reconciled_at, "Provenance", "reconciled_at")

--- a/domain/references.py
+++ b/domain/references.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
+from domain.values import require_positive, require_unit_interval
+
 
 class EvidenceKind(str, Enum):
     """The kind of record an EvidenceReference points at."""
@@ -30,6 +32,10 @@ class EvidenceReference:
     referenced_id: str
     version: int | None = None
 
+    def __post_init__(self) -> None:
+        if self.version is not None:
+            require_positive(self.version, "EvidenceReference", "version")
+
 
 @dataclass(frozen=True, slots=True)
 class Confidence:
@@ -41,3 +47,6 @@ class Confidence:
     """
 
     score: float
+
+    def __post_init__(self) -> None:
+        require_unit_interval(self.score, "Confidence", "score")

--- a/domain/values.py
+++ b/domain/values.py
@@ -1,0 +1,76 @@
+"""Immutable normalized data-value contract and primitive invariants.
+
+ASA-CORE-001A. These are structural identity constraints on what the domain
+model may hold — not reconciliation, strategy, or calculation behavior.
+
+A **normalized value** is the only shape a domain ``value`` field may take:
+
+- a scalar: ``None``, ``bool``, ``int``, ``float``, ``Decimal``, ``str``,
+  or a timezone-aware ``datetime``
+- a ``tuple`` of normalized values (an ordered sequence), or
+- a ``tuple`` of ``(str, normalized value)`` pairs (a mapping rendered
+  immutably; keys are field names from the Observation schema).
+
+Mutable containers (``list``, ``dict``, ``set``, ``bytearray``) are never
+normalized values, so no domain entity can contain a mutable nested value.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+_SCALAR_TYPES = (bool, int, float, Decimal, str)
+
+
+class DomainInvariantError(ValueError):
+    """A domain object was constructed in violation of a structural invariant."""
+
+
+def is_normalized_value(value: object) -> bool:
+    """True if ``value`` satisfies the immutable normalized-value contract."""
+    if value is None or isinstance(value, _SCALAR_TYPES):
+        return True
+    if isinstance(value, datetime):
+        return value.tzinfo is not None
+    if isinstance(value, tuple):
+        return all(
+            (
+                isinstance(item, tuple)
+                and len(item) == 2
+                and isinstance(item[0], str)
+                and is_normalized_value(item[1])
+            )
+            or is_normalized_value(item)
+            for item in value
+        )
+    return False
+
+
+def require_normalized(value: object, owner: str, field_name: str) -> None:
+    if not is_normalized_value(value):
+        raise DomainInvariantError(
+            f"{owner}.{field_name} is not an immutable normalized value: "
+            f"{type(value).__name__!s}. Allowed: scalars, tz-aware datetimes, "
+            f"and (nested) tuples — never list/dict/set."
+        )
+
+
+def require_tz_aware(value: datetime, owner: str, field_name: str) -> None:
+    if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+        raise DomainInvariantError(
+            f"{owner}.{field_name} must be timezone-aware; got naive {value!r}"
+        )
+
+
+def require_unit_interval(value: float | Decimal, owner: str, field_name: str) -> None:
+    if not (0 <= value <= 1):
+        raise DomainInvariantError(
+            f"{owner}.{field_name} must be within [0, 1]; got {value!r}"
+        )
+
+
+def require_positive(value: int, owner: str, field_name: str) -> None:
+    if value < 1:
+        raise DomainInvariantError(
+            f"{owner}.{field_name} must be a positive integer; got {value!r}"
+        )

--- a/tests/domain/test_invariants.py
+++ b/tests/domain/test_invariants.py
@@ -1,0 +1,281 @@
+"""ASA-CORE-001A: primitive invariant enforcement tests.
+
+Exit criteria covered:
+- no domain entity can contain a mutable nested value
+- confidence/probability cannot fall outside [0, 1]
+- versions must be positive
+- all persisted timestamps must be timezone-aware
+- an Opportunity cannot carry an entirely empty comparison payload
+- every financial metric has an explicit unit and interpretation
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from domain import (
+    CanonicalFact,
+    Confidence,
+    DomainInvariantError,
+    EvidenceKind,
+    EvidenceReference,
+    ExpectedOutcomeMetrics,
+    GuardrailOutcome,
+    Indicator,
+    Observation,
+    Opportunity,
+    Provenance,
+    ProviderDisagreement,
+    RecommendationState,
+    is_normalized_value,
+)
+
+AWARE = datetime(2026, 7, 21, tzinfo=timezone.utc)
+NAIVE = datetime(2026, 7, 21)
+
+
+def _provenance(**overrides):
+    kwargs = dict(
+        contributing_observation_ids=("obs-1",),
+        contributing_provider_ids=("prov-a",),
+        selected_provider_id="prov-a",
+        disagreements=(),
+        reconciled_at=AWARE,
+    )
+    kwargs.update(overrides)
+    return Provenance(**kwargs)
+
+
+def _metrics(**overrides):
+    kwargs = dict(
+        expected_return=Decimal("0.10"),
+        maximum_loss=Decimal("-100"),
+        capital_required=Decimal("1000"),
+    )
+    kwargs.update(overrides)
+    return ExpectedOutcomeMetrics(**kwargs)
+
+
+def _observation(**overrides):
+    kwargs = dict(
+        observation_id="obs-1", observation_type="price", provider_id="prov-a",
+        value=100.0, effective_time=AWARE, recorded_time=AWARE,
+    )
+    kwargs.update(overrides)
+    return Observation(**kwargs)
+
+
+def _fact(**overrides):
+    kwargs = dict(
+        fact_id="fact-1", version=1, fact_type="price", value=100.0,
+        confidence=Confidence(score=0.9), provenance=_provenance(),
+        effective_time=AWARE, created_time=AWARE,
+    )
+    kwargs.update(overrides)
+    return CanonicalFact(**kwargs)
+
+
+def _indicator(**overrides):
+    kwargs = dict(
+        indicator_id="ind-1", version=1, logic_version="1.0.0", value=1.5,
+        computed_from=(), effective_time=AWARE, created_time=AWARE,
+    )
+    kwargs.update(overrides)
+    return Indicator(**kwargs)
+
+
+def _opportunity(**overrides):
+    kwargs = dict(
+        opportunity_id="opp-1", version=1,
+        strategy_id="strat-1", strategy_version="1.0.0",
+        supporting_indicators=(), evidence=(), assumptions=(),
+        evidence_confidence=Confidence(score=0.5),
+        expected_outcome_metrics=_metrics(),
+        state=RecommendationState.DISCOVERED,
+        effective_time=AWARE, created_time=AWARE,
+    )
+    kwargs.update(overrides)
+    return Opportunity(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Normalized value contract — no mutable nested values
+# ---------------------------------------------------------------------------
+
+class TestNormalizedValueContract:
+    @pytest.mark.parametrize("good", [
+        None, True, 1, 1.5, Decimal("1.5"), "text", AWARE,
+        (1, 2, 3),
+        (("bid", 1.0), ("ask", 1.1)),
+        ((("nested", (1, 2)),),),
+    ])
+    def test_accepts_normalized(self, good):
+        assert is_normalized_value(good)
+
+    @pytest.mark.parametrize("bad", [
+        [1, 2], {"a": 1}, {1, 2}, bytearray(b"x"), (1, [2]), (("k", [1]),), NAIVE,
+    ])
+    def test_rejects_mutable_or_naive(self, bad):
+        assert not is_normalized_value(bad)
+
+    def test_observation_rejects_mutable_value(self):
+        with pytest.raises(DomainInvariantError):
+            _observation(value=[1, 2, 3])
+
+    def test_observation_rejects_dict_value(self):
+        with pytest.raises(DomainInvariantError):
+            _observation(value={"price": 100})
+
+    def test_canonical_fact_rejects_mutable_value(self):
+        with pytest.raises(DomainInvariantError):
+            _fact(value={"resolved": 100})
+
+    def test_indicator_rejects_mutable_value(self):
+        with pytest.raises(DomainInvariantError):
+            _indicator(value=[1.5])
+
+    def test_disagreement_rejects_mutable_value(self):
+        with pytest.raises(DomainInvariantError):
+            ProviderDisagreement(provider_id="p", observation_id="o",
+                                 reported_value={"v": 1})
+
+    def test_nested_tuple_mapping_accepted(self):
+        obs = _observation(value=(("bid", Decimal("1.0")), ("ask", Decimal("1.1"))))
+        assert obs.value[0] == ("bid", Decimal("1.0"))
+
+
+# ---------------------------------------------------------------------------
+# Range invariants
+# ---------------------------------------------------------------------------
+
+class TestRangeInvariants:
+    @pytest.mark.parametrize("score", [-0.01, 1.01, 2.0])
+    def test_confidence_out_of_range_rejected(self, score):
+        with pytest.raises(DomainInvariantError):
+            Confidence(score=score)
+
+    @pytest.mark.parametrize("score", [0.0, 0.5, 1.0])
+    def test_confidence_in_range_accepted(self, score):
+        assert Confidence(score=score).score == score
+
+    @pytest.mark.parametrize("p", [Decimal("-0.1"), Decimal("1.1")])
+    def test_probability_out_of_range_rejected(self, p):
+        with pytest.raises(DomainInvariantError):
+            _metrics(probability_of_profit=p)
+
+    def test_probability_bounds_accepted(self):
+        assert _metrics(probability_of_profit=Decimal("0")).probability_of_profit == 0
+        assert _metrics(probability_of_profit=Decimal("1")).probability_of_profit == 1
+
+
+# ---------------------------------------------------------------------------
+# Version invariants
+# ---------------------------------------------------------------------------
+
+class TestVersionInvariants:
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_fact_version_must_be_positive(self, bad):
+        with pytest.raises(DomainInvariantError):
+            _fact(version=bad)
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_indicator_version_must_be_positive(self, bad):
+        with pytest.raises(DomainInvariantError):
+            _indicator(version=bad)
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_opportunity_version_must_be_positive(self, bad):
+        with pytest.raises(DomainInvariantError):
+            _opportunity(version=bad)
+
+    def test_evidence_reference_version_must_be_positive(self):
+        with pytest.raises(DomainInvariantError):
+            EvidenceReference(kind=EvidenceKind.CANONICAL_FACT,
+                              referenced_id="f", version=0)
+
+    def test_evidence_reference_none_version_allowed(self):
+        ref = EvidenceReference(kind=EvidenceKind.OBSERVATION, referenced_id="o")
+        assert ref.version is None
+
+
+# ---------------------------------------------------------------------------
+# Timezone-aware timestamps
+# ---------------------------------------------------------------------------
+
+class TestTimezoneInvariants:
+    def test_observation_rejects_naive_effective(self):
+        with pytest.raises(DomainInvariantError):
+            _observation(effective_time=NAIVE)
+
+    def test_observation_rejects_naive_recorded(self):
+        with pytest.raises(DomainInvariantError):
+            _observation(recorded_time=NAIVE)
+
+    def test_fact_rejects_naive_timestamps(self):
+        with pytest.raises(DomainInvariantError):
+            _fact(created_time=NAIVE)
+
+    def test_indicator_rejects_naive_timestamps(self):
+        with pytest.raises(DomainInvariantError):
+            _indicator(effective_time=NAIVE)
+
+    def test_opportunity_rejects_naive_timestamps(self):
+        with pytest.raises(DomainInvariantError):
+            _opportunity(created_time=NAIVE)
+
+    def test_provenance_rejects_naive_reconciled_at(self):
+        with pytest.raises(DomainInvariantError):
+            _provenance(reconciled_at=NAIVE)
+
+    def test_guardrail_outcome_rejects_naive_evaluated_at(self):
+        with pytest.raises(DomainInvariantError):
+            GuardrailOutcome(guardrail_id="g", guardrail_version="1", passed=True,
+                             reason="ok", evidence=(), evaluated_at=NAIVE)
+
+
+# ---------------------------------------------------------------------------
+# Expected Outcome Metrics: mandatory payload and unit semantics
+# ---------------------------------------------------------------------------
+
+class TestOutcomeMetricsContract:
+    @pytest.mark.parametrize("missing", ["expected_return", "maximum_loss", "capital_required"])
+    def test_mandatory_metrics_cannot_be_none(self, missing):
+        with pytest.raises(DomainInvariantError):
+            _metrics(**{missing: None})
+
+    def test_optional_metrics_default_to_none(self):
+        m = _metrics()
+        assert m.maximum_gain is None
+        assert m.probability_of_profit is None
+        assert m.time_horizon_days is None
+
+    def test_maximum_loss_must_be_non_positive(self):
+        with pytest.raises(DomainInvariantError):
+            _metrics(maximum_loss=Decimal("50"))
+
+    def test_zero_maximum_loss_allowed(self):
+        assert _metrics(maximum_loss=Decimal("0")).maximum_loss == 0
+
+    def test_capital_required_must_be_non_negative(self):
+        with pytest.raises(DomainInvariantError):
+            _metrics(capital_required=Decimal("-1"))
+
+    def test_maximum_gain_must_be_non_negative_when_present(self):
+        with pytest.raises(DomainInvariantError):
+            _metrics(maximum_gain=Decimal("-1"))
+
+    def test_time_horizon_must_be_positive_when_present(self):
+        with pytest.raises(DomainInvariantError):
+            _metrics(time_horizon_days=0)
+
+    def test_opportunity_cannot_have_empty_comparison_payload(self):
+        """Mandatory metrics guarantee a non-empty payload on every Opportunity."""
+        with pytest.raises(DomainInvariantError):
+            _opportunity(expected_outcome_metrics=ExpectedOutcomeMetrics(
+                expected_return=None, maximum_loss=None, capital_required=None))
+
+    def test_units_documented_in_docstring(self):
+        doc = ExpectedOutcomeMetrics.__doc__
+        assert "USD" in doc and "[0, 1]" in doc and "decimal fraction" in doc


### PR DESCRIPTION
## Summary

Implements ticket ASA-CORE-001A (P0), on top of merged ASA-CORE-001. Branched from `origin/main` at `06ae3d9`.

### Immutable normalized data-value contract
New `domain/values.py` defines what a domain `value` field may hold: scalars (`None`/`bool`/`int`/`float`/`Decimal`/`str`), timezone-aware `datetime`s, and nested tuples (including tuple-of-`(str, value)`-pairs as immutable mappings). Mutable containers (`list`/`dict`/`set`/`bytearray`) are rejected recursively. Enforced at construction on `Observation.value`, `CanonicalFact.value`, `Indicator.value`, and `ProviderDisagreement.reported_value` via `DomainInvariantError`.

### Expected Outcome Metrics — units, semantics, mandatory/optional
Fixed at the domain level per the amended ADR-003:
- **Mandatory**: `expected_return` (signed decimal fraction of capital, not annualized), `maximum_loss` (USD, non-positive), `capital_required` (USD, non-negative)
- **Optional** (None when not meaningful, never fabricated): `maximum_gain` (USD, ≥0), `probability_of_profit` ([0,1]), `time_horizon_days` (positive whole days)

Because the three mandatory metrics can never be None, an Opportunity structurally cannot carry an empty comparison payload.

### Primitive invariants (construction-time, all entities)
- `Confidence.score` and `probability_of_profit` confined to [0, 1]
- Versions must be positive (`CanonicalFact`, `Indicator`, `Opportunity`, `EvidenceReference` when present)
- Every persisted timestamp must be timezone-aware (`Observation`, `CanonicalFact`, `Indicator`, `Opportunity`, `Provenance.reconciled_at`, `GuardrailOutcome.evaluated_at`)

### CI
`validate-architecture.yml` now runs on pushes to `main` in addition to PRs.

### Documentation hygiene
- Obsolete `docs/architecture/decisions/` path comments corrected to `architecture/` across all 11 architecture documents, plus the README document-set table and its open-question entry
- Decision Log: the four stale `_pending_` rows (duplicates with incorrect ADR references) collapsed into one dated ADR-001 adoption row; new dated entry records the 001A domain-level decisions

### Tests
58 new invariant tests in `tests/domain/test_invariants.py`; **160 architecture+domain tests passing**. POS suite untouched.

### Constraints respected
No database, no provider implementation, no reconciliation algorithm, no strategy implementation, no API or UI.

## Exit criteria
- [x] No domain entity can contain a mutable nested value (recursive contract, enforced + tested)
- [x] Every financial metric has an explicit unit and interpretation (docstring contract + range enforcement)
- [x] An Opportunity cannot contain an entirely empty comparison payload (mandatory metrics)
- [x] Confidence and probability values cannot fall outside their legal ranges
- [x] Versions must be positive
- [x] All persisted timestamps must be timezone-aware
- [x] Architecture checks run on both PRs and main-branch pushes

---
_Generated by [Claude Code](https://claude.ai/code/session_0171U6QSQe39nnsDLYLbmbG1)_