### PR TITLE
STRAT-004: add immutable component registry

### DIFF
--- a/docs/contracts/strategy-component-registry-v1.md
+++ b/docs/contracts/strategy-component-registry-v1.md
@@ -1,0 +1,21 @@
+# Strategy Component Registry v1
+
+The Component Registry is an immutable exact-version catalog constructed from a finite tuple of
+explicitly supplied `BaseComponent` instances. Construction completes before manifest compilation.
+
+The registry:
+
+- validates every component port and parameter type against one immutable Strategy Type System;
+- rejects duplicate `(namespace, name, version)` identities;
+- rejects capabilities outside the closed Core capability vocabulary;
+- resolves only exact Component References;
+- sorts registrations canonically;
+- derives a pinned SHA-256 identity from the type-system identity and ordered Component identities;
+- exposes no registration, removal, scanning, discovery, entry-point, import, or patch API.
+
+Input order never affects registry contents or identity. Unknown names and compatible-looking,
+range, or latest versions fail closed. The registry does not inspect the filesystem, installed
+packages, environment, network, or manifest import strings.
+
+Plugin Packages will later be explicitly supplied to this same construction boundary after Plugin
+SDK validation. Plugins do not introduce a second registry or loading mechanism.

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -20,6 +20,12 @@ from strategies.components import (
     component_definition_data,
     component_identity,
 )
