### PR TITLE
ASA-CORE-009: add deterministic Portfolio Engine

### DIFF
--- a/.github/workflows/validate-architecture.yml
+++ b/.github/workflows/validate-architecture.yml
@@ -13,6 +13,8 @@ on:
       - 'strategies/**'
       - 'guardrails/**'
       - 'ranking/**'
+      - 'position_proposals/**'
+      - 'portfolio/**'
       - 'presentation/**'
       - 'domain/**'
       - 'architecture/**'
@@ -26,6 +28,8 @@ on:
       - 'tests/strategies/**'
       - 'tests/guardrails/**'
       - 'tests/ranking/**'
+      - 'tests/position_proposals/**'
+      - 'tests/portfolio/**'
   workflow_dispatch:
 
 jobs:
@@ -46,7 +50,21 @@ jobs:
         run: python -m pip install pytest
 
       - name: Run architecture and intelligence pipeline tests
-        run: python -m pytest tests/architecture tests/domain tests/observation tests/providers tests/reconciliation tests/facts tests/indicators tests/strategies tests/guardrails tests/ranking -v
+        run: >-
+          python -m pytest
+          tests/architecture
+          tests/domain
+          tests/observation
+          tests/providers
+          tests/reconciliation
+          tests/facts
+          tests/indicators
+          tests/strategies
+          tests/guardrails
+          tests/ranking
+          tests/position_proposals
+          tests/portfolio
+          -v
 
 # Mechanical checks only. A passing workflow does NOT constitute approval,
 # merge authorization, or deployment authorization.

--- a/portfolio/__init__.py
+++ b/portfolio/__init__.py
@@ -1,0 +1,13 @@
+"""Deterministic portfolio-policy layer (ASA-CORE-009)."""
+
+from portfolio.engine import evaluate_portfolio
+from portfolio.models import PORTFOLIO_ALGORITHM_VERSION, PortfolioParameters
+from portfolio.registry import PolicyRegistry, build_default_registry
+
+__all__ = [
+    "PORTFOLIO_ALGORITHM_VERSION",
+    "PolicyRegistry",
+    "PortfolioParameters",
+    "build_default_registry",
+    "evaluate_portfolio",
+]

