### PR TITLE
ASA-CORE-007 Phase 0: harden guardrail evaluation identity

### DIFF
--- a/guardrails/__init__.py
+++ b/guardrails/__init__.py
@@ -19,7 +19,9 @@ from guardrails.errors import (
 from guardrails.evaluations import (
     GUARDRAIL_EVALUATION_IDENTITY_NAMESPACE,
     GUARDRAIL_EVALUATION_IDENTITY_VERSION,
+    EffectivePolicyParameters,
     OpportunityGuardrailEvaluation,
+    guardrail_cited_evidence,
     guardrail_evaluation_identity,
 )
 from guardrails.registry import DEFAULT_REGISTRY, GuardrailRegistry
@@ -28,6 +30,7 @@ __all__ = [
     "DEFAULT_REGISTRY",
     "DuplicateGuardrailRegistrationError",
     "EmptyOpportunityEvidenceError",
+    "EffectivePolicyParameters",
     "GUARDRAIL_EVALUATION_IDENTITY_NAMESPACE",
     "GUARDRAIL_EVALUATION_IDENTITY_VERSION",
     "GuardrailError",
@@ -37,5 +40,6 @@ __all__ = [
     "UnknownGuardrailIdError",
     "evaluate_guardrail",
     "evaluate_opportunity",
+    "guardrail_cited_evidence",
     "guardrail_evaluation_identity",
 ]

--- a/guardrails/engine.py
+++ b/guardrails/engine.py
@@ -13,13 +13,15 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from domain.canonicalization import serialize_canonical
 from domain.guardrail import GuardrailOutcome
 from domain.opportunity import Opportunity
 from domain.values import require_tz_aware
 from guardrails.evaluations import (
+    EffectivePolicyParameters,
     OpportunityGuardrailEvaluation,
+    guardrail_cited_evidence,
     guardrail_evaluation_identity,
-    opportunity_cited_evidence,
 )
 from guardrails.registry import DEFAULT_REGISTRY, GuardrailRegistry
 
@@ -27,7 +29,7 @@ from guardrails.registry import DEFAULT_REGISTRY, GuardrailRegistry
 def evaluate_guardrail(
     guardrail_id: str,
     opportunity: Opportunity,
-    params: dict | None = None,
+    params: dict[str, object] | None = None,
     evaluated_at: datetime | None = None,
     registry: GuardrailRegistry = DEFAULT_REGISTRY,
 ) -> GuardrailOutcome:
@@ -45,7 +47,7 @@ def evaluate_guardrail(
 
     definition = registry.get(guardrail_id)
     passed, reason = definition.check(opportunity, params)
-    evidence = opportunity_cited_evidence(opportunity)
+    evidence = guardrail_cited_evidence(guardrail_id, opportunity)
 
     return GuardrailOutcome(
         guardrail_id=guardrail_id,
@@ -59,7 +61,7 @@ def evaluate_guardrail(
 
 def evaluate_opportunity(
     opportunity: Opportunity,
-    params_by_guardrail: dict[str, dict] | None = None,
+    params_by_guardrail: dict[str, dict[str, object]] | None = None,
     evaluated_at: datetime | None = None,
     registry: GuardrailRegistry = DEFAULT_REGISTRY,
 ) -> OpportunityGuardrailEvaluation:
@@ -86,13 +88,24 @@ def evaluate_opportunity(
         for guardrail_id in registry.registered_ids()
     )
     overall_passed = all(outcome.passed for outcome in outcomes)
+    effective_parameters: EffectivePolicyParameters = tuple(
+        (
+            guardrail_id,
+            tuple(
+                (name, serialize_canonical(params_by_guardrail.get(guardrail_id, {})[name]))
+                for name in registry.get(guardrail_id).parameter_names
+            ),
+        )
+        for guardrail_id in registry.registered_ids()
+    )
 
     return OpportunityGuardrailEvaluation(
         evaluation_id=guardrail_evaluation_identity(
-            opportunity.opportunity_id, outcomes, evaluated_at
+            opportunity.opportunity_id, outcomes, effective_parameters
         ),
         opportunity_id=opportunity.opportunity_id,
         outcomes=outcomes,
         passed=overall_passed,
         evaluated_at=evaluated_at,
+        effective_parameters=effective_parameters,
     )

--- a/guardrails/evaluations.py
+++ b/guardrails/evaluations.py
@@ -26,7 +26,8 @@ from domain.values import require_tz_aware
 from guardrails.errors import EmptyOpportunityEvidenceError, InvalidGuardrailParameterError
 
 GUARDRAIL_EVALUATION_IDENTITY_NAMESPACE = "asa.guardrail_evaluation"
-GUARDRAIL_EVALUATION_IDENTITY_VERSION = "v1"
+GUARDRAIL_EVALUATION_IDENTITY_VERSION = "v2"
+EffectivePolicyParameters = tuple[tuple[str, tuple[tuple[str, str], ...]], ...]
 
 
 @dataclass(frozen=True)
@@ -38,7 +39,8 @@ class OpportunityGuardrailEvaluation:
     (unanimous — a single failing guardrail blocks the Opportunity, per
     ADR-005's "eligibility rule" framing). ``outcomes`` is ordered
     deterministically by ``guardrail_id`` — never insertion or evaluation
-    order.
+    order. ``effective_parameters`` preserves the canonical policy inputs
+    included in the v2 deterministic identity.
     """
 
     evaluation_id: str
@@ -46,6 +48,7 @@ class OpportunityGuardrailEvaluation:
     outcomes: tuple[GuardrailOutcome, ...]
     passed: bool
     evaluated_at: datetime
+    effective_parameters: EffectivePolicyParameters
 
     def __post_init__(self) -> None:
         require_tz_aware(self.evaluated_at, "OpportunityGuardrailEvaluation", "evaluated_at")
@@ -54,17 +57,15 @@ class OpportunityGuardrailEvaluation:
 def guardrail_evaluation_identity(
     opportunity_id: str,
     outcomes: tuple[GuardrailOutcome, ...],
-    evaluated_at: datetime,
+    effective_parameters: EffectivePolicyParameters,
 ) -> str:
-    """Deterministic, versioned GuardrailEvaluation identity (algorithm v1).
+    """Deterministic, versioned GuardrailEvaluation identity (algorithm v2).
 
     Inputs: opportunity_id, sorted (guardrail_id, guardrail_version, passed)
-    triples, evaluated_at — mirroring the established identity style
-    (``asa.canonical_fact``, ``asa.indicator``, ``asa.opportunity``) under
-    a distinct namespace. No UUIDs, no sequence numbers, no insertion
-    time, no randomness.
+    triples, and effective policy parameters. ``evaluated_at`` is excluded:
+    it records execution time, not a semantic policy input. No UUIDs,
+    sequence numbers, insertion time, or randomness.
     """
-    require_tz_aware(evaluated_at, "guardrail_evaluation_identity", "evaluated_at")
     outcome_triples = tuple(sorted(
         (outcome.guardrail_id, outcome.guardrail_version, outcome.passed)
         for outcome in outcomes
@@ -75,7 +76,7 @@ def guardrail_evaluation_identity(
             GUARDRAIL_EVALUATION_IDENTITY_VERSION,
             serialize_canonical(opportunity_id),
             serialize_canonical(outcome_triples),
-            serialize_canonical(evaluated_at),
+            serialize_canonical(effective_parameters),
         )
     )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
@@ -99,7 +100,22 @@ def opportunity_cited_evidence(opportunity: Opportunity) -> tuple[EvidenceRefere
     return tuple(sorted(combined, key=lambda ref: (ref.kind.value, ref.referenced_id)))
 
 
-def _require_decimal_param(guardrail_id: str, params: dict, key: str) -> Decimal:
+def guardrail_cited_evidence(
+    guardrail_id: str, opportunity: Opportunity
+) -> tuple[EvidenceReference, ...]:
+    """Return only evidence consumed by a guardrail where attribution is known.
+
+    Current financial-metric and confidence fields do not expose field-level
+    provenance, so those guardrails retain the complete Opportunity evidence
+    chain. ``placeholder_metrics_rejection`` reads assumptions only and cites
+    no unrelated Fact or Indicator evidence.
+    """
+    if guardrail_id == "placeholder_metrics_rejection":
+        return ()
+    return opportunity_cited_evidence(opportunity)
+
+
+def _require_decimal_param(guardrail_id: str, params: dict[str, object], key: str) -> Decimal:
     if key not in params:
         raise InvalidGuardrailParameterError(guardrail_id, f"missing required parameter {key!r}")
     value = params[key]
@@ -110,7 +126,7 @@ def _require_decimal_param(guardrail_id: str, params: dict, key: str) -> Decimal
     return value
 
 
-def _require_int_param(guardrail_id: str, params: dict, key: str) -> int:
+def _require_int_param(guardrail_id: str, params: dict[str, object], key: str) -> int:
     if key not in params:
         raise InvalidGuardrailParameterError(guardrail_id, f"missing required parameter {key!r}")
     value = params[key]
@@ -127,7 +143,9 @@ def _require_int_param(guardrail_id: str, params: dict, key: str) -> int:
 # Required guardrail checks
 # ---------------------------------------------------------------------------
 
-def minimum_evidence_confidence(opportunity: Opportunity, params: dict) -> tuple[bool, str]:
+def minimum_evidence_confidence(
+    opportunity: Opportunity, params: dict[str, object]
+) -> tuple[bool, str]:
     """Reject Opportunities whose evidence_confidence falls below a threshold."""
     threshold = _require_decimal_param("minimum_evidence_confidence", params, "threshold")
     score = Decimal(str(opportunity.evidence_confidence.score))
@@ -138,7 +156,9 @@ def minimum_evidence_confidence(opportunity: Opportunity, params: dict) -> tuple
     return passed, reason
 
 
-def maximum_capital_required(opportunity: Opportunity, params: dict) -> tuple[bool, str]:
+def maximum_capital_required(
+    opportunity: Opportunity, params: dict[str, object]
+) -> tuple[bool, str]:
     """Reject Opportunities whose capital_required exceeds a threshold."""
     threshold = _require_decimal_param("maximum_capital_required", params, "threshold")
     capital = opportunity.expected_outcome_metrics.capital_required
@@ -147,7 +167,7 @@ def maximum_capital_required(opportunity: Opportunity, params: dict) -> tuple[bo
     return passed, reason
 
 
-def maximum_loss(opportunity: Opportunity, params: dict) -> tuple[bool, str]:
+def maximum_loss(opportunity: Opportunity, params: dict[str, object]) -> tuple[bool, str]:
     """Reject Opportunities whose maximum_loss magnitude exceeds a threshold.
 
     ``expected_outcome_metrics.maximum_loss`` is stored as a non-positive
@@ -164,7 +184,9 @@ def maximum_loss(opportunity: Opportunity, params: dict) -> tuple[bool, str]:
     return passed, reason
 
 
-def allowed_time_horizon(opportunity: Opportunity, params: dict) -> tuple[bool, str]:
+def allowed_time_horizon(
+    opportunity: Opportunity, params: dict[str, object]
+) -> tuple[bool, str]:
     """Reject Opportunities whose time_horizon_days falls outside [min, max]."""
     minimum = _require_int_param("allowed_time_horizon", params, "minimum_days")
     maximum = _require_int_param("allowed_time_horizon", params, "maximum_days")
@@ -182,7 +204,9 @@ def allowed_time_horizon(opportunity: Opportunity, params: dict) -> tuple[bool, 
 PLACEHOLDER_MARKER = "placeholder"
 
 
-def placeholder_metrics_rejection(opportunity: Opportunity, params: dict) -> tuple[bool, str]:
+def placeholder_metrics_rejection(
+    opportunity: Opportunity, params: dict[str, object]
+) -> tuple[bool, str]:
     """Reject Opportunities whose Strategy admits (via ``assumptions``) to
     using uncalibrated placeholder Expected Outcome Metrics.
 

--- a/guardrails/registry.py
+++ b/guardrails/registry.py
@@ -21,7 +21,7 @@ from guardrails.evaluations import (
     placeholder_metrics_rejection,
 )
 
-GuardrailCheckFn = Callable[[Opportunity, dict], "tuple[bool, str]"]
+GuardrailCheckFn = Callable[[Opportunity, dict[str, object]], "tuple[bool, str]"]
 
 
 @dataclass(frozen=True)
@@ -34,6 +34,7 @@ class GuardrailDefinition:
 
     guardrail_id: str
     guardrail_version: str
+    parameter_names: tuple[str, ...]
     check: GuardrailCheckFn
 
 
@@ -43,12 +44,20 @@ class GuardrailRegistry:
     def __init__(self) -> None:
         self._definitions: dict[str, GuardrailDefinition] = {}
 
-    def register(self, guardrail_id: str, guardrail_version: str,
-                 check: GuardrailCheckFn) -> None:
+    def register(
+        self,
+        guardrail_id: str,
+        guardrail_version: str,
+        check: GuardrailCheckFn,
+        parameter_names: tuple[str, ...] = (),
+    ) -> None:
         if guardrail_id in self._definitions:
             raise DuplicateGuardrailRegistrationError(guardrail_id)
         self._definitions[guardrail_id] = GuardrailDefinition(
-            guardrail_id=guardrail_id, guardrail_version=guardrail_version, check=check,
+            guardrail_id=guardrail_id,
+            guardrail_version=guardrail_version,
+            parameter_names=tuple(sorted(parameter_names)),
+            check=check,
         )
 
     def get(self, guardrail_id: str) -> GuardrailDefinition:
@@ -67,10 +76,22 @@ class GuardrailRegistry:
 def build_default_registry() -> GuardrailRegistry:
     """Registry pre-loaded with the five required guardrails (ASA-CORE-006)."""
     registry = GuardrailRegistry()
-    registry.register("minimum_evidence_confidence", "v1", minimum_evidence_confidence)
-    registry.register("maximum_capital_required", "v1", maximum_capital_required)
-    registry.register("maximum_loss", "v1", maximum_loss)
-    registry.register("allowed_time_horizon", "v1", allowed_time_horizon)
+    registry.register(
+        "minimum_evidence_confidence",
+        "v1",
+        minimum_evidence_confidence,
+        ("threshold",),
+    )
+    registry.register(
+        "maximum_capital_required", "v1", maximum_capital_required, ("threshold",)
+    )
+    registry.register("maximum_loss", "v1", maximum_loss, ("threshold",))
+    registry.register(
+        "allowed_time_horizon",
+        "v1",
+        allowed_time_horizon,
+        ("minimum_days", "maximum_days"),
+    )
     registry.register("placeholder_metrics_rejection", "v1", placeholder_metrics_rejection)
     return registry
 

--- a/tests/guardrails/test_guardrail_engine.py
+++ b/tests/guardrails/test_guardrail_engine.py
@@ -1,7 +1,7 @@
 """ASA-CORE-006: guardrail engine tests — determinism, replay, identity, ordering."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -131,21 +131,34 @@ class TestGuardrailEvaluationIdentity:
     def test_same_input_same_id(self):
         opp = _opp()
         eval1 = evaluate_opportunity(opp, PARAMS)
-        a = guardrail_evaluation_identity(opp.opportunity_id, eval1.outcomes, T0)
-        b = guardrail_evaluation_identity(opp.opportunity_id, eval1.outcomes, T0)
+        a = guardrail_evaluation_identity(
+            opp.opportunity_id, eval1.outcomes, eval1.effective_parameters
+        )
+        b = guardrail_evaluation_identity(
+            opp.opportunity_id, eval1.outcomes, eval1.effective_parameters
+        )
         assert a == b
 
     def test_outcome_order_does_not_change_identity(self):
         opp = _opp()
         evaluation = evaluate_opportunity(opp, PARAMS)
-        forward = guardrail_evaluation_identity(opp.opportunity_id, evaluation.outcomes, T0)
+        forward = guardrail_evaluation_identity(
+            opp.opportunity_id, evaluation.outcomes, evaluation.effective_parameters
+        )
         backward = guardrail_evaluation_identity(
-            opp.opportunity_id, tuple(reversed(evaluation.outcomes)), T0)
+            opp.opportunity_id,
+            tuple(reversed(evaluation.outcomes)),
+            evaluation.effective_parameters,
+        )
         assert forward == backward
 
     def test_different_opportunity_different_id(self):
         opp = _opp()
         evaluation = evaluate_opportunity(opp, PARAMS)
-        a = guardrail_evaluation_identity("opp-1", evaluation.outcomes, T0)
-        b = guardrail_evaluation_identity("opp-2", evaluation.outcomes, T0)
+        a = guardrail_evaluation_identity(
+            "opp-1", evaluation.outcomes, evaluation.effective_parameters
+        )
+        b = guardrail_evaluation_identity(
+            "opp-2", evaluation.outcomes, evaluation.effective_parameters
+        )
         assert a != b

--- a/tests/guardrails/test_ranking_phase0_hardening.py
+++ b/tests/guardrails/test_ranking_phase0_hardening.py
@@ -1,0 +1,134 @@
+"""ASA-CORE-007 Phase 0 regression coverage for guardrail hardening."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from domain.opportunity import Opportunity, RecommendationState
+from domain.outcome_metrics import ExpectedOutcomeMetrics
+from domain.references import Confidence, EvidenceKind, EvidenceReference
+from guardrails.engine import evaluate_guardrail, evaluate_opportunity
+from guardrails.evaluations import GUARDRAIL_EVALUATION_IDENTITY_VERSION
+from guardrails.registry import DEFAULT_REGISTRY
+
+T0 = datetime(2026, 7, 21, 14, 0, tzinfo=timezone.utc)
+
+
+def _opportunity() -> Opportunity:
+    return Opportunity(
+        opportunity_id="phase0-opportunity",
+        version=1,
+        strategy_id="strategy",
+        strategy_version="v1",
+        supporting_indicators=(
+            EvidenceReference(kind=EvidenceKind.INDICATOR, referenced_id="indicator", version=1),
+        ),
+        evidence=(
+            EvidenceReference(
+                kind=EvidenceKind.CANONICAL_FACT, referenced_id="fact", version=1
+            ),
+        ),
+        assumptions=("calibrated model",),
+        evidence_confidence=Confidence(score=0.8),
+        expected_outcome_metrics=ExpectedOutcomeMetrics(
+            expected_return=Decimal("0.1"),
+            maximum_loss=Decimal("-10"),
+            capital_required=Decimal("100"),
+            time_horizon_days=10,
+        ),
+        state=RecommendationState.DISCOVERED,
+        effective_time=T0,
+        created_time=T0,
+    )
+
+
+def _parameters(loss_threshold: str = "20") -> dict[str, dict]:
+    return {
+        "minimum_evidence_confidence": {"threshold": Decimal("0.5")},
+        "maximum_capital_required": {"threshold": Decimal("200")},
+        "maximum_loss": {"threshold": Decimal(loss_threshold)},
+        "allowed_time_horizon": {"minimum_days": 1, "maximum_days": 30},
+    }
+
+
+def test_effective_policy_change_changes_identity_even_when_outcomes_match() -> None:
+    opportunity = _opportunity()
+    conservative = evaluate_opportunity(opportunity, _parameters("20"))
+    permissive = evaluate_opportunity(opportunity, _parameters("50"))
+
+    assert conservative.passed and permissive.passed
+    assert tuple(outcome.passed for outcome in conservative.outcomes) == tuple(
+        outcome.passed for outcome in permissive.outcomes
+    )
+    assert conservative.evaluation_id != permissive.evaluation_id
+    assert conservative.effective_parameters != permissive.effective_parameters
+
+
+def test_hardened_identity_algorithm_version_is_pinned() -> None:
+    assert GUARDRAIL_EVALUATION_IDENTITY_VERSION == "v2"
+    assert evaluate_opportunity(_opportunity(), _parameters()).evaluation_id == (
+        "7537bc401a3068e01f99cdcb4d7ccc5baad51ec65de517cbdeecde874de7d2f0"
+    )
+
+
+def test_registry_declares_every_effective_policy_parameter() -> None:
+    assert {
+        guardrail_id: DEFAULT_REGISTRY.get(guardrail_id).parameter_names
+        for guardrail_id in DEFAULT_REGISTRY.registered_ids()
+    } == {
+        "allowed_time_horizon": ("maximum_days", "minimum_days"),
+        "maximum_capital_required": ("threshold",),
+        "maximum_loss": ("threshold",),
+        "minimum_evidence_confidence": ("threshold",),
+        "placeholder_metrics_rejection": (),
+    }
+
+
+def test_execution_timestamp_is_excluded_from_identity() -> None:
+    opportunity = _opportunity()
+    first = evaluate_opportunity(opportunity, _parameters(), evaluated_at=T0)
+    replay = evaluate_opportunity(
+        opportunity, _parameters(), evaluated_at=T0 + timedelta(hours=2)
+    )
+
+    assert first.evaluated_at != replay.evaluated_at
+    assert first.evaluation_id == replay.evaluation_id
+
+
+def test_policy_mapping_order_does_not_change_identity() -> None:
+    opportunity = _opportunity()
+    forward = _parameters()
+    reversed_mapping = {key: forward[key] for key in reversed(tuple(forward))}
+
+    assert evaluate_opportunity(opportunity, forward).evaluation_id == evaluate_opportunity(
+        opportunity, reversed_mapping
+    ).evaluation_id
+
+
+def test_irrelevant_unconsumed_parameter_does_not_change_identity() -> None:
+    opportunity = _opportunity()
+    baseline = _parameters()
+    extra = _parameters()
+    extra["maximum_loss"] = {**extra["maximum_loss"], "unused": Decimal("999")}
+
+    assert evaluate_opportunity(opportunity, baseline).evaluation_id == evaluate_opportunity(
+        opportunity, extra
+    ).evaluation_id
+
+
+def test_placeholder_guardrail_cites_no_unconsumed_evidence() -> None:
+    outcome = evaluate_guardrail("placeholder_metrics_rejection", _opportunity())
+    assert outcome.evidence == ()
+
+
+def test_metric_guardrail_retains_available_opportunity_evidence() -> None:
+    opportunity = _opportunity()
+    outcome = evaluate_guardrail(
+        "maximum_loss", opportunity, {"threshold": Decimal("20")}
+    )
+    assert outcome.evidence == tuple(
+        sorted(
+            opportunity.evidence + opportunity.supporting_indicators,
+            key=lambda reference: (reference.kind.value, reference.referenced_id),
+        )
+    )


### PR DESCRIPTION
## Summary

Completes the required ASA-CORE-007 Phase 0 adjacent hardening before Ranking Engine implementation begins.

- resolves GH-49 by including canonical effective policy parameters in GuardrailEvaluation identity
- removes `evaluated_at` execution time from semantic identity
- pins the changed aggregate identity algorithm as `asa.guardrail_evaluation` `v2`
- preserves canonical effective parameters on the immutable evaluation output
- narrows GH-50 evidence attribution where the current model can do so safely
- adds deterministic regression vectors and architecture-preserving tests

## GH-49: policy-aware identity

Each registered guardrail now declares the parameter names its policy actually consumes. `evaluate_opportunity` records those effective values as immutable, canonical strings and hashes them with opportunity identity and sorted outcome semantics. Extra ignored mapping entries do not alter identity, while two thresholds producing the same pass/fail shape now produce different identities.

## Execution timestamp identity

`evaluated_at` remains on outcomes and evaluations as execution metadata, but is excluded from aggregate identity. Replaying the same semantic evaluation at a different execution time produces the same `evaluation_id`.

Because this changes identity semantics, the algorithm marker advances from `v1` to `v2`. A pinned SHA-256 regression vector protects the new contract.

## GH-50: bounded attribution improvement

The `placeholder_metrics_rejection` guardrail consumes Opportunity assumptions only, so it now cites no unrelated Fact or Indicator evidence. Metric and evidence-confidence guardrails retain the complete Opportunity evidence chain because field-level provenance does not exist in the current domain model; narrowing those further would invent attribution or expand scope.

GH-50 should remain open for the larger field-level provenance decision.

## Architecture boundaries

- no new dependency roots
- no provider, observation, persistence, execution, broker, random, ML, or LLM access
- no Ranking Engine implementation in this PR
- guardrail API parameter mappings receive strict `dict[str, object]` typing

## Verification

- `.venv/bin/python -m ruff check guardrails tests/guardrails/test_guardrail_engine.py tests/guardrails/test_ranking_phase0_hardening.py tests/architecture/test_guardrail_boundaries.py` — passed
- `.venv/bin/python -m mypy guardrails` — passed, 5 source files
- `.venv/bin/python -m pytest -q tests --ignore=tests/pos` — 704 passed
- `.venv/bin/python -m compileall -q domain facts observation reconciliation indicators strategies guardrails ranking presentation providers` — passed
- `.venv/bin/python tools/pos/lean/pre_push_check.py` — all 5 checks passed
- `git diff --check` — passed

## Required merge gate

ASA-CORE-007 Ranking Engine work remains paused until this PR is Founder-merged and post-merge replay, identity, guardrail integration, and architecture validation pass.

## Blocking ranking-contract finding

`OpportunityGuardrailEvaluation` currently contains only `opportunity_id`, outcomes, pass/fail, execution time, and effective policy parameters. It does not carry the Opportunity or its Expected Outcome Metrics. The declared Ranking input is `OpportunityGuardrailEvaluation`, while required scoring dimensions need expected return, downside risk, evidence confidence, capital efficiency, liquidity, and opportunity quality, and Ranking may not use persistence.

Before Ranking implementation, the architecture must make those semantic inputs available through the evaluation contract (the narrowest likely correction is retaining the immutable Opportunity on `OpportunityGuardrailEvaluation`) or explicitly broaden the Ranking Engine input. This PR does not silently choose or implement that contract change.
