### PR TITLE
SPRINT-002: close final strict typing gap

### DIFF
--- a/strategies/expressions.py
+++ b/strategies/expressions.py
@@ -571,7 +571,7 @@ def _require(condition: bool, message: str) -> None:
 
 
 def _booleanish(value: StrategyTypeReference) -> bool:
-    return value.name == "Boolean" or value == UNKNOWN
+    return bool(value.name == "Boolean" or value == UNKNOWN)
 
 
 def _type_data(value: StrategyTypeReference) -> dict[str, object]:


### PR DESCRIPTION
## Summary
Normalize the expression Boolean-type predicate to an explicit bool. The combined final strict-MyPy command exposed Any propagation from skipped imported type definitions; runtime semantics are unchanged.

## Validation
- combined strict scoped MyPy: passed for all Strategy Core runtime modules
- focused expression/integrated replay tests: 22 passed
- complete architecture/analytical suite: 1008 passed
- POS/observer suite: 644 passed, 1 established conditional skip
- Lean pre-push: all 5 gates passed
- Ruff and git diff checks passed

This is the bounded final-validation remediation required before SPRINT-002 can be considered genuinely complete.