### PR TITLE
Resolve canonical instrument propagation for CORE-008

### DIFF
--- a/architecture/ADR-003-opportunity-model.md
+++ b/architecture/ADR-003-opportunity-model.md
@@ -15,6 +15,10 @@ An **Opportunity**, from the moment it is produced by the Strategy Layer through
 
 - **Identity.** A stable identifier for the Opportunity that persists across its lifecycle (Strategy discovery → Guardrail evaluation → Ranking → Presentation or rejection), so its full history can be reconstructed from any stage.
 - **Originating Strategy.** The specific Strategy, and the specific version of that Strategy, that produced this Opportunity. Recording the version, not just the Strategy's name, is required for Constitution Law 7 (deterministic, reproducible evaluation) — re-running history must use the Strategy version that actually ran, not whatever version exists today.
+- **Canonical Instrument.** The provider-neutral `Instrument` this Opportunity concerns. The
+  Strategy receives this identity explicitly and records it unchanged; it never resolves a symbol,
+  parses an evidence ID, or consults a Provider. Guardrails and Ranking preserve the same immutable
+  Opportunity envelope, so instrument identity reaches Position Proposal without a parallel field.
 - **Supporting Indicators.** The specific Indicator values the Strategy relied on, each referencing the Canonical Fact version(s) (ADR-001) they were computed from — not just the final numbers, but a traceable path back to Evidence.
 - **Evidence.** The structured Observations and Canonical Facts underlying the above, per `DOMAIN_GLOSSARY.md`'s existing Evidence definition. This is what the Presentation Layer is permitted to summarize; anything not present here is not available for the Presentation Layer to reference.
 - **Assumptions.** Any modeling assumption the Strategy relied on that is not itself a Fact or Indicator (for example, an assumption about normal market conditions, or a simplification in how a spread's risk is modeled). Assumptions are recorded explicitly by the Strategy, not left implicit in code, so they can be surfaced as caveats.
@@ -38,6 +42,8 @@ An **Opportunity**, from the moment it is produced by the Strategy Layer through
 
 - Opportunity records are substantially larger than a "final score plus a label" model would produce, since they must carry a full evidence and Guardrail trail. This is treated as a direct, accepted cost of Constitution Law 6, not an inefficiency to be optimized away later.
 - Every Strategy author must explicitly emit Assumptions and the full set of Expected Outcome Metrics — this is a discipline requirement on Strategy implementation, not merely a data-model nicety. A Strategy that cannot state its Opportunity's expected financial characteristics in the standard vocabulary is not a complete Strategy.
+- Opportunity identity includes canonical Instrument identity. Otherwise identical evidence and
+  metrics concerning different Instruments cannot collide.
 - Rejected Opportunities are retained with their full Guardrail trail rather than discarded, which has a storage-cost and retention-policy implication (see Open Questions), but directly enables future "why wasn't this recommended" functionality without further architectural work.
 - Because the Decision Journal is defined as the Opportunity record itself at presentation time, no separate persistence mechanism needs to be designed or maintained for it.
 
@@ -61,3 +67,9 @@ This ADR originally defined a two-value Confidence model on the Opportunity: *ev
 - `DOMAIN_GLOSSARY.md`: Opportunity, Evidence, Recommendation, Guardrail, Confidence, Decision Journal (provisional), Indicator
 - ADR-001 (Observation & Canonical Fact Model)
 - ADR-006 (Indicator Versioning and Immutability) — clarifies that "Supporting Indicators" here means a pinned Indicator version, not a live value
+
+## Revision note (Issue #63)
+
+Opportunity now references the canonical Instrument it concerns. This closes the missing
+propagation path required by the Position Proposal Engine without adding provider lookup or
+duplicating Instrument fields in Guardrail and Ranking outputs.

--- a/architecture/ADR-007-ranking-model.md
+++ b/architecture/ADR-007-ranking-model.md
@@ -19,6 +19,8 @@ data, or hiding judgment inside an opaque score.
 Ranking accepts only `OpportunityGuardrailEvaluation` values. It filters to aggregate `PASS`
 decisions, retains each complete evaluation envelope, and produces immutable
 `RankedOpportunity` values in one `RankingResult`. It never mutates or recreates an Opportunity.
+Because Opportunity owns canonical Instrument identity, Ranking preserves that Instrument through
+the retained envelope; it performs no symbol resolution and creates no parallel instrument field.
 
 The algorithm is pinned as `asa.ranking` `v1`. Six independently versioned component scorers
 produce scores in `[0, 1]` with complete provenance:

--- a/architecture/ADR-008-operational-trading-contracts.md
+++ b/architecture/ADR-008-operational-trading-contracts.md
@@ -34,10 +34,10 @@ The shared `domain/` package owns five cross-boundary objects and their supporti
   semantic observation time.
 - `ProposedPosition` is Intelligence's evidence-backed description of desired exposure. It
   references the Opportunity, Ranked Opportunity, and Ranking Result that produced it but
-  contains no order type, route, time-in-force, broker identifier, or write operation. It pins
+  contains no account, portfolio, quantity, market price, order type, route, time-in-force, broker
+  identifier, or write operation. It preserves the Opportunity's canonical Instrument and pins
   proposal-algorithm version, target allocation, effective sizing parameters, confidence,
-  rationale, quantity, and gross exposure. Quantity is the absolute size of the proposal, not an
-  order delta or final portfolio target.
+  rationale, lineage, and Evidence.
 - `PortfolioDecisionRequest` pairs one snapshot with Proposed Positions in Ranking order. It is
   the input envelope for future deterministic portfolio policy; it contains no policy behavior.
 
@@ -80,9 +80,10 @@ Every monetary amount uses finite `Decimal` arithmetic and an explicit currency.
 and holding valuations use the snapshot base currency; currency conversion must occur before
 construction and must be evidenced upstream.
 
-Holding `market_value` is absolute current value. Holding and proposal `gross_exposure` are
-non-negative policy exposure amounts supplied by the valuation owner. Direction is carried
-separately. `net_liquidation_value` is the signed portfolio value supplied by the same snapshot.
+Holding `market_value` is absolute current value. Holding and Portfolio Snapshot
+`gross_exposure` are non-negative policy exposure amounts supplied by the valuation owner.
+Direction is carried separately. `net_liquidation_value` is the signed portfolio value supplied
+by the same snapshot.
 No contract multiplies quantity by price, derives option exposure, substitutes average cost, or
 performs currency conversion.
 

--- a/architecture/ADR-009-execution-semantics.md
+++ b/architecture/ADR-009-execution-semantics.md
@@ -56,7 +56,7 @@ engine responsibility, not a second domain object.
 ### Semantic ownership
 
 - `RankingResult` answers **what is attractive**. It orders Opportunities with confidence,
-  scoring provenance, and Evidence. It never reads portfolio state.
+  canonical Instrument, scoring provenance, and Evidence. It never reads portfolio state.
 - `ProposedPosition` answers **what exposure Intelligence would want without portfolio
   constraints**. The Position Proposal Engine owns target-allocation and sizing policy and
   propagates the ranked thesis, confidence, effective sizing parameters, rationale, and Evidence.
@@ -67,10 +67,12 @@ Engine's explicitly parameterized reference capital. It is desired unconstrained
 a percentage derived from the observed Portfolio Snapshot. The reference-capital and sizing
 policy values must be present in the proposal's effective parameters, so replay never depends on
 hidden configuration.
+
 - `PortfolioDecision` answers **how much of that proposed exposure survives current portfolio
   constraints**. It references exactly one Proposed Position and Portfolio Snapshot, pins policy
   versions and effective parameters, and records `ACCEPT`, `REJECT`, `REDUCE`, or `HOLD` with
-  approved quantity, approved exposure, reasons, and Evidence.
+  approved allocation, reasons, and Evidence. Account selection and valuation are later-stage
+  portfolio concerns; they are never fields on Proposed Position.
 - `ExecutionPlan` answers **how the approved decision would be decomposed and sequenced**. It
   retains the complete Portfolio Decision and owns an ordered tuple of analytical
   `BrokerRequest` records. A rejected or held decision has an empty tuple.
@@ -121,8 +123,7 @@ complete semantic inputs:
 
 Proposed Position identity remains in the `asa.proposed_position` namespace and includes the
 Opportunity, Ranked Opportunity, and Ranking Result identities; proposal algorithm version;
-portfolio and account identities; instrument and direction; target allocation; quantity; price;
-gross exposure; confidence; rationale; effective parameters; and Evidence.
+canonical Instrument; target allocation; confidence; rationale; effective parameters; and Evidence.
 
 Identity excludes timestamps, process execution order, serialization order of keyed parameters,
 randomness, provider payloads, and broker state. Contract fields contain no timestamps. Engines
@@ -130,8 +131,8 @@ must canonicalize keyed parameters by key before hashing and reject duplicate ke
 
 ## State Semantics
 
-- `ACCEPT` approves the complete proposed quantity and gross exposure.
-- `REDUCE` approves a smaller positive quantity and gross exposure.
+- `ACCEPT` approves the complete proposed target allocation.
+- `REDUCE` approves a smaller positive target allocation.
 - `REJECT` approves no new exposure because portfolio policy disallows the proposal.
 - `HOLD` approves no new exposure because no portfolio change should be planned.
 
@@ -153,6 +154,12 @@ Workers may implement, test, refactor within ticket scope, file issues, and mark
 merge. They may not merge. Founder remains the sole merge authority, and every sprint PR requires
 Founder approval after tests, replay, dependency, forbidden-import, circularity, and quality gates
 pass.
+
+Opportunity is the canonical owner of Instrument identity before the operational boundary.
+Strategy evaluation receives an explicit canonical Instrument and includes its identity in
+Opportunity identity. Guardrails and Ranking retain the complete immutable Opportunity; neither
+copies, resolves, parses, or looks up Instrument data. Position Proposal therefore consumes the
+Instrument already present in Ranking Result.
 
 ## Alternatives Considered
 
@@ -176,9 +183,17 @@ pass.
 - The architecture can describe a hypothetical execution plan while remaining unable to execute it.
 - Any future broker adapter is a new, explicitly governed concern beyond this sprint.
 
+## Revision note (Issue #63)
+
+`ProposedPosition` is narrowed to desired analytical allocation. Account, portfolio, quantity,
+market price, broker, provider, and order fields belong to later stages. Opportunity now owns the
+canonical Instrument and Ranking preserves it through its existing evaluation envelope, closing
+the last required source path without hidden mappings.
+
 ## References
 
 - GitHub issue #59
+- GitHub issue #63
 - ADR-007: Deterministic Ranking Model
 - ADR-008: Operational Trading Contracts
 - Architecture Constitution, Laws 5, 7, 9, and 10

--- a/architecture/DECISION_LOG.md
+++ b/architecture/DECISION_LOG.md
@@ -8,6 +8,7 @@ Do not add substantive reasoning to this file. If an entry needs more than two s
 
 | Date | Summary | ADR |
 |---|---|---|
+| 2026-07-21 | Opportunity owns canonical Instrument identity and Ranking preserves it unchanged; ProposedPosition is narrowed to desired allocation and contains no account, portfolio, quantity, price, provider, broker, or order fields. | ADR-003/ADR-009 amendments (Issue #63) |
 | 2026-07-21 | The analytical execution pipeline is RankingResult → ProposedPosition → PortfolioDecision → ExecutionPlan → BrokerRequest; external broker communication alone crosses Constitution Law 5, and no adapter is authorized. | ADR-009 (ASA-ARCH-002) |
 | 2026-07-21 | Provider-neutral immutable Instrument, Holding, PortfolioSnapshot, ProposedPosition, and PortfolioDecisionRequest contracts separate ranked intelligence from read-only operational portfolio policy without introducing broker models, persistence, or execution. | ADR-008 (ASA-ARCH-001) |
 | 2026-07-21 | Ranking v1 deterministically orders eligible Opportunities using six versioned, provenance-preserving component scorers, explicit parameters, and stable tie-breakers; missing liquidity uses an explicit neutral placeholder rather than an invented proxy. | ADR-007 (ASA-CORE-007) |

--- a/architecture/DOMAIN_GLOSSARY.md
+++ b/architecture/DOMAIN_GLOSSARY.md
@@ -45,7 +45,7 @@ One immutable, currently valued position within a Portfolio Snapshot. Direction,
 Immutable, raw evidence as reported by an external Provider. An Observation is a historical record: once written, it is never altered, even if later shown to be wrong. Corrections are represented as new Observations and reconciled at the Canonical Fact layer, not by editing history.
 
 **Opportunity**
-A candidate investment action surfaced by the Strategy Layer, prior to Guardrail evaluation and Ranking. An Opportunity that does not pass Guardrail evaluation is never presented to a user as a Recommendation.
+A candidate investment action surfaced by the Strategy Layer, prior to Guardrail evaluation and Ranking. It references exactly one canonical provider-neutral Instrument, which Guardrails and Ranking preserve unchanged. An Opportunity that does not pass Guardrail evaluation is never presented to a user as a Recommendation.
 
 **Portfolio Decision**
 The immutable result of evaluating one Proposed Position against one Portfolio Snapshot. It records the approved portion, policy versions, effective parameters, reasons, and Evidence; it does not plan execution.
@@ -57,7 +57,7 @@ The immutable Operational Portfolio input envelope pairing one Portfolio Snapsho
 Complete immutable portfolio financial state at one semantic observation time: holdings, signed settled cash, non-negative buying power, net liquidation value, gross exposure, base currency, and Evidence. Any state change produces a new snapshot; the object is not a mutable portfolio tracker.
 
 **Proposed Position**
-An evidence-backed description of desired instrument exposure produced from ranked Intelligence. It identifies quantity, direction, estimated price, and gross exposure, but is not an order and carries no broker routing or write semantics.
+An evidence-backed description of desired allocation produced from ranked Intelligence. It retains canonical Instrument, target allocation, confidence, rationale, algorithm version, effective parameters, lineage, and Evidence. It has no account, portfolio, quantity, price, broker, provider, or order semantics.
 
 **Provider**
 An external source of raw data — market data, options data, broker data, financial events, or similar — that ASA does not control. ASA does not assume Providers agree with one another; see Provenance and Confidence.

--- a/domain/execution.py
+++ b/domain/execution.py
@@ -74,9 +74,9 @@ class TimeInForce(str, Enum):
 class PortfolioDecision:
     """Portfolio-policy result for one immutable ProposedPosition.
 
-    Approved quantity and exposure describe how much of the proposal survives
-    portfolio constraints.  They are policy outputs supplied to this contract,
-    never values calculated by it.
+    ``approved_allocation`` describes how much of the desired allocation
+    survives portfolio constraints. It is a policy output supplied to this
+    contract, never a value calculated by it.
     """
 
     portfolio_decision_id: str
@@ -84,8 +84,7 @@ class PortfolioDecision:
     portfolio_snapshot_id: str
     proposed_position: ProposedPosition
     state: PortfolioDecisionState
-    approved_quantity: Decimal
-    approved_gross_exposure: MonetaryAmount
+    approved_allocation: Decimal
     policy_versions: tuple[tuple[str, str], ...]
     effective_parameters: tuple[tuple[str, Decimal], ...]
     reasons: tuple[str, ...]
@@ -98,40 +97,21 @@ class PortfolioDecision:
             "portfolio_snapshot_id",
         ):
             _require_text(getattr(self, field_name), "PortfolioDecision", field_name)
-        _require_non_negative(
-            self.approved_quantity, "PortfolioDecision", "approved_quantity"
-        )
-        _require_non_negative(
-            self.approved_gross_exposure.amount,
-            "PortfolioDecision",
-            "approved_gross_exposure.amount",
-        )
-        if self.approved_gross_exposure.currency != self.proposed_position.gross_exposure.currency:
+        _require_non_negative(self.approved_allocation, "PortfolioDecision", "approved_allocation")
+        if self.approved_allocation > self.proposed_position.target_allocation:
             raise DomainInvariantError(
-                "PortfolioDecision approved exposure currency must match the proposal"
-            )
-        if self.approved_quantity > self.proposed_position.quantity:
-            raise DomainInvariantError(
-                "PortfolioDecision approved_quantity cannot exceed proposed quantity"
-            )
-        if self.approved_gross_exposure.amount > self.proposed_position.gross_exposure.amount:
-            raise DomainInvariantError(
-                "PortfolioDecision approved exposure cannot exceed proposed exposure"
+                "PortfolioDecision approved_allocation cannot exceed proposed allocation"
             )
         if self.state in {PortfolioDecisionState.REJECT, PortfolioDecisionState.HOLD} and (
-            self.approved_quantity != 0 or self.approved_gross_exposure.amount != 0
+            self.approved_allocation != 0
         ):
             raise DomainInvariantError("REJECT and HOLD decisions cannot approve new exposure")
         if self.state is PortfolioDecisionState.ACCEPT and (
-            self.approved_quantity != self.proposed_position.quantity
-            or self.approved_gross_exposure != self.proposed_position.gross_exposure
+            self.approved_allocation != self.proposed_position.target_allocation
         ):
             raise DomainInvariantError("ACCEPT must preserve the complete proposed exposure")
         if self.state is PortfolioDecisionState.REDUCE and not (
-            0 < self.approved_quantity < self.proposed_position.quantity
-            and 0
-            < self.approved_gross_exposure.amount
-            < self.proposed_position.gross_exposure.amount
+            0 < self.approved_allocation < self.proposed_position.target_allocation
         ):
             raise DomainInvariantError("REDUCE must approve a smaller positive exposure")
         _require_unique_keys(self.policy_versions, "PortfolioDecision", "policy_versions")

--- a/domain/operational.py
+++ b/domain/operational.py
@@ -191,26 +191,15 @@ class PortfolioSnapshot:
 
 @dataclass(frozen=True, slots=True)
 class ProposedPosition:
-    """Intelligence output describing desired exposure, never an order.
-
-    ``quantity`` is the absolute size of this proposal, not an order delta or
-    a post-execution portfolio target.  Operational policy compares it with
-    the separately supplied snapshot before any read-only plan is presented.
-    """
+    """Intelligence output describing desired allocation, never an order."""
 
     proposed_position_id: str
     opportunity_id: str
     ranking_result_id: str
     ranking_id: str
     proposal_algorithm_version: str
-    portfolio_id: str
-    account_id: str
     instrument: Instrument
-    direction: PositionDirection
     target_allocation: Decimal
-    quantity: Decimal
-    estimated_unit_price: MonetaryAmount
-    gross_exposure: MonetaryAmount
     evidence_confidence: Confidence
     rationale: tuple[str, ...]
     effective_parameters: tuple[tuple[str, Decimal], ...]
@@ -223,27 +212,12 @@ class ProposedPosition:
             "ranking_result_id",
             "ranking_id",
             "proposal_algorithm_version",
-            "portfolio_id",
-            "account_id",
         ):
             _require_text(getattr(self, field_name), "ProposedPosition", field_name)
         require_finite_decimal(self.target_allocation, "ProposedPosition", "target_allocation")
         require_unit_interval(self.target_allocation, "ProposedPosition", "target_allocation")
         if self.target_allocation == 0:
             raise DomainInvariantError("ProposedPosition.target_allocation must be greater than zero")
