### PR TITLE
ASA-CORE-008: add Position Proposal Engine

### DIFF
--- a/position_proposals/__init__.py
+++ b/position_proposals/__init__.py
@@ -1,0 +1,11 @@
+"""Deterministic Position Proposal Engine (ASA-CORE-008)."""
+
+from position_proposals.engine import propose_positions, proposed_position_identity
+from position_proposals.models import PROPOSAL_ALGORITHM_VERSION, ProposalParameters
+
+__all__ = [
+    "PROPOSAL_ALGORITHM_VERSION",
+    "ProposalParameters",
+    "propose_positions",
+    "proposed_position_identity",
+]

--- a/position_proposals/engine.py
+++ b/position_proposals/engine.py
@@ -1,0 +1,111 @@
+"""Pure deterministic Position Proposal Engine (ASA-CORE-008)."""
+
+from __future__ import annotations
+
+import hashlib
+from decimal import Decimal, localcontext
+
+from domain.canonicalization import serialize_canonical
+from domain.operational import ProposedPosition
+from domain.references import EvidenceReference
+from position_proposals.models import (
+    ALLOCATION_QUANTUM,
+    PROPOSAL_ALGORITHM_VERSION,
+    PROPOSAL_IDENTITY_NAMESPACE,
+    ProposalParameters,
+)
+from ranking.models import RankedOpportunity, RankingResult
+
+
+def _evidence_identity(reference: EvidenceReference) -> tuple[object, ...]:
+    return (reference.kind.value, reference.referenced_id, reference.version)
+
+
+def _proposal_evidence(ranked: RankedOpportunity) -> tuple[EvidenceReference, ...]:
+    references = ranked.opportunity.evidence + ranked.opportunity.supporting_indicators
+    unique = {
+        (reference.kind.value, reference.referenced_id, reference.version): reference
+        for reference in references
+    }
+    return tuple(unique[key] for key in sorted(unique))
+
+
+def _target_allocation(score: Decimal, parameters: ProposalParameters) -> Decimal:
+    with localcontext() as context:
+        context.prec = 40
+        spread = parameters.allocation_ceiling - parameters.allocation_floor
+        return (parameters.allocation_floor + spread * score).quantize(ALLOCATION_QUANTUM)
+
+
+def proposed_position_identity(
+    ranking_result_id: str,
+    ranked: RankedOpportunity,
+    target_allocation: Decimal,
+    effective_parameters: tuple[tuple[str, Decimal], ...],
+    rationale: tuple[str, ...],
+    evidence: tuple[EvidenceReference, ...],
+) -> str:
+    """Return the content identity for one v1 ProposedPosition."""
+    instrument = ranked.opportunity.instrument
+    payload = "\n".join(
+        (
+            PROPOSAL_IDENTITY_NAMESPACE,
+            PROPOSAL_ALGORITHM_VERSION,
+            serialize_canonical(ranking_result_id),
+            serialize_canonical(ranked.ranking_id),
+            serialize_canonical(ranked.opportunity.opportunity_id),
+            serialize_canonical((instrument.identity.scheme, instrument.identity.value)),
+            serialize_canonical(target_allocation),
+            serialize_canonical(Decimal(str(ranked.opportunity.evidence_confidence.score))),
+            serialize_canonical(rationale),
+            serialize_canonical(effective_parameters),
+            serialize_canonical(tuple(_evidence_identity(item) for item in evidence)),
+        )
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def propose_positions(
+    ranking_result: RankingResult,
+    parameters: ProposalParameters | None = None,
+) -> tuple[ProposedPosition, ...]:
+    """Convert ranked Opportunities to desired allocations in rank order.
+
+    This function has no PortfolioSnapshot, Holding, account, price, quantity,
+    provider, repository, persistence, or network input. Allocation is a pure
+    linear interpolation of the pinned Ranking score within explicit policy
+    bounds; Portfolio policy may accept, reduce, reject, or hold it later.
+    """
+    parameters = parameters or ProposalParameters()
+    effective_parameters = parameters.canonical_items()
+    proposals: list[ProposedPosition] = []
+    for ranked in ranking_result.ranked_opportunities:
+        target_allocation = _target_allocation(ranked.total_score, parameters)
+        rationale = (
+            f"{PROPOSAL_ALGORITHM_VERSION} allocation from ranking score {ranked.total_score}",
+            *ranked.opportunity.assumptions,
+        )
+        evidence = _proposal_evidence(ranked)
+        proposals.append(
+            ProposedPosition(
+                proposed_position_id=proposed_position_identity(
+                    ranking_result.result_id,
+                    ranked,
+                    target_allocation,
+                    effective_parameters,
+                    rationale,
+                    evidence,
+                ),
+                opportunity_id=ranked.opportunity.opportunity_id,
+                ranking_result_id=ranking_result.result_id,
+                ranking_id=ranked.ranking_id,
+                proposal_algorithm_version=PROPOSAL_ALGORITHM_VERSION,
+                instrument=ranked.opportunity.instrument,
+                target_allocation=target_allocation,
+                evidence_confidence=ranked.opportunity.evidence_confidence,
+                rationale=rationale,
+                effective_parameters=effective_parameters,
+                evidence=evidence,
+            )
+        )
+    return tuple(proposals)

--- a/position_proposals/errors.py
+++ b/position_proposals/errors.py
@@ -1,0 +1,9 @@
+"""Position Proposal Engine errors."""
+
+
+class PositionProposalError(ValueError):
+    """Base error for invalid proposal inputs or outputs."""
+
+
+class InvalidProposalParameterError(PositionProposalError):
+    """The effective deterministic sizing policy is invalid."""

--- a/position_proposals/models.py
+++ b/position_proposals/models.py
@@ -1,0 +1,43 @@
+"""Immutable Position Proposal Engine policy inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from domain.values import require_finite_decimal
+from position_proposals.errors import InvalidProposalParameterError
+
+PROPOSAL_ALGORITHM_VERSION = "v1"
+PROPOSAL_IDENTITY_NAMESPACE = "asa.proposed_position"
+ALLOCATION_QUANTUM = Decimal("0.000000000001")
+
+
+@dataclass(frozen=True, slots=True)
+class ProposalParameters:
+    """Complete v1 sizing policy with no hidden module-level inputs."""
+
+    allocation_floor: Decimal = Decimal("0.01")
+    allocation_ceiling: Decimal = Decimal("0.10")
+    reference_capital: Decimal = Decimal("100000")
+
+    def __post_init__(self) -> None:
+        for name in self.__dataclass_fields__:
+            value = getattr(self, name)
+            try:
+                require_finite_decimal(value, "ProposalParameters", name)
+            except (TypeError, ValueError) as error:
+                raise InvalidProposalParameterError(str(error)) from error
+        if not Decimal("0") < self.allocation_floor <= Decimal("1"):
+            raise InvalidProposalParameterError("allocation_floor must be within (0, 1]")
+        if not Decimal("0") < self.allocation_ceiling <= Decimal("1"):
+            raise InvalidProposalParameterError("allocation_ceiling must be within (0, 1]")
+        if self.allocation_floor > self.allocation_ceiling:
+            raise InvalidProposalParameterError(
+                "allocation_floor cannot exceed allocation_ceiling"
+            )
+        if self.reference_capital <= 0:
+            raise InvalidProposalParameterError("reference_capital must be positive")
+
+    def canonical_items(self) -> tuple[tuple[str, Decimal], ...]:
+        return tuple(sorted((name, getattr(self, name)) for name in self.__dataclass_fields__))

--- a/tests/architecture/test_dependency_boundaries.py
+++ b/tests/architecture/test_dependency_boundaries.py
@@ -4,7 +4,8 @@ Scans every Python file in each layer package with the AST module and asserts
 that no module imports a module above it in the pipeline order:
 
     providers -> observation -> reconciliation -> facts -> indicators
-        -> strategies -> guardrails -> ranking -> presentation
+        -> strategies -> guardrails -> ranking -> position_proposals
+        -> presentation
 
 Each module may import itself, `domain`, and modules strictly below it.
 `presentation` is narrower: only `ranking` and `domain` (ADR-004 revision).
@@ -32,6 +33,7 @@ PIPELINE_ORDER = [
     "strategies",
     "guardrails",
     "ranking",
+    "position_proposals",
     "presentation",
 ]
 
@@ -69,6 +71,11 @@ def _allowed_imports(layer: str) -> set[str]:
             "reconciliation",
             "domain",
         }
+    if layer == "position_proposals":
+        # ASA-CORE-008: consume ranked envelopes and shared domain contracts
+        # only. Portfolio state and lower evidence/provider layers are not
+        # Position Proposal inputs.
+        return {"position_proposals", "ranking", "domain"}
     idx = PIPELINE_ORDER.index(layer)
     return set(PIPELINE_ORDER[: idx + 1]) | {"domain"}
 

--- a/tests/architecture/test_position_proposal_boundaries.py
+++ b/tests/architecture/test_position_proposal_boundaries.py
@@ -1,0 +1,90 @@
+"""ASA-CORE-008 Position Proposal Layer architecture validation."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALLOWED_ROOTS = {
+    "__future__",
+    "dataclasses",
+    "decimal",
+    "domain",
+    "hashlib",
+    "position_proposals",
+    "ranking",
+}
+PROHIBITED_ROOTS = {
+    "backend",
+    "brokers",
+    "execution",
+    "facts",
+    "infrastructure",
+    "observation",
+    "providers",
+    "sqlalchemy",
+}
+
+
+def _files() -> list[Path]:
+    return sorted((REPO_ROOT / "position_proposals").glob("*.py"))
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text())
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            roots.add(node.module.split(".")[0])
+    return roots
+
+
+@pytest.mark.parametrize("path", _files())
+def test_position_proposals_import_only_ranking_and_domain(path: Path) -> None:
+    imported = _imports(path)
+    assert imported <= ALLOWED_ROOTS
+    assert not imported & PROHIBITED_ROOTS
+
+
+def test_required_modules_exist_and_no_repository_exists() -> None:
+    assert {path.name for path in _files()} == {
+        "__init__.py",
+        "engine.py",
+        "errors.py",
+        "models.py",
+    }
+    assert not (REPO_ROOT / "position_proposals" / "repository.py").exists()
+    assert not (REPO_ROOT / "position_proposals" / "persistence.py").exists()
+
+
+def test_engine_has_no_portfolio_or_operational_input_imports() -> None:
+    tree = ast.parse((REPO_ROOT / "position_proposals" / "engine.py").read_text())
+    imported_names = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    }
+    assert not imported_names & {"Holding", "PortfolioSnapshot", "PortfolioDecision"}
+
+
+def test_no_randomness_networking_or_side_effect_imports() -> None:
+    prohibited = {
+        "asyncio",
+        "httpx",
+        "openai",
+        "random",
+        "requests",
+        "secrets",
+        "socket",
+        "threading",
+        "urllib",
+        "uuid",
+    }
+    for path in _files():
+        assert not _imports(path) & prohibited

