### PR TITLE
STONK-006: establish official ASA Strategy Library

### DIFF
--- a/docs/strategies/stonk-strategy-library.md
+++ b/docs/strategies/stonk-strategy-library.md
@@ -1,0 +1,29 @@
+# ASA Stonk Strategy Library
+
+Version `1.0.0` is ASA's first official extracted Strategy Library. It is an
+immutable, deterministically ordered catalog of canonical Strategy Manifests;
+it does not dispatch legacy service code.
+
+| Strategy ID | Version | Component dependencies | Purpose |
+|---|---:|---|---|
+| `asa.stonk.earnings_calendar` | `1.0.0` | shared + options | confirmed-event calendar candidate |
+| `asa.stonk.forward_factor_calendar` | `1.1.0` | shared + options | forward-volatility double-calendar candidate |
+| `asa.stonk.skew_momentum_vertical` | `1.0.0` | shared + options | skew/momentum vertical candidate |
+| `asa.stonk.stock_momentum` | `1.0.0` | shared | deterministic equity momentum candidate set |
+
+## Use
+
+```python
+from strategies import STONK_STRATEGY_LIBRARY
+
+manifest = STONK_STRATEGY_LIBRARY.get("asa.stonk.earnings_calendar")
+```
+
+Compile `manifest` with the existing Component Registry and Graph Runtime. The
+library performs no execution, provider lookup, portfolio evaluation, dynamic
+discovery, or mutation. Its identity is derived from its version and ordered
+manifest content identities, so catalog drift is visible and replayable.
+
+Detailed parameters and graph ownership are documented in
+`docs/migration/stonk-strategy-manifests.md`; behavioral evidence is in
+`docs/migration/stonk-behavioral-equivalence.md`.

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -162,6 +162,12 @@ from strategies.stonk_manifests import (
     STOCK_MOMENTUM_MANIFEST,
     STONK_STRATEGY_MANIFESTS,
 )
