### PR TITLE
ASA-ARCH-001: define operational trading contracts

### DIFF
--- a/architecture/ADR-008-operational-trading-contracts.md
+++ b/architecture/ADR-008-operational-trading-contracts.md
@@ -1,0 +1,141 @@
+<!-- Repository path: architecture/ADR-008-operational-trading-contracts.md -->
+
+# ADR-008: Operational Trading Contracts
+
+**Status:** Accepted
+**Date:** 2026-07-21
+
+## Context
+
+Ranking produces ordered Opportunities, but an Opportunity is deliberately an intelligence
+record: it does not identify a broker position, encode an order, or contain the current financial
+state of a portfolio. ASA-CORE-008 exposed the missing boundary. Portfolio policy cannot safely
+infer an instrument from opaque evidence IDs, treat average cost as current value, or import the
+broker-ingestion model from the product backend. Those shortcuts would violate Laws 3, 4, 5, 9,
+and 10 of the Constitution.
+
+The domain needs immutable provider-neutral contracts that let Intelligence describe desired
+exposure and let an Operational Portfolio layer compare that exposure with an observed portfolio.
+This decision defines only data semantics. It introduces no engine, calculation, repository,
+provider integration, persistence, broker write, order, or execution capability. In particular,
+"operational" does not amend Constitution Law 5: ASA remains read-only and a
+`ProposedPosition` is never an order.
+
+## Decision
+
+The shared `domain/` package owns five cross-boundary objects and their supporting value types:
+
+- `Instrument` describes a provider-neutral instrument using a
+  `CanonicalInstrumentIdentity`, kind, display symbol, currency, optional pinned sector
+  classification, and (for an option) explicit underlying identity.
+- `Holding` describes one current, valued position in an account. Direction and absolute
+  quantity are separate; no consumer interprets a signed quantity.
+- `PortfolioSnapshot` is the complete immutable financial-state input for one portfolio at one
+  semantic observation time.
+- `ProposedPosition` is Intelligence's evidence-backed description of desired exposure. It
+  references the Opportunity, Ranked Opportunity, and Ranking Result that produced it but
+  contains no order type, route, time-in-force, broker identifier, or write operation. Its
+  quantity is the absolute size of the proposal, not an order delta or final portfolio target.
+- `PortfolioDecisionRequest` pairs one snapshot with Proposed Positions in Ranking order. It is
+  the input envelope for future deterministic portfolio policy; it contains no policy behavior.
+
+All objects are frozen, slot-based dataclasses. Nested collections are tuples. IDs are opaque and
+must be supplied by the owning upstream component; downstream consumers never derive meaning by
+parsing them.
+
+## Canonical Semantics
+
+### Instrument identity
+
+Identity is the complete `(scheme, value)` pair in `CanonicalInstrumentIdentity`. The scheme
+names a stable canonical namespace; the value is opaque within that namespace. Display symbols,
+option descriptions, and provider instrument IDs are attributes or adapter concerns, never
+identity inputs inferred downstream. Equality compares the complete identity object. Options
+carry their underlying identity explicitly, so no consumer parses an option symbol.
+
+### Portfolio snapshot
+
+A snapshot has a stable `portfolio_snapshot_id`, portfolio identity, one base currency, unique
+holdings, cash balance, buying power, net liquidation value, gross exposure, semantic
+`observed_at`, and source Evidence. Every holding carries its valuation time and Evidence. An
+empty holding tuple is valid: an account-only or cash-only portfolio remains representable.
+
+The snapshot is a value, not a mutable aggregate. A changed balance, holding, valuation, or
+observation time requires a new snapshot and identity. Persistence ownership is intentionally not
+part of this contract.
+
+### Buying power and cash
+
+`cash_balance` is the signed settled ledger cash reported for the snapshot. `buying_power` is the
+non-negative amount available for new exposure after external account restrictions. They are
+independent supplied values: neither is calculated from the other. A negative cash balance can
+therefore coexist with positive buying power. Policy may consume these fields later but this
+contract does not decide whether a proposal is affordable.
+
+### Exposure and valuation
+
+Every monetary amount uses finite `Decimal` arithmetic and an explicit currency. Snapshot values
+and holding valuations use the snapshot base currency; currency conversion must occur before
+construction and must be evidenced upstream.
+
+Holding `market_value` is absolute current value. Holding and proposal `gross_exposure` are
+non-negative policy exposure amounts supplied by the valuation owner. Direction is carried
+separately. `net_liquidation_value` is the signed portfolio value supplied by the same snapshot.
+No contract multiplies quantity by price, derives option exposure, substitutes average cost, or
+performs currency conversion.
+
+### Sector
+
+Sector is an optional `SectorClassification` containing taxonomy, pinned taxonomy version, and
+code. `None` means no classification was supplied; it never means a default sector. Policy must
+handle absence explicitly. Options do not infer sector by parsing their symbols; an upstream
+normalizer may supply the correct classification while retaining the explicit underlying identity.
+
+## Boundaries
+
+The Intelligence pipeline continues through Ranking. It may produce a `ProposedPosition` from a
+`RankedOpportunity`, preserving the Opportunity and Ranking IDs and the Evidence actually used.
+That transformation is not implemented by this ADR.
+
+The Operational Portfolio boundary consumes `ProposedPosition` and `PortfolioSnapshot` through a
+`PortfolioDecisionRequest`. A provider or broker adapter may normalize read-only account data
+into these shared contracts, but provider payload classes, SDK objects, repositories, and
+provider identifiers never enter `domain/`. No Operational component may mutate an Opportunity
+or place operational logic inside Ranking or Strategies.
+
+This boundary supplies the state needed by portfolio policy and read-only execution-plan
+presentation. It does not authorize order creation or broker writes; those remain prohibited by
+Constitution Law 5.
+
+## Alternatives Considered
+
+1. **Add instrument and portfolio fields directly to Ranking models.** Rejected: Ranking orders
+   Opportunities and must not become the owner of operational financial state.
+2. **Reuse the backend broker-ingestion snapshot.** Rejected: it is an integration-specific
+   publication model outside the intelligence dependency boundary and lacks the canonical
+   valuation semantics required by portfolio policy.
+3. **Infer exposure from quantity and average cost.** Rejected: average cost is not current value,
+   and option exposure cannot be derived correctly without a valuation policy.
+4. **Use symbols as canonical identity.** Rejected: symbols are display/routing attributes,
+   ambiguous across markets, and especially unsafe when parsed as option contracts.
+5. **Put a repository on the request.** Rejected: it would make replay depend on mutable external
+   state and violate the pure contract boundary.
+
+## Consequences
+
+- ASA-CORE-008 can evaluate cash, buying power, duplicate identity, current value, gross
+  exposure, and sector without broker or repository access.
+- Read-only broker adapters have an explicit normalization target without leaking SDK models.
+- Proposed exposure is independently inspectable and traceable to Ranking and Evidence.
+- Upstream normalization or valuation must supply canonical identities and financial values;
+  absence is represented explicitly rather than hidden behind a fallback calculation.
+- Supporting more instrument kinds or a new canonical identity scheme is a deliberate contract
+  change, not dynamic parsing.
+
+## References
+
+- GitHub issue #57
+- ADR-003: Explainable Opportunity Model
+- ADR-004: Repository Organization
+- ADR-007: Deterministic Ranking Model
+- Architecture Constitution, Laws 3, 4, 5, 9, and 10