--- a/portfolio/engine.py
+++ b/portfolio/engine.py
@@ -1,0 +1,154 @@
+"""Pure deterministic Portfolio Engine (ASA-CORE-009)."""
+
+from __future__ import annotations
+
+import hashlib
+from decimal import Decimal
+
+from domain.canonicalization import serialize_canonical
+from domain.execution import PortfolioDecision, PortfolioDecisionState
+from domain.operational import PortfolioDecisionRequest, PortfolioSnapshot, ProposedPosition
+from domain.references import EvidenceReference
+from portfolio.models import (
+    ALLOCATION_QUANTUM,
+    PORTFOLIO_ALGORITHM_VERSION,
+    PORTFOLIO_IDENTITY_NAMESPACE,
+    PolicyOutcome,
+    PortfolioParameters,
+)
+from portfolio.errors import InvalidPolicyOutcomeError
+from portfolio.registry import PolicyRegistry, build_default_registry
+
+
+def _evidence_identity(reference: EvidenceReference) -> tuple[object, ...]:
+    return (reference.kind.value, reference.referenced_id, reference.version)
+
+
+def _decision_evidence(
+    proposal: ProposedPosition, snapshot: PortfolioSnapshot
+) -> tuple[EvidenceReference, ...]:
+    references = proposal.evidence + snapshot.evidence + tuple(
+        reference
+        for holding in snapshot.holdings
+        for reference in holding.valuation_evidence
+    )
+    unique = {
+        _evidence_identity(reference): reference
+        for reference in references
+    }
+    return tuple(unique[key] for key in sorted(unique))
+
+
+def _identity(
+    proposal: ProposedPosition,
+    snapshot: PortfolioSnapshot,
+    state: PortfolioDecisionState,
+    approved_allocation: Decimal,
+    policy_versions: tuple[tuple[str, str], ...],
+    effective_parameters: tuple[tuple[str, Decimal], ...],
+    reasons: tuple[str, ...],
+    evidence: tuple[EvidenceReference, ...],
+) -> str:
+    payload = "\n".join(
+        (
+            PORTFOLIO_IDENTITY_NAMESPACE,
+            PORTFOLIO_ALGORITHM_VERSION,
+            serialize_canonical(proposal.proposed_position_id),
+            serialize_canonical(snapshot.portfolio_snapshot_id),
+            serialize_canonical(state.value),
+            serialize_canonical(approved_allocation),
+            serialize_canonical(policy_versions),
+            serialize_canonical(effective_parameters),
+            serialize_canonical(reasons),
+            serialize_canonical(tuple(_evidence_identity(item) for item in evidence)),
+        )
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _disposition(
+    proposal: ProposedPosition,
+    snapshot: PortfolioSnapshot,
+    outcomes: tuple[PolicyOutcome, ...],
+) -> tuple[PortfolioDecisionState, Decimal, tuple[str, ...]]:
+    reasons = tuple(outcome.reason for outcome in outcomes)
+    if proposal.instrument.currency != snapshot.base_currency:
+        return (
+            PortfolioDecisionState.REJECT,
+            Decimal("0"),
+            (*reasons, "instrument currency does not match portfolio base currency"),
+        )
+    terminal = next(
+        (outcome.terminal_state for outcome in outcomes if outcome.terminal_state is not None),
+        None,
+    )
+    if terminal is not None:
+        return terminal, Decimal("0"), reasons
+    approved = min(
+        (proposal.target_allocation, *(outcome.maximum_allocation for outcome in outcomes))
+    )
+    approved = max(Decimal("0"), approved).quantize(ALLOCATION_QUANTUM)
+    if approved == 0:
+        return PortfolioDecisionState.REJECT, approved, reasons
+    if approved < proposal.target_allocation:
+        return PortfolioDecisionState.REDUCE, approved, reasons
+    return PortfolioDecisionState.ACCEPT, proposal.target_allocation, reasons
+
+
+def _evaluate_one(
+    proposal: ProposedPosition,
+    snapshot: PortfolioSnapshot,
+    parameters: PortfolioParameters,
+    registry: PolicyRegistry,
+) -> PortfolioDecision:
+    definitions = registry.definitions()
+    outcomes = tuple(
+        definition.policy(proposal, snapshot, parameters) for definition in definitions
+    )
+    if any(
+        outcome.policy_name != definition.name
+        for definition, outcome in zip(definitions, outcomes, strict=True)
+    ):
+        raise InvalidPolicyOutcomeError("policy outcome name does not match registry definition")
+    state, approved, reasons = _disposition(proposal, snapshot, outcomes)
+    policy_versions = tuple(
+        (outcome.policy_name, outcome.policy_version) for outcome in outcomes
+    )
+    effective_parameters = parameters.canonical_items()
+    evidence = _decision_evidence(proposal, snapshot)
+    return PortfolioDecision(
+        portfolio_decision_id=_identity(
+            proposal,
+            snapshot,
+            state,
+            approved,
+            policy_versions,
+            effective_parameters,
+            reasons,
+            evidence,
+        ),
+        decision_algorithm_version=PORTFOLIO_ALGORITHM_VERSION,
+        portfolio_snapshot_id=snapshot.portfolio_snapshot_id,
+        proposed_position=proposal,
+        state=state,
+        approved_allocation=approved,
+        policy_versions=policy_versions,
+        effective_parameters=effective_parameters,
+        reasons=reasons,
+        evidence=evidence,
+    )
+
+
+def evaluate_portfolio(
+    request: PortfolioDecisionRequest,
+    parameters: PortfolioParameters | None = None,
+    registry: PolicyRegistry | None = None,
+) -> tuple[PortfolioDecision, ...]:
+    """Evaluate proposals in ranking order against one immutable snapshot."""
+    active_parameters = parameters or PortfolioParameters()
+    active_registry = registry or build_default_registry()
+    active_registry.validate()
+    return tuple(
+        _evaluate_one(proposal, request.portfolio_snapshot, active_parameters, active_registry)
+        for proposal in request.proposed_positions
+    )

--- a/portfolio/errors.py
+++ b/portfolio/errors.py
@@ -1,0 +1,21 @@
+"""Portfolio Engine errors."""
+
+
+class PortfolioEngineError(ValueError):
+    """Base error for deterministic portfolio evaluation."""
+
+
+class InvalidPortfolioParameterError(PortfolioEngineError):
+    """Raised when effective portfolio policy parameters are invalid."""
+
+
+class DuplicatePolicyRegistrationError(PortfolioEngineError):
+    """Raised when a policy name is registered more than once."""
+
+
+class InvalidPolicyRegistryError(PortfolioEngineError):
+    """Raised when the registry does not contain the complete v1 policy set."""
+
+
+class InvalidPolicyOutcomeError(PortfolioEngineError):
+    """Raised when a policy returns incoherent provenance or allocation."""

--- a/portfolio/models.py
+++ b/portfolio/models.py
@@ -1,0 +1,88 @@
+"""Immutable Portfolio Engine policy inputs and outcomes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from domain.execution import PortfolioDecisionState
+from domain.values import require_finite_decimal, require_unit_interval
+from portfolio.errors import InvalidPolicyOutcomeError, InvalidPortfolioParameterError
+
+PORTFOLIO_ALGORITHM_VERSION = "v1"
+PORTFOLIO_IDENTITY_NAMESPACE = "asa.portfolio_decision"
+ALLOCATION_QUANTUM = Decimal("0.000000000001")
+POLICY_VERSION = "v1"
+POLICY_NAMES = (
+    "buying_power_validation",
+    "cash_reserve",
+    "duplicate_position",
+    "maximum_position_size",
+    "maximum_sector_exposure",
+    "maximum_single_asset_exposure",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioParameters:
+    """Complete v1 portfolio policy with no hidden runtime configuration."""
+
+    cash_reserve_ratio: Decimal = Decimal("0.10")
+    maximum_position_allocation: Decimal = Decimal("0.20")
+    maximum_sector_exposure: Decimal = Decimal("0.40")
+    maximum_single_asset_exposure: Decimal = Decimal("0.20")
+
+    def __post_init__(self) -> None:
+        for name in self.__dataclass_fields__:
+            value = getattr(self, name)
+            try:
+                require_finite_decimal(value, "PortfolioParameters", name)
+                require_unit_interval(value, "PortfolioParameters", name)
+            except (TypeError, ValueError) as error:
+                raise InvalidPortfolioParameterError(str(error)) from error
+        if self.maximum_position_allocation == 0:
+            raise InvalidPortfolioParameterError(
+                "maximum_position_allocation must be greater than zero"
+            )
+        if self.maximum_sector_exposure == 0:
+            raise InvalidPortfolioParameterError(
+                "maximum_sector_exposure must be greater than zero"
+            )
+        if self.maximum_single_asset_exposure == 0:
+            raise InvalidPortfolioParameterError(
+                "maximum_single_asset_exposure must be greater than zero"
+            )
+
+    def canonical_items(self) -> tuple[tuple[str, Decimal], ...]:
+        return tuple(sorted((name, getattr(self, name)) for name in self.__dataclass_fields__))
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyOutcome:
+    """One deterministic policy's allocation ceiling and disposition."""
+
+    policy_name: str
+    policy_version: str
+    maximum_allocation: Decimal
+    reason: str
+    terminal_state: PortfolioDecisionState | None = None
+
+    def __post_init__(self) -> None:
+        if self.policy_name not in POLICY_NAMES:
+            raise InvalidPolicyOutcomeError("policy outcome name is not registered in v1")
+        if not self.policy_version or self.policy_version != self.policy_version.strip():
+            raise InvalidPolicyOutcomeError("policy outcome version must be normalized text")
+        if not self.reason or self.reason != self.reason.strip():
+            raise InvalidPolicyOutcomeError("policy outcome reason must be normalized text")
+        try:
+            require_finite_decimal(
+                self.maximum_allocation,
+                "PolicyOutcome",
+                "maximum_allocation",
+            )
+        except (TypeError, ValueError) as error:
+            raise InvalidPolicyOutcomeError(str(error)) from error
+        if self.maximum_allocation < 0:
+            raise InvalidPolicyOutcomeError("policy outcome allocation cannot be negative")
+        if self.terminal_state not in {None, PortfolioDecisionState.HOLD, PortfolioDecisionState.REJECT}:
+            raise InvalidPolicyOutcomeError("policy terminal state must be HOLD or REJECT")

--- a/portfolio/policies.py
+++ b/portfolio/policies.py
@@ -1,0 +1,151 @@
+"""Pinned v1 portfolio policies.
+
+Each policy returns an allocation ceiling expressed in the ProposedPosition's
+reference-capital frame. Policies never mutate or infer missing portfolio data.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, localcontext
+
+from domain.execution import PortfolioDecisionState
+from domain.operational import PortfolioSnapshot, ProposedPosition
+from portfolio.models import ALLOCATION_QUANTUM, POLICY_VERSION, PolicyOutcome, PortfolioParameters
+
+
+def _reference_capital(proposal: ProposedPosition) -> Decimal:
+    return dict(proposal.effective_parameters)["reference_capital"]
+
+
+def _allocation_for_amount(amount: Decimal, proposal: ProposedPosition) -> Decimal:
+    if amount <= 0:
+        return Decimal("0")
+    with localcontext() as context:
+        context.prec = 40
+        return (amount / _reference_capital(proposal)).quantize(ALLOCATION_QUANTUM)
+
+
+def buying_power_validation(
+    proposal: ProposedPosition,
+    snapshot: PortfolioSnapshot,
+    parameters: PortfolioParameters,
+) -> PolicyOutcome:
+    del parameters
+    ceiling = _allocation_for_amount(snapshot.buying_power.amount, proposal)
+    return PolicyOutcome(
+        "buying_power_validation",
+        POLICY_VERSION,
+        ceiling,
+        "buying power limits new exposure" if ceiling < proposal.target_allocation else
+        "buying power supports proposed exposure",
+    )
+
+
+def cash_reserve(
+    proposal: ProposedPosition,
+    snapshot: PortfolioSnapshot,
+    parameters: PortfolioParameters,
+) -> PolicyOutcome:
+    reserve = snapshot.net_liquidation_value.amount * parameters.cash_reserve_ratio
+    ceiling = _allocation_for_amount(snapshot.cash_balance.amount - reserve, proposal)
+    return PolicyOutcome(
+        "cash_reserve",
+        POLICY_VERSION,
+        ceiling,
+        "cash reserve limits new exposure" if ceiling < proposal.target_allocation else
+        "cash reserve remains satisfied",
+    )
+
+
+def duplicate_position(
+    proposal: ProposedPosition,
+    snapshot: PortfolioSnapshot,
+    parameters: PortfolioParameters,
+) -> PolicyOutcome:
+    del parameters
+    duplicate = any(
+        holding.instrument.identity == proposal.instrument.identity
+        for holding in snapshot.holdings
+    )
+    return PolicyOutcome(
+        "duplicate_position",
+        POLICY_VERSION,
+        Decimal("0") if duplicate else proposal.target_allocation,
+        "existing canonical instrument exposure requires hold" if duplicate else
+        "no duplicate canonical instrument exposure",
+        PortfolioDecisionState.HOLD if duplicate else None,
+    )
+
+
+def maximum_position_size(
+    proposal: ProposedPosition,
+    snapshot: PortfolioSnapshot,
+    parameters: PortfolioParameters,
+) -> PolicyOutcome:
+    del snapshot
+    ceiling = parameters.maximum_position_allocation
+    return PolicyOutcome(
+        "maximum_position_size",
+        POLICY_VERSION,
+        ceiling,
+        "maximum position size limits proposed exposure" if ceiling < proposal.target_allocation
+        else "proposed exposure is within maximum position size",
+    )
+
+
+def maximum_sector_exposure(
+    proposal: ProposedPosition,
+    snapshot: PortfolioSnapshot,
+    parameters: PortfolioParameters,
+) -> PolicyOutcome:
+    sector = proposal.instrument.sector
+    if sector is None:
+        return PolicyOutcome(
+            "maximum_sector_exposure",
+            POLICY_VERSION,
+            proposal.target_allocation,
+            "sector policy is not applicable to an unclassified instrument",
+        )
+    current = sum(
+        (
+            holding.gross_exposure.amount
+            for holding in snapshot.holdings
+            if holding.instrument.sector == sector
+        ),
+        Decimal("0"),
+    )
+    capacity = snapshot.net_liquidation_value.amount * parameters.maximum_sector_exposure - current
+    ceiling = _allocation_for_amount(capacity, proposal)
+    return PolicyOutcome(
+        "maximum_sector_exposure",
+        POLICY_VERSION,
+        ceiling,
+        "sector exposure limit constrains diversification" if ceiling < proposal.target_allocation
+        else "sector exposure remains diversified",
+    )
+
+
+def maximum_single_asset_exposure(
+    proposal: ProposedPosition,
+    snapshot: PortfolioSnapshot,
+    parameters: PortfolioParameters,
+) -> PolicyOutcome:
+    current = sum(
+        (
+            holding.gross_exposure.amount
+            for holding in snapshot.holdings
+            if holding.instrument.identity == proposal.instrument.identity
+        ),
+        Decimal("0"),
+    )
+    capacity = (
+        snapshot.net_liquidation_value.amount * parameters.maximum_single_asset_exposure - current
+    )
+    ceiling = _allocation_for_amount(capacity, proposal)
+    return PolicyOutcome(
+        "maximum_single_asset_exposure",
+        POLICY_VERSION,
+        ceiling,
+        "single asset concentration limits new exposure" if ceiling < proposal.target_allocation
+        else "single asset exposure remains within concentration limit",
+    )

--- a/portfolio/registry.py
+++ b/portfolio/registry.py
@@ -1,0 +1,55 @@
+"""Explicit deterministic portfolio-policy registry."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from domain.operational import PortfolioSnapshot, ProposedPosition
+from portfolio.errors import DuplicatePolicyRegistrationError, InvalidPolicyRegistryError
+from portfolio.models import POLICY_NAMES, PolicyOutcome, PortfolioParameters
+from portfolio.policies import (
+    buying_power_validation,
+    cash_reserve,
+    duplicate_position,
+    maximum_position_size,
+    maximum_sector_exposure,
+    maximum_single_asset_exposure,
+)
+
+Policy = Callable[[ProposedPosition, PortfolioSnapshot, PortfolioParameters], PolicyOutcome]
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDefinition:
+    name: str
+    policy: Policy
+
+
+class PolicyRegistry:
+    def __init__(self) -> None:
+        self._definitions: dict[str, PolicyDefinition] = {}
+
+    def register(self, name: str, policy: Policy) -> None:
+        if name in self._definitions:
+            raise DuplicatePolicyRegistrationError(name)
+        self._definitions[name] = PolicyDefinition(name, policy)
+
+    def definitions(self) -> tuple[PolicyDefinition, ...]:
+        return tuple(self._definitions[name] for name in sorted(self._definitions))
+
+    def validate(self) -> None:
+        if tuple(item.name for item in self.definitions()) != POLICY_NAMES:
+            raise InvalidPolicyRegistryError("portfolio registry must contain all pinned v1 policies")
+
+
+def build_default_registry() -> PolicyRegistry:
+    registry = PolicyRegistry()
+    registry.register("buying_power_validation", buying_power_validation)
+    registry.register("cash_reserve", cash_reserve)
+    registry.register("duplicate_position", duplicate_position)
+    registry.register("maximum_position_size", maximum_position_size)
+    registry.register("maximum_sector_exposure", maximum_sector_exposure)
+    registry.register("maximum_single_asset_exposure", maximum_single_asset_exposure)
+    registry.validate()
+    return registry

--- a/tests/architecture/test_portfolio_boundaries.py
+++ b/tests/architecture/test_portfolio_boundaries.py
@@ -1,0 +1,82 @@
+"""ASA-CORE-009 Portfolio Layer architecture validation."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALLOWED_ROOTS = {
+    "__future__",
+    "collections",
+    "dataclasses",
+    "decimal",
+    "domain",
+    "hashlib",
+    "portfolio",
+}
+PROHIBITED_ROOTS = {
+    "backend",
+    "brokers",
+    "execution",
+    "infrastructure",
+    "observation",
+    "position_proposals",
+    "providers",
+    "ranking",
+    "sqlalchemy",
+}
+
+
+def _files() -> list[Path]:
+    return sorted((REPO_ROOT / "portfolio").glob("*.py"))
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text())
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            roots.add(node.module.split(".")[0])
+    return roots
+
+
+@pytest.mark.parametrize("path", _files())
+def test_portfolio_imports_only_domain_and_portfolio(path: Path) -> None:
+    imported = _imports(path)
+    assert imported <= ALLOWED_ROOTS
+    assert not imported & PROHIBITED_ROOTS
+
+
+def test_required_modules_exist_and_no_repository_exists() -> None:
+    assert {path.name for path in _files()} == {
+        "__init__.py",
+        "engine.py",
+        "errors.py",
+        "models.py",
+        "policies.py",
+        "registry.py",
+    }
+    assert not (REPO_ROOT / "portfolio" / "repository.py").exists()
+    assert not (REPO_ROOT / "portfolio" / "persistence.py").exists()
+
+
+def test_no_randomness_networking_or_side_effect_imports() -> None:
+    prohibited = {
+        "asyncio",
+        "httpx",
+        "openai",
+        "random",
+        "requests",
+        "secrets",
+        "socket",
+        "threading",
+        "urllib",
+        "uuid",
+    }
+    for path in _files():
+        assert not _imports(path) & prohibited

--- a/tests/portfolio/__init__.py
+++ b/tests/portfolio/__init__.py
@@ -1,0 +1,1 @@
+"""Portfolio Engine tests."""

--- a/tests/portfolio/helpers.py
+++ b/tests/portfolio/helpers.py
@@ -1,0 +1,92 @@
+"""Fixtures for deterministic Portfolio Engine tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from domain.operational import (
+    CanonicalInstrumentIdentity,
+    Holding,
+    Instrument,
+    InstrumentKind,
+    MonetaryAmount,
+    PortfolioDecisionRequest,
+    PortfolioSnapshot,
+    PositionDirection,
+    SectorClassification,
+)
+from domain.references import EvidenceKind, EvidenceReference
+from position_proposals.engine import propose_positions
+from ranking.engine import rank_opportunities
+from tests.ranking.helpers import evaluation
+
+NOW = datetime(2026, 7, 21, tzinfo=timezone.utc)
+USD = "USD"
+PORTFOLIO_EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "portfolio-observation"),)
+VALUATION_EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "holding-valuation"),)
+TECHNOLOGY = SectorClassification("GICS", "2023", "45")
+
+
+def instrument(
+    value: str = "BBG000B9XRY4",
+    symbol: str = "AAPL",
+    sector: SectorClassification | None = TECHNOLOGY,
+) -> Instrument:
+    return Instrument(
+        CanonicalInstrumentIdentity("figi", value),
+        InstrumentKind.EQUITY,
+        symbol,
+        USD,
+        sector,
+    )
+
+
+def holding(
+    held_instrument: Instrument | None = None,
+    exposure: Decimal = Decimal("1000"),
+) -> Holding:
+    return Holding(
+        "holding-1",
+        "account-1",
+        held_instrument or instrument("BBG-OTHER", "MSFT"),
+        PositionDirection.LONG,
+        Decimal("5"),
+        MonetaryAmount(exposure, USD),
+        MonetaryAmount(exposure, USD),
+        NOW,
+        VALUATION_EVIDENCE,
+    )
+
+
+def snapshot(
+    *,
+    holdings: tuple[Holding, ...] = (),
+    cash: Decimal = Decimal("50000"),
+    buying_power: Decimal = Decimal("50000"),
+    net_liquidation_value: Decimal = Decimal("100000"),
+) -> PortfolioSnapshot:
+    gross = sum((item.gross_exposure.amount for item in holdings), Decimal("0"))
+    return PortfolioSnapshot(
+        "snapshot-1",
+        "portfolio-1",
+        USD,
+        holdings,
+        MonetaryAmount(cash, USD),
+        MonetaryAmount(buying_power, USD),
+        MonetaryAmount(net_liquidation_value, USD),
+        MonetaryAmount(gross, USD),
+        NOW,
+        PORTFOLIO_EVIDENCE,
+    )
+
+
+def request(portfolio_snapshot: PortfolioSnapshot | None = None) -> PortfolioDecisionRequest:
+    ranking = rank_opportunities((evaluation("candidate", expected_return="0.20"),))
+    proposals = propose_positions(ranking)
+    return PortfolioDecisionRequest(
+        "decision-request-1",
+        ranking.result_id,
+        portfolio_snapshot or snapshot(),
+        proposals,
+    )

