### PR TITLE
STRAT-011: complete Strategy Core validation suite

### DIFF
--- a/docs/contracts/strategy-core-validation.md
+++ b/docs/contracts/strategy-core-validation.md
@@ -1,0 +1,16 @@
+# Strategy Core Validation Matrix
+
+STRAT-011 validates the complete Strategy Core through focused and integrated suites:
+
+- manifest schema, canonical serialization, identity, version rejection, and immutability;
+- exact Type System compatibility and immutable typed values;
+- component metadata, purity, static registry validation, and plugin isolation;
+- expression parsing, typing, exact arithmetic, limits, trace, and replay;
+- DAG topology, connection typing, deterministic ordering, reachability, execution, and provenance;
+- all Core components independently and through the reference manifest;
+- end-to-end serialize → register → compile → execute → replay equivalence;
+- static architecture-import and forbidden runtime-surface checks.
+
+The suite uses no network, provider, broker, persistence, wall clock, randomness, or mutable
+runtime state. Identical semantic inputs must produce identical graph identities, evaluation
+identities, outputs, and trace events.

--- a/tests/strategies/test_strategy_core_validation.py
+++ b/tests/strategies/test_strategy_core_validation.py
@@ -1,0 +1,94 @@
+"""STRAT-011 integrated Strategy Core validation suite."""
+
+from __future__ import annotations
+
+import ast
+from decimal import Decimal
+from pathlib import Path
+
+from strategies.component_registry import ComponentRegistry
+from strategies.core_components import CORE_COMPONENTS, D
+from strategies.manifest import deserialize_manifest, serialize_manifest
+from strategies.plugins import build_plugin_registry
+from strategies.reference_strategy import MOVING_AVERAGE_CROSSOVER_MANIFEST
+from strategies.runtime import compile_strategy_graph, execute_strategy_graph
+from strategies.type_system import ComponentValues, TypedValue
+
+
+def semantic_inputs() -> ComponentValues:
+    return ComponentValues(
+        (
+            ("crossover.left", TypedValue(D, Decimal("101.25"))),
+            ("crossover.right", TypedValue(D, Decimal("99.75"))),
+        )
+    )
+
+
+def test_complete_strategy_core_replay_pipeline() -> None:
+    wire = serialize_manifest(MOVING_AVERAGE_CROSSOVER_MANIFEST)
+    manifest = deserialize_manifest(wire)
+    registry = build_plugin_registry(CORE_COMPONENTS, ())
+    graph = compile_strategy_graph(manifest, registry)
+    original = execute_strategy_graph(graph, semantic_inputs())
+
+    replay_manifest = deserialize_manifest(wire)
+    replay_registry = ComponentRegistry(tuple(reversed(CORE_COMPONENTS)))
+    replay_graph = compile_strategy_graph(replay_manifest, replay_registry)
+    replay = execute_strategy_graph(replay_graph, semantic_inputs())
+
+    assert replay_graph.graph_id == graph.graph_id
+    assert replay == original
+    assert replay.outputs.get("signal").value is True
+    assert replay.trace.evaluation_id == original.trace.evaluation_id
+
+
+def test_trace_has_complete_node_provenance() -> None:
+    graph = compile_strategy_graph(
+        MOVING_AVERAGE_CROSSOVER_MANIFEST, ComponentRegistry(CORE_COMPONENTS)
+    )
+    result = execute_strategy_graph(graph, semantic_inputs())
+    completed = [event for event in result.trace.events if event.kind == "node_completed"]
+    assert [event.node_id for event in completed] == list(graph.execution_order)
+    assert all(event.input_identities and event.output_identities for event in completed)
+
+
+def test_strategy_core_has_no_forbidden_boundary_imports() -> None:
+    forbidden = {
+        "backend",
+        "brokers",
+        "execution_planning",
+        "infrastructure",
+        "observation",
+        "providers",
+    }
+    root = Path(__file__).parents[2] / "strategies"
+    violations: list[str] = []
+    for path in sorted(root.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = {alias.name.split(".")[0] for alias in node.names}
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                names = {node.module.split(".")[0]}
+            else:
+                continue
+            if names & forbidden:
+                violations.append(f"{path.name}:{node.lineno}")
+    assert violations == []
+
+
+def test_public_runtime_has_no_mutation_or_dynamic_loading_surface() -> None:
+    prohibited = {
+        "add_node",
+        "remove_node",
+        "register_runtime",
+        "discover_plugins",
+        "load_plugin",
+        "patch",
+        "retry",
+        "run_async",
+        "start_worker",
+    }
+    import strategies.runtime as runtime
+
+    assert not prohibited & set(vars(runtime))


### PR DESCRIPTION
## Summary
- add an integrated canonical serialize/register/compile/execute/replay acceptance path
- verify complete node input/output provenance and deterministic reconstruction
- add static forbidden-import and runtime mutation/loading surface checks
- document the full Strategy Core validation matrix

## Validation
- 1008 architecture, analytical, strategy, replay, identity, and immutability tests passed
- 644 POS/observer tests passed; 1 established conditional skip
- Ruff passed
- strict scoped MyPy passed
- Lean entrypoint and governance integrity checks passed
- git diff --check passed

The integrated suite uses no providers, brokers, persistence, networking, wall clock, randomness, or mutable runtime state.