+from strategies.component_registry import (
+    REGISTRY_IDENTITY_NAMESPACE,
+    REGISTRY_IDENTITY_VERSION,
+    SUPPORTED_COMPONENT_CAPABILITIES,
+    ComponentRegistry,
+)
 from strategies.engine import (
     OPPORTUNITY_IDENTITY_NAMESPACE,
     OPPORTUNITY_IDENTITY_VERSION,
@@ -81,6 +87,9 @@ __all__ = [
     "COMPONENT_IDENTITY_VERSION",
     "DEFAULT_REGISTRY",
     "DEFAULT_TYPE_SYSTEM",
+    "REGISTRY_IDENTITY_NAMESPACE",
+    "REGISTRY_IDENTITY_VERSION",
+    "SUPPORTED_COMPONENT_CAPABILITIES",
     "TYPE_SYSTEM_VERSION",
     "BaseComponent",
     "CapabilityRequirement",
@@ -88,6 +97,7 @@ __all__ = [
     "ComponentContractError",
     "ComponentDefinition",
     "ComponentReference",
+    "ComponentRegistry",
     "ComponentValues",
     "DuplicateStrategyRegistrationError",
     "EdgeSpec",

--- a/strategies/component_registry.py
+++ b/strategies/component_registry.py
@@ -1,0 +1,131 @@
+"""Immutable explicit Component Registry (STRAT-004, ASA-ARCH-003)."""
+from __future__ import annotations
+
+import hashlib
+
+from strategies.components import BaseComponent, ComponentDefinition
+from strategies.errors import ComponentContractError
+from strategies.manifest import ComponentReference, canonical_strategy_json
+from strategies.type_system import DEFAULT_TYPE_SYSTEM, StrategyTypeSystem
+
+REGISTRY_IDENTITY_NAMESPACE = "asa.strategy_component_registry"
+REGISTRY_IDENTITY_VERSION = "v1"
+
+SUPPORTED_COMPONENT_CAPABILITIES = frozenset(
+    {
+        "aggregate",
+        "boolean_logic",
+        "compare",
+        "constant",
+        "consume_facts",
+        "consume_indicators",
+        "constrain_portfolio",
+        "emit_opportunity",
+        "filter",
+        "passthrough",
+        "rank",
+        "score",
+        "transform",
+    }
+)
+
+
+class ComponentRegistry:
+    """Exact immutable catalog built from an explicit finite component tuple."""
+
+    __slots__ = ("_components", "_identity", "_type_system")
+    _components: tuple[BaseComponent, ...]
+    _identity: str
+    _type_system: StrategyTypeSystem
+
+    def __init__(
+        self,
+        components: tuple[BaseComponent, ...],
+        type_system: StrategyTypeSystem = DEFAULT_TYPE_SYSTEM,
+    ) -> None:
+        if not isinstance(type_system, StrategyTypeSystem):
+            raise ComponentContractError("registry requires a StrategyTypeSystem")
+        for component in components:
+            if not isinstance(component, BaseComponent):
+                raise ComponentContractError("registry entries must implement BaseComponent")
+            _validate_definition(component.definition, type_system)
+        ordered = tuple(
+            sorted(
+                components,
+                key=lambda item: (
+                    item.definition.namespace,
+                    item.definition.name,
+                    item.definition.version,
+                ),
+            )
+        )
+        keys = tuple(_definition_key(item.definition) for item in ordered)
+        if len(keys) != len(set(keys)):
+            raise ComponentContractError("duplicate Component Type registration")
+        object.__setattr__(self, "_components", ordered)
+        object.__setattr__(self, "_type_system", type_system)
+        payload = {
+            "identity_namespace": REGISTRY_IDENTITY_NAMESPACE,
+            "identity_version": REGISTRY_IDENTITY_VERSION,
+            "type_system_identity": type_system.identity,
+            "component_ids": [item.definition.component_id for item in ordered],
+        }
+        object.__setattr__(
+            self,
+            "_identity",
+            hashlib.sha256(canonical_strategy_json(payload)).hexdigest(),
+        )
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if hasattr(self, name):
+            raise AttributeError("ComponentRegistry is immutable")
+        object.__setattr__(self, name, value)
+
+    @property
+    def components(self) -> tuple[BaseComponent, ...]:
+        return self._components
+
+    @property
+    def identity(self) -> str:
+        return self._identity
+
+    @property
+    def type_system(self) -> StrategyTypeSystem:
+        return self._type_system
+
+    def resolve(self, reference: ComponentReference) -> BaseComponent:
+        key = (reference.namespace, reference.name, reference.version)
+        for component in self._components:
+            if _definition_key(component.definition) == key:
+                return component
+        raise ComponentContractError(
+            f"unknown Component Type: {reference.namespace}.{reference.name}@{reference.version}"
+        )
+
+    def registered_references(self) -> tuple[ComponentReference, ...]:
+        return tuple(
+            ComponentReference(
+                item.definition.namespace,
+                item.definition.name,
+                item.definition.version,
+            )
+            for item in self._components
+        )
+
+
+def _definition_key(definition: ComponentDefinition) -> tuple[str, str, str]:
+    return definition.namespace, definition.name, definition.version
+
+
+def _validate_definition(
+    definition: ComponentDefinition, type_system: StrategyTypeSystem
+) -> None:
+    for port in (*definition.input_ports, *definition.output_ports):
+        type_system.resolve(port.type_ref)
+    for parameter in definition.parameters:
+        type_system.resolve(parameter.type_ref)
+    for capability in definition.capabilities:
+        if capability.name not in SUPPORTED_COMPONENT_CAPABILITIES:
+            raise ComponentContractError(
+                f"unsupported Component capability: {capability.name}"
+            )

--- a/tests/strategies/test_component_registry.py
+++ b/tests/strategies/test_component_registry.py
@@ -1,0 +1,138 @@
+"""STRAT-004: immutable explicit Component Registry tests."""
+from __future__ import annotations
+
+import pytest
+
+from strategies import (
+    REGISTRY_IDENTITY_NAMESPACE,
+    REGISTRY_IDENTITY_VERSION,
+    BaseComponent,
+    CapabilityRequirement,
+    ComponentCategory,
+    ComponentContractError,
+    ComponentDefinition,
+    ComponentReference,
+    ComponentRegistry,
+    ComponentValues,
+    PortDefinition,
+    StrategyTypeReference,
+)
+
+TEXT = StrategyTypeReference("Text", "1.0.0")
+
+
+class PassThrough(BaseComponent):
+    __slots__ = ()
+    definition = ComponentDefinition(
+        "asa.core",
+        "PassThrough",
+        "1.0.0",
+        ComponentCategory.UTILITY,
+        (PortDefinition("value", TEXT),),
+        (PortDefinition("value", TEXT),),
+        capabilities=(CapabilityRequirement("passthrough", "1.0.0"),),
+    )
+
+    def evaluate(self, inputs: ComponentValues, parameters: ComponentValues) -> ComponentValues:
+        return inputs
+
+
+class Filter(BaseComponent):
+    __slots__ = ()
+    definition = ComponentDefinition(
+        "asa.core",
+        "Filter",
+        "1.0.0",
+        ComponentCategory.TRANSFORM,
+        (PortDefinition("value", TEXT),),
+        (PortDefinition("value", TEXT),),
+        capabilities=(CapabilityRequirement("filter", "1.0.0"),),
+    )
+
+    def evaluate(self, inputs: ComponentValues, parameters: ComponentValues) -> ComponentValues:
+        return inputs
+
+
+class TestRegistry:
+    def test_explicit_components_are_sorted_and_resolved_exactly(self):
+        passthrough = PassThrough()
+        filter_component = Filter()
+        registry = ComponentRegistry((passthrough, filter_component))
+        assert tuple(item.name for item in registry.registered_references()) == (
+            "Filter",
+            "PassThrough",
+        )
+        assert registry.resolve(ComponentReference("asa.core", "PassThrough", "1.0.0")) is passthrough
+
+    def test_input_order_does_not_change_identity(self):
+        first = ComponentRegistry((PassThrough(), Filter()))
+        second = ComponentRegistry((Filter(), PassThrough()))
+        assert first.identity == second.identity
+        assert first.registered_references() == second.registered_references()
+
+    def test_identity_contract_is_pinned(self):
+        registry = ComponentRegistry((PassThrough(), Filter()))
+        assert REGISTRY_IDENTITY_NAMESPACE == "asa.strategy_component_registry"
+        assert REGISTRY_IDENTITY_VERSION == "v1"
+        assert registry.identity == (
+            "84e53fbedc86346a7ad76bcfb29095b0647467bcd645983776f6ff89e21050fc"
+        )
+
+    def test_duplicate_exact_registration_is_rejected(self):
+        with pytest.raises(ComponentContractError, match="duplicate"):
+            ComponentRegistry((PassThrough(), PassThrough()))
+
+    def test_unknown_and_inexact_version_fail_closed(self):
+        registry = ComponentRegistry((PassThrough(),))
+        with pytest.raises(ComponentContractError, match="unknown"):
+            registry.resolve(ComponentReference("asa.core", "PassThrough", "2.0.0"))
+
+    def test_registry_is_immutable(self):
+        registry = ComponentRegistry((PassThrough(),))
+        with pytest.raises(AttributeError, match="immutable"):
+            registry._components = ()  # type: ignore[misc]
+
+    def test_invalid_type_dependency_is_rejected(self):
+        class UnknownTypeComponent(BaseComponent):
+            __slots__ = ()
+            definition = ComponentDefinition(
+                "test",
+                "UnknownType",
+                "1.0.0",
+                ComponentCategory.UTILITY,
+                (),
+                (PortDefinition("value", StrategyTypeReference("Missing", "1.0.0")),),
+            )
+
+            def evaluate(
+                self, inputs: ComponentValues, parameters: ComponentValues
+            ) -> ComponentValues:
+                return inputs
+
+        with pytest.raises(ComponentContractError, match="unknown Strategy Type"):
+            ComponentRegistry((UnknownTypeComponent(),))
+
+    def test_unknown_capability_is_rejected(self):
+        class UnknownCapabilityComponent(BaseComponent):
+            __slots__ = ()
+            definition = ComponentDefinition(
+                "test",
+                "UnknownCapability",
+                "1.0.0",
+                ComponentCategory.UTILITY,
+                (),
+                (PortDefinition("value", TEXT),),
+                capabilities=(CapabilityRequirement("network", "1.0.0"),),
+            )
+
+            def evaluate(
+                self, inputs: ComponentValues, parameters: ComponentValues
+            ) -> ComponentValues:
+                return inputs
+
+        with pytest.raises(ComponentContractError, match="unsupported Component capability"):
+            ComponentRegistry((UnknownCapabilityComponent(),))
+
+    def test_no_discovery_or_runtime_mutation_api_exists(self):
+        prohibited = {"discover", "scan", "load", "register", "unregister", "patch"}
+        assert not prohibited & set(dir(ComponentRegistry))


### PR DESCRIPTION
## Summary

- Adds the immutable explicit v1 Component Registry.
- Validates exact type dependencies and closed capabilities, rejects duplicate registrations, resolves exact Component References, canonicalizes input order, and pins registry identity.
- Exposes no scanning, discovery, loading, registration mutation, entry-point, or import API.

## Validation

- Full analytical and architecture suite: 941 passed, 0 skipped.
- Lean POS: 574 passed, 1 established conditional skip outside sprint tests.
- Changed-file Ruff: PASS.
- Strict MyPy across registry, type system, components, and manifest: PASS.
- Entry points, frozen governance integrity, pre-push, and diff checks: PASS.
- Repository Ruff baseline tracked in #77.

## Self-review and authority

- STRAT-004 only; no plugin, graph, expression, I/O, persistence, provider, or runtime behavior.
- Identity pinned at 84e53fbedc86346a7ad76bcfb29095b0647467bcd645983776f6ff89e21050fc.
- No blocking issue, architecture/governance change, skipped sprint test, or scope expansion.
- Eligible for delegated merge only after GitHub Architecture Validation passes under AMD-013-SPRINT-002.
