### PR TITLE
ASA-CORE-003: Canonical Fact Engine

### DIFF
--- a/.github/workflows/validate-architecture.yml
+++ b/.github/workflows/validate-architecture.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'providers/**'
       - 'observation/**'
+      - 'reconciliation/**'
       - 'facts/**'
       - 'indicators/**'
       - 'strategies/**'
@@ -19,6 +20,8 @@ on:
       - 'tests/domain/**'
       - 'tests/observation/**'
       - 'tests/providers/**'
+      - 'tests/reconciliation/**'
+      - 'tests/facts/**'
   workflow_dispatch:
 
 jobs:
@@ -38,8 +41,8 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install pytest
 
-      - name: Run architecture, domain, observation, and provider tests
-        run: python -m pytest tests/architecture tests/domain tests/observation tests/providers -v
+      - name: Run architecture, domain, observation, provider, reconciliation, and facts tests
+        run: python -m pytest tests/architecture tests/domain tests/observation tests/providers tests/reconciliation tests/facts -v
 
 # Mechanical checks only. A passing workflow does NOT constitute approval,
 # merge authorization, or deployment authorization.

--- a/architecture/ADR-004-repository-organization.md
+++ b/architecture/ADR-004-repository-organization.md
@@ -17,7 +17,8 @@ The repository is organized into one top-level module per pipeline layer, plus o
 
 - `providers/` — Provider adapters (ADR-002). Owns all Provider-specific fetching, normalization, and retry logic.
 - `observation/` — Observation Layer. Owns Observation storage and identity (ADR-001).
-- `facts/` — Canonical Fact Layer. Owns reconciliation and Canonical Fact versioning (ADR-001).
+- `reconciliation/` — sits within the Canonical Fact Layer's pipeline position, immediately after `observation/` and before `facts/` (see Revision note, ASA-CORE-003). Owns pure, deterministic Observation-to-Canonical-Fact reconciliation logic — grouping, value resolution, disagreement detection, confidence, and fact identity (ADR-001). No repository access, no I/O.
+- `facts/` — Canonical Fact Layer. Owns Canonical Fact storage and versioning orchestration, depending on `reconciliation/` for the reconciliation logic itself (ADR-001).
 - `indicators/` — Derived Indicator Layer. Owns shared, reusable indicator calculations.
 - `strategies/` — Strategy Layer, including a `capabilities/` sub-package for the Capability concept defined in `DOMAIN_GLOSSARY.md`. Owns deterministic Strategy evaluation and Opportunity production (ADR-003).
 - `guardrails/` — Guardrail Layer. Owns platform-wide risk and eligibility rules, shared across all Strategies (Constitution Law 8).
@@ -28,7 +29,7 @@ The repository is organized into one top-level module per pipeline layer, plus o
 **Dependency direction** is strictly one-way and mirrors the Vision's pipeline order:
 
 ```
-providers → observation → facts → indicators → strategies → guardrails → ranking → presentation
+providers → observation → reconciliation → facts → indicators → strategies → guardrails → ranking → presentation
 ```
 
 Each module may depend on itself, on `domain/`, and on any module strictly below it in this order. No module may depend on a module above it. `presentation/` may be depended on by nothing — it is the terminal layer. This directly operationalizes `ARCHITECTURE_VISION.md`'s Open Question about Ranking-versus-Guardrail dependency direction: Ranking depends on Guardrail output; Guardrail never depends on Ranking.
@@ -64,6 +65,8 @@ Each module may depend on itself, on `domain/`, and on any module strictly below
 `ARCHITECTURE_VISION.md`'s Open Questions section currently asks whether Ranking ever depends on Guardrail output only, or whether the reverse is possible. This ADR settles it: the dependency is strictly one-way, Ranking depends on Guardrail, never the reverse. Recommend removing that Open Question from `ARCHITECTURE_VISION.md` and replacing it with a reference to this ADR.
 
 **Revision note (post-review):** this ADR originally permitted `presentation/` to depend on any module below it, which directly contradicted ADR-003's constraint that the Presentation Layer never has independent access to raw Evidence sources. That contradiction is fixed above by narrowing `presentation/`'s allowed dependencies to `ranking/` and `domain/` only. This ADR also originally asserted a settled Architect/Founder approval hierarchy for repository-organization decisions; that assertion has been walked back to an explicitly flagged assumption, since no other reviewed document establishes such a hierarchy — see Open Questions.
+
+**Revision note (ASA-CORE-003):** this ADR originally assigned reconciliation logic and Canonical Fact versioning to a single `facts/` module. Implementing the reconciliation engine surfaced a reason to split them: reconciliation is a pure, deterministic function of an Observation set (no repository access, fully replayable), while Canonical Fact storage and version-sequence enforcement inherently require repository state. Splitting them keeps `reconciliation/`'s replayability guarantee structurally enforceable (it cannot accidentally acquire a repository dependency) and keeps `facts/`'s storage concerns from leaking into what should be a pure function. `reconciliation/` is added at the Canonical Fact Layer's pipeline position — before `facts/`, which now depends on it — rather than as a new, separately-ranked layer; this is a decomposition of the existing Canonical Fact Layer, not a new pipeline stage.
 
 ## References
 

--- a/architecture/DECISION_LOG.md
+++ b/architecture/DECISION_LOG.md
@@ -8,6 +8,7 @@ Do not add substantive reasoning to this file. If an entry needs more than two s
 
 | Date | Summary | ADR |
 |---|---|---|
+| 2026-07-21 | `reconciliation/` split out of `facts/` as a pure, repository-free module at the Canonical Fact Layer's pipeline position; `facts/` now depends on it for storage/versioning orchestration. | ADR-004 (amended, ASA-CORE-003) |
 | 2026-07-21 | Expected Outcome Metrics units fixed at the domain level (decimal-fraction return, USD amounts, [0,1] probability); expected_return, maximum_loss, and capital_required are mandatory. Domain primitives enforce normalized immutable values, legal ranges, positive versions, and timezone-aware timestamps. | ADR-003 (domain level, ASA-CORE-001A) |
 | 2026-07-21 | "Strategy confidence" is removed and replaced by Expected Outcome Metrics — standardized, objective financial characteristics every Strategy must produce; Ranking compares Opportunities using these common metrics. | ADR-003 (amended) |
 | 2026-07-21 | Reconciliation confidence is clarified as an internal attribute; Provenance is elevated to a first-class externally visible concept with a binding drill-down requirement (contributing providers, selected provider, disagreements, timestamps, reconciliation metadata). | ADR-001 (amended) |

--- a/facts/__init__.py
+++ b/facts/__init__.py
@@ -1,5 +1,23 @@
 """Canonical Fact Layer (ADR-001).
 
-Owns reconciliation and Canonical Fact versioning.
-May depend on: facts, observation, providers, domain (ADR-004).
+Owns Canonical Fact storage and versioning orchestration; deterministic
+reconciliation logic itself lives in ``reconciliation/`` (ASA-CORE-003).
+May depend on: facts, reconciliation, observation, providers, domain (ADR-004).
 """
+from facts.errors import (
+    DuplicateFactError,
+    FactIdentityCollisionError,
+    FactNotFoundError,
+    FactRepositoryError,
+    NonMonotonicVersionError,
+)
+from facts.repository import InMemoryCanonicalFactRepository
+
+__all__ = [
+    "DuplicateFactError",
+    "FactIdentityCollisionError",
+    "FactNotFoundError",
+    "FactRepositoryError",
+    "InMemoryCanonicalFactRepository",
+    "NonMonotonicVersionError",
+]