--- a/tests/portfolio/test_engine.py
+++ b/tests/portfolio/test_engine.py
@@ -1,0 +1,183 @@
+"""ASA-CORE-009 deterministic Portfolio Engine tests."""
+
+from __future__ import annotations
+
+import dataclasses
+from decimal import Decimal
+
+import pytest
+
+from domain.execution import PortfolioDecisionState
+from domain.operational import PortfolioDecisionRequest
+from portfolio.engine import evaluate_portfolio
+from portfolio.models import PORTFOLIO_ALGORITHM_VERSION, PortfolioParameters
+from tests.portfolio.helpers import holding, instrument, request, snapshot
+
+
+def test_accepts_complete_proposal_when_every_policy_passes() -> None:
+    proposal = request().proposed_positions[0]
+    decision = evaluate_portfolio(request())[0]
+    assert decision.state is PortfolioDecisionState.ACCEPT
+    assert decision.approved_allocation == proposal.target_allocation
+
+
+def test_replay_and_identity_are_stable() -> None:
+    decision_request = request()
+    first = evaluate_portfolio(decision_request)
+    second = evaluate_portfolio(decision_request)
+    assert first == second
+    assert first[0].portfolio_decision_id == second[0].portfolio_decision_id
+
+
+def test_request_order_is_preserved() -> None:
+    original = request()
+    first = original.proposed_positions[0]
+    second = dataclasses.replace(
+        first,
+        proposed_position_id="proposal-second",
+        opportunity_id="opportunity-second",
+    )
+    decision_request = PortfolioDecisionRequest(
+        "request-two",
+        original.ranking_result_id,
+        original.portfolio_snapshot,
+        (second, first),
+    )
+    decisions = evaluate_portfolio(decision_request)
+    assert tuple(item.proposed_position for item in decisions) == (second, first)
+
+
+def test_insufficient_cash_rejects() -> None:
+    decision = evaluate_portfolio(request(snapshot(cash=Decimal("1000"))))[0]
+    assert decision.state is PortfolioDecisionState.REJECT
+    assert decision.approved_allocation == 0
+    assert "cash reserve limits new exposure" in decision.reasons
+
+
+def test_buying_power_reduces_to_available_capacity() -> None:
+    decision = evaluate_portfolio(
+        request(snapshot(buying_power=Decimal("5000")))
+    )[0]
+    assert decision.state is PortfolioDecisionState.REDUCE
+    assert decision.approved_allocation == Decimal("0.050000000000")
+
+
+def test_duplicate_instrument_holds_without_new_exposure() -> None:
+    duplicate = holding(instrument())
+    decision = evaluate_portfolio(request(snapshot(holdings=(duplicate,))))[0]
+    assert decision.state is PortfolioDecisionState.HOLD
+    assert decision.approved_allocation == 0
+    assert "existing canonical instrument exposure requires hold" in decision.reasons
+
+
+def test_sector_diversification_limit_reduces_allocation() -> None:
+    existing = holding(exposure=Decimal("38000"))
+    original = request(snapshot(holdings=(existing,)))
+    classified = dataclasses.replace(original.proposed_positions[0], instrument=instrument())
+    decision_request = PortfolioDecisionRequest(
+        original.decision_request_id,
+        original.ranking_result_id,
+        original.portfolio_snapshot,
+        (classified,),
+    )
+    decision = evaluate_portfolio(decision_request)[0]
+    assert decision.state is PortfolioDecisionState.REDUCE
+    assert decision.approved_allocation == Decimal("0.020000000000")
+    assert "sector exposure limit constrains diversification" in decision.reasons
+
+
+def test_single_asset_concentration_limit_is_enforced() -> None:
+    decision = evaluate_portfolio(
+        request(),
+        PortfolioParameters(maximum_single_asset_exposure=Decimal("0.05")),
+    )[0]
+    assert decision.state is PortfolioDecisionState.REDUCE
+    assert decision.approved_allocation == Decimal("0.050000000000")
+
+
+def test_maximum_position_boundary_is_exact() -> None:
+    decision = evaluate_portfolio(
+        request(),
+        PortfolioParameters(maximum_position_allocation=Decimal("0.082")),
+    )[0]
+    assert decision.state is PortfolioDecisionState.ACCEPT
+    assert decision.approved_allocation == Decimal("0.082000000000")
+
+
+def test_decision_records_versions_parameters_reasons_and_complete_evidence() -> None:
+    existing = holding()
+    decision = evaluate_portfolio(request(snapshot(holdings=(existing,))))[0]
+    assert decision.decision_algorithm_version == PORTFOLIO_ALGORITHM_VERSION == "v1"
+    assert tuple(name for name, _ in decision.policy_versions) == tuple(
+        sorted(name for name, _ in decision.policy_versions)
+    )
+    assert decision.effective_parameters == PortfolioParameters().canonical_items()
+    assert len(decision.reasons) == len(decision.policy_versions)
+    evidence_ids = {item.referenced_id for item in decision.evidence}
+    assert {"portfolio-observation", "holding-valuation"} <= evidence_ids
+
+
+def test_policy_parameter_change_changes_identity() -> None:
+    decision_request = request()
+    first = evaluate_portfolio(decision_request)[0]
+    second = evaluate_portfolio(
+        decision_request,
+        PortfolioParameters(cash_reserve_ratio=Decimal("0.05")),
+    )[0]
+    assert first.portfolio_decision_id != second.portfolio_decision_id
+
+
+def test_output_is_deeply_immutable() -> None:
+    decision = evaluate_portfolio(request())[0]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        decision.state = PortfolioDecisionState.REJECT
+    assert not isinstance(decision.reasons, list)
+
+
+def test_empty_request_produces_no_decisions() -> None:
+    original = request()
+    empty = PortfolioDecisionRequest(
+        "empty-request",
+        original.ranking_result_id,
+        original.portfolio_snapshot,
+        (),
+    )
+    assert evaluate_portfolio(empty) == ()
+
+
+def test_unclassified_instrument_does_not_fabricate_sector() -> None:
+    original = request()
+    unclassified = dataclasses.replace(
+        original.proposed_positions[0],
+        instrument=instrument("BBG-UNCLASSIFIED", "OTHER", sector=None),
+    )
+    decision_request = PortfolioDecisionRequest(
+        "unclassified-request",
+        original.ranking_result_id,
+        original.portfolio_snapshot,
+        (unclassified,),
+    )
+    decision = evaluate_portfolio(decision_request)[0]
+    assert decision.state is PortfolioDecisionState.ACCEPT
+    assert "sector policy is not applicable to an unclassified instrument" in decision.reasons
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"cash_reserve_ratio": Decimal("-0.01")},
+        {"maximum_position_allocation": Decimal("0")},
+        {"maximum_sector_exposure": Decimal("1.01")},
+        {"maximum_single_asset_exposure": Decimal("0")},
+    ],
+)
+def test_invalid_parameters_are_rejected(changes: dict[str, Decimal]) -> None:
+    with pytest.raises(ValueError):
+        dataclasses.replace(PortfolioParameters(), **changes)
+
+
+def test_v1_identity_regression_vector() -> None:
+    decision = evaluate_portfolio(request())[0]
+    assert decision.portfolio_decision_id == (
+        "5c6a980f268389799d24bac468842568535257b727539216c49d846e018eef0e"
+    )