+from strategies.library import (
+    STRATEGY_LIBRARY_IDENTITY_NAMESPACE,
+    STRATEGY_LIBRARY_VERSION,
+    STONK_STRATEGY_LIBRARY,
+    StrategyLibrary,
+)
 from strategies.type_system import (
     DEFAULT_TYPE_SYSTEM,
     TYPE_SYSTEM_VERSION,
@@ -262,6 +268,10 @@ __all__ = [
     "SKEW_MOMENTUM_VERTICAL_MANIFEST",
     "STOCK_MOMENTUM_MANIFEST",
     "STONK_STRATEGY_MANIFESTS",
+    "STONK_STRATEGY_LIBRARY",
+    "STRATEGY_LIBRARY_IDENTITY_NAMESPACE",
+    "STRATEGY_LIBRARY_VERSION",
+    "StrategyLibrary",
     "CalendarStructure",
     "DtePairSelector",
     "DeltaNearestLeg",

--- a/strategies/library.py
+++ b/strategies/library.py
@@ -1,0 +1,71 @@
+"""Immutable canonical Strategy Library catalog (STONK-006)."""
+
+from __future__ import annotations
+
+import hashlib
+
+from strategies.errors import ManifestValidationError
+from strategies.manifest import StrategyManifest, canonical_strategy_json
+from strategies.stonk_manifests import STONK_STRATEGY_MANIFESTS
+
+STRATEGY_LIBRARY_IDENTITY_NAMESPACE = "asa.strategy_library"
+STRATEGY_LIBRARY_VERSION = "1.0.0"
+
+
+class StrategyLibrary:
+    """Finite deterministic catalog of complete Strategy Manifests."""
+
+    __slots__ = ("_identity", "_manifests")
+    _identity: str
+    _manifests: tuple[StrategyManifest, ...]
+
+    def __init__(self, manifests: tuple[StrategyManifest, ...]) -> None:
+        if not manifests:
+            raise ManifestValidationError("Strategy Library cannot be empty")
+        ordered = tuple(
+            sorted(manifests, key=lambda item: (item.strategy_id, item.strategy_version))
+        )
+        keys = tuple((item.strategy_id, item.strategy_version) for item in ordered)
+        if len(keys) != len(set(keys)):
+            raise ManifestValidationError("duplicate strategy ID and version in Strategy Library")
+        current_ids = tuple(item.strategy_id for item in ordered)
+        if len(current_ids) != len(set(current_ids)):
+            raise ManifestValidationError(
+                "Strategy Library v1 supports one current version per strategy ID"
+            )
+        object.__setattr__(self, "_manifests", ordered)
+        payload = {
+            "identity_namespace": STRATEGY_LIBRARY_IDENTITY_NAMESPACE,
+            "library_version": STRATEGY_LIBRARY_VERSION,
+            "manifest_ids": [item.manifest_id for item in ordered],
+        }
+        object.__setattr__(
+            self,
+            "_identity",
+            hashlib.sha256(canonical_strategy_json(payload)).hexdigest(),
+        )
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if hasattr(self, name):
+            raise AttributeError("StrategyLibrary is immutable")
+        object.__setattr__(self, name, value)
+
+    @property
+    def manifests(self) -> tuple[StrategyManifest, ...]:
+        return self._manifests
+
+    @property
+    def identity(self) -> str:
+        return self._identity
+
+    def strategy_ids(self) -> tuple[str, ...]:
+        return tuple(item.strategy_id for item in self._manifests)
+
+    def get(self, strategy_id: str) -> StrategyManifest:
+        for manifest in self._manifests:
+            if manifest.strategy_id == strategy_id:
+                return manifest
+        raise KeyError(strategy_id)
+
+
+STONK_STRATEGY_LIBRARY = StrategyLibrary(STONK_STRATEGY_MANIFESTS)

--- a/tests/strategies/test_strategy_library.py
+++ b/tests/strategies/test_strategy_library.py
@@ -1,0 +1,60 @@
+"""STONK-006 official Strategy Library coverage."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from strategies import (
+    EARNINGS_CALENDAR_MANIFEST,
+    STONK_STRATEGY_LIBRARY,
+    STONK_STRATEGY_MANIFESTS,
+    StrategyLibrary,
+)
+from strategies.errors import ManifestValidationError
+
+
+def test_library_is_complete_ordered_and_identity_pinned() -> None:
+    assert STONK_STRATEGY_LIBRARY.strategy_ids() == (
+        "asa.stonk.earnings_calendar",
+        "asa.stonk.forward_factor_calendar",
+        "asa.stonk.skew_momentum_vertical",
+        "asa.stonk.stock_momentum",
+    )
+    assert (
+        STONK_STRATEGY_LIBRARY.identity
+        == StrategyLibrary(tuple(reversed(STONK_STRATEGY_MANIFESTS))).identity
+    )
+    assert STONK_STRATEGY_LIBRARY.identity == (
+        "9b947dbb83d56473c1a11b7f345fa738026bed361c0f81b7653160e7d779a235"
+    )
+
+
+def test_library_returns_canonical_manifest_without_copy_or_mutation() -> None:
+    assert STONK_STRATEGY_LIBRARY.get("asa.stonk.earnings_calendar") is EARNINGS_CALENDAR_MANIFEST
+    with pytest.raises(KeyError):
+        STONK_STRATEGY_LIBRARY.get("unknown.strategy")
+    with pytest.raises(AttributeError):
+        STONK_STRATEGY_LIBRARY._identity = "changed"  # type: ignore[misc]
+
+
+def test_library_rejects_empty_duplicate_and_multiple_current_versions() -> None:
+    with pytest.raises(ManifestValidationError, match="cannot be empty"):
+        StrategyLibrary(())
+    with pytest.raises(ManifestValidationError, match="duplicate"):
+        StrategyLibrary((EARNINGS_CALENDAR_MANIFEST, EARNINGS_CALENDAR_MANIFEST))
+    next_version = replace(EARNINGS_CALENDAR_MANIFEST, strategy_version="1.0.1")
+    with pytest.raises(ManifestValidationError, match="one current version"):
+        StrategyLibrary((EARNINGS_CALENDAR_MANIFEST, next_version))
+
+
+def test_strategy_catalog_documents_every_library_entry_and_example() -> None:
+    document = (
+        Path(__file__).parents[2] / "docs" / "strategies" / "stonk-strategy-library.md"
+    ).read_text(encoding="utf-8")
+    for strategy_id in STONK_STRATEGY_LIBRARY.strategy_ids():
+        assert f"`{strategy_id}`" in document
+    assert "STONK_STRATEGY_LIBRARY.get" in document
+    assert "dynamic" in document


### PR DESCRIPTION
## Summary

Establishes ASA's first official extracted Strategy Library as an immutable, deterministic catalog of the four canonical migrated manifests.

## Design

- finite explicit catalog; no dynamic discovery
- one current version per strategy ID
- deterministic ordering and pinned content identity
- returns canonical manifests without copying or mutation
- no execution, providers, portfolio policy, or compatibility runtime

## Documentation

Adds the library catalog, component dependencies, versions, purposes, and a manifest lookup example.

## Validation

- complete Strategy suite: 252 passed
- scoped Ruff: passed
- Lean pre-push: all 5 checks passed
- `git diff --check`: passed

Repository mypy retains known transitive baseline errors outside this ticket; the new library's explicit slot annotations introduce no additional local typing diagnostics.

## Delegation

STONK-006 is an enumerated SPRINT-003 delegated implementation ticket. Self-merge is permitted only after required CI and self-review are green.