-        _require_non_negative(self.quantity, "ProposedPosition", "quantity")
-        if self.quantity == 0:
-            raise DomainInvariantError("ProposedPosition.quantity must be greater than zero")
-        _require_non_negative(
-            self.estimated_unit_price.amount,
-            "ProposedPosition",
-            "estimated_unit_price.amount",
-        )
-        _require_non_negative(
-            self.gross_exposure.amount, "ProposedPosition", "gross_exposure.amount"
-        )
-        if self.estimated_unit_price.currency != self.gross_exposure.currency:
-            raise DomainInvariantError("ProposedPosition valuation currencies must match")
         if not self.rationale:
             raise DomainInvariantError("ProposedPosition.rationale cannot be empty")
         if any(not item or item != item.strip() for item in self.rationale):
@@ -291,11 +265,4 @@ class PortfolioDecisionRequest:
         ):
             raise DomainInvariantError(
                 "PortfolioDecisionRequest proposals must reference ranking_result_id"
-            )
-        if any(
-            item.portfolio_id != self.portfolio_snapshot.portfolio_id
-            for item in self.proposed_positions
-        ):
-            raise DomainInvariantError(
-                "PortfolioDecisionRequest proposals must target the snapshot portfolio_id"
             )

--- a/domain/opportunity.py
+++ b/domain/opportunity.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from enum import Enum
 
 from domain.guardrail import GuardrailOutcome