--- a/tests/portfolio/test_registry.py
+++ b/tests/portfolio/test_registry.py
@@ -1,0 +1,47 @@
+"""Portfolio policy registry tests."""
+
+from decimal import Decimal
+
+import pytest
+
+from domain.execution import PortfolioDecisionState
+from portfolio.errors import (
+    DuplicatePolicyRegistrationError,
+    InvalidPolicyOutcomeError,
+    InvalidPolicyRegistryError,
+)
+from portfolio.models import POLICY_NAMES, POLICY_VERSION, PolicyOutcome
+from portfolio.policies import buying_power_validation
+from portfolio.registry import PolicyRegistry, build_default_registry
+
+
+def test_default_registry_is_complete_and_canonically_ordered() -> None:
+    registry = build_default_registry()
+    assert tuple(item.name for item in registry.definitions()) == POLICY_NAMES
+
+
+def test_duplicate_registration_is_rejected() -> None:
+    registry = PolicyRegistry()
+    registry.register("buying_power_validation", buying_power_validation)
+    with pytest.raises(DuplicatePolicyRegistrationError):
+        registry.register("buying_power_validation", buying_power_validation)
+
+
+def test_incomplete_registry_is_rejected() -> None:
+    registry = PolicyRegistry()
+    registry.register("buying_power_validation", buying_power_validation)
+    with pytest.raises(InvalidPolicyRegistryError):
+        registry.validate()
+
+
+def test_policy_outcome_rejects_invalid_provenance_and_terminal_state() -> None:
+    with pytest.raises(InvalidPolicyOutcomeError):
+        PolicyOutcome("unknown", POLICY_VERSION, Decimal("0"), "invalid")
+    with pytest.raises(InvalidPolicyOutcomeError):
+        PolicyOutcome(
+            "cash_reserve",
+            POLICY_VERSION,
+            Decimal("0"),
+            "invalid terminal state",
+            PortfolioDecisionState.ACCEPT,
+        )


