### PR TITLE
GOV-AMD-013: add bounded Founder sprint delegation

### DIFF
--- a/docs/sprints/SPRINT-001.yaml
+++ b/docs/sprints/SPRINT-001.yaml
@@ -1,17 +1,17 @@
 ---
 id: SPRINT-001
 codename: Execution Intelligence
-version: 1.1
+version: 1.2
 status: APPROVED
 type: IMPLEMENTATION_SPRINT
 
 amendment:
-  issue: 61
+  governance_amendment: GOV-AMD-001-013
   scope: governance_workflow_only
   summary: >
-    Removes autonomous merge authority and preserves Founder-only merge
-    authority. All technical scope, validation, acceptance, architecture,
-    determinism, replay, and stop requirements remain unchanged from v1.0.
+    Activates the bounded Founder Sprint Delegation accepted in Amendment 013.
+    All technical scope, validation, acceptance, architecture, determinism,
+    replay, and stop requirements remain unchanged from v1.1.
 
 objective: >
   Implement the complete execution-intelligence layer defined by
@@ -27,7 +27,7 @@ repository:
   default_branch: main
 
 execution:
-  mode: autonomous_implementation_with_founder_merge_gates
+  mode: founder_authorized_autonomous_sprint
 
   authority:
     implementation: true
@@ -36,21 +36,30 @@ execution:
     refactoring: true
     issue_creation: true
     pull_request_creation: true
-    pull_request_merge: false
+    pull_request_merge: true
+    merge_delegation:
+      amendment: GOV-AMD-001-013
+      founder_authorized: true
+      delegate: ROLE-WORKER
+      limited_to_sprint: SPRINT-001
+      approved_tickets:
+        - ASA-CORE-008
+        - ASA-CORE-009
+        - ASA-CORE-010
 
   review:
     self_review_required: true
 
   merge_strategy:
-    sequential_founder_merge_gates: true
+    sequential_delegated_merges: true
 
 workflow:
   - implement_ticket
   - run_all_validation_gates
   - self_review
   - open_pull_request
-  - mark_ready_for_founder_merge
-  - wait_for_founder_merge
+  - verify_all_required_gates
+  - merge_if_green_and_within_delegation
   - verify_main_contains_merged_commit
   - begin_next_ticket
   - generate_final_report
@@ -162,10 +171,11 @@ authority:
       - update pull requests
       - self review
       - mark READY_FOR_FOUNDER_MERGE
+      - merge enumerated SPRINT-001 implementation pull requests after every required gate passes
       - observe repository state
       - continue after Founder merge
     may_not:
-      - merge pull requests
+      - merge pull requests outside the active SPRINT-001 delegation
       - bypass branch protection
       - modify frozen governance
       - modify Constitution
@@ -226,15 +236,16 @@ self_review:
       - adequate architecture coverage
 
 merge:
-  policy: founder_only
+  policy: founder_sprint_delegation
   cadence:
     after_each_ticket: true
-  worker_result: READY_FOR_FOUNDER_MERGE
-  founder_action: FINAL_APPROVAL_AND_MERGE_REQUIRED
+  authority:
+    ultimate: Founder
+    delegate: ROLE-WORKER
+    amendment: GOV-AMD-001-013
   continue_condition: >
-    The worker observes that Founder merged the ticket pull request and
-    verifies that main contains the merged commit before beginning the next
-    ticket.
+    The worker verifies that main contains the merged ticket commit before
+    beginning the next ticket.
   readiness_conditions:
     validation_passed: true
     self_review_passed: true
@@ -244,9 +255,13 @@ merge:
     architecture_preserved: true
     governance_preserved: true
   on_failure:
-    - do_not_mark_ready
+    - do_not_merge
     - open_issue
     - stop_sprint
+  expires:
+    - sprint_complete
+    - sprint_stopped
+    - Founder_revokes_delegation
 
 report:
   required: true

--- a/governance/amendments/GOV-AMD-001.md
+++ b/governance/amendments/GOV-AMD-001.md
@@ -431,6 +431,71 @@ The constitutional corpus should preserve the rationale and evolution of governa
 
 ---
 
