### PR TITLE
STRAT-008: add static Strategy Component plugin SDK

### DIFF
--- a/docs/contracts/strategy-plugin-sdk-v1.md
+++ b/docs/contracts/strategy-plugin-sdk-v1.md
@@ -1,0 +1,10 @@
+# Strategy Plugin SDK v1
+
+A plugin is immutable metadata plus a finite tuple of stateless Component instances. Plugins are
+constructed explicitly by the application at process startup and combined into the ordinary
+validated `ComponentRegistry`. The SDK performs no discovery, importing, entry-point scanning,
+downloading, hot registration, runtime patching, or execution hooks.
+
+Every contributed Component must use the plugin namespace and satisfy the same Component and Type
+System contracts as Core components. Plugins extend vocabulary only; Core retains exclusive
+ownership of graph validation, ordering, execution, tracing, replay, and lifecycle semantics.

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -102,6 +102,14 @@ from strategies.manifest import (
     validate_strategy_identifier,
 )
 from strategies.registry import DEFAULT_REGISTRY, StrategyRegistry
+from strategies.plugins import (
+    PLUGIN_IDENTITY_NAMESPACE,
+    PLUGIN_IDENTITY_VERSION,
+    PLUGIN_SDK_VERSION,
+    PluginMetadata,
+    StrategyPlugin,
+    build_plugin_registry,
+)
 from strategies.signal import StrategySignal
 from strategies.type_system import (
     DEFAULT_TYPE_SYSTEM,
@@ -169,14 +177,19 @@ __all__ = [
     "NodeSpec",
     "OPPORTUNITY_IDENTITY_NAMESPACE",
     "OPPORTUNITY_IDENTITY_VERSION",
+    "PLUGIN_IDENTITY_NAMESPACE",
+    "PLUGIN_IDENTITY_VERSION",
+    "PLUGIN_SDK_VERSION",
     "OutputSpec",
     "ParameterDefinition",
     "ParameterSpec",
     "PortCardinality",
     "PortDefinition",
+    "PluginMetadata",
     "SUPPORTED_MANIFEST_SCHEMA_VERSIONS",
     "StrategyError",
     "StrategyManifest",
+    "StrategyPlugin",
     "StrategyRegistry",
     "StrategySignal",
     "StrategyTypeReference",
@@ -189,6 +202,7 @@ __all__ = [
     "UnknownStrategyIdError",
     "canonical_strategy_json",
     "build_default_type_system",
+    "build_plugin_registry",
     "component_definition_data",
     "component_identity",
     "compile_expression",

--- a/strategies/plugins.py
+++ b/strategies/plugins.py
@@ -1,0 +1,102 @@
+"""Static immutable Strategy Component Plugin SDK (STRAT-008)."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from strategies.component_registry import ComponentRegistry
+from strategies.components import BaseComponent
+from strategies.errors import ComponentContractError
+from strategies.manifest import (
+    canonical_strategy_json,
+    validate_semantic_version,
+    validate_strategy_identifier,
+)
+from strategies.type_system import DEFAULT_TYPE_SYSTEM, StrategyTypeSystem
+
+PLUGIN_SDK_VERSION = "1.0.0"
+PLUGIN_IDENTITY_NAMESPACE = "asa.strategy_plugin"
+PLUGIN_IDENTITY_VERSION = "v1"
+
+
+@dataclass(frozen=True, slots=True)
+class PluginMetadata:
+    namespace: str
+    name: str
+    version: str
+    description: str
+
+    def __post_init__(self) -> None:
+        validate_strategy_identifier(self.namespace, "plugin.namespace")
+        validate_strategy_identifier(self.name, "plugin.name")
+        validate_semantic_version(self.version, "plugin.version")
+        if not self.description.strip():
+            raise ComponentContractError("plugin.description must not be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyPlugin:
+    metadata: PluginMetadata
+    components: tuple[BaseComponent, ...]
+
+    def __post_init__(self) -> None:
+        if not self.components:
+            raise ComponentContractError("plugin must contribute at least one component")
+        for component in self.components:
+            if not isinstance(component, BaseComponent):
+                raise ComponentContractError("plugin components must implement BaseComponent")
+            if component.definition.namespace != self.metadata.namespace:
+                raise ComponentContractError(
+                    "plugin component namespace must match plugin namespace"
+                )
+        keys = tuple(
+            (item.definition.namespace, item.definition.name, item.definition.version)
+            for item in self.components
+        )
+        if len(keys) != len(set(keys)):
+            raise ComponentContractError("plugin contains duplicate components")
+        object.__setattr__(
+            self,
+            "components",
+            tuple(
+                sorted(
+                    self.components,
+                    key=lambda item: (item.definition.name, item.definition.version),
+                )
+            ),
+        )
+
+    @property
+    def plugin_id(self) -> str:
+        return hashlib.sha256(
+            canonical_strategy_json(
+                {
+                    "namespace": PLUGIN_IDENTITY_NAMESPACE,
+                    "identity_version": PLUGIN_IDENTITY_VERSION,
+                    "sdk_version": PLUGIN_SDK_VERSION,
+                    "metadata": {
+                        "namespace": self.metadata.namespace,
+                        "name": self.metadata.name,
+                        "version": self.metadata.version,
+                        "description": self.metadata.description,
+                    },
+                    "component_ids": [item.definition.component_id for item in self.components],
+                }
+            )
+        ).hexdigest()
+
+
+def build_plugin_registry(
+    core_components: tuple[BaseComponent, ...],
+    plugins: tuple[StrategyPlugin, ...],
+    type_system: StrategyTypeSystem = DEFAULT_TYPE_SYSTEM,
+) -> ComponentRegistry:
+    """Build one registry from an explicit, process-startup plugin tuple."""
+    ordered = tuple(sorted(plugins, key=lambda item: item.plugin_id))
+    if len({item.plugin_id for item in ordered}) != len(ordered):
+        raise ComponentContractError("duplicate plugin registration")
+    return ComponentRegistry(
+        core_components + tuple(component for plugin in ordered for component in plugin.components),
+        type_system,
+    )

--- a/tests/strategies/test_plugins.py
+++ b/tests/strategies/test_plugins.py
@@ -1,0 +1,67 @@
+"""STRAT-008 static plugin SDK tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from strategies.components import (
+    BaseComponent,
+    ComponentCategory,
+    ComponentDefinition,
+    PortDefinition,
+)
+from strategies.errors import ComponentContractError
+from strategies.manifest import ComponentReference
+from strategies.plugins import PluginMetadata, StrategyPlugin, build_plugin_registry
+from strategies.type_system import ComponentValues, StrategyTypeReference, TypedValue
+
+TEXT = StrategyTypeReference("Text", "1.0.0")
+
+
+class SamplePluginComponent(BaseComponent):
+    __slots__ = ()
+    definition = ComponentDefinition(
+        "sample",
+        "echo",
+        "1.0.0",
+        ComponentCategory.UTILITY,
+        (PortDefinition("value", TEXT),),
+        (PortDefinition("result", TEXT),),
+    )
+
+    def evaluate(self, inputs: ComponentValues, parameters: ComponentValues) -> ComponentValues:
+        return ComponentValues((("result", TypedValue(TEXT, inputs.get("value").value)),))
+
+
+def plugin() -> StrategyPlugin:
+    return StrategyPlugin(
+        PluginMetadata("sample", "sample_plugin", "1.0.0", "Static SDK example"),
+        (SamplePluginComponent(),),
+    )
+
+
+def test_sample_plugin_registers_without_core_modification():
+    registry = build_plugin_registry((), (plugin(),))
+    assert isinstance(
+        registry.resolve(ComponentReference("sample", "echo", "1.0.0")), SamplePluginComponent
+    )
+
+
+def test_plugin_identity_and_registry_are_order_independent():
+    first = plugin()
+    second = plugin()
+    assert first.plugin_id == second.plugin_id
+    assert (
+        build_plugin_registry((), (first,)).identity
+        == build_plugin_registry((), (second,)).identity
+    )
+
+
+def test_namespace_mismatch_fails_closed():
+    with pytest.raises(ComponentContractError, match="namespace"):
+        StrategyPlugin(PluginMetadata("other", "bad", "1.0.0", "Bad"), (SamplePluginComponent(),))
+
+
+def test_no_runtime_loading_or_mutation_api_exists():
+    forbidden = {"discover", "load", "reload", "register", "unregister", "patch_runtime"}
+    assert not forbidden & set(dir(StrategyPlugin))


### PR DESCRIPTION
## Summary
- define immutable plugin metadata and component package contracts
- build one ordinary validated registry from explicit startup plugin tuples
- pin plugin identity and deterministic registration ordering
- document and test isolation, namespace, capability, and no-runtime-loading boundaries

## Validation
- 979 architecture and analytical tests passed
- Ruff passed
- scoped strict MyPy passed
- Lean entrypoint and governance integrity checks passed
- git diff --check passed

Plugins extend component vocabulary only; they cannot discover, load, patch, mutate, or hook Core runtime behavior.