+from domain.operational import Instrument
 from domain.outcome_metrics import ExpectedOutcomeMetrics
 from domain.references import Confidence, EvidenceReference
 from domain.values import require_positive, require_tz_aware
@@ -28,7 +29,8 @@ class RecommendationState(str, Enum):
 class Opportunity:
     """One immutable version of an Opportunity record (ADR-003 as amended).
 
-    Carries the full minimum structural content: pinned Strategy version,
+    Carries the full minimum structural content: canonical Instrument,
+    pinned Strategy version,
     supporting Indicator versions, Evidence, Assumptions, evidence
     confidence, Expected Outcome Metrics, Guardrail outcomes, and an
     explicit lifecycle state. The Decision Journal entry for a presented
@@ -41,6 +43,7 @@ class Opportunity:
     version: int
     strategy_id: str
     strategy_version: str
+    instrument: Instrument
     supporting_indicators: tuple[EvidenceReference, ...]
     evidence: tuple[EvidenceReference, ...]
     assumptions: tuple[str, ...]

--- a/strategies/engine.py
+++ b/strategies/engine.py
@@ -18,16 +18,19 @@ from domain.canonical_fact import CanonicalFact
 from domain.canonicalization import serialize_canonical
 from domain.indicator import Indicator
 from domain.opportunity import Opportunity, RecommendationState
+from domain.operational import Instrument
 from domain.outcome_metrics import ExpectedOutcomeMetrics
 from domain.references import Confidence, EvidenceKind, EvidenceReference
 from domain.values import require_tz_aware
 from strategies.registry import DEFAULT_REGISTRY, StrategyRegistry
 
 OPPORTUNITY_IDENTITY_NAMESPACE = "asa.opportunity"
-OPPORTUNITY_IDENTITY_VERSION = "v1"
+OPPORTUNITY_IDENTITY_VERSION = "v2"
 
 
-def _metrics_as_normalized_value(metrics: ExpectedOutcomeMetrics) -> tuple:
+def _metrics_as_normalized_value(
+    metrics: ExpectedOutcomeMetrics,
+) -> tuple[tuple[str, object], ...]:
     return (
         ("capital_required", metrics.capital_required),
         ("expected_return", metrics.expected_return),
@@ -40,6 +43,7 @@ def _metrics_as_normalized_value(metrics: ExpectedOutcomeMetrics) -> tuple:
 
 def opportunity_identity(
     strategy_id: str,
+    instrument: Instrument,
     source_indicator_ids: tuple[str, ...],
     source_fact_ids: tuple[str, ...],
     effective_time: datetime,
@@ -47,8 +51,8 @@ def opportunity_identity(
 ) -> str:
     """Deterministic, versioned Opportunity identity (algorithm v1).
 