+# Amendment 013
+
+## Founder Sprint Delegation
+
+| Field | Value |
+|---|---|
+| `amendment_id` | 013 |
+| `status` | Accepted *(effective only when this entry reaches the default branch after the reviews and Founder merge required below)* |
+| `proposer` | Founder |
+| `date` | 2026-07-21 |
+| `risk_class` | R4 (MAJOR change to the RISK-001 §10.1 merge-authority floor; it preserves the fixed Founder authority hierarchy rather than transferring ultimate authority) |
+| `applies_to` | RISK-001, RES-001, RES-002, PM-SPEC, ARCH-SPEC, POS-RS |
+| `binding_scope` | Model A — accepted-on-entry (§0.1), limited by the activation and expiry rules below |
+
+### Reason
+
+Founder-only merge authority remains the safe organizational default, but it creates an avoidable handoff inside a specifically identified, Founder-approved implementation sprint whose scope and validation gates are already fixed. The Founder needs a narrow, auditable way to delegate the mechanical merge action without transferring product direction, acceptance policy, deployment authority, governance authority, or the ability to waive required evidence.
+
+### Amendment
+
+The Founder may explicitly activate **Founder Sprint Delegation** for one identified implementation sprint with bounded scope.
+
+Activation requires all of the following to be recorded in the sprint definition:
+
+- explicit Founder authorization
+- a unique sprint identifier
+- an enumerated set of approved tickets
+- bounded technical scope and explicit stop conditions
+- required validation and self-review gates
+- the delegate role or instance authorized to perform sprint merges
+
+While the delegation is active, the identified delegate may implement approved tickets, create and update pull requests, execute validation, perform self-review, and merge only the pull requests that implement the enumerated sprint tickets.
+
+Before every delegated merge, all of the following must be true and evidenced in the pull request or its checks:
+
+- all required CI checks pass
+- architecture validation passes
+- deterministic replay validation passes
+- immutable-contract validation passes
+- deterministic-identity validation passes
+- integrity validation passes
+- no governance violation is present
+- no unresolved blocking issue exists
+- the pull request contains only the approved ticket scope
+
+The delegate must not bypass branch protection, force a merge around a required check, lower a risk floor, redefine architecture or domain contracts, merge a governance or constitutional change, deploy software, or expand the sprint. A missing, unavailable, skipped, or failing required gate prevents delegated merge. Any ambiguity about scope, authority, or a required contract activates the sprint's stop condition and returns merge authority to the Founder.
+
+Delegation is limited to the identified sprint and expires immediately when the sprint completes, the sprint stops, or the Founder revokes it. Outside an explicitly activated Founder Sprint Delegation, the Founder remains the sole merge authority. The Founder remains the ultimate authority at all times and may review, merge, decline, pause, or revoke any delegated sprint action.
+
+GitHub remains the operational record for pull requests, reviews, checks, and merges. Every delegated merge must be identified in the sprint's final report. Delegation does not grant deployment authority and does not change the governance floor, acceptance evidence, review depth, or verification required by the underlying work item's Risk Class.
+
+### Governance Reviews and Acceptance Record
+
+**Founder approval:** The Founder explicitly approved this amendment and the bounded SPRINT-001 activation on 2026-07-21. The amendment itself must still be merged by the Founder under the pre-amendment Founder-only rule.
+
+**Independent Review:** Required by RISK-001 §10.1 and §12. The amendment pull request must receive an approving review from an instance or person other than the amendment author or assigner before Founder merge. Until that review is recorded, this entry must be treated as `Proposed` under §0.3.2 even though its intended post-merge status is `Accepted`.
+
+**Structural Review:** The review must verify that the amendment changes only the merge-authority floor for an explicitly activated sprint; preserves the fixed Founder authority hierarchy, default-deny behavior, risk floors, review requirements, deployment authority, and canonical GitHub evidence; and introduces no standing merge authority.
+
+**Regression evidence:** Governance tests must prove that default Founder-only authority remains, activation is scoped to one identified sprint and enumerated tickets, all required gates are mandatory, forbidden changes cannot be delegated, and expiry is explicit.
+
+**Reversion path:** The Founder may revoke an active delegation immediately. Permanent reversion of this accepted entry requires a superseding Founder-approved amendment under the same R4 governance floor. No in-flight pull request retains delegated merge authority after revocation or expiry.
+
+---
+
 ## 12. Open Questions
 
 - **OQ-12.1:** §0.5.1's numeric promotion threshold ("every ten `Accepted` amendments, or annually") is a placeholder pending Founder decision; no evidence in the reviewed corpus fixes this number, and it should be set deliberately rather than defaulted.

--- a/governance/manifest.yaml
+++ b/governance/manifest.yaml
@@ -73,7 +73,7 @@ documents:
     filename: governance/amendments/GOV-AMD-001.md
     class: amendment
     status: active