### PR DESCRIPTION
## Summary

- adds the pure deterministic Portfolio Engine
- evaluates each ProposedPosition against one immutable PortfolioSnapshot
- enforces buying power, cash reserve, duplicate exposure, position size, sector diversification, and single-asset concentration policies
- produces immutable ACCEPT, REJECT, REDUCE, or HOLD PortfolioDecision values in proposal rank order
- pins v1 policy versions, effective parameters, reasons, complete evidence, and content identity

## Boundaries

The layer imports only `domain` and `portfolio`. It has no execution planning, broker, provider, observation, infrastructure, networking, persistence, repository, randomness, ML, or LLM dependency. It never mutates ProposedPosition or PortfolioSnapshot.

## CI coverage correction

The architecture workflow previously omitted the already-merged Position Proposal tests. It now triggers on and runs both `position_proposals` and `portfolio`, so the execution-intelligence merge gate exercises the complete implemented pipeline.

## Validation

- architecture/intelligence suite: 775 passed
- Portfolio focused suite and boundaries: 31 passed
- strict MyPy on `domain ranking position_proposals portfolio`: passed
- scoped Ruff: passed
- deterministic replay and pinned v1 identity vector: passed
- immutable-output, registry, forbidden-import, and circular-boundary checks: passed
- workflow YAML parse: passed
- frozen-governance integrity: passed
- entrypoint invariants: passed
- Lean pre-push check: all 5 passed
- `git diff --check`: passed

## Self-review

All CORE-009 acceptance criteria are satisfied. No TODOs, skipped tests, blocking issues, architecture changes, governance changes, provider leakage, infrastructure leakage, persistence, or execution-planning behavior remain.

Amendment 013 is active. This PR is within the enumerated SPRINT-001 scope and may be merged by the delegated worker only after every required CI and validation gate passes.