--- a/facts/errors.py
+++ b/facts/errors.py
@@ -1,0 +1,61 @@
+"""Canonical Fact repository errors (ASA-CORE-003)."""
+from __future__ import annotations
+
+
+class FactRepositoryError(Exception):
+    """Base error for Canonical Fact repository operations."""
+
+
+class DuplicateFactError(FactRepositoryError):
+    """The exact same Canonical Fact record was appended twice."""
+
+    def __init__(self, fact_id: str, version: int) -> None:
+        super().__init__(
+            f"duplicate canonical fact append rejected: {fact_id} v{version}"
+        )
+        self.fact_id = fact_id
+        self.version = version
+
+
+class FactIdentityCollisionError(FactRepositoryError):
+    """A different record was appended under an already-stored fact_id.
+
+    The original record is preserved; the colliding record is rejected.
+    """
+
+    def __init__(self, fact_id: str) -> None:
+        super().__init__(
+            f"canonical fact identity collision rejected: a different "
+            f"record is already stored under {fact_id}; original preserved"
+        )
+        self.fact_id = fact_id
+
+
+class NonMonotonicVersionError(FactRepositoryError):
+    """An appended fact's version does not extend its group's history by exactly one.
+
+    Enforces monotonic versioning as a repository-level invariant, in
+    addition to ``reconciliation.engine.reconcile``'s own version
+    computation — defense in depth against a caller appending out of
+    sequence or from stale state.
+    """
+
+    def __init__(self, fact_type: str, effective_time: object,
+                expected_version: int, got_version: int) -> None:
+        super().__init__(
+            f"non-monotonic version for ({fact_type!r}, {effective_time!r}): "
+            f"expected version {expected_version}, got {got_version}"
+        )
+        self.fact_type = fact_type
+        self.effective_time = effective_time
+        self.expected_version = expected_version
+        self.got_version = got_version
+
+
+class FactNotFoundError(FactRepositoryError):
+    """No Canonical Fact is stored for the requested group."""
+
+    def __init__(self, fact_type: str, effective_time: object) -> None:
+        super().__init__(f"no canonical fact found for ({fact_type!r}, {effective_time!r})")
+        self.fact_type = fact_type
+        self.effective_time = effective_time

--- a/facts/repository.py
+++ b/facts/repository.py
@@ -1,0 +1,97 @@
+"""In-memory, append-only Canonical Fact repository (ASA-CORE-003).
+
+Immutable version history per ``(fact_type, effective_time)`` group (the
+v1 grouping key — see ``reconciliation/rules.py``): append-only, no update,
+no delete, no mutation of stored records. Query results are tuples of the
+stored (frozen) CanonicalFact objects, so no returned collection can
+mutate repository state.
+
+Versioning is enforced here as a repository-level invariant — in addition
+to ``reconciliation.engine.reconcile``'s own version computation — so an
+out-of-sequence or stale-state append fails loudly (``NonMonotonicVersionError``)
+rather than corrupting version history.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from domain.canonical_fact import CanonicalFact
+from domain.observation import Observation
+from facts.errors import (
+    DuplicateFactError,
+    FactIdentityCollisionError,
+    FactNotFoundError,
+    NonMonotonicVersionError,
+)
+from reconciliation.engine import reconcile
+from reconciliation.rules import FactGroupKey, require_single_group
+
+
+class InMemoryCanonicalFactRepository:
+    """Append-only in-memory Canonical Fact store with monotonic versioning."""
+
+    def __init__(self) -> None:
+        self._groups: dict[FactGroupKey, list[CanonicalFact]] = {}
+        self._by_id: dict[str, CanonicalFact] = {}
+        self._all: list[CanonicalFact] = []
+
+    def append(self, fact: CanonicalFact) -> None:
+        existing = self._by_id.get(fact.fact_id)
+        if existing is not None:
+            if existing == fact:
+                raise DuplicateFactError(fact.fact_id, fact.version)
+            raise FactIdentityCollisionError(fact.fact_id)
+
+        key: FactGroupKey = (fact.fact_type, fact.effective_time)
+        history = self._groups.setdefault(key, [])
+        expected_version = 1 if not history else history[-1].version + 1
+        if fact.version != expected_version:
+            raise NonMonotonicVersionError(
+                fact.fact_type, fact.effective_time, expected_version, fact.version
+            )
+
+        history.append(fact)
+        self._by_id[fact.fact_id] = fact
+        self._all.append(fact)
+
+    def latest(self, fact_type: str, effective_time: datetime) -> CanonicalFact:
+        history = self._groups.get((fact_type, effective_time))
+        if not history:
+            raise FactNotFoundError(fact_type, effective_time)
+        return history[-1]
+
+    def history(self, fact_type: str, effective_time: datetime) -> tuple[CanonicalFact, ...]:
+        """Version-ordered (oldest first) history for one group; empty if none."""
+        return tuple(self._groups.get((fact_type, effective_time), ()))
+
+    def by_type(self, fact_type: str) -> tuple[CanonicalFact, ...]:
+        return tuple(fact for fact in self._all if fact.fact_type == fact_type)
+
+    def by_effective_time(self, effective_time: datetime) -> tuple[CanonicalFact, ...]:
+        return tuple(fact for fact in self._all if fact.effective_time == effective_time)
+
+    def reconcile_and_append(
+        self,
+        observations: tuple[Observation, ...],
+        reconciled_at: datetime,
+    ) -> CanonicalFact | None:
+        """Reconcile one group and append the result if it is a new version.
+
+        Convenience orchestration: looks up this group's latest known
+        version, reconciles against it, and appends only when reconciling
+        produces a new version. Returns the appended fact, or ``None`` if
+        the reconciliation was an idempotent replay (no new version).
+        """
+        require_single_group(observations)  # raises before any indexing on empty input
+        fact_type = observations[0].observation_type
+        effective_time = observations[0].effective_time
+        try:
+            previous = self.latest(fact_type, effective_time)
+        except FactNotFoundError:
+            previous = None
+
+        fact, is_new_version = reconcile(observations, reconciled_at, previous_fact=previous)
+        if not is_new_version:
+            return None
+        self.append(fact)
+        return fact

--- a/reconciliation/__init__.py
+++ b/reconciliation/__init__.py
@@ -1,0 +1,37 @@
+"""Reconciliation module (ASA-CORE-003).
+
+Owns deterministic Observation-to-Canonical-Fact reconciliation: grouping,
+value resolution, disagreement detection, confidence, and fact identity.
+Pure — no repository access, no I/O, no randomness, no machine learning, no
+provider weighting (see ``reconciliation/rules.py`` for the documented v1
+policy). ``facts/`` owns storage/versioning orchestration and depends on
+this module; this module never depends on ``facts/``.
+
+Pipeline position (ADR-004, amended by ASA-CORE-003): sits between
+``observation/`` and ``facts/`` — may depend on reconciliation, observation,
+providers, and domain; nothing above may import this module except facts/
+and layers already permitted to depend on facts/.
+"""
+from reconciliation.engine import reconcile
+from reconciliation.errors import (
+    EmptyObservationGroupError,
+    InconsistentGroupError,
+    ReconciliationError,
+)
+from reconciliation.rules import (
+    FACT_IDENTITY_NAMESPACE,
+    FACT_IDENTITY_VERSION,
+    fact_identity,
+    group_by_fact_identity,
+)
+
+__all__ = [
+    "EmptyObservationGroupError",
+    "FACT_IDENTITY_NAMESPACE",
+    "FACT_IDENTITY_VERSION",
+    "InconsistentGroupError",
+    "ReconciliationError",
+    "fact_identity",
+    "group_by_fact_identity",
+    "reconcile",
+]

--- a/reconciliation/engine.py
+++ b/reconciliation/engine.py
@@ -1,0 +1,112 @@
+"""Deterministic reconciliation engine (ASA-CORE-003).
+
+Pure orchestration over ``reconciliation/rules.py``: given one group's
+Observations (all sharing ``fact_type`` and ``effective_time`` — see
+``rules.py`` module docstring for the v1 grouping key), produces the next
+immutable ``CanonicalFact`` version. No I/O, no repository access, no
+randomness, no machine learning, no provider weighting — a total,
+deterministic function of its arguments, making reconciliation fully
+replayable.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from domain.canonical_fact import CanonicalFact
+from domain.provenance import Provenance
+from domain.references import Confidence
+from domain.values import require_tz_aware
+from observation.canonicalization import canonicalize_value
+from reconciliation.errors import InconsistentGroupError
+from reconciliation.rules import (
+    require_single_group,
+    compute_confidence,
+    fact_identity,
+    resolve_value,
+)
+from domain.observation import Observation
+
+
+def reconcile(
+    observations: tuple[Observation, ...],
+    reconciled_at: datetime,
+    previous_fact: CanonicalFact | None = None,
+) -> tuple[CanonicalFact, bool]:
+    """Reconcile one group's Observations into a Canonical Fact.
+
+    ``previous_fact`` is the latest known version for this group (``None``
+    if this is the first reconciliation). Version assignment: ``1`` if no
+    previous fact; ``previous_fact.version`` (unchanged) if the resolved
+    canonical value equals ``previous_fact``'s value (idempotent replay —
+    no new version); ``previous_fact.version + 1`` otherwise.
+
+    Returns ``(fact, is_new_version)``. When ``is_new_version`` is False,
+    ``fact`` is byte-identical to ``previous_fact`` in every field except
+    possibly ``provenance``/``confidence`` (new corroborating evidence can
+    arrive without changing the resolved value); callers that only care
+    about the stored version history should not append in that case.
+
+    Raises ``InconsistentGroupError`` if ``previous_fact`` belongs to a
+    different (fact_type, effective_time) group than ``observations``.
+    """
+    require_single_group(observations)
+    require_tz_aware(reconciled_at, "reconcile", "reconciled_at")
+
+    fact_type = observations[0].observation_type
+    effective_time = observations[0].effective_time
+
+    if previous_fact is not None:
+        if previous_fact.fact_type != fact_type:
+            raise InconsistentGroupError(
+                f"previous_fact.fact_type {previous_fact.fact_type!r} does not "
+                f"match observation group's fact_type {fact_type!r}"
+            )
+        if previous_fact.effective_time != effective_time:
+            raise InconsistentGroupError(
+                f"previous_fact.effective_time {previous_fact.effective_time!r} does "
+                f"not match observation group's effective_time {effective_time!r}"
+            )
+
+    selected_value, disagreements, selected_provider_id = resolve_value(observations)
+
+    contributing_observation_ids = tuple(
+        sorted(obs.observation_id for obs in observations)
+    )
+    contributing_provider_ids = tuple(
+        sorted({obs.provider_id for obs in observations})
+    )
+    selected_provider_ids = frozenset(
+        obs.provider_id for obs in observations
+        if canonicalize_value(obs.value) == selected_value
+    )
+
+    is_new_version = (
+        previous_fact is None
+        or canonicalize_value(previous_fact.value) != selected_value
+    )
+
+    if not is_new_version:
+        return previous_fact, False
+
+    version = 1 if previous_fact is None else previous_fact.version + 1
+    confidence_score = compute_confidence(observations, selected_provider_ids)
+
+    provenance = Provenance(
+        contributing_observation_ids=contributing_observation_ids,
+        contributing_provider_ids=contributing_provider_ids,
+        selected_provider_id=selected_provider_id,
+        disagreements=disagreements,
+        reconciled_at=reconciled_at,
+    )
+
+    fact = CanonicalFact(
+        fact_id=fact_identity(fact_type, effective_time, selected_value),
+        version=version,
+        fact_type=fact_type,
+        value=selected_value,
+        confidence=Confidence(score=confidence_score),
+        provenance=provenance,
+        effective_time=effective_time,
+        created_time=reconciled_at,
+    )
+    return fact, True