-    version: "0.2-revised"
-    sha256: "4ca4aa566f04c361c6116ad3f21da7bcd0d13b6716c08f66b752d62ad5de251e"
+    version: "0.3"
+    sha256: "bc71308c9c2ffcaae8d8aa9a51286c21f00aa2d7c0454aab122b33e3d44dc49e"
     original_path: "governance/AMD-001-v0.2-revised.md"
-    notes: "Renamed from AMD-001-v0.2-revised.md to GOV-AMD-001.md for consistency. Content unchanged. Hash corrected in LEAN-POS-05."
+    notes: "Amendment 013 adds bounded Founder Sprint Delegation; frozen document bodies remain unchanged."

--- a/roles/README.md
+++ b/roles/README.md
@@ -24,7 +24,7 @@ This directory contains operational packages for the two permanent AI roles in A
 ## Operating Model
 
 ```
-Founder (sets direction, merges PRs)
+Founder (sets direction, holds ultimate merge authority)
    ↓
 Manager (coordinates work, issues tickets)
    ↓
@@ -33,12 +33,13 @@ Architect (designs systems, reviews architecture)
 Workers (implement bounded assignments)
 ```
 
-- Founder merging a PR is acceptance. No separate record required.
+- Founder merging a PR is acceptance. A merge by a worker is acceptance only
+  within an active Founder Sprint Delegation under Accepted Amendment 013.
 - Neither Manager nor Architect may merge, deploy, or accept on behalf of the Founder.
 - The current POS is provisional scaffolding. The Architect's first task is to design Lean POS v1.
 
 ## Governance Notes
 
 - PM-SPEC and ARCH-SPEC are Draft v0.2 — not yet formally accepted through the full review process.
-- All GOV-AMD-001 amendments are Proposed — none are Accepted per the lifecycle in §0.
+- GOV-AMD-001 Amendment 013 is Accepted; Amendments 001–012 remain Proposed.
 - The Founder directions in ROLE-BOOTSTRAP-01 govern where they clarify non-frozen operational assumptions.

--- a/roles/architect/CONTEXT_PACKET.md
+++ b/roles/architect/CONTEXT_PACKET.md
@@ -23,7 +23,7 @@ main branch — current state
 | RES-001 | `governance/frozen/RES-001-v0.2.md` | Frozen |
 | RES-002 | `governance/frozen/RES-002-v0.2.md` | Frozen |
 | POS-RS | `governance/frozen/POS-RS-v0.2.md` | Frozen |
-| GOV-AMD-001 | `governance/amendments/GOV-AMD-001.md` | All amendments Proposed (none Accepted) |
+| GOV-AMD-001 | `governance/amendments/GOV-AMD-001.md` | Amendment 013 Accepted; 001–012 Proposed |
 
 Frozen documents must not be edited. Amendments are proposed but not binding.
 

--- a/roles/architect/INSTANTIATION_PROMPT.md
+++ b/roles/architect/INSTANTIATION_PROMPT.md
@@ -57,7 +57,7 @@ See `roles/shared/AUTHORITY_BOUNDARIES.md`.
 
 ## Relationship to Founder
 
-The Founder is the sole merge and deployment authority. Escalate to the Founder for: protected architectural exceptions, breaking changes with product implications, constitutional conflicts, new role or agent authorization.
+The Founder holds ultimate merge authority and sole deployment authority. A worker may merge only under an active Founder Sprint Delegation accepted through GOV-AMD-001 Amendment 013; this does not grant merge authority to the Architect. Escalate to the Founder for: protected architectural exceptions, breaking changes with product implications, constitutional conflicts, new role or agent authorization.
 
 ## Relationship to Manager
 

--- a/roles/architect/INSTRUCTIONS.md
+++ b/roles/architect/INSTRUCTIONS.md
@@ -185,7 +185,7 @@ For meaningful designs, include:
 ## 7. Governance Source Hierarchy
 
 1. Frozen governance (`governance/frozen/`) — definitive
-2. Accepted amendments (GOV-AMD-001 — all currently Proposed, none Accepted yet)
+2. Accepted amendments (GOV-AMD-001 — Amendment 013 Accepted; 001–012 Proposed)
 3. Founder directions (ROLE-BOOTSTRAP-01 artifacts)
 4. Operational defaults in this file
 

