### PR TITLE
EXEC-007: add deterministic analytical simulation

### DIFF
--- a/domain/__init__.py
+++ b/domain/__init__.py
@@ -80,6 +80,16 @@ from domain.outcome_metrics import ExpectedOutcomeMetrics
 from domain.provenance import Provenance, ProviderDisagreement
 from domain.provider import Provider
 from domain.references import Confidence, EvidenceKind, EvidenceReference
+from domain.simulation import (
+    SimulatedFill,
+    SimulatedOrderState,
+    SimulationFrame,
+    SimulationMarketData,
+    SimulationResult,
+    SimulationTerminalReason,
+    SimulationTraceEvent,
+    SimulationTraceEventType,
+)
 from domain.values import DomainInvariantError, is_normalized_value
 
 __all__ = [
@@ -150,6 +160,14 @@ __all__ = [
     "Security",
     "SecurityAssetType",
     "SecurityCollection",
+    "SimulatedFill",
+    "SimulatedOrderState",
+    "SimulationFrame",
+    "SimulationMarketData",
+    "SimulationResult",
+    "SimulationTerminalReason",
+    "SimulationTraceEvent",
+    "SimulationTraceEventType",
     "SectorClassification",
     "TimeInForce",
     "VolatilityEvidence",

--- a/domain/execution.py
+++ b/domain/execution.py
@@ -231,6 +231,9 @@ class PlannedOrder:
         required_stop = self.order_type in {PlannedOrderType.STOP, PlannedOrderType.STOP_LIMIT}
         if required_limit != (self.limit_price is not None) or required_stop != (self.stop_price is not None):
             raise DomainInvariantError("PlannedOrder price fields do not match order type")
+        for price in (self.limit_price, self.stop_price):
+            if price is not None and (price.amount <= 0 or price.currency != self.instrument.currency):
+                raise DomainInvariantError("PlannedOrder prices must be positive Instrument currency")
         if self.initial_status is not PlannedOrderStatus.PLANNED:
             raise DomainInvariantError("PlannedOrder initial status must be PLANNED")
         if not self.reasoning:
@@ -291,6 +294,12 @@ class ExecutionPlan:
             raise DomainInvariantError("ExecutionPlan requires PlannedOrders")
         if tuple(order.sequence for order in self.planned_orders) != tuple(range(1, len(self.planned_orders) + 1)):
             raise DomainInvariantError("PlannedOrder sequences must be contiguous")
+        if any(order.risk_decision_id != self.risk_decision.risk_decision_id for order in self.planned_orders):
+            raise DomainInvariantError("PlannedOrders must reference RiskDecision")
+        if any(order.source_snapshot_id != self.source_snapshot.portfolio_snapshot_id for order in self.planned_orders):
+            raise DomainInvariantError("PlannedOrders must reference source Snapshot")
+        if self.execution_summary.order_count != len(self.planned_orders):
+            raise DomainInvariantError("ExecutionSummary order count must match PlannedOrders")
         _evidence(self.evidence, "ExecutionPlan")
 
 

--- a/domain/simulation.py
+++ b/domain/simulation.py
@@ -1,0 +1,154 @@
+"""Immutable deterministic analytical simulation contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+
+from domain.execution import PlannedOrderStatus
+from domain.operational import CanonicalInstrumentIdentity, MonetaryAmount
+from domain.references import EvidenceReference
+from domain.values import DomainInvariantError, require_tz_aware
+
+
+class SimulationTerminalReason(str, Enum):
+    FILLED = "filled"
+    DAY_EXPIRED = "day_expired"
+    IOC_REMAINDER_CANCELLED = "ioc_remainder_cancelled"
+    FOK_NOT_SATISFIED = "fok_not_satisfied"
+    GTC_FRAMES_EXHAUSTED = "gtc_frames_exhausted"
+    NO_MARKET_FRAME = "no_market_frame"
+    NOT_MARKETABLE = "not_marketable"
+
+
+class SimulationTraceEventType(str, Enum):
+    SIMULATION_STARTED = "simulation_started"
+    ORDER_EVALUATED = "order_evaluated"
+    TRIGGER_EVALUATED = "trigger_evaluated"
+    PRICE_EVALUATED = "price_evaluated"
+    LIQUIDITY_EVALUATED = "liquidity_evaluated"
+    FILL_CREATED = "fill_created"
+    ORDER_TERMINATED = "order_terminated"
+    SIMULATION_COMPLETED = "simulation_completed"
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationFrame:
+    simulation_frame_id: str
+    sequence: int
+    instrument_identity: CanonicalInstrumentIdentity
+    bid: MonetaryAmount
+    ask: MonetaryAmount
+    last: MonetaryAmount
+    available_quantity: Decimal
+    evidence: tuple[EvidenceReference, ...]
+
+    def __post_init__(self) -> None:
+        if self.sequence <= 0 or self.available_quantity < 0:
+            raise DomainInvariantError("SimulationFrame sequence and quantity are invalid")
+        if len({self.bid.currency, self.ask.currency, self.last.currency}) != 1:
+            raise DomainInvariantError("SimulationFrame currencies must match")
+        if min(self.bid.amount, self.ask.amount, self.last.amount) <= 0 or self.bid.amount > self.ask.amount:
+            raise DomainInvariantError("SimulationFrame requires positive non-crossed prices")
+        if not self.evidence:
+            raise DomainInvariantError("SimulationFrame.evidence cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationMarketData:
+    simulation_market_data_id: str
+    as_of: datetime
+    ordered_frames: tuple[SimulationFrame, ...]
+    evidence: tuple[EvidenceReference, ...]
+
+    def __post_init__(self) -> None:
+        require_tz_aware(self.as_of, "SimulationMarketData", "as_of")
+        keys = tuple((frame.instrument_identity, frame.sequence) for frame in self.ordered_frames)
+        if len(keys) != len(set(keys)):
+            raise DomainInvariantError("Simulation frames must be unique")
+        for identity in {frame.instrument_identity for frame in self.ordered_frames}:
+            sequences = tuple(frame.sequence for frame in self.ordered_frames if frame.instrument_identity == identity)
+            if sequences != tuple(range(1, len(sequences) + 1)):
+                raise DomainInvariantError("Simulation frame sequences must be contiguous")
+        if not self.evidence:
+            raise DomainInvariantError("SimulationMarketData.evidence cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class SimulatedFill:
+    simulated_fill_id: str
+    planned_order_id: str
+    order_fill_sequence: int
+    global_fill_sequence: int
+    quantity: Decimal
+    price: MonetaryAmount
+    frame_sequence: int
+    resulting_status: PlannedOrderStatus
+    evidence: tuple[EvidenceReference, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SimulatedOrderState:
+    simulated_order_state_id: str
+    simulation_algorithm_version: str
+    planned_order_id: str
+    status: PlannedOrderStatus
+    filled_quantity: Decimal
+    remaining_quantity: Decimal
+    simulated_fill_ids: tuple[str, ...]
+    terminal_reason: SimulationTerminalReason
+    evidence: tuple[EvidenceReference, ...]
+
+    def __post_init__(self) -> None:
+        if self.filled_quantity < 0 or self.remaining_quantity < 0:
+            raise DomainInvariantError("SimulatedOrderState quantities cannot be negative")
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationTraceEvent:
+    simulation_trace_event_id: str
+    simulation_algorithm_version: str
+    sequence: int
+    event_type: SimulationTraceEventType
+    planned_order_id: str | None
+    frame_sequence: int | None
+    input_identities: tuple[str, ...]
+    output_identities: tuple[str, ...]
+    evidence: tuple[EvidenceReference, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationResult:
+    simulation_result_id: str
+    simulation_algorithm_version: str
+    execution_plan_id: str
+    market_data_id: str
+    ordered_order_states: tuple[SimulatedOrderState, ...]
+    simulated_fills: tuple[SimulatedFill, ...]
+    unfilled_quantities: tuple[tuple[str, Decimal], ...]
+    trace: tuple[SimulationTraceEvent, ...]
+    evidence: tuple[EvidenceReference, ...]
+
+    def __post_init__(self) -> None:
+        if tuple(event.sequence for event in self.trace) != tuple(range(1, len(self.trace) + 1)):
+            raise DomainInvariantError("Simulation trace sequence must be contiguous")
+        state_ids = tuple(state.planned_order_id for state in self.ordered_order_states)
+        if len(state_ids) != len(set(state_ids)):
+            raise DomainInvariantError("SimulationResult requires one state per PlannedOrder")
+        if state_ids != tuple(order_id for order_id, _ in self.unfilled_quantities):
+            raise DomainInvariantError("Simulation unfilled quantities must follow order states")
+        if tuple(fill.global_fill_sequence for fill in self.simulated_fills) != tuple(
+            range(1, len(self.simulated_fills) + 1)
+        ):
+            raise DomainInvariantError("global fill sequence must be contiguous")
+        for state in self.ordered_order_states:
+            order_fills = tuple(
+                fill for fill in self.simulated_fills
+                if fill.planned_order_id == state.planned_order_id
+            )
+            if state.simulated_fill_ids != tuple(fill.simulated_fill_id for fill in order_fills):
+                raise DomainInvariantError("order state fill IDs are incoherent")
+            if state.filled_quantity != sum((fill.quantity for fill in order_fills), Decimal("0")):
+                raise DomainInvariantError("order state filled quantity is incoherent")

--- a/portfolio/__init__.py
+++ b/portfolio/__init__.py
@@ -1,11 +1,12 @@
 """Deterministic Portfolio Engine calculation layer."""
 
-from portfolio.engine import evaluate_one, evaluate_portfolio, reduction_candidates
+from portfolio.engine import apply_simulation, evaluate_one, evaluate_portfolio, reduction_candidates
 from portfolio.models import PORTFOLIO_ALGORITHM_VERSION, PortfolioParameters
 
 __all__ = [
     "PORTFOLIO_ALGORITHM_VERSION",
     "PortfolioParameters",
+    "apply_simulation",
     "evaluate_one",
     "evaluate_portfolio",
     "reduction_candidates",

--- a/portfolio/engine.py
+++ b/portfolio/engine.py
@@ -8,6 +8,8 @@ from decimal import Decimal, ROUND_FLOOR, ROUND_HALF_EVEN, localcontext
 
 from domain.canonicalization import serialize_canonical
 from domain.execution import (
+    ExecutionPlan,
+    PlannedOrderSide,
     PortfolioDelta,
     PortfolioDeltaKind,
     PortfolioEvaluationDisposition,
@@ -16,6 +18,7 @@ from domain.execution import (
 from domain.operational import (
     InstrumentValuation,
     MonetaryAmount,
+    Portfolio,
     PortfolioEvaluationRequest,
     PortfolioSnapshot,
     Position,
@@ -23,6 +26,7 @@ from domain.operational import (
     ProposedPosition,
 )
 from domain.references import EvidenceReference
+from domain.simulation import SimulationMarketData, SimulationResult
 from domain.values import DomainInvariantError
 from portfolio.models import (
     PORTFOLIO_ALGORITHM_VERSION,
@@ -249,3 +253,150 @@ def reduction_candidates(
             rationale=(*delta.rationale, "risk reduction candidate"),
         ))
     return tuple(candidates)
+
+
+def apply_simulation(
+    plan: ExecutionPlan,
+    result: SimulationResult,
+    market_data: SimulationMarketData,
+) -> tuple[PortfolioDelta, PortfolioSnapshot]:
+    """Apply simulated fills as the sole owner of next Portfolio calculations."""
+    if result.execution_plan_id != plan.execution_plan_id:
+        raise DomainInvariantError("SimulationResult must reference ExecutionPlan")
+    if result.market_data_id != market_data.simulation_market_data_id:
+        raise DomainInvariantError("SimulationResult must reference SimulationMarketData")
+    approved = plan.risk_decision.approved_delta
+    if approved is None:
+        raise DomainInvariantError("simulation application requires approved delta")
+    source = plan.source_snapshot
+    portfolio = source.portfolio
+    order_by_id = {order.planned_order_id: order for order in plan.planned_orders}
+    fills = tuple(sorted(result.simulated_fills, key=lambda item: item.global_fill_sequence))
+    target_position = next((
+        item for item in portfolio.positions
+        if item.instrument.identity == approved.instrument.identity
+    ), None)
+    direction = target_position.direction if target_position else None
+    quantity = target_position.quantity if target_position else Decimal("0")
+    average = target_position.average_cost_per_unit.amount if target_position else Decimal("0")
+    position_realized = target_position.realized_pnl.amount if target_position else Decimal("0")
+    newly_realized = Decimal("0")
+    cash_change = Decimal("0")
+    last_price: Decimal | None = None
+    for fill in fills:
+        order = order_by_id[fill.planned_order_id]
+        economic = fill.price.amount * order.price_multiplier * fill.quantity
+        last_price = fill.price.amount
+        if order.side is PlannedOrderSide.BUY:
+            if direction not in {None, PositionDirection.LONG}:
+                raise DomainInvariantError("BUY cannot increase an uncovered short")
+            previous_cost = average * quantity
+            quantity += fill.quantity
+            average = (previous_cost + fill.price.amount * fill.quantity) / quantity
+            direction = PositionDirection.LONG
+            cash_change -= economic
+        elif order.side is PlannedOrderSide.SELL:
+            if direction is not PositionDirection.LONG or fill.quantity > quantity:
+                raise DomainInvariantError("SELL requires sufficient long Position")
+            realized = (fill.price.amount - average) * order.price_multiplier * fill.quantity
+            newly_realized += realized
+            position_realized += realized
+            quantity -= fill.quantity
+            cash_change += economic
+            if quantity == 0:
+                direction = None
+                average = Decimal("0")
+        else:
+            if direction is not PositionDirection.SHORT or fill.quantity > quantity:
+                raise DomainInvariantError("BUY_TO_COVER requires sufficient short Position")
+            realized = (average - fill.price.amount) * order.price_multiplier * fill.quantity
+            newly_realized += realized
+            position_realized += realized
+            quantity -= fill.quantity
+            cash_change -= economic
+            if quantity == 0:
+                direction = None
+                average = Decimal("0")
+    valuation = _valuation_by_identity(source, approved.instrument.identity)
+    next_positions = [
+        item for item in portfolio.positions
+        if item.instrument.identity != approved.instrument.identity
+    ]
+    if quantity > 0 and direction is not None:
+        current = last_price if last_price is not None else valuation.current_price.amount
+        unit = current * valuation.price_multiplier
+        market_value = quantity * unit
+        unrealized = (
+            (current - average) if direction is PositionDirection.LONG else (average - current)
+        ) * valuation.price_multiplier * quantity
+        position_evidence = _evidence(
+            valuation.evidence,
+            *(fill.evidence for fill in fills),
+        )
+        next_positions.append(Position(
+            _identity("asa.position.v1", approved.instrument.identity.scheme, approved.instrument.identity.value, direction.value, quantity, average, current, market_data.as_of, tuple(_evidence_key(item) for item in position_evidence)),
+            portfolio.account_id, approved.instrument, direction, quantity,
+            valuation.quantity_increment, MonetaryAmount(average, "USD"),
+            MonetaryAmount(current, "USD"), valuation.price_multiplier,
+            MonetaryAmount(unit, "USD"), MonetaryAmount(market_value, "USD"),
+            MonetaryAmount(market_value, "USD"), MonetaryAmount(position_realized, "USD"),
+            MonetaryAmount(unrealized, "USD"), market_data.as_of, position_evidence,
+        ))
+    next_positions.sort(key=lambda item: (item.instrument.identity.scheme, item.instrument.identity.value))
+    next_cash = _quantize(portfolio.cash_balance.amount + cash_change, portfolio.currency_quantum)
+    next_buying_power = _quantize(portfolio.buying_power.amount + cash_change, portfolio.currency_quantum)
+    if next_buying_power < 0:
+        raise DomainInvariantError("simulated transition cannot produce negative buying power")
+    gross = sum((item.gross_exposure.amount for item in next_positions), Decimal("0"))
+    unrealized_total = sum((item.unrealized_pnl.amount for item in next_positions), Decimal("0"))
+    long_value = sum((item.market_value.amount for item in next_positions if item.direction is PositionDirection.LONG), Decimal("0"))
+    short_value = sum((item.market_value.amount for item in next_positions if item.direction is PositionDirection.SHORT), Decimal("0"))
+    nlv = next_cash + long_value - short_value
+    next_realized = portfolio.realized_pnl.amount + newly_realized
+    transition_evidence = _evidence(source.evidence, plan.evidence, result.evidence, market_data.evidence)
+    state_inputs = (
+        portfolio.portfolio_id, portfolio.revision + 1,
+        tuple(item.position_id for item in next_positions), next_cash, next_buying_power,
+        nlv, gross, next_realized, unrealized_total, tuple(_evidence_key(item) for item in transition_evidence),
+    )
+    next_portfolio = Portfolio(
+        portfolio.portfolio_id, _identity("asa.portfolio.v1", state_inputs), portfolio.revision + 1,
+        portfolio.account_id, portfolio.base_currency, portfolio.currency_quantum,
+        tuple(next_positions), MonetaryAmount(next_cash, "USD"),
+        MonetaryAmount(next_buying_power, "USD"), MonetaryAmount(nlv, "USD"),
+        MonetaryAmount(gross, "USD"), MonetaryAmount(next_realized, "USD"),
+        MonetaryAmount(unrealized_total, "USD"), portfolio.platform_risk_policies,
+        portfolio.policy_activation_evidence,
+    )
+    next_snapshot = PortfolioSnapshot(
+        _identity("asa.portfolio_snapshot.v2", next_portfolio.portfolio_state_id, market_data.as_of, tuple(item.instrument_valuation_id for item in source.instrument_valuations), tuple(_evidence_key(item) for item in transition_evidence)),
+        next_portfolio, source.instrument_valuations, market_data.as_of, transition_evidence,
+    )
+    filled_target = quantity
+    loss = Decimal("0")
+    if approved.target_quantity:
+        loss = _quantize(
+            approved.projected_maximum_loss.amount * filled_target / approved.target_quantity,
+            portfolio.currency_quantum,
+        )
+    simulated_delta = replace(
+        approved,
+        portfolio_delta_id=_identity("asa.portfolio_delta.v1", approved.portfolio_delta_id, result.simulation_result_id, filled_target, cash_change, loss),
+        kind=PortfolioDeltaKind.SIMULATED,
+        predecessor_delta_id=approved.portfolio_delta_id,
+        target_direction=direction,
+        target_quantity=filled_target,
+        cash_change=MonetaryAmount(_quantize(cash_change, portfolio.currency_quantum), "USD"),
+        buying_power_change=MonetaryAmount(_quantize(cash_change, portfolio.currency_quantum), "USD"),
+        projected_maximum_loss=MonetaryAmount(loss, "USD"),
+        rationale=(*approved.rationale, "derived from deterministic simulated fills"),
+        evidence=transition_evidence,
+    )
+    return simulated_delta, next_snapshot
+
+
+def _valuation_by_identity(snapshot: PortfolioSnapshot, identity: object) -> InstrumentValuation:
+    matches = tuple(item for item in snapshot.instrument_valuations if item.instrument.identity == identity)
+    if len(matches) != 1:
+        raise DomainInvariantError("portfolio transition requires one valuation")
+    return matches[0]

--- a/simulation/__init__.py
+++ b/simulation/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic analytical Simulation Engine."""
+
+from simulation.engine import simulate
+
+__all__ = ["simulate"]

--- a/simulation/engine.py
+++ b/simulation/engine.py
@@ -1,0 +1,178 @@
+"""Pure deterministic interpretation of Execution Plans against explicit frames."""
+
+from __future__ import annotations
+
+import hashlib
+from decimal import Decimal
+
+from domain.canonicalization import serialize_canonical
+from domain.execution import (
+    ExecutionPlan,
+    PlannedOrder,
+    PlannedOrderSide,
+    PlannedOrderStatus,
+    PlannedOrderType,
+    TimeInForce,
+)
+from domain.references import EvidenceReference
+from domain.simulation import (
+    SimulatedFill,
+    SimulatedOrderState,
+    SimulationFrame,
+    SimulationMarketData,
+    SimulationResult,
+    SimulationTerminalReason,
+    SimulationTraceEvent,
+    SimulationTraceEventType,
+)
+from simulation.models import SIMULATION_ALGORITHM_VERSION
+
+
+def _key(item: EvidenceReference) -> tuple[object, ...]:
+    return item.kind.value, item.referenced_id, item.version
+
+
+def _id(namespace: str, *values: object) -> str:
+    payload = "\n".join((namespace, *(serialize_canonical(value) for value in values)))
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _evidence(*groups: tuple[EvidenceReference, ...]) -> tuple[EvidenceReference, ...]:
+    unique = {_key(item): item for group in groups for item in group}
+    return tuple(unique[key] for key in sorted(unique))
+
+
+def _price(order: PlannedOrder, frame: SimulationFrame, triggered: bool) -> tuple[Decimal | None, bool]:
+    buy = order.side in {PlannedOrderSide.BUY, PlannedOrderSide.BUY_TO_COVER}
+    if order.order_type in {PlannedOrderType.STOP, PlannedOrderType.STOP_LIMIT} and not triggered:
+        stop = order.stop_price
+        assert stop is not None
+        triggered = frame.last.amount >= stop.amount if buy else frame.last.amount <= stop.amount
+        if not triggered:
+            return None, False
+    if order.order_type in {PlannedOrderType.MARKET, PlannedOrderType.STOP}:
+        return (frame.ask.amount if buy else frame.bid.amount), triggered
+    limit = order.limit_price
+    assert limit is not None
+    marketable = frame.ask.amount <= limit.amount if buy else frame.bid.amount >= limit.amount
+    return ((frame.ask.amount if buy else frame.bid.amount) if marketable else None), triggered
+
+
+def _terminal(
+    order: PlannedOrder,
+    filled: Decimal,
+    had_frames: bool,
+) -> tuple[PlannedOrderStatus, SimulationTerminalReason]:
+    if filled == order.quantity:
+        return PlannedOrderStatus.SIMULATED_FILLED, SimulationTerminalReason.FILLED
+    if order.time_in_force is TimeInForce.FOK:
+        return PlannedOrderStatus.SIMULATED_REJECTED, SimulationTerminalReason.FOK_NOT_SATISFIED
+    if order.time_in_force is TimeInForce.IOC:
+        status = PlannedOrderStatus.SIMULATED_PARTIALLY_FILLED if filled else PlannedOrderStatus.SIMULATED_CANCELLED
+        return status, SimulationTerminalReason.IOC_REMAINDER_CANCELLED
+    if order.time_in_force is TimeInForce.GTC:
+        status = PlannedOrderStatus.SIMULATED_PARTIALLY_FILLED if filled else PlannedOrderStatus.SIMULATED_ACCEPTED
+        reason = SimulationTerminalReason.GTC_FRAMES_EXHAUSTED if had_frames else SimulationTerminalReason.NO_MARKET_FRAME
+        return status, reason
+    status = PlannedOrderStatus.SIMULATED_PARTIALLY_FILLED if filled else PlannedOrderStatus.SIMULATED_CANCELLED
+    reason = SimulationTerminalReason.DAY_EXPIRED if had_frames else SimulationTerminalReason.NO_MARKET_FRAME
+    return status, reason
+
+
+def simulate(plan: ExecutionPlan, market_data: SimulationMarketData) -> SimulationResult:
+    """Simulate all orders with a shared per-frame liquidity ledger."""
+    if market_data.as_of < plan.source_snapshot.observed_at:
+        raise ValueError("SimulationMarketData cannot precede source PortfolioSnapshot")
+    valuations = {
+        item.instrument.identity: item for item in plan.source_snapshot.instrument_valuations
+    }
+    for frame in market_data.ordered_frames:
+        valuation = valuations.get(frame.instrument_identity)
+        if valuation is None:
+            raise ValueError("Simulation frame has no source InstrumentValuation")
+        if frame.available_quantity % valuation.quantity_increment:
+            raise ValueError("Simulation liquidity must use Instrument quantity increment")
+        if frame.bid.currency != plan.source_snapshot.portfolio.base_currency:
+            raise ValueError("Simulation frame must use Portfolio base currency")
+    frame_by_order = {
+        order.planned_order_id: tuple(
+            frame for frame in market_data.ordered_frames
+            if frame.instrument_identity == order.instrument.identity
+        )
+        for order in plan.planned_orders
+    }
+    liquidity = {frame.simulation_frame_id: frame.available_quantity for frame in market_data.ordered_frames}
+    fills: list[SimulatedFill] = []
+    states: list[SimulatedOrderState] = []
+    trace_specs: list[tuple[SimulationTraceEventType, str | None, int | None, tuple[str, ...]]] = [
+        (SimulationTraceEventType.SIMULATION_STARTED, None, None, (plan.execution_plan_id, market_data.simulation_market_data_id))
+    ]
+    global_fill_sequence = 0
+    for order in plan.planned_orders:
+        frames = frame_by_order[order.planned_order_id]
+        if order.time_in_force in {TimeInForce.IOC, TimeInForce.FOK}:
+            frames = frames[:1]
+        remaining = order.quantity
+        order_fills: list[SimulatedFill] = []
+        triggered = order.order_type not in {PlannedOrderType.STOP, PlannedOrderType.STOP_LIMIT}
+        trace_specs.append((SimulationTraceEventType.ORDER_EVALUATED, order.planned_order_id, None, (order.planned_order_id,)))
+        for frame in frames:
+            if order.order_type in {PlannedOrderType.STOP, PlannedOrderType.STOP_LIMIT}:
+                trace_specs.append((SimulationTraceEventType.TRIGGER_EVALUATED, order.planned_order_id, frame.sequence, (frame.simulation_frame_id,)))
+            price, triggered = _price(order, frame, triggered)
+            trace_specs.append((SimulationTraceEventType.PRICE_EVALUATED, order.planned_order_id, frame.sequence, (frame.simulation_frame_id,)))
+            if price is None:
+                continue
+            available = liquidity[frame.simulation_frame_id]
+            trace_specs.append((SimulationTraceEventType.LIQUIDITY_EVALUATED, order.planned_order_id, frame.sequence, (frame.simulation_frame_id,)))
+            if order.time_in_force is TimeInForce.FOK and available < remaining:
+                break
+            quantity = min(remaining, available)
+            if quantity <= 0:
+                continue
+            liquidity[frame.simulation_frame_id] -= quantity
+            remaining -= quantity
+            global_fill_sequence += 1
+            evidence = _evidence(order.evidence, frame.evidence, market_data.evidence)
+            resulting = PlannedOrderStatus.SIMULATED_FILLED if remaining == 0 else PlannedOrderStatus.SIMULATED_PARTIALLY_FILLED
+            fill = SimulatedFill(
+                _id("asa.simulated_fill.v1", order.planned_order_id, len(order_fills) + 1, global_fill_sequence, quantity, price, frame.sequence, tuple(_key(item) for item in evidence)),
+                order.planned_order_id, len(order_fills) + 1, global_fill_sequence, quantity,
+                type(frame.bid)(price, frame.bid.currency), frame.sequence, resulting, evidence,
+            )
+            order_fills.append(fill)
+            fills.append(fill)
+            trace_specs.append((SimulationTraceEventType.FILL_CREATED, order.planned_order_id, frame.sequence, (fill.simulated_fill_id,)))
+            if remaining == 0 or order.time_in_force in {TimeInForce.IOC, TimeInForce.FOK}:
+                break
+        filled = order.quantity - remaining
+        status, reason = _terminal(order, filled, bool(frames))
+        state_evidence = _evidence(order.evidence, *(fill.evidence for fill in order_fills))
+        state = SimulatedOrderState(
+            _id("asa.simulated_order_state.v1", SIMULATION_ALGORITHM_VERSION, order.planned_order_id, status.value, filled, remaining, tuple(fill.simulated_fill_id for fill in order_fills), reason.value, tuple(_key(item) for item in state_evidence)),
+            SIMULATION_ALGORITHM_VERSION, order.planned_order_id, status, filled, remaining,
+            tuple(fill.simulated_fill_id for fill in order_fills), reason, state_evidence,
+        )
+        states.append(state)
+        trace_specs.append((SimulationTraceEventType.ORDER_TERMINATED, order.planned_order_id, None, (state.simulated_order_state_id,)))
+    trace_specs.append((SimulationTraceEventType.SIMULATION_COMPLETED, None, None, tuple(state.simulated_order_state_id for state in states)))
+    trace = tuple(
+        SimulationTraceEvent(
+            _id("asa.simulation_trace_event.v1", SIMULATION_ALGORITHM_VERSION, sequence, event_type.value, order_id, frame_sequence, identities),
+            SIMULATION_ALGORITHM_VERSION, sequence, event_type, order_id, frame_sequence,
+            identities, (), _evidence(plan.evidence, market_data.evidence),
+        )
+        for sequence, (event_type, order_id, frame_sequence, identities) in enumerate(trace_specs, 1)
+    )
+    unfilled = tuple((state.planned_order_id, state.remaining_quantity) for state in states)
+    evidence = _evidence(plan.evidence, market_data.evidence, *(fill.evidence for fill in fills))
+    result_id = _id(
+        "asa.simulation_result.v1", SIMULATION_ALGORITHM_VERSION, plan.execution_plan_id,
+        market_data.simulation_market_data_id, tuple(state.simulated_order_state_id for state in states),
+        tuple(fill.simulated_fill_id for fill in fills), unfilled,
+        tuple(event.simulation_trace_event_id for event in trace), tuple(_key(item) for item in evidence),
+    )
+    return SimulationResult(
+        result_id, SIMULATION_ALGORITHM_VERSION, plan.execution_plan_id,
+        market_data.simulation_market_data_id, tuple(states), tuple(fills), unfilled, trace, evidence,
+    )

--- a/simulation/errors.py
+++ b/simulation/errors.py
@@ -1,0 +1,5 @@
+"""Simulation errors."""
+
+
+class InvalidSimulationInputError(ValueError):
+    pass

--- a/simulation/models.py
+++ b/simulation/models.py
@@ -1,0 +1,3 @@
+"""Pinned Simulation Engine version."""
+
+SIMULATION_ALGORITHM_VERSION = "v1"

--- a/tests/architecture/test_simulation_boundaries.py
+++ b/tests/architecture/test_simulation_boundaries.py
@@ -1,0 +1,29 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+FILES = sorted((ROOT / "simulation").glob("*.py"))
+
+
+def _roots(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            roots.add(node.module.split(".")[0])
+    return roots
+
+
+@pytest.mark.parametrize("path", FILES)
+def test_simulation_imports_only_domain_and_itself(path: Path) -> None:
+    assert _roots(path) <= {"__future__", "decimal", "domain", "hashlib", "simulation"}
+
+
+def test_no_operational_capability_is_reachable() -> None:
+    source = "\n".join(path.read_text(encoding="utf-8") for path in FILES)
+    for value in ("requests", "providers", "broker", "authenticate", "submit_order", "sqlalchemy"):
+        assert value not in source.lower()

--- a/tests/domain/test_simulation_contracts.py
+++ b/tests/domain/test_simulation_contracts.py
@@ -1,0 +1,19 @@
+import dataclasses
+
+from domain.simulation import (
+    SimulatedFill,
+    SimulatedOrderState,
+    SimulationFrame,
+    SimulationMarketData,
+    SimulationResult,
+    SimulationTraceEvent,
+)
+
+
+def test_simulation_contracts_are_immutable() -> None:
+    for contract in (
+        SimulationFrame, SimulationMarketData, SimulatedFill,
+        SimulatedOrderState, SimulationTraceEvent, SimulationResult,
+    ):
+        assert dataclasses.is_dataclass(contract)
+        assert contract.__dataclass_params__.frozen

--- a/tests/simulation/__init__.py
+++ b/tests/simulation/__init__.py
@@ -1,0 +1,1 @@
+"""Simulation tests."""

--- a/tests/simulation/test_engine.py
+++ b/tests/simulation/test_engine.py
@@ -1,0 +1,88 @@
+from dataclasses import replace
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from domain.execution import PlannedOrderStatus, PlannedOrderType, TimeInForce
+from domain.operational import MonetaryAmount
+from domain.simulation import SimulationFrame, SimulationMarketData, SimulationTerminalReason
+from execution_planning.engine import plan_execution
+from portfolio.engine import apply_simulation
+from simulation.engine import simulate
+from tests.execution_planning.helpers import decision, snapshot
+from tests.portfolio.helpers import EVIDENCE
+
+AS_OF = datetime(2026, 7, 21, 20, 0, tzinfo=timezone.utc)
+
+
+def plan():  # type: ignore[no-untyped-def]
+    return plan_execution(decision(), snapshot())
+
+
+def market_data(*, available: Decimal = Decimal("1000"), ask: Decimal = Decimal("101")) -> SimulationMarketData:
+    order = plan().planned_orders[0]
+    frame = SimulationFrame(
+        "frame-1", 1, order.instrument.identity, MonetaryAmount(Decimal("99"), "USD"),
+        MonetaryAmount(ask, "USD"), MonetaryAmount(Decimal("100"), "USD"),
+        available, EVIDENCE,
+    )
+    return SimulationMarketData("market-data-1", AS_OF, (frame,), EVIDENCE)
+
+
+def test_market_order_fills_deterministically_at_ask() -> None:
+    execution_plan = plan()
+    data = market_data()
+    first = simulate(execution_plan, data)
+    assert first == simulate(execution_plan, data)
+    assert first.simulated_fills[0].price.amount == Decimal("101")
+    assert first.ordered_order_states[0].status is PlannedOrderStatus.SIMULATED_FILLED
+
+
+def test_fok_rejects_without_consuming_partial_liquidity() -> None:
+    base = plan()
+    order = replace(base.planned_orders[0], time_in_force=TimeInForce.FOK)
+    execution_plan = replace(base, planned_orders=(order,))
+    result = simulate(execution_plan, market_data(available=Decimal("1")))
+    assert result.simulated_fills == ()
+    assert result.ordered_order_states[0].terminal_reason is SimulationTerminalReason.FOK_NOT_SATISFIED
+
+
+def test_limit_not_marketable_expires_without_fill() -> None:
+    base = plan()
+    order = replace(
+        base.planned_orders[0], order_type=PlannedOrderType.LIMIT,
+        limit_price=MonetaryAmount(Decimal("90"), "USD"),
+    )
+    result = simulate(replace(base, planned_orders=(order,)), market_data())
+    assert result.simulated_fills == ()
+    assert result.ordered_order_states[0].terminal_reason is SimulationTerminalReason.DAY_EXPIRED
+
+
+def test_frame_liquidity_is_shared_once_across_plan_order_sequence() -> None:
+    base = plan()
+    first = replace(base.planned_orders[0], quantity=Decimal("3"))
+    second = replace(
+        first,
+        planned_order_id="planned-order-2",
+        sequence=2,
+        quantity=Decimal("3"),
+    )
+    execution_plan = replace(
+        base,
+        planned_orders=(first, second),
+        execution_summary=replace(base.execution_summary, order_count=2),
+    )
+    result = simulate(execution_plan, market_data(available=Decimal("4")))
+    assert tuple(fill.quantity for fill in result.simulated_fills) == (Decimal("3"), Decimal("1"))
+    assert result.unfilled_quantities == ((first.planned_order_id, Decimal("0")), (second.planned_order_id, Decimal("2")))
+
+
+def test_portfolio_engine_applies_fills_to_new_immutable_snapshot() -> None:
+    execution_plan = plan()
+    data = market_data()
+    result = simulate(execution_plan, data)
+    delta, next_snapshot = apply_simulation(execution_plan, result, data)
+    assert next_snapshot.portfolio.revision == execution_plan.source_snapshot.portfolio.revision + 1
+    assert next_snapshot.observed_at == AS_OF
+    assert next_snapshot.portfolio.positions
+    assert delta.target_quantity == result.ordered_order_states[0].filled_quantity
+    assert delta.evidence


### PR DESCRIPTION
## Summary

Implements the ARCH-006 analytical Simulation Engine and Portfolio-owned simulated fill application.

## Changes

- Adds immutable SimulationFrame, SimulationMarketData, SimulatedFill, SimulatedOrderState, SimulationTraceEvent, and SimulationResult contracts.
- Implements deterministic MARKET, LIMIT, STOP, and STOP_LIMIT evaluation.
- Implements DAY, GTC, IOC, and FOK terminal semantics.
- Shares explicit frame liquidity once across orders in canonical plan order.
- Emits bounded, identified provenance and execution traces.
- Applies fills through Portfolio Engine into a new immutable Portfolio revision, simulated PortfolioDelta, and PortfolioSnapshot.
- Adds architecture, contract, replay, liquidity, TIF, and portfolio-transition tests.

## Safety

No provider, broker, adapter, authentication, network, persistence, clock read, randomness, or live execution capability is introduced.

## Validation

- Full suite: 1,709 passed; one unchanged environment-only legacy POS skip.
- Strict MyPy: passed on domain, portfolio, simulation, and execution planning.
- Changed-scope Ruff: passed.
- Entrypoint and frozen governance integrity: passed.
- Lean pre-push: all five checks passed.
- git diff --check: passed.

Delegated SPRINT-004 ticket. Self-merge only after GitHub Architecture Validation passes.