--- a/reconciliation/errors.py
+++ b/reconciliation/errors.py
@@ -1,0 +1,26 @@
+"""Reconciliation errors (ASA-CORE-003)."""
+from __future__ import annotations
+
+
+class ReconciliationError(Exception):
+    """Base error for reconciliation operations."""
+
+
+class InconsistentGroupError(ReconciliationError):
+    """Observations passed to reconcile() do not share fact_type/effective_time.
+
+    The reconciliation engine reconciles exactly one (fact_type,
+    effective_time) group at a time (ASA-CORE-003 v1 grouping — see
+    ``reconciliation/rules.py`` module docstring); mixed-group input is a
+    caller error, not something the engine silently repairs.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+class EmptyObservationGroupError(ReconciliationError):
+    """reconcile() was called with zero observations."""
+
+    def __init__(self) -> None:
+        super().__init__("reconcile() requires at least one observation")

--- a/reconciliation/rules.py
+++ b/reconciliation/rules.py
@@ -1,0 +1,187 @@
+"""Deterministic reconciliation rules (ASA-CORE-003).
+
+Pure functions only — no I/O, no repository access, no randomness, no
+machine learning, no provider weighting. Every function here is a total,
+deterministic function of its explicit arguments, so ``reconciliation/``
+can be replayed byte-identically given the same Observation set.
+
+**v1 grouping key.** A Canonical Fact "group" — the set of Observations
+reconciled together into successive versions of one logical fact — is
+identified by ``(fact_type, effective_time)`` alone. Observation carries no
+separate subject/instrument identifier field (ASA-CORE-002); this is a
+documented, tested v1 simplification, not an oversight. It means two
+different real-world subjects sharing a ``fact_type`` at the same
+``effective_time`` (e.g. two different symbols' market prices at the same
+instant) are not currently disambiguated. Tracked as a non-blocking
+follow-up (see PR for the linked GitHub Issue) — out of scope to resolve
+here since the only current provider (ASA-CORE-002's synthetic provider)
+and this ticket's test fixtures are single-subject.
+
+**v1 reconciliation policy — unweighted agreement, no provider priority.**
+ADR-001 describes reconciliation as "provider priority combined with a
+confidence input." This ticket explicitly prohibits provider weighting, and
+the ``Provider`` domain object (ASA-CORE-001) carries no priority field to
+weight by. v1 therefore resolves disagreement by **provider agreement
+count** — the canonical value supported by the most distinct providers
+wins; ties break on the lexicographically smallest canonical serialized
+value, never on provider identity. This is fully deterministic, treats
+every provider identically (no weighting), and makes Confidence and
+Provenance functionally meaningful (ADR-001's Alternative 3 concern),
+though it does not yet implement ADR-001's provider-priority tiebreak.
+Tracked as a non-blocking follow-up pending a Provider-priority
+configuration mechanism, which does not exist yet.
+"""
+from __future__ import annotations
+
+import hashlib
+from collections import defaultdict
+from datetime import datetime
+
+from domain.observation import Observation
+from domain.provenance import ProviderDisagreement
+from domain.values import require_tz_aware
+from observation.canonicalization import canonicalize_value, serialize_canonical
+from reconciliation.errors import EmptyObservationGroupError, InconsistentGroupError
+
+FACT_IDENTITY_NAMESPACE = "asa.canonical_fact"
+FACT_IDENTITY_VERSION = "v1"
+
+FactGroupKey = tuple[str, datetime]
+
+
+def group_by_fact_identity(
+    observations: tuple[Observation, ...],
+) -> dict[FactGroupKey, tuple[Observation, ...]]:
+    """Group Observations by ``(fact_type, effective_time)`` (v1 key).
+
+    Grouping is independent of input order: two calls with the same
+    Observations in different orders produce groups with identical
+    membership (though tuple order within a group follows input order,
+    which downstream rules treat as insignificant — see
+    ``resolve_value``'s and ``build_provenance``'s deterministic sorting).
+    """
+    groups: dict[FactGroupKey, list[Observation]] = defaultdict(list)
+    for obs in observations:
+        key = (obs.observation_type, obs.effective_time)
+        groups[key].append(obs)
+    return {key: tuple(members) for key, members in groups.items()}
+
+
+def require_single_group(observations: tuple[Observation, ...]) -> None:
+    if not observations:
+        raise EmptyObservationGroupError()
+    fact_type = observations[0].observation_type
+    effective_time = observations[0].effective_time
+    for obs in observations[1:]:
+        if obs.observation_type != fact_type:
+            raise InconsistentGroupError(
+                f"mixed observation_type in reconciliation group: "
+                f"{fact_type!r} vs {obs.observation_type!r}"
+            )
+        if obs.effective_time != effective_time:
+            raise InconsistentGroupError(
+                f"mixed effective_time in reconciliation group: "
+                f"{effective_time!r} vs {obs.effective_time!r}"
+            )
+
+
+def resolve_value(
+    observations: tuple[Observation, ...],
+) -> tuple[object, tuple[ProviderDisagreement, ...], str]:
+    """Resolve one group's Observations to a value (v1 policy, see module doc).
+
+    Returns ``(selected_canonical_value, disagreements, selected_provider_id)``.
+    ``disagreements`` preserves every Observation whose canonical value
+    differs from the selected value — never discarded. Deterministic and
+    independent of input order.
+    """
+    require_single_group(observations)
+
+    # canonical serialized form -> (canonical value, set of distinct provider_ids, observations)
+    by_value: dict[str, tuple[object, set[str], list[Observation]]] = {}
+    for obs in observations:
+        canonical = canonicalize_value(obs.value)
+        key = serialize_canonical(canonical)
+        if key not in by_value:
+            by_value[key] = (canonical, set(), [])
+        by_value[key][1].add(obs.provider_id)
+        by_value[key][2].append(obs)
+
+    # Winner: most distinct supporting providers; tie-break on canonical
+    # serialized value (deterministic, content-based — never provider identity).
+    winning_key = max(
+        by_value.keys(),
+        key=lambda k: (len(by_value[k][1]), k),
+    )
+    selected_value = by_value[winning_key][0]
+
+    supporting_provider_ids = sorted(by_value[winning_key][1])
+    selected_provider_id = supporting_provider_ids[0]
+
+    disagreements: list[ProviderDisagreement] = []
+    for key, (_, _, obs_list) in by_value.items():
+        if key == winning_key:
+            continue
+        for obs in obs_list:
+            disagreements.append(
+                ProviderDisagreement(
+                    provider_id=obs.provider_id,
+                    observation_id=obs.observation_id,
+                    reported_value=obs.value,
+                )
+            )
+    disagreements.sort(key=lambda d: (d.provider_id, d.observation_id))
+
+    return selected_value, tuple(disagreements), selected_provider_id
+
+
+def compute_confidence(
+    observations: tuple[Observation, ...],
+    selected_provider_ids: frozenset[str],
+) -> float:
+    """Deterministic reconciliation confidence in [0, 1] (v1 formula).
+
+    ``agreement_ratio`` — fraction of distinct contributing providers that
+    support the selected value. ``corroboration_factor`` — 0.5 for a
+    single supporting provider, 1.0 for two or more (multiple independent
+    providers agreeing raises confidence; a single-provider Observation
+    set lowers it, per ADR-001). This is an explicit, documented v1
+    formula; ADR-001 itself defers the exact formula to a future
+    engineering document, so no further design ADR is required for this
+    choice specifically (see module docstring for the two items that are
+    tracked as follow-ups).
+    """
+    all_provider_ids = {obs.provider_id for obs in observations}
+    agreement_ratio = len(selected_provider_ids) / len(all_provider_ids)
+    corroboration_factor = 1.0 if len(selected_provider_ids) >= 2 else 0.5
+    return agreement_ratio * corroboration_factor
+
+
+def fact_identity(fact_type: str, effective_time: datetime, value: object) -> str:
+    """Deterministic, versioned Canonical Fact identity (algorithm v1).
+
+    Inputs: fact_type, canonical normalized value, effective_time — per
+    ticket spec. sha256 over type-tagged, length-prefixed serialization,
+    mirroring ``observation.identity.observation_identity``'s algorithm
+    style under a distinct namespace. No UUIDs, no sequence numbers, no
+    insertion time, no randomness.
+
+    Note (documented limitation — see module docstring / PR issue list):
+    because inputs are exactly the three above, two reconciliations of the
+    same group that resolve to the same value produce the same identity
+    even if they occur at different versions (e.g. a value that changes
+    and later reverts). ``facts/repository.py`` treats a same-identity,
+    different-content append as an explicit collision error rather than
+    silently corrupting state — fails closed, never silent.
+    """
+    require_tz_aware(effective_time, "fact_identity", "effective_time")
+    payload = "\n".join(
+        (
+            FACT_IDENTITY_NAMESPACE,
+            FACT_IDENTITY_VERSION,
+            serialize_canonical(fact_type),
+            serialize_canonical(effective_time),
+            serialize_canonical(value),
+        )
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/tests/architecture/test_dependency_boundaries.py
+++ b/tests/architecture/test_dependency_boundaries.py
@@ -3,12 +3,16 @@
 Scans every Python file in each layer package with the AST module and asserts
 that no module imports a module above it in the pipeline order:
 
-    providers -> observation -> facts -> indicators -> strategies
-        -> guardrails -> ranking -> presentation
+    providers -> observation -> reconciliation -> facts -> indicators
+        -> strategies -> guardrails -> ranking -> presentation
 
 Each module may import itself, `domain`, and modules strictly below it.
 `presentation` is narrower: only `ranking` and `domain` (ADR-004 revision).
-`domain` imports nothing but itself.
+`domain` imports nothing but itself. `reconciliation` occupies the Canonical
+Fact Layer's pipeline position alongside `facts` (ADR-004 revision,
+ASA-CORE-003): `facts/` owns storage/versioning orchestration and depends on
+`reconciliation/`'s pure, repository-free reconciliation logic; nothing in
+`reconciliation/` depends on `facts/`.
 """
 from __future__ import annotations
 
@@ -22,6 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PIPELINE_ORDER = [
     "providers",
     "observation",
+    "reconciliation",
     "facts",
     "indicators",
     "strategies",

--- a/tests/architecture/test_reconciliation_boundaries.py
+++ b/tests/architecture/test_reconciliation_boundaries.py
@@ -1,0 +1,114 @@
+"""ASA-CORE-003: reconciliation-specific architecture validation.
+
+Codifies the ticket's explicit architecture_validation clauses beyond the
+general AST-based boundary sweep in test_dependency_boundaries.py.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+FORBIDDEN_INFRASTRUCTURE_MODULES = {
+    "sqlite3", "psycopg2", "sqlalchemy", "asyncio", "threading",
+    "multiprocessing", "socket", "http", "urllib", "requests",
+    "random", "secrets",
+}
+
+STDLIB_ALLOWED = {"__future__", "datetime", "hashlib", "collections", "typing", "decimal"}
+
+
+def _imported_roots(py_file: Path) -> set[str]:
+    tree = ast.parse(py_file.read_text())
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots |= {a.name.split(".")[0] for a in node.names}
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            roots.add(node.module.split(".")[0])
+    return roots
+
+
+class TestReconciliationImportScope:
+    """reconciliation/ imports only domain, observation, reconciliation."""
+
+    @pytest.mark.parametrize("py_file", sorted((REPO_ROOT / "reconciliation").glob("*.py")))
+    def test_only_allowed_roots(self, py_file):
+        allowed = {"domain", "observation", "reconciliation"} | STDLIB_ALLOWED
+        imported = _imported_roots(py_file)
+        assert imported <= allowed, (
+            f"{py_file.name} imports outside {allowed}: {imported - allowed}"
+        )
+
+    @pytest.mark.parametrize("py_file", sorted((REPO_ROOT / "reconciliation").glob("*.py")))
+    def test_no_strategy_or_ranking_imports(self, py_file):
+        imported = _imported_roots(py_file)
+        assert "strategies" not in imported
+        assert "ranking" not in imported
+        assert "guardrails" not in imported
+
+    @pytest.mark.parametrize("py_file", sorted((REPO_ROOT / "reconciliation").glob("*.py")))
+    def test_no_provider_package_import(self, py_file):
+        """reconciliation may reference provider_id strings but not import providers/."""
+        imported = _imported_roots(py_file)
+        assert "providers" not in imported
+
+    @pytest.mark.parametrize("py_file", sorted((REPO_ROOT / "reconciliation").glob("*.py")))
+    def test_no_infrastructure_dependencies(self, py_file):
+        imported = _imported_roots(py_file)
+        assert not (imported & FORBIDDEN_INFRASTRUCTURE_MODULES), (
+            f"{py_file.name} imports infrastructure module(s): "
+            f"{imported & FORBIDDEN_INFRASTRUCTURE_MODULES}"
+        )
+
+    @pytest.mark.parametrize("py_file", sorted((REPO_ROOT / "reconciliation").glob("*.py")))
+    def test_no_facts_import(self, py_file):
+        """reconciliation must never depend on facts/ (facts depends on it, not vice versa)."""
+        imported = _imported_roots(py_file)
+        assert "facts" not in imported
+
+
+class TestFactsImportScope:
+    @pytest.mark.parametrize("py_file", sorted((REPO_ROOT / "facts").glob("*.py")))
+    def test_no_infrastructure_dependencies(self, py_file):
+        imported = _imported_roots(py_file)
+        assert not (imported & FORBIDDEN_INFRASTRUCTURE_MODULES), (
+            f"{py_file.name} imports infrastructure module(s): "
+            f"{imported & FORBIDDEN_INFRASTRUCTURE_MODULES}"
+        )
+
+    @pytest.mark.parametrize("py_file", sorted((REPO_ROOT / "facts").glob("*.py")))
+    def test_no_strategy_ranking_or_provider_imports(self, py_file):
+        imported = _imported_roots(py_file)
+        assert not (imported & {"strategies", "ranking", "guardrails", "providers"})
+
+
+class TestNoReconciliationProhibitedTechniques:
+    """Ticket's reconciliation_engine.prohibited: ML, heuristics-as-libraries,
+    randomness, provider weighting configuration, external APIs."""
+
+    def test_no_ml_libraries_imported(self):
+        forbidden = {"sklearn", "torch", "tensorflow", "numpy", "scipy", "pandas"}
+        for py_file in (REPO_ROOT / "reconciliation").glob("*.py"):
+            imported = _imported_roots(py_file)
+            assert not (imported & forbidden), f"{py_file.name} imports ML library"
+
+    def test_no_random_or_uuid_usage(self):
+        for py_file in (REPO_ROOT / "reconciliation").glob("*.py"):
+            imported = _imported_roots(py_file)
+            assert "random" not in imported
+            assert "uuid" not in imported
+
+    def test_no_network_calls(self):
+        forbidden = {"socket", "http", "urllib", "requests", "aiohttp"}
+        for py_file in (REPO_ROOT / "reconciliation").glob("*.py"):
+            imported = _imported_roots(py_file)
+            assert not (imported & forbidden)
+
+    def test_no_provider_priority_attribute_on_domain_provider(self):
+        """Provider weighting is prohibited and has no field to weight by (ASA-CORE-001)."""
+        content = (REPO_ROOT / "domain" / "provider.py").read_text()
+        assert "priority" not in content.lower()

--- a/tests/architecture/test_scaffold.py
+++ b/tests/architecture/test_scaffold.py
@@ -10,6 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ADR_004_PACKAGES = [
     "providers",
     "observation",
+    "reconciliation",
     "facts",
     "indicators",
     "strategies",

--- a/tests/facts/test_fact_repository.py
+++ b/tests/facts/test_fact_repository.py
@@ -1,0 +1,187 @@
+"""ASA-CORE-003: Canonical Fact repository tests."""
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from domain.canonical_fact import CanonicalFact
+from domain.observation import Observation
+from domain.provenance import Provenance
+from domain.references import Confidence
+from facts.errors import (
+    DuplicateFactError,
+    FactIdentityCollisionError,
+    FactNotFoundError,
+    NonMonotonicVersionError,
+)
+from facts.repository import InMemoryCanonicalFactRepository
+
+T = datetime(2026, 7, 21, 14, 30, tzinfo=timezone.utc)
+T2 = datetime(2026, 7, 21, 15, 0, tzinfo=timezone.utc)
+RT = datetime(2026, 7, 21, 14, 31, tzinfo=timezone.utc)
+
+V1 = (("currency", "USD"), ("price", Decimal("201.55")), ("symbol", "AAPL"))
+V2 = (("currency", "USD"), ("price", Decimal("201.60")), ("symbol", "AAPL"))
+
+
+def _obs(oid: str, provider: str, value: object, effective_time: datetime = T,
+         otype: str = "market_price") -> Observation:
+    return Observation(observation_id=oid, observation_type=otype,
+                       provider_id=provider, value=value,
+                       effective_time=effective_time, recorded_time=RT)
+
+
+def _fact(fact_id: str, version: int, fact_type: str = "market_price",
+          value: object = V1, effective_time: datetime = T) -> CanonicalFact:
+    return CanonicalFact(
+        fact_id=fact_id, version=version, fact_type=fact_type, value=value,
+        confidence=Confidence(score=1.0),
+        provenance=Provenance(
+            contributing_observation_ids=("o1",), contributing_provider_ids=("p1",),
+            selected_provider_id="p1", disagreements=(), reconciled_at=RT),
+        effective_time=effective_time, created_time=RT,
+    )
+
+
+class TestAppendAndLatest:
+    def test_append_then_latest(self):
+        repo = InMemoryCanonicalFactRepository()
+        fact = _fact("f1", 1)
+        repo.append(fact)
+        assert repo.latest("market_price", T) == fact
+
+    def test_latest_missing_raises(self):
+        repo = InMemoryCanonicalFactRepository()
+        with pytest.raises(FactNotFoundError):
+            repo.latest("market_price", T)
+
+    def test_no_update_or_delete_operations(self):
+        repo = InMemoryCanonicalFactRepository()
+        for forbidden in ("update", "delete", "remove", "clear", "replace"):
+            assert not hasattr(repo, forbidden)
+
+
+class TestHistory:
+    def test_history_version_ordered(self):
+        repo = InMemoryCanonicalFactRepository()
+        repo.append(_fact("f1", 1, value=V1))
+        repo.append(_fact("f2", 2, value=V2))
+        history = repo.history("market_price", T)
+        assert [f.version for f in history] == [1, 2]
+
+    def test_history_empty_for_unknown_group(self):
+        repo = InMemoryCanonicalFactRepository()
+        assert repo.history("market_price", T) == ()
+
+    def test_history_immutable(self):
+        repo = InMemoryCanonicalFactRepository()
+        repo.append(_fact("f1", 1))
+        history = repo.history("market_price", T)
+        assert isinstance(history, tuple)
+        with pytest.raises(TypeError):
+            history[0] = _fact("f2", 2)
+
+
+class TestVersionMonotonicity:
+    def test_first_version_must_be_1(self):
+        repo = InMemoryCanonicalFactRepository()
+        with pytest.raises(NonMonotonicVersionError):
+            repo.append(_fact("f1", 2))
+
+    def test_version_must_increment_by_exactly_1(self):
+        repo = InMemoryCanonicalFactRepository()
+        repo.append(_fact("f1", 1, value=V1))
+        with pytest.raises(NonMonotonicVersionError):
+            repo.append(_fact("f2", 3, value=V2))
+
+    def test_correct_sequential_versions_accepted(self):
+        repo = InMemoryCanonicalFactRepository()
+        repo.append(_fact("f1", 1, value=V1))
+        repo.append(_fact("f2", 2, value=V2))
+        assert repo.latest("market_price", T).version == 2
+
+
+class TestDuplicateBehavior:
+    def test_duplicate_append_rejected(self):
+        repo = InMemoryCanonicalFactRepository()
+        fact = _fact("f1", 1)
+        repo.append(fact)
+        with pytest.raises(DuplicateFactError):
+            repo.append(fact)
+
+    def test_identity_collision_rejected(self):
+        repo = InMemoryCanonicalFactRepository()
+        original = _fact("f1", 1)
+        repo.append(original)
+        colliding = dataclasses.replace(original, confidence=Confidence(score=0.1))
+        with pytest.raises(FactIdentityCollisionError):
+            repo.append(colliding)
+
+    def test_original_preserved_after_collision_rejection(self):
+        repo = InMemoryCanonicalFactRepository()
+        original = _fact("f1", 1)
+        repo.append(original)
+        colliding = dataclasses.replace(original, confidence=Confidence(score=0.1))
+        with pytest.raises(FactIdentityCollisionError):
+            repo.append(colliding)
+        assert repo.latest("market_price", T) == original
+        assert repo.latest("market_price", T).confidence.score == 1.0
+
+
+class TestQuerySemantics:
+    def _filled(self) -> InMemoryCanonicalFactRepository:
+        repo = InMemoryCanonicalFactRepository()
+        repo.append(_fact("f1", 1, fact_type="market_price", value=V1, effective_time=T))
+        repo.append(_fact("f2", 1, fact_type="quote", value=V1, effective_time=T))
+        repo.append(_fact("f3", 2, fact_type="market_price", value=V2, effective_time=T))
+        repo.append(_fact("f4", 1, fact_type="market_price", value=V1, effective_time=T2))
+        return repo
+
+    def test_by_type_insertion_order(self):
+        repo = self._filled()
+        assert [f.fact_id for f in repo.by_type("market_price")] == ["f1", "f3", "f4"]
+
+    def test_by_effective_time_insertion_order(self):
+        repo = self._filled()
+        assert [f.fact_id for f in repo.by_effective_time(T)] == ["f1", "f2", "f3"]
+
+    def test_returned_collections_are_tuples(self):
+        repo = self._filled()
+        assert isinstance(repo.by_type("market_price"), tuple)
+        assert isinstance(repo.by_effective_time(T), tuple)
+        assert isinstance(repo.history("market_price", T), tuple)
+
+
+class TestReconcileAndAppend:
+    def test_new_version_appended(self):
+        repo = InMemoryCanonicalFactRepository()
+        group = (_obs("o1", "p1", V1),)
+        fact = repo.reconcile_and_append(group, RT)
+        assert fact is not None
+        assert fact.version == 1
+        assert repo.latest("market_price", T) == fact
+
+    def test_idempotent_replay_returns_none_and_does_not_append(self):
+        repo = InMemoryCanonicalFactRepository()
+        group = (_obs("o1", "p1", V1), _obs("o2", "p2", V1))
+        first = repo.reconcile_and_append(group, RT)
+        replay = repo.reconcile_and_append(group, RT)
+        assert replay is None
+        assert len(repo.history("market_price", T)) == 1
+
+    def test_changed_value_produces_new_version(self):
+        repo = InMemoryCanonicalFactRepository()
+        group1 = (_obs("o1", "p1", V1),)
+        repo.reconcile_and_append(group1, RT)
+        group2 = (_obs("o1", "p1", V1), _obs("o2", "p2", V2), _obs("o3", "p3", V2))
+        fact2 = repo.reconcile_and_append(group2, RT)
+        assert fact2.version == 2
+
+    def test_empty_observations_raises(self):
+        repo = InMemoryCanonicalFactRepository()
+        from reconciliation.errors import EmptyObservationGroupError
+        with pytest.raises(EmptyObservationGroupError):
+            repo.reconcile_and_append((), RT)

--- a/tests/reconciliation/test_engine.py
+++ b/tests/reconciliation/test_engine.py
@@ -1,0 +1,177 @@
+"""ASA-CORE-003: reconciliation engine tests, including pinned regression vectors."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from domain.canonical_fact import CanonicalFact
+from domain.observation import Observation
+from domain.provenance import Provenance
+from domain.references import Confidence
+from reconciliation.engine import reconcile
+from reconciliation.errors import InconsistentGroupError
+
+T = datetime(2026, 7, 21, 14, 30, tzinfo=timezone.utc)
+RT = datetime(2026, 7, 21, 14, 31, tzinfo=timezone.utc)
+RT2 = datetime(2026, 7, 21, 15, 0, tzinfo=timezone.utc)
+
+V1 = (("currency", "USD"), ("price", Decimal("201.55")), ("symbol", "AAPL"))
+V2 = (("currency", "USD"), ("price", Decimal("201.60")), ("symbol", "AAPL"))
+
+
+def _obs(oid: str, provider: str, value: object) -> Observation:
+    return Observation(observation_id=oid, observation_type="market_price",
+                       provider_id=provider, value=value,
+                       effective_time=T, recorded_time=RT)
+
+
+def _fact(**overrides) -> CanonicalFact:
+    kwargs = dict(
+        fact_id="stub", version=1, fact_type="market_price", value=V1,
+        confidence=Confidence(score=1.0),
+        provenance=Provenance(
+            contributing_observation_ids=("o1",), contributing_provider_ids=("p1",),
+            selected_provider_id="p1", disagreements=(), reconciled_at=RT),
+        effective_time=T, created_time=RT,
+    )
+    kwargs.update(overrides)
+    return CanonicalFact(**kwargs)
+
+
+class TestReconcileBasics:
+    def test_first_reconciliation_is_version_1(self):
+        group = (_obs("o1", "p1", V1),)
+        fact, is_new = reconcile(group, RT)
+        assert is_new
+        assert fact.version == 1
+
+    def test_reconcile_produces_immutable_fact(self):
+        group = (_obs("o1", "p1", V1),)
+        fact, _ = reconcile(group, RT)
+        with pytest.raises(Exception):
+            fact.version = 2
+
+    def test_provenance_complete(self):
+        group = (_obs("o1", "p1", V1), _obs("o2", "p2", V1), _obs("o3", "p3", V2))
+        fact, _ = reconcile(group, RT)
+        prov = fact.provenance
+        assert prov.contributing_observation_ids == ("o1", "o2", "o3")
+        assert prov.contributing_provider_ids == ("p1", "p2", "p3")
+        assert prov.selected_provider_id in ("p1", "p2")
+        assert len(prov.disagreements) == 1
+        assert prov.reconciled_at == RT
+
+    def test_mismatched_previous_fact_type_raises(self):
+        group = (_obs("o1", "p1", V1),)
+        previous = _fact(fact_type="other_type")
+        with pytest.raises(InconsistentGroupError):
+            reconcile(group, RT, previous_fact=previous)
+
+    def test_mismatched_previous_effective_time_raises(self):
+        group = (_obs("o1", "p1", V1),)
+        previous = _fact(effective_time=RT2)
+        with pytest.raises(InconsistentGroupError):
+            reconcile(group, RT, previous_fact=previous)
+
+
+class TestDeterminismAndReplay:
+    def test_identical_observations_reconcile_identically(self):
+        group = (_obs("o1", "p1", V1), _obs("o2", "p2", V1))
+        fact_a, _ = reconcile(group, RT)
+        fact_b, _ = reconcile(group, RT)
+        assert fact_a == fact_b
+
+    def test_observation_ordering_does_not_change_result(self):
+        group = (_obs("o1", "p1", V1), _obs("o2", "p2", V1), _obs("o3", "p3", V2))
+        fact_forward, _ = reconcile(group, RT)
+        fact_backward, _ = reconcile(tuple(reversed(group)), RT)
+        assert fact_forward == fact_backward
+
+    def test_replay_produces_byte_identical_facts(self):
+        group = (_obs("o1", "p1", V1), _obs("o2", "p2", V2), _obs("o3", "p3", V2))
+        first, _ = reconcile(group, RT)
+        replay, _ = reconcile(group, RT)
+        assert first.fact_id == replay.fact_id
+        assert first.value == replay.value
+        assert first.confidence == replay.confidence
+        assert first.provenance == replay.provenance
+
+    def test_conflicting_observations_generate_disagreements(self):
+        group = (_obs("o1", "p1", V1), _obs("o2", "p2", V2))
+        fact, _ = reconcile(group, RT)
+        assert len(fact.provenance.disagreements) == 1
+
+    def test_confidence_deterministic_across_calls(self):
+        group = (_obs("o1", "p1", V1), _obs("o2", "p2", V1))
+        a, _ = reconcile(group, RT)
+        b, _ = reconcile(group, RT)
+        assert a.confidence.score == b.confidence.score
+
+
+class TestVersioning:
+    def test_first_version_equals_1(self):
+        group = (_obs("o1", "p1", V1),)
+        fact, _ = reconcile(group, RT)
+        assert fact.version == 1
+
+    def test_changed_value_increments_version(self):
+        group1 = (_obs("o1", "p1", V1),)
+        fact1, _ = reconcile(group1, RT)
+        group2 = (_obs("o1", "p1", V1), _obs("o2", "p2", V2), _obs("o3", "p3", V2))
+        fact2, is_new = reconcile(group2, RT2, previous_fact=fact1)
+        assert is_new
+        assert fact2.version == fact1.version + 1
+        assert fact2.value != fact1.value
+
+    def test_identical_replay_does_not_increment_version(self):
+        group = (_obs("o1", "p1", V1), _obs("o2", "p2", V1))
+        fact1, _ = reconcile(group, RT)
+        fact2, is_new = reconcile(group, RT2, previous_fact=fact1)
+        assert not is_new
+        assert fact2 is fact1
+        assert fact2.version == fact1.version
+
+    def test_new_corroborating_evidence_same_value_no_version_bump(self):
+        group1 = (_obs("o1", "p1", V1),)
+        fact1, _ = reconcile(group1, RT)
+        group2 = (_obs("o1", "p1", V1), _obs("o2", "p2", V1))
+        fact2, is_new = reconcile(group2, RT2, previous_fact=fact1)
+        assert not is_new  # same resolved value -> no new version
+
+
+# ---------------------------------------------------------------------------
+# Pinned regression vectors — a failure here means engine behavior changed.
+# ---------------------------------------------------------------------------
+
+class TestPinnedReconciliationVectors:
+    PINNED_FACT_ID = "cb7cd96706fac8fc183dbcee9c29a5050f060a23152b8aeae7665e20e3f2eaaf"
+    PINNED_CONFIDENCE = 2 / 3
+
+    def _group(self):
+        return (_obs("o1", "prov-a", V1), _obs("o2", "prov-b", V1), _obs("o3", "prov-c", V2))
+
+    def test_pinned_fact_id(self):
+        fact, _ = reconcile(self._group(), RT)
+        assert fact.fact_id == self.PINNED_FACT_ID
+
+    def test_pinned_confidence(self):
+        fact, _ = reconcile(self._group(), RT)
+        assert fact.confidence.score == pytest.approx(self.PINNED_CONFIDENCE)
+
+    def test_pinned_provenance_shape(self):
+        fact, _ = reconcile(self._group(), RT)
+        assert fact.provenance.contributing_observation_ids == ("o1", "o2", "o3")
+        assert fact.provenance.contributing_provider_ids == ("prov-a", "prov-b", "prov-c")
+        assert fact.provenance.selected_provider_id == "prov-a"
+        assert len(fact.provenance.disagreements) == 1
+        assert fact.provenance.disagreements[0].provider_id == "prov-c"
+
+    def test_pinned_resolved_value(self):
+        fact, _ = reconcile(self._group(), RT)
+        assert fact.value == V1
+
+    def test_pinned_version(self):
+        fact, _ = reconcile(self._group(), RT)
+        assert fact.version == 1

--- a/tests/reconciliation/test_rules.py
+++ b/tests/reconciliation/test_rules.py
@@ -1,0 +1,178 @@
+"""ASA-CORE-003: reconciliation rules unit tests."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from domain.observation import Observation
+from reconciliation.errors import EmptyObservationGroupError, InconsistentGroupError
+from reconciliation.rules import (
+    compute_confidence,
+    fact_identity,
+    group_by_fact_identity,
+    require_single_group,
+    resolve_value,
+)
+
+T = datetime(2026, 7, 21, 14, 30, tzinfo=timezone.utc)
+T2 = datetime(2026, 7, 21, 15, 0, tzinfo=timezone.utc)
+RT = datetime(2026, 7, 21, 14, 31, tzinfo=timezone.utc)
+
+V1 = (("currency", "USD"), ("price", Decimal("201.55")), ("symbol", "AAPL"))
+V2 = (("currency", "USD"), ("price", Decimal("201.60")), ("symbol", "AAPL"))
+
+
+def _obs(oid: str, provider: str, value: object, otype: str = "market_price",
+         effective_time: datetime = T) -> Observation:
+    return Observation(observation_id=oid, observation_type=otype,
+                       provider_id=provider, value=value,
+                       effective_time=effective_time, recorded_time=RT)
+
+
+class TestGrouping:
+    def test_groups_by_type_and_effective_time(self):
+        obs = (
+            _obs("o1", "p1", V1, otype="a", effective_time=T),
+            _obs("o2", "p2", V1, otype="b", effective_time=T),
+            _obs("o3", "p3", V1, otype="a", effective_time=T2),
+        )
+        groups = group_by_fact_identity(obs)
+        assert set(groups.keys()) == {("a", T), ("b", T), ("a", T2)}
+
+    def test_grouping_independent_of_order(self):
+        obs = (_obs("o1", "p1", V1), _obs("o2", "p2", V2))
+        forward = group_by_fact_identity(obs)
+        backward = group_by_fact_identity(tuple(reversed(obs)))
+        assert set(forward.keys()) == set(backward.keys())
+        for key in forward:
+            assert set(o.observation_id for o in forward[key]) == \
+                set(o.observation_id for o in backward[key])
+
+
+class TestRequireSingleGroup:
+    def test_empty_raises(self):
+        with pytest.raises(EmptyObservationGroupError):
+            require_single_group(())
+
+    def test_mixed_type_raises(self):
+        obs = (_obs("o1", "p1", V1, otype="a"), _obs("o2", "p2", V1, otype="b"))
+        with pytest.raises(InconsistentGroupError):
+            require_single_group(obs)
+
+    def test_mixed_effective_time_raises(self):
+        obs = (_obs("o1", "p1", V1, effective_time=T), _obs("o2", "p2", V1, effective_time=T2))
+        with pytest.raises(InconsistentGroupError):
+            require_single_group(obs)
+
+    def test_consistent_group_passes(self):
+        obs = (_obs("o1", "p1", V1), _obs("o2", "p2", V1))
+        require_single_group(obs)  # does not raise
+
+
+class TestResolveValue:
+    def test_unanimous_agreement(self):
+        obs = (_obs("o1", "p1", V1), _obs("o2", "p2", V1))
+        value, disagreements, selected = resolve_value(obs)
+        assert value == V1
+        assert disagreements == ()
+
+    def test_majority_wins(self):
+        obs = (_obs("o1", "p1", V1), _obs("o2", "p2", V1), _obs("o3", "p3", V2))
+        value, disagreements, selected = resolve_value(obs)
+        assert value == V1
+        assert len(disagreements) == 1
+        assert disagreements[0].provider_id == "p3"
+
+    def test_no_observation_discarded(self):
+        obs = (_obs("o1", "p1", V1), _obs("o2", "p2", V2), _obs("o3", "p3", V2))
+        value, disagreements, selected = resolve_value(obs)
+        assert value == V2  # p2 and p3 both support V2, majority
+        assert len(disagreements) == 1
+        assert disagreements[0].observation_id == "o1"
+
+    def test_disagreement_preserves_reported_value(self):
+        obs = (_obs("o1", "p1", V1), _obs("o2", "p2", V1), _obs("o3", "p3", V2))
+        _, disagreements, _ = resolve_value(obs)
+        assert disagreements[0].reported_value == V2
+
+    def test_deterministic_tie_break_not_provider_identity(self):
+        """A 1-1 tie must break on canonical value content, not provider id."""
+        obs_a_first = (_obs("o1", "z-provider", V1), _obs("o2", "a-provider", V2))
+        obs_b_first = (_obs("o1", "a-provider", V2), _obs("o2", "z-provider", V1))
+        value_a, _, _ = resolve_value(obs_a_first)
+        value_b, _, _ = resolve_value(obs_b_first)
+        assert value_a == value_b  # same tie-break outcome regardless of which provider is which
+
+    def test_order_independent_result(self):
+        obs = (_obs("o1", "p1", V1), _obs("o2", "p2", V1), _obs("o3", "p3", V2))
+        forward = resolve_value(obs)
+        backward = resolve_value(tuple(reversed(obs)))
+        assert forward[0] == backward[0]
+        assert set(d.observation_id for d in forward[1]) == \
+            set(d.observation_id for d in backward[1])
+
+    def test_selected_provider_supports_selected_value(self):
+        obs = (_obs("o1", "p1", V1), _obs("o2", "p2", V1))
+        value, _, selected = resolve_value(obs)
+        supporting = {o.provider_id for o in obs if o.value == value}
+        assert selected in supporting
+
+    def test_raises_on_inconsistent_group(self):
+        obs = (_obs("o1", "p1", V1, otype="a"), _obs("o2", "p2", V1, otype="b"))
+        with pytest.raises(InconsistentGroupError):
+            resolve_value(obs)
+
+
+class TestComputeConfidence:
+    def test_single_provider_confidence(self):
+        obs = (_obs("o1", "p1", V1),)
+        conf = compute_confidence(obs, frozenset({"p1"}))
+        assert conf == 0.5
+
+    def test_two_agreeing_providers_full_corroboration(self):
+        obs = (_obs("o1", "p1", V1), _obs("o2", "p2", V1))
+        conf = compute_confidence(obs, frozenset({"p1", "p2"}))
+        assert conf == 1.0
+
+    def test_partial_agreement_lower_confidence(self):
+        obs = (_obs("o1", "p1", V1), _obs("o2", "p2", V1), _obs("o3", "p3", V2))
+        conf = compute_confidence(obs, frozenset({"p1", "p2"}))
+        assert conf == pytest.approx(2 / 3)
+
+    def test_confidence_always_in_unit_interval(self):
+        for n_agree in range(1, 5):
+            for n_total in range(n_agree, n_agree + 5):
+                agree_ids = frozenset(f"p{i}" for i in range(n_agree))
+                obs = tuple(_obs(f"o{i}", f"p{i}", V1) for i in range(n_total))
+                conf = compute_confidence(obs, agree_ids)
+                assert 0.0 <= conf <= 1.0
+
+    def test_deterministic(self):
+        obs = (_obs("o1", "p1", V1), _obs("o2", "p2", V1))
+        a = compute_confidence(obs, frozenset({"p1", "p2"}))
+        b = compute_confidence(obs, frozenset({"p1", "p2"}))
+        assert a == b
+
+
+class TestFactIdentity:
+    def test_same_input_same_id(self):
+        a = fact_identity("market_price", T, V1)
+        b = fact_identity("market_price", T, V1)
+        assert a == b
+
+    def test_different_type_different_id(self):
+        assert fact_identity("a", T, V1) != fact_identity("b", T, V1)
+
+    def test_different_time_different_id(self):
+        assert fact_identity("market_price", T, V1) != fact_identity("market_price", T2, V1)
+
+    def test_different_value_different_id(self):
+        assert fact_identity("market_price", T, V1) != fact_identity("market_price", T, V2)
+
+    def test_output_is_lowercase_hex_sha256(self):
+        fid = fact_identity("market_price", T, V1)
+        assert len(fid) == 64
+        assert fid == fid.lower()
+        int(fid, 16)


### PR DESCRIPTION
## Summary

Implements ticket ASA-CORE-003 (P0), the first business-logic layer in ASA. Branched from `origin/main` at `26e04eb` (all three preconditions merged).

### Module split — `reconciliation/` (ADR-004 amended)
Reconciliation is pure and repository-free: a total, deterministic function of its Observation-set input, making it fully replayable. `facts/` now owns storage/versioning orchestration and depends on `reconciliation/`; `reconciliation/` never depends on `facts/`. Inserted at the Canonical Fact Layer's existing pipeline position (between `observation/` and `facts/`) — a decomposition of the existing layer, not a new pipeline stage. ADR-004 amended with a revision note explaining the rationale; Decision Log updated.

### Reconciliation engine
- **Grouping**: `(fact_type, effective_time)` — documented v1 key (Issue #40 tracks the multi-subject gap)
- **Value resolution**: unweighted provider-agreement count, deterministic content-based tiebreak (never provider identity) — ADR-001 describes provider-priority weighting, which this ticket explicitly prohibits and `Provider` has no field for yet (Issue #39). Every disagreeing observation preserved, never discarded.
- **Confidence**: deterministic v1 formula (agreement ratio × corroboration factor), ADR-001-consistent — multiple agreeing providers raise it, single-provider lowers it
- **Fact identity**: `asa.canonical_fact` v1 — SHA-256 over type-tagged serialization of `(fact_type, canonical value, effective_time)`, no UUIDs/sequence numbers/insertion time/randomness (Issue #41 tracks a documented, fail-closed edge case on value oscillation across versions)
- **`reconcile()`**: pure orchestration returning `(fact, is_new_version)` — version 1 if none prior, unchanged on idempotent replay, +1 on value change

### Canonical Fact repository (in-memory, append-only)
`append`/`latest`/`history`/`by_type`/`by_effective_time` per spec, no update/delete/mutation. Monotonic versioning enforced as a **repository-level** invariant (`NonMonotonicVersionError`) independent of the engine's own computation — defense in depth. Duplicate append → `DuplicateFactError`; same identity, different content → `FactIdentityCollisionError` with original preserved. `reconcile_and_append()` ties engine + repository together.

### Architecture validation
New `tests/architecture/test_reconciliation_boundaries.py` codifies the ticket's exact clauses: reconciliation imports only domain/observation/reconciliation; no strategy/ranking/guardrail/provider imports; no ML/network/infrastructure imports; `Provider` has no priority field. All pass.

### GitHub Issues (non-blocking, filed before this PR per the ticket's merge gate)
- [#39](https://github.com/jaiaFoster/ASA/issues/39) — provider-priority weighting deferred (ADR-001 conformance gap)
- [#40](https://github.com/jaiaFoster/ASA/issues/40) — grouping key has no subject/instrument disambiguation
- [#41](https://github.com/jaiaFoster/ASA/issues/41) — fact_id collision risk on value oscillation (fails closed, not silent)

### Tests
95 new tests (rules, engine incl. 5 pinned regression vectors, versioning, repository, architecture boundaries). **346 total non-POS tests passing.** POS entrypoint/integrity checks green; `compileall` clean.

## Acceptance criteria
- [x] Identical evidence always produces identical Canonical Facts
- [x] Replay produces byte-identical results
- [x] Provenance completely reconstructs evidence chain
- [x] Disagreement information never loses observations
- [x] Version history immutable
- [x] Repository append-only
- [x] Deterministic test suite passes
- [x] Architecture validation passes
- [x] All non-blocking architectural concerns tracked as GitHub Issues before merge

---
_Generated by [Claude Code](https://claude.ai/code/session_0171U6QSQe39nnsDLYLbmbG1)_