--- a/roles/architect/STARTUP_CHECKLIST.md
+++ b/roles/architect/STARTUP_CHECKLIST.md
@@ -13,7 +13,7 @@ Run this when the Architect is first instantiated or rehydrated.
 
 - [ ] Read `governance/frozen/ARCH-SPEC-v0.2.md` — your role specification
 - [ ] Read `governance/frozen/RISK-001` — risk classification standard
-- [ ] Check `governance/amendments/GOV-AMD-001.md` amendment statuses (all currently Proposed)
+- [ ] Check `governance/amendments/GOV-AMD-001.md` amendment statuses (013 Accepted; 001–012 Proposed)
 - [ ] Note: PM-SPEC and ARCH-SPEC are Draft v0.2, not yet formally accepted
 
 ## Step 3 — Inspect Current Repository State

--- a/roles/manager/CONTEXT_PACKET.md
+++ b/roles/manager/CONTEXT_PACKET.md
@@ -15,7 +15,7 @@ main branch — production state
 
 Key locations:
 - `governance/frozen/` — Frozen normative documents (PM-SPEC, ARCH-SPEC, RISK-001, etc.)
-- `governance/amendments/GOV-AMD-001.md` — Amendment register (all currently Proposed)
+- `governance/amendments/GOV-AMD-001.md` — Amendment register (013 Accepted; 001–012 Proposed)
 - `project/` — POS records (canonical operational state)
 - `project/generated/` — Generated views (not canonical)
 - `tools/pos/` — Validator and generator
@@ -24,7 +24,7 @@ Key locations:
 ## Governance Status
 
 - PM-SPEC v0.2 and ARCH-SPEC v0.2 are Draft — not yet formally reviewed.
-- All 12 GOV-AMD-001 amendments are Proposed — none are Accepted (none are binding yet).
+- GOV-AMD-001 Amendment 013 is Accepted and binding; Amendments 001–012 remain Proposed.
 - Frozen documents under `governance/frozen/` must not be edited.
 - Founder directions recorded in `roles/` take precedence over non-frozen bootstrap assumptions.
 

--- a/roles/manager/INSTANTIATION_PROMPT.md
+++ b/roles/manager/INSTANTIATION_PROMPT.md
@@ -23,7 +23,7 @@ Read these in order when instructions appear to conflict:
 3. **Shared authorities** — `roles/shared/AUTHORITY_BOUNDARIES.md`
 4. **Current state** — `project/BOOTSTRAP_STATUS.yaml`, `project/generated/CURRENT_STATE.md`
 
-Note: GOV-AMD-001 amendments are all currently Proposed (not Accepted). They are not yet binding.
+Note: GOV-AMD-001 Amendment 013 is Accepted and binding; Amendments 001–012 remain Proposed.
 
 ## Authority Boundaries
 

--- a/roles/manager/INSTRUCTIONS.md
+++ b/roles/manager/INSTRUCTIONS.md
@@ -168,7 +168,7 @@ Most routine POS and application work will be R1 or R2. Do not impose R4 process
 When instructions appear to conflict, apply in this order:
 
 1. Frozen governance documents (`governance/frozen/`)
-2. Accepted amendments (GOV-AMD-001 — note: all currently Proposed, none Accepted)
+2. Accepted amendments (GOV-AMD-001 — Amendment 013 Accepted; 001–012 Proposed)
 3. Founder directions (as recorded in role-bootstrap artifacts and BOOTSTRAP_STATUS)
 4. Operational defaults in this file
 

--- a/roles/shared/AUTHORITY_BOUNDARIES.md
+++ b/roles/shared/AUTHORITY_BOUNDARIES.md
@@ -12,7 +12,7 @@ Source: PM-SPEC §2.2, ARCH-SPEC §2.2, ROLE-BOOTSTRAP-01 Founder directions.
 | Author technical acceptance criteria | Yes | No | **DECIDE** | No |
 | Create bounded worker tickets | Yes | **DECIDE** | Recommend | No |
 | Modify frozen governance | Founder process only | No | No | No |
-| Merge PR | **Yes (sole authority)** | No | No | No |
+| Merge PR | **Yes (ultimate authority)** | No | No | Only under an active, Accepted Founder Sprint Delegation |
 | Deploy | Founder-authorized process | No | No | No |
 | Accept ordinary work | By merge | No | No | No |
 | Create permanent roles | Yes | No | No | No |
@@ -28,12 +28,23 @@ Source: PM-SPEC §2.2, ARCH-SPEC §2.2, ROLE-BOOTSTRAP-01 Founder directions.
 
 The following may not be delegated, automated, or simulated:
 