--- a/tests/position_proposals/__init__.py
+++ b/tests/position_proposals/__init__.py
@@ -1,0 +1,1 @@
+"""Position Proposal Engine tests."""

--- a/tests/position_proposals/test_engine.py
+++ b/tests/position_proposals/test_engine.py
@@ -1,0 +1,128 @@
+"""ASA-CORE-008 deterministic Position Proposal Engine tests."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from decimal import Decimal
+
+import pytest
+
+from position_proposals.engine import propose_positions
+from position_proposals.errors import InvalidProposalParameterError
+from position_proposals.models import PROPOSAL_ALGORITHM_VERSION, ProposalParameters
+from ranking.engine import rank_opportunities
+from tests.instrument_helpers import TEST_INSTRUMENT
+from tests.ranking.helpers import evaluation
+
+
+def _ranking():  # type: ignore[no-untyped-def]
+    return rank_opportunities(
+        (
+            evaluation("lower", expected_return="0.02", confidence=0.6),
+            evaluation("higher", expected_return="0.20", confidence=0.9),
+        )
+    )
+
+
+def test_proposes_one_position_per_ranked_opportunity_in_rank_order() -> None:
+    ranking = _ranking()
+    proposals = propose_positions(ranking)
+    assert tuple(item.opportunity_id for item in proposals) == tuple(
+        item.opportunity.opportunity_id for item in ranking.ranked_opportunities
+    )
+    assert len(proposals) == 2
+
+
+def test_replay_is_byte_identical() -> None:
+    ranking = _ranking()
+    assert propose_positions(ranking) == propose_positions(ranking)
+
+
+def test_input_order_cannot_change_proposals_after_ranking() -> None:
+    evaluations = (
+        evaluation("one", expected_return="0.02"),
+        evaluation("two", expected_return="0.20"),
+    )
+    forward = rank_opportunities(evaluations)
+    backward = rank_opportunities(tuple(reversed(evaluations)))
+    assert propose_positions(forward) == propose_positions(backward)
+
+
+def test_instrument_confidence_rationale_and_evidence_are_propagated() -> None:
+    ranking = _ranking()
+    ranked = ranking.ranked_opportunities[0]
+    proposal = propose_positions(ranking)[0]
+    assert proposal.instrument is ranked.opportunity.instrument is TEST_INSTRUMENT
+    assert proposal.evidence_confidence is ranked.opportunity.evidence_confidence
+    assert ranked.opportunity.assumptions[0] in proposal.rationale
+    assert proposal.evidence
+
+
+def test_allocation_is_bounded_and_monotonic_with_score() -> None:
+    proposals = propose_positions(_ranking())
+    assert Decimal("0.01") <= proposals[1].target_allocation
+    assert proposals[0].target_allocation <= Decimal("0.10")
+    assert proposals[0].target_allocation > proposals[1].target_allocation
+
+
+def test_policy_version_and_all_effective_parameters_are_recorded() -> None:
+    proposal = propose_positions(_ranking())[0]
+    assert proposal.proposal_algorithm_version == PROPOSAL_ALGORITHM_VERSION == "v1"
+    assert proposal.effective_parameters == (
+        ("allocation_ceiling", Decimal("0.10")),
+        ("allocation_floor", Decimal("0.01")),
+        ("reference_capital", Decimal("100000")),
+    )
+
+
+def test_v1_regression_vector_pins_allocation_and_identity() -> None:
+    proposals = propose_positions(_ranking())
+    assert tuple((item.target_allocation, item.proposed_position_id) for item in proposals) == (
+        (
+            Decimal("0.083500000000"),
+            "071766e085034fc1f0ac52c5e6a4557a031f44633869d336706277ef42336a0f",
+        ),
+        (
+            Decimal("0.067600000000"),
+            "7095cf0b4f6f10b3d2881bcd062b157cfc7e274e3bf2f91c88c259306288bfc9",
+        ),
+    )
+
+
+def test_policy_change_changes_allocation_and_identity() -> None:
+    ranking = _ranking()
+    baseline = propose_positions(ranking)[0]
+    changed = propose_positions(
+        ranking,
+        ProposalParameters(
+            allocation_floor=Decimal("0.02"),
+            allocation_ceiling=Decimal("0.20"),
+        ),
+    )[0]
+    assert baseline.target_allocation != changed.target_allocation
+    assert baseline.proposed_position_id != changed.proposed_position_id
+
+
+def test_output_is_immutable() -> None:
+    proposal = propose_positions(_ranking())[0]
+    with pytest.raises(Exception):
+        proposal.target_allocation = Decimal("0.5")
+
+
+def test_empty_ranking_produces_no_proposals() -> None:
+    empty = rank_opportunities(())
+    assert propose_positions(empty) == ()
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"allocation_floor": Decimal("0")},
+        {"allocation_ceiling": Decimal("1.1")},
+        {"allocation_floor": Decimal("0.2"), "allocation_ceiling": Decimal("0.1")},
+        {"reference_capital": Decimal("0")},
+    ],
+)
+def test_invalid_policy_parameters_are_rejected(changes: dict[str, Decimal]) -> None:
+    with pytest.raises(InvalidProposalParameterError):
+        replace(ProposalParameters(), **changes)


### PR DESCRIPTION
## Summary

- adds the pure deterministic Position Proposal Engine
- converts each RankedOpportunity into one ProposedPosition in stable rank order
- uses a pinned v1 linear allocation policy with explicit floor, ceiling, and reference capital
- propagates canonical Instrument, confidence, rationale, lineage, and Evidence unchanged
- includes all effective policy parameters in deterministic content identity

## Boundaries

The engine accepts only RankingResult and explicit ProposalParameters. It has no PortfolioSnapshot, Holding, cash, buying-power, diversification, execution, broker, provider, repository, persistence, or networking dependency.

## Validation

- full architecture/intelligence suite: 744 passed
- Ruff on the new layer and architecture tests: passed
- strict MyPy on `position_proposals`: passed
- strict MyPy on `domain`: passed
- Lean POS entrypoint check: passed
- frozen-governance integrity check: passed
- deterministic replay and pinned v1 regression vectors: passed
- immutable output and forbidden-import validation: passed
- `git diff --check`: passed

## Self-review

All acceptance criteria are satisfied. No TODOs, skipped tests, provider leakage, infrastructure leakage, architecture changes, governance changes, or blocking issues remain.