--- a/architecture/ARCHITECTURE_VISION.md
+++ b/architecture/ARCHITECTURE_VISION.md
@@ -60,9 +60,13 @@ Guardrail Layer
         │
         ▼
 Ranking Layer
-        │
-        ▼
-Presentation Layer
+      ┌─┴──────────────┐
+      ▼                ▼
+Presentation       Proposed Position
+Layer                   │
+                        ▼
+              Operational Portfolio Policy
+                  (read-only decision)
 ```
 
 Each layer consumes only from the layer(s) below it and has a single, well-defined responsibility:
@@ -75,6 +79,7 @@ Each layer consumes only from the layer(s) below it and has a single, well-defin
 - **Guardrail Layer** applies platform-wide risk and eligibility rules to those candidates.
 - **Ranking Layer** orders surviving Opportunities for presentation.
 - **Presentation Layer** communicates the result to the user, including any natural-language summarization. This is the only layer where a language model may participate.
+- **Operational Portfolio Policy** compares evidence-backed Proposed Positions with one immutable, provider-neutral Portfolio Snapshot. It does not gather broker data, mutate Opportunities, or execute trades. ADR-008 defines this separate contract boundary without changing ASA's read-only constitutional limit.
 
 Provider independence follows from this structure: a provider can be added, removed, or reprioritized without altering any layer above the Observation Layer, because everything above it consumes Canonical Facts, not raw provider payloads.
 

--- a/architecture/DECISION_LOG.md
+++ b/architecture/DECISION_LOG.md
@@ -8,6 +8,7 @@ Do not add substantive reasoning to this file. If an entry needs more than two s
 
 | Date | Summary | ADR |
 |---|---|---|
+| 2026-07-21 | Provider-neutral immutable Instrument, Holding, PortfolioSnapshot, ProposedPosition, and PortfolioDecisionRequest contracts separate ranked intelligence from read-only operational portfolio policy without introducing broker models, persistence, or execution. | ADR-008 (ASA-ARCH-001) |
 | 2026-07-21 | Ranking v1 deterministically orders eligible Opportunities using six versioned, provenance-preserving component scorers, explicit parameters, and stable tie-breakers; missing liquidity uses an explicit neutral placeholder rather than an invented proxy. | ADR-007 (ASA-CORE-007) |
 | 2026-07-21 | Guardrail evaluation is the pipeline envelope containing the immutable Opportunity, ordered Guardrail outcomes, and aggregate decision; Ranking never reconstructs Opportunity data from outcomes or persistence. | ADR-005 (amended, ASA-CORE-007) |
 | 2026-07-21 | `guardrails/`'s allowed dependencies narrowed to `strategies/`, `indicators/`, `facts/`, `reconciliation/`, `domain/` — not `observation/` or `providers/` — making ADR-005's existing "no raw Observation access" prose structurally enforceable. | ADR-004 (amended, ASA-CORE-006) |
@@ -24,7 +25,8 @@ Do not add substantive reasoning to this file. If an entry needs more than two s
 
 ## Open Questions / Requires ADR
 
-- ADR-001 through ADR-007 cover the Observation/Canonical Fact model, Provider contract,
+- ADR-001 through ADR-008 cover the Observation/Canonical Fact model, Provider contract,
   Opportunity model, repository organization, Guardrail model, Indicator versioning, and
-  Ranking model. Cross-Opportunity (portfolio-level) Guardrails remain open; see ADR-005.
+  Ranking model, plus the Intelligence-to-Operational Portfolio contract. Cross-Opportunity
+  (portfolio-level) Guardrails remain open; see ADR-005.
 - No ADR numbering or storage convention has been formally adopted (see `README.md`'s Open Questions). This log assumes ADRs will be referenced by filename or number once that convention exists.

--- a/architecture/DOMAIN_GLOSSARY.md
+++ b/architecture/DOMAIN_GLOSSARY.md
@@ -29,11 +29,26 @@ A platform-owned rule that determines whether a candidate Opportunity is eligibl
 **Indicator**
 A derived, shared quantity computed from one or more Canonical Facts. Indicators are computed exactly once and consumed by every Strategy that needs them (Constitution Law 3) — a Strategy never maintains its own private copy of an Indicator's calculation.
 
+**Instrument**
+A provider-neutral financial instrument identified by one complete opaque, namespaced canonical identity. A display symbol or broker identifier is not canonical identity, and consumers never parse identity strings to recover instrument attributes.
+
+**Holding**
+One immutable, currently valued position within a Portfolio Snapshot. Direction, absolute quantity, current market value, gross exposure, valuation time, and valuation Evidence are explicit; average cost is not substituted for current value.
+
 **Observation**
 Immutable, raw evidence as reported by an external Provider. An Observation is a historical record: once written, it is never altered, even if later shown to be wrong. Corrections are represented as new Observations and reconciled at the Canonical Fact layer, not by editing history.
 
 **Opportunity**
 A candidate investment action surfaced by the Strategy Layer, prior to Guardrail evaluation and Ranking. An Opportunity that does not pass Guardrail evaluation is never presented to a user as a Recommendation.
+
+**Portfolio Decision Request**
+The immutable Operational Portfolio input envelope pairing one Portfolio Snapshot with evidence-backed Proposed Positions in Ranking order. It contains no policy implementation, repository, broker object, or execution instruction.
+
+**Portfolio Snapshot**
+Complete immutable portfolio financial state at one semantic observation time: holdings, signed settled cash, non-negative buying power, net liquidation value, gross exposure, base currency, and Evidence. Any state change produces a new snapshot; the object is not a mutable portfolio tracker.
+
+**Proposed Position**
+An evidence-backed description of desired instrument exposure produced from ranked Intelligence. It identifies quantity, direction, estimated price, and gross exposure, but is not an order and carries no broker routing or write semantics.
 
 **Provider**
 An external source of raw data — market data, options data, broker data, financial events, or similar — that ASA does not control. ASA does not assume Providers agree with one another; see Provenance and Confidence.

--- a/domain/__init__.py
+++ b/domain/__init__.py
@@ -11,6 +11,18 @@ from domain.guardrail import GuardrailOutcome
 from domain.indicator import Indicator
 from domain.observation import Observation
 from domain.opportunity import Opportunity, RecommendationState
+from domain.operational import (
+    CanonicalInstrumentIdentity,
+    Holding,
+    Instrument,
+    InstrumentKind,
+    MonetaryAmount,
+    PortfolioDecisionRequest,
+    PortfolioSnapshot,
+    PositionDirection,
+    ProposedPosition,
+    SectorClassification,
+)
 from domain.outcome_metrics import ExpectedOutcomeMetrics
 from domain.provenance import Provenance, ProviderDisagreement
 from domain.provider import Provider
@@ -19,6 +31,7 @@ from domain.values import DomainInvariantError, is_normalized_value
 
 __all__ = [
     "CanonicalFact",
+    "CanonicalInstrumentIdentity",
     "Confidence",
     "DomainInvariantError",
     "is_normalized_value",
@@ -26,11 +39,20 @@ __all__ = [
     "EvidenceReference",
     "ExpectedOutcomeMetrics",
     "GuardrailOutcome",
+    "Holding",
     "Indicator",
+    "Instrument",
+    "InstrumentKind",
+    "MonetaryAmount",
     "Observation",
     "Opportunity",
+    "PortfolioDecisionRequest",
+    "PortfolioSnapshot",
+    "PositionDirection",
     "Provenance",
     "Provider",
     "ProviderDisagreement",
+    "ProposedPosition",
     "RecommendationState",
+    "SectorClassification",
 ]

--- a/domain/operational.py
+++ b/domain/operational.py
@@ -1,0 +1,266 @@
+"""Provider-neutral contracts between intelligence and operations (ASA-ARCH-001).
+
+Structural definitions only.  These values contain no portfolio policy,
+execution planning, persistence, provider, or broker behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+
+from domain.references import EvidenceReference
+from domain.values import DomainInvariantError, require_finite_decimal, require_tz_aware
+
+
+def _require_text(value: str, owner: str, field_name: str) -> None:
+    if not value or value != value.strip():
+        raise DomainInvariantError(f"{owner}.{field_name} must be non-empty normalized text")
+
+
+def _require_non_negative(value: Decimal, owner: str, field_name: str) -> None:
+    require_finite_decimal(value, owner, field_name)
+    if value < 0:
+        raise DomainInvariantError(f"{owner}.{field_name} cannot be negative")
+
+
+class InstrumentKind(str, Enum):
+    """Instrument categories understood by the provider-neutral domain."""
+
+    EQUITY = "equity"
+    OPTION = "option"
+    CASH = "cash"
+
+
+class PositionDirection(str, Enum):
+    """Explicit exposure direction; quantity values never encode direction."""
+
+    LONG = "long"
+    SHORT = "short"
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalInstrumentIdentity:
+    """Opaque, namespaced identity assigned before entering the domain.
+
+    Consumers compare the complete ``(scheme, value)`` pair.  They must not
+    parse either string to recover symbol, expiry, strike, or provider IDs.
+    """
+
+    scheme: str
+    value: str
+
+    def __post_init__(self) -> None:
+        _require_text(self.scheme, "CanonicalInstrumentIdentity", "scheme")
+        _require_text(self.value, "CanonicalInstrumentIdentity", "value")
+
+
+@dataclass(frozen=True, slots=True)
+class SectorClassification:
+    """A pinned sector code in an explicitly named taxonomy."""
+
+    taxonomy: str
+    taxonomy_version: str
+    code: str
+
+    def __post_init__(self) -> None:
+        for field_name in ("taxonomy", "taxonomy_version", "code"):
+            _require_text(getattr(self, field_name), "SectorClassification", field_name)
+
+
+@dataclass(frozen=True, slots=True)
+class MonetaryAmount:
+    """A finite decimal amount with an explicit ISO-style currency code."""
+
+    amount: Decimal
+    currency: str
+
+    def __post_init__(self) -> None:
+        require_finite_decimal(self.amount, "MonetaryAmount", "amount")
+        _require_text(self.currency, "MonetaryAmount", "currency")
+
+
+@dataclass(frozen=True, slots=True)
+class Instrument:
+    """Canonical instrument description, independent of every broker model."""
+
+    identity: CanonicalInstrumentIdentity
+    kind: InstrumentKind
+    display_symbol: str
+    currency: str
+    sector: SectorClassification | None = None
+    underlying_identity: CanonicalInstrumentIdentity | None = None
+
+    def __post_init__(self) -> None:
+        _require_text(self.display_symbol, "Instrument", "display_symbol")
+        _require_text(self.currency, "Instrument", "currency")
+        if self.kind is InstrumentKind.OPTION and self.underlying_identity is None:
+            raise DomainInvariantError("Instrument.underlying_identity is required for options")
+        if self.kind is not InstrumentKind.OPTION and self.underlying_identity is not None:
+            raise DomainInvariantError(
+                "Instrument.underlying_identity is only valid for option instruments"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class Holding:
+    """One valued position in an immutable PortfolioSnapshot.
+
+    ``quantity`` is an absolute unit count and ``direction`` carries its sign.
+    ``market_value`` is absolute current value; ``gross_exposure`` is the
+    supplied non-negative policy exposure.  Neither is derived in this model.
+    """
+
+    holding_id: str
+    account_id: str
+    instrument: Instrument
+    direction: PositionDirection
+    quantity: Decimal
+    market_value: MonetaryAmount
+    gross_exposure: MonetaryAmount
+    valued_at: datetime
+    valuation_evidence: tuple[EvidenceReference, ...]
+
+    def __post_init__(self) -> None:
+        _require_text(self.holding_id, "Holding", "holding_id")
+        _require_text(self.account_id, "Holding", "account_id")
+        _require_non_negative(self.quantity, "Holding", "quantity")
+        if self.quantity == 0:
+            raise DomainInvariantError("Holding.quantity must be greater than zero")
+        _require_non_negative(self.market_value.amount, "Holding", "market_value.amount")
+        _require_non_negative(self.gross_exposure.amount, "Holding", "gross_exposure.amount")
+        if self.market_value.currency != self.gross_exposure.currency:
+            raise DomainInvariantError("Holding valuation currencies must match")
+        require_tz_aware(self.valued_at, "Holding", "valued_at")
+        if not self.valuation_evidence:
+            raise DomainInvariantError("Holding.valuation_evidence cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioSnapshot:
+    """Complete portfolio state at one semantic observation time.
+
+    Cash is the signed settled ledger balance.  Buying power is the
+    non-negative amount currently available for new positions after external
+    account restrictions.  Gross exposure is supplied valuation evidence,
+    not a quantity or average-cost calculation performed by this contract.
+    """
+
+    portfolio_snapshot_id: str
+    portfolio_id: str
+    base_currency: str
+    holdings: tuple[Holding, ...]
+    cash_balance: MonetaryAmount
+    buying_power: MonetaryAmount
+    net_liquidation_value: MonetaryAmount
+    gross_exposure: MonetaryAmount
+    observed_at: datetime
+    evidence: tuple[EvidenceReference, ...]
+
+    def __post_init__(self) -> None:
+        _require_text(self.portfolio_snapshot_id, "PortfolioSnapshot", "portfolio_snapshot_id")
+        _require_text(self.portfolio_id, "PortfolioSnapshot", "portfolio_id")
+        _require_text(self.base_currency, "PortfolioSnapshot", "base_currency")
+        require_tz_aware(self.observed_at, "PortfolioSnapshot", "observed_at")
+        currencies = {
+            self.cash_balance.currency,
+            self.buying_power.currency,
+            self.net_liquidation_value.currency,
+            self.gross_exposure.currency,
+            *(holding.market_value.currency for holding in self.holdings),
+        }
+        if currencies != {self.base_currency}:
+            raise DomainInvariantError("PortfolioSnapshot monetary values must use base_currency")
+        _require_non_negative(self.buying_power.amount, "PortfolioSnapshot", "buying_power.amount")
+        _require_non_negative(
+            self.gross_exposure.amount, "PortfolioSnapshot", "gross_exposure.amount"
+        )
+        holding_ids = tuple(holding.holding_id for holding in self.holdings)
+        if len(holding_ids) != len(set(holding_ids)):
+            raise DomainInvariantError("PortfolioSnapshot contains duplicate holding_id values")
+        if not self.evidence:
+            raise DomainInvariantError("PortfolioSnapshot.evidence cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class ProposedPosition:
+    """Intelligence output describing desired exposure, never an order.
+
+    ``quantity`` is the absolute size of this proposal, not an order delta or
+    a post-execution portfolio target.  Operational policy compares it with
+    the separately supplied snapshot before any read-only plan is presented.
+    """
+
+    proposed_position_id: str
+    opportunity_id: str
+    ranking_result_id: str
+    ranking_id: str
+    portfolio_id: str
+    account_id: str
+    instrument: Instrument
+    direction: PositionDirection
+    quantity: Decimal
+    estimated_unit_price: MonetaryAmount
+    gross_exposure: MonetaryAmount
+    evidence: tuple[EvidenceReference, ...]
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "proposed_position_id",
+            "opportunity_id",
+            "ranking_result_id",
+            "ranking_id",
+            "portfolio_id",
+            "account_id",
+        ):
+            _require_text(getattr(self, field_name), "ProposedPosition", field_name)
+        _require_non_negative(self.quantity, "ProposedPosition", "quantity")
+        if self.quantity == 0:
+            raise DomainInvariantError("ProposedPosition.quantity must be greater than zero")
+        _require_non_negative(
+            self.estimated_unit_price.amount,
+            "ProposedPosition",
+            "estimated_unit_price.amount",
+        )
+        _require_non_negative(
+            self.gross_exposure.amount, "ProposedPosition", "gross_exposure.amount"
+        )
+        if self.estimated_unit_price.currency != self.gross_exposure.currency:
+            raise DomainInvariantError("ProposedPosition valuation currencies must match")
+        if not self.evidence:
+            raise DomainInvariantError("ProposedPosition.evidence cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioDecisionRequest:
+    """Operational input envelope; proposal order preserves Ranking order."""
+
+    decision_request_id: str
+    ranking_result_id: str
+    portfolio_snapshot: PortfolioSnapshot
+    proposed_positions: tuple[ProposedPosition, ...]
+
+    def __post_init__(self) -> None:
+        _require_text(self.decision_request_id, "PortfolioDecisionRequest", "decision_request_id")
+        _require_text(self.ranking_result_id, "PortfolioDecisionRequest", "ranking_result_id")
+        proposal_ids = tuple(item.proposed_position_id for item in self.proposed_positions)
+        if len(proposal_ids) != len(set(proposal_ids)):
+            raise DomainInvariantError(
+                "PortfolioDecisionRequest contains duplicate proposed_position_id values"
+            )
+        if any(
+            item.ranking_result_id != self.ranking_result_id
+            for item in self.proposed_positions
+        ):
+            raise DomainInvariantError(
+                "PortfolioDecisionRequest proposals must reference ranking_result_id"
+            )
+        if any(
+            item.portfolio_id != self.portfolio_snapshot.portfolio_id
+            for item in self.proposed_positions
+        ):
+            raise DomainInvariantError(
+                "PortfolioDecisionRequest proposals must target the snapshot portfolio_id"
+            )

--- a/tests/domain/test_operational_contracts.py
+++ b/tests/domain/test_operational_contracts.py
@@ -1,0 +1,192 @@
+"""ASA-ARCH-001 operational contract regression coverage."""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from domain import (
+    CanonicalInstrumentIdentity,
+    DomainInvariantError,
+    EvidenceKind,
+    EvidenceReference,
+    Holding,
+    Instrument,
+    InstrumentKind,
+    MonetaryAmount,
+    PortfolioDecisionRequest,
+    PortfolioSnapshot,
+    PositionDirection,
+    ProposedPosition,
+    SectorClassification,
+)
+
+NOW = datetime(2026, 7, 22, tzinfo=timezone.utc)
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "obs-portfolio-1"),)
+USD = "USD"
+
+
+def _instrument() -> Instrument:
+    return Instrument(
+        identity=CanonicalInstrumentIdentity("figi", "BBG000B9XRY4"),
+        kind=InstrumentKind.EQUITY,
+        display_symbol="AAPL",
+        currency=USD,
+        sector=SectorClassification("GICS", "2023", "45"),
+    )
+
+
+def _holding(**overrides: object) -> Holding:
+    values: dict[str, object] = {
+        "holding_id": "holding-1",
+        "account_id": "account-1",
+        "instrument": _instrument(),
+        "direction": PositionDirection.LONG,
+        "quantity": Decimal("10"),
+        "market_value": MonetaryAmount(Decimal("2100"), USD),
+        "gross_exposure": MonetaryAmount(Decimal("2100"), USD),
+        "valued_at": NOW,
+        "valuation_evidence": EVIDENCE,
+    }
+    values.update(overrides)
+    return Holding(**values)  # type: ignore[arg-type]
+
+
+def _snapshot(**overrides: object) -> PortfolioSnapshot:
+    values: dict[str, object] = {
+        "portfolio_snapshot_id": "snapshot-1",
+        "portfolio_id": "portfolio-1",
+        "base_currency": USD,
+        "holdings": (_holding(),),
+        "cash_balance": MonetaryAmount(Decimal("5000"), USD),
+        "buying_power": MonetaryAmount(Decimal("8000"), USD),
+        "net_liquidation_value": MonetaryAmount(Decimal("7100"), USD),
+        "gross_exposure": MonetaryAmount(Decimal("2100"), USD),
+        "observed_at": NOW,
+        "evidence": EVIDENCE,
+    }
+    values.update(overrides)
+    return PortfolioSnapshot(**values)  # type: ignore[arg-type]
+
+
+def _proposal(**overrides: object) -> ProposedPosition:
+    values: dict[str, object] = {
+        "proposed_position_id": "proposal-1",
+        "opportunity_id": "opportunity-1",
+        "ranking_result_id": "ranking-result-1",
+        "ranking_id": "ranked-opportunity-1",
+        "portfolio_id": "portfolio-1",
+        "account_id": "account-1",
+        "instrument": _instrument(),
+        "direction": PositionDirection.LONG,
+        "quantity": Decimal("2"),
+        "estimated_unit_price": MonetaryAmount(Decimal("210"), USD),
+        "gross_exposure": MonetaryAmount(Decimal("420"), USD),
+        "evidence": EVIDENCE,
+    }
+    values.update(overrides)
+    return ProposedPosition(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        _instrument(),
+        _holding(),
+        _snapshot(),
+        _proposal(),
+        PortfolioDecisionRequest(
+            "request-1", "ranking-result-1", _snapshot(), (_proposal(),)
+        ),
+    ],
+)
+def test_operational_contracts_are_deeply_immutable(value: object) -> None:
+    assert dataclasses.is_dataclass(value)
+    assert value.__dataclass_params__.frozen  # type: ignore[attr-defined]
+    first_field = dataclasses.fields(value)[0].name
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(value, first_field, "changed")
+    assert all(
+        not isinstance(getattr(value, field.name), (list, dict, set))
+        for field in dataclasses.fields(value)
+    )
+
+
+def test_instrument_identity_is_opaque_and_not_derived_from_display_symbol() -> None:
+    first = _instrument()
+    renamed = dataclasses.replace(first, display_symbol="APPLE")
+    assert renamed.identity == first.identity
+
+
+def test_option_requires_explicit_underlying_identity() -> None:
+    with pytest.raises(DomainInvariantError, match="underlying_identity is required"):
+        Instrument(
+            identity=CanonicalInstrumentIdentity("occ", "AAPL270115C00200000"),
+            kind=InstrumentKind.OPTION,
+            display_symbol="AAPL 2027-01-15 200C",
+            currency=USD,
+        )
+
+
+def test_snapshot_keeps_cash_and_buying_power_distinct() -> None:
+    snapshot = _snapshot(
+        cash_balance=MonetaryAmount(Decimal("-100"), USD),
+        buying_power=MonetaryAmount(Decimal("500"), USD),
+    )
+    assert snapshot.cash_balance.amount == Decimal("-100")
+    assert snapshot.buying_power.amount == Decimal("500")
+
+
+def test_account_only_snapshot_is_supported() -> None:
+    snapshot = _snapshot(
+        holdings=(),
+        gross_exposure=MonetaryAmount(Decimal("0"), USD),
+    )
+    assert snapshot.holdings == ()
+
+
+def test_snapshot_rejects_negative_buying_power() -> None:
+    with pytest.raises(DomainInvariantError, match="buying_power.amount cannot be negative"):
+        _snapshot(buying_power=MonetaryAmount(Decimal("-0.01"), USD))
+
+
+def test_snapshot_rejects_mixed_valuation_currencies() -> None:
+    with pytest.raises(DomainInvariantError, match="must use base_currency"):
+        _snapshot(cash_balance=MonetaryAmount(Decimal("5000"), "EUR"))
+
+
+def test_holding_requires_explicit_valuation_evidence() -> None:
+    with pytest.raises(DomainInvariantError, match="valuation_evidence cannot be empty"):
+        _holding(valuation_evidence=())
+
+
+def test_decision_request_preserves_rank_order_and_requires_matching_ids() -> None:
+    first = _proposal()
+    second = _proposal(
+        proposed_position_id="proposal-2",
+        opportunity_id="opportunity-2",
+    )
+    request = PortfolioDecisionRequest(
+        "request-1", "ranking-result-1", _snapshot(), (first, second)
+    )
+    assert request.proposed_positions == (first, second)
+
+    with pytest.raises(DomainInvariantError, match="reference ranking_result_id"):
+        PortfolioDecisionRequest(
+            "request-2",
+            "other-ranking",
+            _snapshot(),
+            (first,),
+        )
+
+
+def test_contract_fields_contain_no_broker_or_repository_models() -> None:
+    field_names = {
+        field.name
+        for cls in (Instrument, Holding, PortfolioSnapshot, ProposedPosition)
+        for field in dataclasses.fields(cls)
+    }
+    assert not any("broker" in name or "repository" in name for name in field_names)


### PR DESCRIPTION
## Summary

- defines immutable provider-neutral Instrument, Holding, PortfolioSnapshot, ProposedPosition, and PortfolioDecisionRequest contracts
- pins instrument identity, cash, buying-power, exposure, sector, and valuation semantics in ADR-008
- separates ranked Intelligence from read-only Operational Portfolio policy without adding engines, persistence, broker integration, or execution
- preserves the existing Ranking and Opportunity contracts unchanged

## Boundary and constitutional safety

ProposedPosition is an evidence-backed desired exposure, never an order. No broker model, provider import, repository, mutable portfolio object, ID parsing, execution behavior, or operational logic in Ranking/Strategies was introduced. Constitution Law 5 remains unchanged: ASA is read-only.

## Verification

- `PYTHONPATH=. .venv/bin/python -m pytest tests/architecture tests/domain tests/observation tests/providers tests/reconciliation tests/facts tests/indicators tests/strategies tests/guardrails tests/ranking -q` — 701 passed
- `.venv/bin/ruff check domain/operational.py domain/__init__.py tests/domain/test_operational_contracts.py` — passed
- `.venv/bin/mypy domain` — passed
- `.venv/bin/python tools/pos/lean/check_entrypoints.py` — passed
- `.venv/bin/python tools/pos/lean/check_integrity.py` — passed
- `git diff --check` — passed

## Known unrelated repository finding

The broader POS suite has a pre-existing generated timestamp mismatch in `project/lean/migration/blockers.yaml` (expected 2026-07-18, committed 2026-07-19). This ticket preserves `project/lean/**` and does not modify that state.

Closes #57