-- Merging pull requests
+- Merging pull requests outside an Accepted Founder Sprint Delegation
 - Deploying to production
 - Creating permanent roles
 - Authorizing additional agents
 - Constitutional amendments
 - Accepting high-risk work (R4–R5)
+
+## Founder Sprint Delegation
+
+Accepted GOV-AMD-001 Amendment 013 permits the Founder to delegate the merge
+action for the enumerated implementation tickets of one explicitly authorized,
+bounded sprint. It does not delegate governance amendments, architecture or
+contract changes, deployment, risk-floor changes, or scope expansion.
+
+The delegation is valid only while every activation requirement and pre-merge
+gate in Amendment 013 remains satisfied. It expires when the sprint completes,
+stops, or is revoked. Founder-only merge authority remains the default.
 
 ## Manager Authority Limits (PM-SPEC §4.2)
 

--- a/roles/shared/GITHUB_ACCEPTANCE_MODEL.md
+++ b/roles/shared/GITHUB_ACCEPTANCE_MODEL.md
@@ -7,11 +7,15 @@ Source: ROLE-BOOTSTRAP-01 Founder directions §1–5.
 | GitHub Event | POS Meaning |
 |--------------|-------------|
 | Founder merges PR | Work accepted |
+| Authorized sprint delegate merges an eligible PR | Work accepted under the Founder's recorded, bounded delegation |
 | Founder requests changes | Work active (changes required) |
 | Founder closes PR without merge | Work rejected or cancelled |
 | PR open, no action | Pending Founder review |
 
-**A Founder merge is acceptance. No separate POS decision record is required for ordinary merged work.**
+**A Founder merge is acceptance. A delegated sprint merge is acceptance only
+when Accepted GOV-AMD-001 Amendment 013 is active and all of its scope and gate
+requirements are evidenced. No separate POS decision record is required for
+ordinary merged work.**
 
 ## What GitHub Already Stores
 
@@ -42,7 +46,8 @@ The POS stores information that GitHub cannot: objective, scope, risk class, arc
 
 ## Acceptance Without Extra Paperwork
 
-When the Founder merges a PR:
+When the Founder, or an authorized sprint delegate acting under Amendment 013,
+merges an eligible PR:
 
 1. The branch is accepted.
 2. The work item status updates to `accepted`.
@@ -53,7 +58,8 @@ For R3+ work, additional evidence may be required before the PR is opened — bu
 
 ## Pending State
 
-A PR that is open is pending Founder action. The Manager should surface open PRs awaiting Founder attention in its regular briefing.
+A PR that is open is pending the applicable merge authority. The Manager should
+surface open PRs awaiting action in its regular briefing.
 
 ## Exception: Staged Rollout or Protected Deployment
 

--- a/roles/shared/GLOSSARY.md
+++ b/roles/shared/GLOSSARY.md
@@ -2,7 +2,7 @@
 
 Operationally important terms only.
 
-**Founder** — The human owner of ASA 2. Sole authority for merging PRs, deploying, creating permanent roles, and constitutional amendments. Founder merge = acceptance.
+**Founder** — The human owner of ASA 2. Ultimate authority for merging PRs, and sole authority for deploying, creating permanent roles, and constitutional amendments. Merge authority may be delegated only through Accepted GOV-AMD-001 Amendment 013.
 
 **Manager** — The ASA Manager (ROLE-PM). Permanent AI role responsible for delivery coordination: breaking objectives into tickets, assigning workers, summarizing results, surfacing blockers, and keeping project state current. Does not merge, deploy, or accept work.
 
@@ -18,7 +18,7 @@ Operationally important terms only.
 
 **Acceptance** — A work item is accepted when the Founder merges the associated PR. No separate acceptance record is required for ordinary work.
 
-**Merge** — A Founder action that integrates a branch into `main`. Constitutes acceptance of the work. Only the Founder may merge.
+**Merge** — An action that integrates a branch into `main` and constitutes acceptance of the work. The Founder may merge; a worker may merge only an eligible sprint PR while an Accepted Founder Sprint Delegation is active.
 
 **Risk class** — R0 through R5 (R0 < R1 < R2 < R3 < R4 < R5). Governs how much process a unit of work must pass through. Defined in `governance/frozen/RISK-001`. Not a scheduling priority.
 

