### PR TITLE
STRAT-010: add manifest-only reference strategy

### DIFF
--- a/docs/reference-strategies/moving-average-crossover.md
+++ b/docs/reference-strategies/moving-average-crossover.md
@@ -1,0 +1,10 @@
+# Moving Average Crossover Reference Strategy
+
+The reference strategy is the canonical manifest value
+`MOVING_AVERAGE_CROSSOVER_MANIFEST`. It receives short and long moving-average Decimal values as
+explicit semantic context, evaluates the closed expression `left >= right`, passes the result
+through the portfolio constraint vocabulary, and exposes one Boolean `signal` output.
+
+There is no handwritten strategy evaluator. Core compiles the manifest against the static Core
+Component registry and executes it through the ordinary deterministic graph runtime. Replays use
+the same manifest, registry, explicit inputs, identities, and lifecycle trace.

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -35,6 +35,7 @@ from strategies.core_components import (
     Clamp,
     Compare,
     Constant,
+    ExpressionPredicate,
     Filter,
     Normalize,
     PortfolioConstraint,
@@ -117,6 +118,7 @@ from strategies.manifest import (
     validate_strategy_identifier,
 )
 from strategies.registry import DEFAULT_REGISTRY, StrategyRegistry
+from strategies.reference_strategy import MOVING_AVERAGE_CROSSOVER_MANIFEST
 from strategies.plugins import (
     PLUGIN_IDENTITY_NAMESPACE,
     PLUGIN_IDENTITY_VERSION,
@@ -176,6 +178,7 @@ __all__ = [
     "ExpressionEvaluationError",
     "ExpressionLimits",
     "ExpressionNode",
+    "ExpressionPredicate",
     "ExpressionResult",
     "ExpressionTrace",
     "Filter",
@@ -195,6 +198,7 @@ __all__ = [
     "ManifestObject",
     "ManifestSerializationError",
     "ManifestValidationError",
+    "MOVING_AVERAGE_CROSSOVER_MANIFEST",
     "MissingIndicatorInputError",
     "NoContributingFactsError",
     "NodeSpec",

--- a/strategies/core_components.py
+++ b/strategies/core_components.py
@@ -13,6 +13,7 @@ from strategies.components import (
     PortDefinition,
 )
 from strategies.errors import ComponentContractError
+from strategies.expressions import compile_expression, evaluate_expression
 from strategies.manifest import ManifestObject
 from strategies.type_system import ComponentValues, StrategyTypeReference, TypedValue
 
@@ -224,6 +225,27 @@ class PositionProposal(BaseComponent):
         return ComponentValues((("target_allocation", inputs.get("target_allocation")),))
 
 
+class ExpressionPredicate(BaseComponent):
+    """Evaluate a closed expression over two Decimal inputs."""
+
+    __slots__ = ()
+    definition = _definition(
+        "expression_predicate",
+        ComponentCategory.PREDICATE,
+        (PortDefinition("left", D), PortDefinition("right", D)),
+        (PortDefinition("result", B),),
+        (ParameterDefinition("expression", StrategyTypeReference("Text", "1.0.0")),),
+    )
+
+    def evaluate(self, inputs: ComponentValues, parameters: ComponentValues) -> ComponentValues:
+        source = cast(str, parameters.get("expression").value)
+        compiled = compile_expression(source, (("left", D), ("right", D)))
+        result = evaluate_expression(compiled, inputs).value
+        if result.type_ref != B:
+            raise ComponentContractError("expression predicate must produce Boolean")
+        return ComponentValues((("result", result),))
+
+
 CORE_COMPONENTS: tuple[BaseComponent, ...] = (
     Constant(),
     Compare(),
@@ -237,4 +259,5 @@ CORE_COMPONENTS: tuple[BaseComponent, ...] = (
     Rank(),
     PortfolioConstraint(),
     PositionProposal(),
+    ExpressionPredicate(),
 )

--- a/strategies/reference_strategy.py
+++ b/strategies/reference_strategy.py
@@ -1,0 +1,39 @@
+"""Manifest-only moving-average crossover reference strategy (STRAT-010)."""
+
+from __future__ import annotations
+
+from strategies.manifest import (
+    ComponentReference,
+    EdgeSpec,
+    ManifestMetadata,
+    NodeSpec,
+    OutputSpec,
+    ParameterSpec,
+    StrategyManifest,
+)
+
+MOVING_AVERAGE_CROSSOVER_MANIFEST = StrategyManifest(
+    schema_version="1.0.0",
+    strategy_id="asa.reference.moving_average_crossover",
+    strategy_version="1.0.0",
+    metadata=ManifestMetadata(
+        "Moving Average Crossover",
+        "Signals when the explicit short moving average is at least the long moving average.",
+        ("reference", "trend"),
+    ),
+    parameters=(),
+    required_capabilities=(),
+    nodes=(
+        NodeSpec(
+            "crossover",
+            ComponentReference("asa.core", "expression_predicate", "1.0.0"),
+            (ParameterSpec("expression", "Text", "left >= right"),),
+        ),
+        NodeSpec(
+            "portfolio_gate",
+            ComponentReference("asa.core", "portfolio_constraint", "1.0.0"),
+        ),
+    ),
+    edges=(EdgeSpec("crossover", "result", "portfolio_gate", "allowed"),),
+    outputs=(OutputSpec("signal", "portfolio_gate", "allowed"),),
+)

--- a/tests/strategies/test_core_components.py
+++ b/tests/strategies/test_core_components.py
@@ -18,6 +18,7 @@ from strategies.core_components import (
     Clamp,
     Compare,
     Constant,
+    ExpressionPredicate,
     Filter,
     Normalize,
     PortfolioConstraint,
@@ -26,7 +27,7 @@ from strategies.core_components import (
     WeightedScore,
 )
 from strategies.manifest import ComponentReference
-from strategies.type_system import ComponentValues, TypedValue
+from strategies.type_system import ComponentValues, StrategyTypeReference, TypedValue
 
 
 def cv(**items: tuple[object, object]) -> ComponentValues:
@@ -50,6 +51,7 @@ def test_every_required_component_is_registered_and_explainable():
         "rank",
         "portfolio_constraint",
         "position_proposal",
+        "expression_predicate",
     }
     assert {item.definition.name for item in CORE_COMPONENTS} == expected
     for name in expected:
@@ -120,6 +122,11 @@ def test_logical_filter_rank_and_portfolio_components():
     assert PositionProposal().evaluate(
         cv(target_allocation=(D, Decimal("0.1"))), ComponentValues(())
     ).get("target_allocation").value == Decimal("0.1")
+    result = ExpressionPredicate().evaluate(
+        cv(left=(D, Decimal("11")), right=(D, Decimal("10"))),
+        cv(expression=(StrategyTypeReference("Text", "1.0.0"), "left >= right")),
+    )
+    assert result.get("result").value is True
 
 
 @pytest.mark.parametrize("component", CORE_COMPONENTS)

--- a/tests/strategies/test_reference_strategy.py
+++ b/tests/strategies/test_reference_strategy.py
@@ -1,0 +1,51 @@
+"""STRAT-010 manifest-only reference strategy acceptance tests."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from strategies.component_registry import ComponentRegistry
+from strategies.core_components import CORE_COMPONENTS, D
+from strategies.reference_strategy import MOVING_AVERAGE_CROSSOVER_MANIFEST
+from strategies.runtime import compile_strategy_graph, execute_strategy_graph
+from strategies.type_system import ComponentValues, TypedValue
+
+
+def context(short: str, long: str) -> ComponentValues:
+    return ComponentValues(
+        (
+            ("crossover.left", TypedValue(D, Decimal(short))),
+            ("crossover.right", TypedValue(D, Decimal(long))),
+        )
+    )
+
+
+def test_reference_strategy_executes_from_manifest_and_registry():
+    graph = compile_strategy_graph(
+        MOVING_AVERAGE_CROSSOVER_MANIFEST, ComponentRegistry(CORE_COMPONENTS)
+    )
+    assert execute_strategy_graph(graph, context("105", "100")).outputs.get("signal").value is True
+    assert execute_strategy_graph(graph, context("95", "100")).outputs.get("signal").value is False
+
+
+def test_reference_strategy_replay_is_identical_and_explainable():
+    graph = compile_strategy_graph(
+        MOVING_AVERAGE_CROSSOVER_MANIFEST, ComponentRegistry(CORE_COMPONENTS)
+    )
+    first = execute_strategy_graph(graph, context("105", "100"))
+    second = execute_strategy_graph(graph, context("105", "100"))
+    assert first == second
+    assert first.trace.events
+    assert all(event.graph_id == graph.graph_id for event in first.trace.events)
+
+
+def test_strategy_module_contains_no_component_instantiation_or_logic():
+    import strategies.reference_strategy as module
+
+    names = set(vars(module))
+    assert not names & {
+        "Compare",
+        "ExpressionPredicate",
+        "PortfolioConstraint",
+        "execute_strategy_graph",
+    }


### PR DESCRIPTION
## Summary
- add a generic typed expression-predicate component backed by the frozen expression engine
- define the moving-average crossover solely as a canonical Strategy Manifest
- execute explicit semantic inputs through the ordinary registry and graph runtime
- prove deterministic positive/negative outputs, replay, trace, and absence of handwritten strategy evaluation

## Validation
- 1004 architecture and analytical tests passed
- Ruff passed
- scoped strict MyPy passed
- Lean entrypoint and governance integrity checks passed
- git diff --check passed

No runtime special cases, direct component construction in the strategy, providers, persistence, networking, or external APIs were added.