-    Inputs: strategy_id, source indicator ids, source fact ids, effective
-    time, and expected outcome metrics — mirroring
+    Inputs: strategy_id, canonical instrument identity, source indicator ids,
+    source fact ids, effective time, and expected outcome metrics — mirroring
     ``indicators.engine.indicator_identity``'s and
     ``reconciliation.rules.fact_identity``'s algorithm style under a
     distinct namespace. No UUIDs, no sequence numbers, no insertion time,
@@ -62,6 +66,7 @@ def opportunity_identity(
             OPPORTUNITY_IDENTITY_NAMESPACE,
             OPPORTUNITY_IDENTITY_VERSION,
             serialize_canonical(strategy_id),
+            serialize_canonical((instrument.identity.scheme, instrument.identity.value)),
             serialize_canonical(tuple(sorted(source_indicator_ids))),
             serialize_canonical(tuple(sorted(source_fact_ids))),
             serialize_canonical(effective_time),
@@ -77,7 +82,8 @@ def evaluate_strategy(
     facts: tuple[CanonicalFact, ...],
     effective_time: datetime,
     created_time: datetime,
-    params: dict | None = None,
+    instrument: Instrument,
+    params: dict[str, object] | None = None,
     registry: StrategyRegistry = DEFAULT_REGISTRY,
 ) -> Opportunity | None:
     """Evaluate one strategy; return a discovered Opportunity, or None.
@@ -89,6 +95,10 @@ def evaluate_strategy(
     contributing facts' own Confidence — the weakest link, per ADR-001's
     "internal reconciliation attribute" framing extended here as a simple,
     documented v1 aggregation choice).
+
+    ``instrument`` is the canonical provider-neutral subject supplied by the
+    caller. The Strategy records it unchanged; it performs no symbol parsing,
+    lookup, or provider resolution.
 
     Returns ``None`` when the strategy finds nothing actionable this cycle
     — a legitimate, common outcome; this is a *no-signal* result, not an
@@ -127,12 +137,13 @@ def evaluate_strategy(
 
     opportunity = Opportunity(
         opportunity_id=opportunity_identity(
-            strategy_id, source_indicator_ids, source_fact_ids,
+            strategy_id, instrument, source_indicator_ids, source_fact_ids,
             effective_time, signal.expected_outcome_metrics,
         ),
         version=1,
         strategy_id=strategy_id,
         strategy_version=definition.strategy_version,
+        instrument=instrument,
         supporting_indicators=supporting_indicators,
         evidence=evidence,
         assumptions=signal.assumptions,

--- a/tests/domain/test_domain_model.py
+++ b/tests/domain/test_domain_model.py
@@ -32,6 +32,7 @@ from domain import (
     ProviderDisagreement,
     RecommendationState,
 )
+from tests.instrument_helpers import TEST_INSTRUMENT
 
 NOW = datetime(2026, 7, 21, tzinfo=timezone.utc)
 
@@ -86,6 +87,7 @@ def _sample_opportunity() -> Opportunity:
     return Opportunity(
         opportunity_id="opp-1", version=1,
         strategy_id="strat-1", strategy_version="1.0.0",
+        instrument=TEST_INSTRUMENT,
         supporting_indicators=(EvidenceReference(
             kind=EvidenceKind.INDICATOR, referenced_id="ind-1", version=3),),
         evidence=(ref,), assumptions=("normal market conditions",),

--- a/tests/domain/test_execution_contracts.py
+++ b/tests/domain/test_execution_contracts.py
@@ -24,7 +24,6 @@ from domain import (
     PortfolioDecision,
     PortfolioDecisionState,
     ProposedPosition,
-    PositionDirection,
     TimeInForce,
 )
 
@@ -46,14 +45,8 @@ def _proposal() -> ProposedPosition:
         ranking_result_id="ranking-result-1",
         ranking_id="ranking-1",
         proposal_algorithm_version="v1",
-        portfolio_id="portfolio-1",
-        account_id="account-1",
         instrument=instrument,
-        direction=PositionDirection.LONG,
         target_allocation=Decimal("0.10"),
-        quantity=Decimal("4"),
-        estimated_unit_price=MonetaryAmount(Decimal("200"), USD),
-        gross_exposure=MonetaryAmount(Decimal("800"), USD),
         evidence_confidence=Confidence(0.8),
         rationale=("ranked opportunity supports desired exposure",),
         effective_parameters=(
@@ -68,22 +61,18 @@ def _decision(
     state: PortfolioDecisionState = PortfolioDecisionState.ACCEPT,
 ) -> PortfolioDecision:
     proposal = _proposal()
-    quantity = proposal.quantity
-    exposure = proposal.gross_exposure
+    allocation = proposal.target_allocation
     if state in {PortfolioDecisionState.REJECT, PortfolioDecisionState.HOLD}:
-        quantity = Decimal("0")
-        exposure = MonetaryAmount(Decimal("0"), USD)
+        allocation = Decimal("0")
     elif state is PortfolioDecisionState.REDUCE:
-        quantity = Decimal("2")
-        exposure = MonetaryAmount(Decimal("400"), USD)
+        allocation = Decimal("0.05")
     return PortfolioDecision(
         portfolio_decision_id="decision-1",
         decision_algorithm_version="v1",
         portfolio_snapshot_id="snapshot-1",
         proposed_position=proposal,
         state=state,
-        approved_quantity=quantity,
-        approved_gross_exposure=exposure,
+        approved_allocation=allocation,
         policy_versions=(("buying_power", "v1"),),
         effective_parameters=(("cash_reserve", Decimal("1000")),),
         reasons=("proposal satisfies portfolio policy",),
@@ -98,11 +87,11 @@ def _request(sequence: int = 1) -> BrokerRequest:
         portfolio_decision_id=decision.portfolio_decision_id,
         sequence=sequence,
         instrument=decision.proposed_position.instrument,
-        account_id=decision.proposed_position.account_id,
+        account_id="account-1",
         side=BrokerRequestSide.BUY,
-        quantity=decision.approved_quantity,
+        quantity=Decimal("4"),
         order_type=OrderType.LIMIT,
-        limit_price=decision.proposed_position.estimated_unit_price,
+        limit_price=MonetaryAmount(Decimal("200"), USD),
         time_in_force=TimeInForce.DAY,
         execution_metadata=(("strategy", "single_limit_v1"),),
         reasoning=EVIDENCE,
@@ -158,19 +147,16 @@ def test_keyed_identity_inputs_require_canonical_order() -> None:
 def test_reject_and_hold_approve_no_new_exposure() -> None:
     for state in (PortfolioDecisionState.REJECT, PortfolioDecisionState.HOLD):
         decision = _decision(state)
-        assert decision.approved_quantity == 0
-        assert decision.approved_gross_exposure.amount == 0
+        assert decision.approved_allocation == 0
         plan = ExecutionPlan("plan-noop", "v1", decision, (), EVIDENCE)
         assert plan.broker_requests == ()
 
 
 def test_reduce_must_be_smaller_than_proposal() -> None:
-    proposal = _proposal()
     with pytest.raises(DomainInvariantError, match="smaller positive exposure"):
         dataclasses.replace(
             _decision(PortfolioDecisionState.REDUCE),
-            approved_quantity=proposal.quantity,
-            approved_gross_exposure=proposal.gross_exposure,
+            approved_allocation=_proposal().target_allocation,
         )
 
 

--- a/tests/domain/test_invariants.py
+++ b/tests/domain/test_invariants.py
@@ -31,6 +31,7 @@ from domain import (
     RecommendationState,
     is_normalized_value,
 )
+from tests.instrument_helpers import TEST_INSTRUMENT
 
 AWARE = datetime(2026, 7, 21, tzinfo=timezone.utc)
 NAIVE = datetime(2026, 7, 21)
@@ -92,6 +93,7 @@ def _opportunity(**overrides):
     kwargs = dict(
         opportunity_id="opp-1", version=1,
         strategy_id="strat-1", strategy_version="1.0.0",
+        instrument=TEST_INSTRUMENT,
         supporting_indicators=(), evidence=(), assumptions=(),
         evidence_confidence=Confidence(score=0.5),
         expected_outcome_metrics=_metrics(),

--- a/tests/domain/test_operational_contracts.py
+++ b/tests/domain/test_operational_contracts.py
@@ -80,14 +80,8 @@ def _proposal(**overrides: object) -> ProposedPosition:
         "ranking_result_id": "ranking-result-1",
         "ranking_id": "ranked-opportunity-1",
         "proposal_algorithm_version": "v1",
-        "portfolio_id": "portfolio-1",
-        "account_id": "account-1",
         "instrument": _instrument(),
-        "direction": PositionDirection.LONG,
         "target_allocation": Decimal("0.10"),
-        "quantity": Decimal("2"),
-        "estimated_unit_price": MonetaryAmount(Decimal("210"), USD),
-        "gross_exposure": MonetaryAmount(Decimal("420"), USD),
         "evidence_confidence": Confidence(0.8),
         "rationale": ("ranked opportunity supports desired exposure",),
         "effective_parameters": (
@@ -190,6 +184,18 @@ def test_decision_request_preserves_rank_order_and_requires_matching_ids() -> No
             _snapshot(),
             (first,),
         )
+
+
+def test_proposal_contains_no_portfolio_or_execution_fields() -> None:
+    names = {field.name for field in dataclasses.fields(ProposedPosition)}
+    assert not names & {
+        "account_id",
+        "portfolio_id",
+        "quantity",
+        "estimated_unit_price",
+        "gross_exposure",
+        "direction",
+    }
 
 
 def test_contract_fields_contain_no_broker_or_repository_models() -> None:

--- a/tests/guardrails/test_guardrail_engine.py
+++ b/tests/guardrails/test_guardrail_engine.py
@@ -12,6 +12,7 @@ from domain.references import Confidence, EvidenceKind, EvidenceReference
 from guardrails.engine import evaluate_guardrail, evaluate_opportunity
 from guardrails.errors import UnknownGuardrailIdError
 from guardrails.evaluations import GuardrailDecision, guardrail_evaluation_identity
+from tests.instrument_helpers import TEST_INSTRUMENT
 
 T0 = datetime(2026, 7, 21, 14, 0, tzinfo=timezone.utc)
 
@@ -19,6 +20,7 @@ T0 = datetime(2026, 7, 21, 14, 0, tzinfo=timezone.utc)
 def _opp(assumptions=("a normal, calibrated assumption",)) -> Opportunity:
     return Opportunity(
         opportunity_id="opp-1", version=1, strategy_id="s1", strategy_version="v1",
+        instrument=TEST_INSTRUMENT,
         supporting_indicators=(EvidenceReference(
             kind=EvidenceKind.INDICATOR, referenced_id="i1", version=1),),
         evidence=(EvidenceReference(

--- a/tests/guardrails/test_guardrail_evaluations.py
+++ b/tests/guardrails/test_guardrail_evaluations.py
@@ -1,15 +1,13 @@
 """ASA-CORE-006: guardrail check unit tests (policy validation)."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from decimal import Decimal
 
 import pytest
 
-from domain.canonical_fact import CanonicalFact
 from domain.opportunity import Opportunity, RecommendationState
 from domain.outcome_metrics import ExpectedOutcomeMetrics
-from domain.provenance import Provenance
 from domain.references import Confidence, EvidenceKind, EvidenceReference
 from guardrails.errors import EmptyOpportunityEvidenceError, InvalidGuardrailParameterError
 from guardrails.evaluations import (
@@ -20,6 +18,7 @@ from guardrails.evaluations import (
     opportunity_cited_evidence,
     placeholder_metrics_rejection,
 )
+from tests.instrument_helpers import TEST_INSTRUMENT
 
 T0 = datetime(2026, 7, 21, 14, 0, tzinfo=timezone.utc)
 
@@ -33,6 +32,7 @@ def _opp(
 ) -> Opportunity:
     return Opportunity(
         opportunity_id="opp-1", version=1, strategy_id="s1", strategy_version="v1",
+        instrument=TEST_INSTRUMENT,
         supporting_indicators=supporting_indicators, evidence=evidence,
         assumptions=assumptions, evidence_confidence=Confidence(score=evidence_confidence),
         expected_outcome_metrics=ExpectedOutcomeMetrics(

--- a/tests/guardrails/test_ranking_phase0_hardening.py
+++ b/tests/guardrails/test_ranking_phase0_hardening.py
@@ -10,6 +10,7 @@ from domain.references import Confidence, EvidenceKind, EvidenceReference
 from guardrails.engine import evaluate_guardrail, evaluate_opportunity
 from guardrails.evaluations import GUARDRAIL_EVALUATION_IDENTITY_VERSION, GuardrailDecision
 from guardrails.registry import DEFAULT_REGISTRY
+from tests.instrument_helpers import TEST_INSTRUMENT
 
 T0 = datetime(2026, 7, 21, 14, 0, tzinfo=timezone.utc)
 
@@ -20,6 +21,7 @@ def _opportunity() -> Opportunity:
         version=1,
         strategy_id="strategy",
         strategy_version="v1",
+        instrument=TEST_INSTRUMENT,
         supporting_indicators=(
             EvidenceReference(kind=EvidenceKind.INDICATOR, referenced_id="indicator", version=1),
         ),

--- a/tests/instrument_helpers.py
+++ b/tests/instrument_helpers.py
@@ -1,0 +1,10 @@
+"""Canonical Instrument fixtures shared by pipeline contract tests."""
+
+from domain.operational import CanonicalInstrumentIdentity, Instrument, InstrumentKind
+
+TEST_INSTRUMENT = Instrument(
+    identity=CanonicalInstrumentIdentity("figi", "BBG000B9XRY4"),
+    kind=InstrumentKind.EQUITY,
+    display_symbol="AAPL",
+    currency="USD",
+)

--- a/tests/ranking/helpers.py
+++ b/tests/ranking/helpers.py
@@ -8,6 +8,7 @@ from domain.outcome_metrics import ExpectedOutcomeMetrics
 from domain.references import Confidence, EvidenceKind, EvidenceReference
 from guardrails.engine import evaluate_opportunity
 from guardrails.evaluations import OpportunityGuardrailEvaluation
+from tests.instrument_helpers import TEST_INSTRUMENT
 
 T0 = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)
 GUARDRAIL_PARAMETERS: dict[str, dict[str, object]] = {
@@ -35,6 +36,7 @@ def evaluation(
         version=1,
         strategy_id="test_strategy",
         strategy_version="v1",
+        instrument=TEST_INSTRUMENT,
         supporting_indicators=(
             EvidenceReference(
                 kind=EvidenceKind.INDICATOR,

--- a/tests/ranking/test_engine.py
+++ b/tests/ranking/test_engine.py
@@ -12,6 +12,7 @@ from ranking.engine import rank_opportunities
 from ranking.errors import DuplicateOpportunityEvaluationError, InvalidRankingOutputError
 from ranking.models import RANKING_ALGORITHM_VERSION, RankingParameters
 from tests.ranking.helpers import T0, evaluation
+from tests.instrument_helpers import TEST_INSTRUMENT
 
 
 def ids(result):  # type: ignore[no-untyped-def]
@@ -113,6 +114,7 @@ def test_outputs_are_immutable_and_retain_exact_opportunity() -> None:
     ranked = rank_opportunities((source,)).ranked_opportunities[0]
     assert ranked.evaluation is source
     assert ranked.opportunity is source.opportunity
+    assert ranked.opportunity.instrument is TEST_INSTRUMENT
     with pytest.raises(Exception):
         ranked.rank = 2
 

--- a/tests/strategies/test_strategy_engine.py
+++ b/tests/strategies/test_strategy_engine.py
@@ -1,6 +1,7 @@
 """ASA-CORE-005: strategy engine tests — determinism, replay, provenance."""
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
@@ -8,13 +9,46 @@ import pytest
 
 from domain.canonical_fact import CanonicalFact
 from domain.opportunity import RecommendationState
+from domain.operational import CanonicalInstrumentIdentity
 from domain.provenance import Provenance
 from domain.references import Confidence, EvidenceKind
 from indicators.engine import compute_indicator
-from strategies.engine import evaluate_strategy, opportunity_identity
+from strategies.engine import (
+    OPPORTUNITY_IDENTITY_VERSION,
+    evaluate_strategy as _evaluate_strategy,
+    opportunity_identity as _opportunity_identity,
+)
 from strategies.errors import UnknownStrategyIdError
+from tests.instrument_helpers import TEST_INSTRUMENT
 
 T0 = datetime(2026, 7, 21, 14, 0, tzinfo=timezone.utc)
+
+
+def evaluate_strategy(
+    strategy_id, indicators, facts, effective_time, created_time, params=None
+):  # type: ignore[no-untyped-def]
+    return _evaluate_strategy(
+        strategy_id,
+        indicators,
+        facts,
+        effective_time,
+        created_time,
+        TEST_INSTRUMENT,
+        params=params,
+    )
+
+
+def opportunity_identity(
+    strategy_id, source_indicator_ids, source_fact_ids, effective_time, metrics
+):  # type: ignore[no-untyped-def]
+    return _opportunity_identity(
+        strategy_id,
+        TEST_INSTRUMENT,
+        source_indicator_ids,
+        source_fact_ids,
+        effective_time,
+        metrics,
+    )
 
 
 def _fact(i: int, price: str) -> CanonicalFact:
@@ -86,6 +120,7 @@ class TestEvaluateStrategyBasics:
             T0 + timedelta(minutes=4), T0 + timedelta(minutes=4))
         assert opp.strategy_id == "breakout"
         assert opp.strategy_version == "v1"
+        assert opp.instrument is TEST_INSTRUMENT
 
 
 class TestDeterminism:
@@ -192,6 +227,9 @@ class TestProvenance:
 
 
 class TestOpportunityIdentity:
+    def test_identity_version_is_pinned_after_instrument_propagation(self):
+        assert OPPORTUNITY_IDENTITY_VERSION == "v2"
+
     def test_same_input_same_id(self):
         a = opportunity_identity("breakout", ("i1",), ("f1",), T0, _dummy_metrics())
         b = opportunity_identity("breakout", ("i1",), ("f1",), T0, _dummy_metrics())
@@ -206,6 +244,20 @@ class TestOpportunityIdentity:
         a = opportunity_identity("breakout", ("i1", "i2"), ("f1",), T0, _dummy_metrics())
         b = opportunity_identity("breakout", ("i2", "i1"), ("f1",), T0, _dummy_metrics())
         assert a == b
+
+    def test_instrument_identity_changes_opportunity_identity(self):
+        other = replace(
+            TEST_INSTRUMENT,
+            identity=CanonicalInstrumentIdentity("figi", "BBG000BLNNH6"),
+            display_symbol="IBM",
+        )
+        a = _opportunity_identity(
+            "breakout", TEST_INSTRUMENT, ("i1",), ("f1",), T0, _dummy_metrics()
+        )
+        b = _opportunity_identity(
+            "breakout", other, ("i1",), ("f1",), T0, _dummy_metrics()
+        )
+        assert a != b
 
 
 def _dummy_metrics():


### PR DESCRIPTION
## Summary

- makes Opportunity the canonical owner of provider-neutral Instrument identity
- includes Instrument identity in Opportunity identity v2
- preserves the exact Opportunity and Instrument through Guardrails and Ranking
- narrows ProposedPosition to desired allocation, confidence, rationale, algorithm parameters, lineage, Evidence, and canonical Instrument
- removes account, portfolio, direction, quantity, price, and gross-exposure fields from ProposedPosition
- updates PortfolioDecision structural semantics from approved quantity/exposure to approved allocation

## Boundary safety

Strategy receives an explicit canonical Instrument and records it unchanged. No symbol parsing, provider lookup, hidden mapping, broker identifier, provider payload, repository, persistence, or network access was added.

## Validation

- full architecture/intelligence suite: 721 passed
- Ruff on all changed Python: passed
- strict MyPy on `domain`: passed
- isolated MyPy on affected Strategy engine: passed
- Lean POS entrypoint check: passed
- frozen-governance integrity check: passed
- `git diff --check`: passed
- self-review: no TODOs, skipped tests, provider leakage, or infrastructure leakage

Closes #63