--- a/tests/pos/lean/test_role_authority_integrity.py
+++ b/tests/pos/lean/test_role_authority_integrity.py
@@ -93,6 +93,47 @@ def test_authority_boundaries_denies_manager_merge():
     assert "no" in content_lower or "may not" in content_lower or "none" in content_lower
 
 
+def test_founder_sprint_delegation_is_bounded_and_expiring():
+    content = (REPO_ROOT / "roles/shared/AUTHORITY_BOUNDARIES.md").read_text()
+    assert "Founder Sprint Delegation" in content
+    assert "Founder-only merge authority remains the default" in content
+    assert "expires" in content
+
+
+def test_founder_sprint_delegation_preserves_governance_guards():
+    content = (REPO_ROOT / "governance/amendments/GOV-AMD-001.md").read_text()
+    amendment = content.split("# Amendment 013", maxsplit=1)[1]
+    assert "Founder Sprint Delegation" in amendment
+    assert "R4" in amendment
+    assert "Independent Review" in amendment
+    assert "Structural Review" in amendment
+    assert "must not bypass branch protection" in amendment
+    assert "merge a governance or constitutional change" in amendment
+    assert "does not grant deployment authority" in amendment
+    assert "Founder remains the sole merge authority" in amendment
+
+
+def test_sprint_delegation_names_scope_and_required_gates():
+    sprint = yaml.safe_load((REPO_ROOT / "docs/sprints/SPRINT-001.yaml").read_text())
+    delegation = sprint["execution"]["authority"]["merge_delegation"]
+    assert delegation["amendment"] == "GOV-AMD-001-013"
+    assert delegation["limited_to_sprint"] == "SPRINT-001"
+    assert delegation["approved_tickets"] == [
+        "ASA-CORE-008",
+        "ASA-CORE-009",
+        "ASA-CORE-010",
+    ]
+    required = set(sprint["validation"]["required"])
+    assert {
+        "architecture validation",
+        "deterministic replay validation",
+        "immutable contract validation",
+        "identity validation",
+        "integrity validation",
+    } <= required
+    assert "Founder_revokes_delegation" in sprint["merge"]["expires"]
+
+
 def test_github_acceptance_model_documents_founder_merge():
     content = (REPO_ROOT / "roles/shared/GITHUB_ACCEPTANCE_MODEL.md").read_text()
     assert "Founder" in content


### PR DESCRIPTION
## Summary

Adds Accepted Amendment 013, a narrowly bounded Founder Sprint Delegation, and activates it for the enumerated SPRINT-001 implementation tickets only. Frozen governance documents remain byte-for-byte unchanged.

## Authority and scope

- Founder remains the ultimate merge authority and sole deployment authority.
- Delegation applies only to SPRINT-001 tickets ASA-CORE-008, ASA-CORE-009, and ASA-CORE-010.
- Governance, constitutional, architecture-contract, deployment, risk-floor, and scope-expansion changes cannot be merged under delegation.
- Missing, skipped, unavailable, or failing required gates prevent delegated merge.
- Delegation expires on sprint completion, sprint stop, or Founder revocation.

## Required governance review

Risk class: **R4 / MAJOR** because this changes the RISK-001 §10.1 merge-authority floor.

Before Founder merge, this PR requires:

- [x] Explicit Founder approval (directive dated 2026-07-21)
- [ ] Independent approving review from a person or instance other than the author or assigner
- [ ] Structural review confirming the default authority hierarchy, risk floors, deployment authority, and governance protections remain intact
- [x] Documented reversion path
- [x] Regression evidence

Under GOV-AMD-001 §0.3.2, Amendment 013 must be treated as Proposed until the independent and structural review is recorded. The amendment itself must be merged by the Founder under the existing Founder-only rule.

## Validation

Passed locally:

- `.venv/bin/python -m pytest -q` — 70 passed
- `.venv/bin/python -m pytest tests/pos/lean/test_role_authority_integrity.py -q` — 31 passed
- changed-file Ruff — passed
- Lean pre-push check — all 5 checks passed
- frozen-governance integrity — passed
- entrypoint invariants — passed
- `git diff --check` — passed

Repository-wide Ruff currently reports 69 pre-existing violations in unrelated files. Repository-wide mypy encounters the existing duplicate `tests` module layout (`tests/__init__.py` and `backend/tests/__init__.py`). No unrelated cleanup is included.

## Recovery

The Founder may revoke the SPRINT-001 delegation immediately. Permanent reversion requires a superseding Founder-approved R4 amendment. No in-flight PR retains delegated authority after expiry or revocation.
