### PR TITLE
EXEC-009: validate and complete SPRINT-004

### DIFF
--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -10,6 +10,8 @@ Replace the dual legacy/Lean POS operation with Lean POS as the sole active proj
 *(source: project_state:lean-ps-cutover)*
 
 **Active constraints:**
+- analytical_execution_must_be_deterministic_and_replayable
+- asa_core_cannot_authenticate_with_or_mutate_a_broker
 - founder_merge_or_other_required_authority_merge_implies_acceptance
 - frozen_governance_changes_require_authorized_process
 - github_is_canonical_for_issues_prs_reviews_checks_and_merges
@@ -19,7 +21,7 @@ Replace the dual legacy/Lean POS operation with Lean POS as the sole active proj
 
 ## Next Action
 
-project=ASA-II repository=jaiaFoster/ASA migration_status=complete completed_phase=CUTOVER-06 active_operating_system=Lean_POS sprint=SPRINT-003 sprint_status=complete next_action=Founder_verification
+project=ASA-II repository=jaiaFoster/ASA migration_status=complete completed_phase=CUTOVER-06 active_operating_system=Lean_POS sprint=SPRINT-004 sprint_status=complete phase=Phase-II milestone=Analytical_Platform merged_through=EXEC-009 completion_ticket=EXEC-009 next_action=Founder_verification
 
 ## Sources
 

--- a/docs/sprints/SPRINT-004.yaml
+++ b/docs/sprints/SPRINT-004.yaml
@@ -1,0 +1,55 @@
+---
+id: SPRINT-004
+name: Analytical Execution Platform
+version: 1.0
+status: COMPLETE_PENDING_FOUNDER_VERIFICATION
+phase: Phase-II
+milestone: Analytical Platform
+
+objective: >
+  Convert immutable Strategy intent into portfolio-aware Risk Decisions,
+  broker-neutral Planned Orders, deterministic analytical Simulation Results,
+  and replay-verified Portfolio transitions without modifying brokerage state.
+
+architecture:
+  constitution_amendment: GOV-AMD-014
+  contract: architecture/ASA-ARCH-006-Analytical-Execution-Contracts.md
+  boundary: analytical_only_no_brokerage_state_mutation
+
+tickets:
+  - ARCH-006
+  - EXEC-001
+  - EXEC-002
+  - EXEC-003
+  - EXEC-004
+  - EXEC-005
+  - EXEC-006
+  - EXEC-007
+  - EXEC-008
+  - EXEC-009
+
+merged_pull_requests:
+  - number: 104
+    purpose: analytical_execution_constitution
+  - number: 105
+    purpose: analytical_execution_contracts
+  - number: 106
+    purpose: atomic_EXEC_001_through_EXEC_006_activation
+  - number: 107
+    purpose: analytical_simulation
+  - number: 108
+    purpose: replay_integration
+
+invariants:
+  - Strategy_owns_investment_intent_only
+  - Portfolio_Engine_owns_portfolio_calculation_and_transition
+  - Risk_Engine_evaluates_only_declared_policies
+  - Execution_Planning_produces_inert_PlannedOrders
+  - Simulation_consumes_only_explicit_market_frames
+  - replay_uses_complete_semantic_inputs
+  - no_broker_provider_network_persistence_or_credentials
+
+completion:
+  report: project/reports/SPRINT-004.md
+  founder_verification_required: true
+  next_sprint_blocked_until_founder_verification: true

--- a/project/lean/state/project-state.yaml
+++ b/project/lean/state/project-state.yaml
@@ -10,13 +10,18 @@ constraints:
   - governance_conflicts_are_reported_not_silently_resolved
   - founder_merge_or_other_required_authority_merge_implies_acceptance
   - total_token_cost_is_an_architectural_constraint
+  - asa_core_cannot_authenticate_with_or_mutate_a_broker
+  - analytical_execution_must_be_deterministic_and_replayable
 refs:
   - governance/frozen/**
   - roles/shared/AUTHORITY_BOUNDARIES.md
   - roles/shared/RISK_SCALED_PROCESS.md
   - project/lean/migration/FINAL_REPORT.md
+  - architecture/CONSTITUTION.md
+  - architecture/ASA-ARCH-006-Analytical-Execution-Contracts.md
 notes: >
   project=ASA-II repository=jaiaFoster/ASA
   migration_status=complete completed_phase=CUTOVER-06 active_operating_system=Lean_POS
-  sprint=SPRINT-003 sprint_status=complete next_action=Founder_verification
-updated_at: "2026-07-21T21:07:16Z"
+  sprint=SPRINT-004 sprint_status=complete phase=Phase-II milestone=Analytical_Platform
+  merged_through=EXEC-009 completion_ticket=EXEC-009 next_action=Founder_verification
+updated_at: "2026-07-22T00:16:36Z"

--- a/project/reports/SPRINT-004.md
+++ b/project/reports/SPRINT-004.md
@@ -1,0 +1,112 @@
+# SPRINT-004 Final Report — Analytical Execution Platform
+
+**Status:** Complete — pending Founder verification
+**Completed:** 2026-07-22
+**Final technical merge before completion:** `340ca9991c3be1805c287e1e5fff2950cfe0f694`
+
+## Sprint summary
+
+SPRINT-004 extends ASA from deterministic Strategy output through a complete analytical execution
+path: snapshot-independent Proposed Position, Portfolio-owned sizing, declared Risk evaluation,
+immutable Planned Orders, explicit-frame simulation, Portfolio-owned fill application, and exact
+replay verification. The system produces analytical intent and simulated state only. No Core path
+can authenticate with a broker, submit/modify/cancel an order, perform network I/O, persist
+execution state, or mutate a brokerage account.
+
+## Completed work
+
+| Work | PR | Merge commit | Result |
+|---|---:|---|---|
+| GOV-AMD-014 | [#104](https://github.com/jaiaFoster/ASA/pull/104) | `7c10940` | Constitutional analytical-execution boundary |
+| ARCH-006 | [#105](https://github.com/jaiaFoster/ASA/pull/105) | `37f02cf` | Public analytical execution contracts frozen |
+| EXEC-001–006 | [#106](https://github.com/jaiaFoster/ASA/pull/106) | `861d875` | Atomic contract and engine activation |
+| EXEC-007 | [#107](https://github.com/jaiaFoster/ASA/pull/107) | `1185787` | Deterministic analytical Simulation Engine |
+| EXEC-008 | [#108](https://github.com/jaiaFoster/ASA/pull/108) | `340ca99` | Canonical replay and complete lifecycle |
+| EXEC-009 | [#109](https://github.com/jaiaFoster/ASA/pull/109) | assigned on merge | Integrated validation, status, and report |
+
+Architecture and the atomic public-contract cohort were Founder merged. EXEC-007 and EXEC-008
+were self-merged only after local validation, self-review, and GitHub Architecture Validation
+passed under the explicit bounded SPRINT-004 continuation delegation.
+
+## Public contracts and ownership
+
+- `Position`, `Portfolio`, `PortfolioSnapshot`, and `InstrumentValuation` are immutable,
+  single-account USD v1 analytical state.
+- `PortfolioEvaluationResult` explicitly distinguishes `DELTA_PRODUCED` from identified,
+  evidenced `NO_CHANGE`.
+- `PortfolioDelta` separates proposed, approved, and simulated change without mutation.
+- `RiskPolicy`, `PolicyOutcome`, and `RiskDecision` preserve complete policy parameters,
+  comparison evidence, and deterministic APPROVE/REDUCE/REJECT outcomes.
+- `PlannedOrder`, `ExecutionSummary`, `PlanningTrace`, `ExecutionPlan`, and
+  `ExecutionPlanningLifecycle` are inert analytical artifacts with acyclic identities.
+- Simulation contracts model explicit frames, shared liquidity, fills, terminal order state,
+  trace, and result without broker vocabulary or side effects.
+- Replay records bind the complete Plan and Market Data inputs to exact Simulation Result,
+  simulated Delta, next Snapshot, and completed lifecycle outputs.
+
+The old production names `Holding`, combined `PortfolioDecision`, `ExecutionContext`, and
+`BrokerRequest` were removed atomically. There is no alias, compatibility shim, dual read, dual
+write, repository, adapter, or alternate execution path.
+
+## Determinism, replay, and provenance
+
+Portfolio sizing uses source Snapshot net liquidation value, explicit Instrument Valuation,
+floor-to-increment quantities, Decimal precision 34, and banker rounding. Maximum-loss sign is
+normalized from the upstream non-positive USD convention. Risk reduction evaluates a finite
+descending quantity lattice and selects the greatest passing candidate. Planned Orders use stable
+sequence and content identities.
+
+Simulation consumes only supplied immutable frames. MARKET/LIMIT/STOP/STOP_LIMIT and
+DAY/GTC/IOC/FOK behavior is closed and tested. Frame liquidity is shared once across orders in
+Plan sequence. Portfolio Engine applies simulated fills, maintains cost basis and cumulative
+realized P&L, and produces a new revision without mutating the Plan or source Snapshot.
+
+Canonical replay serializes every dataclass field, enum, Decimal, semantic datetime, tuple, and
+Evidence reference. Re-execution reproduces the exact result, Delta, Snapshot, lifecycle, and
+digests. Tampered output identity fails closed.
+
+## Validation results
+
+Final EXEC-009 validation on technical `main` at `340ca99` plus the completion patch:
+
+| Gate | Result |
+|---|---|
+| Complete repository suite | **1,722 passed, 1 established conditional POS skip** |
+| Integrated analytical path | **Passed twice with identical outputs** |
+| Replay verification | **Passed; tamper regression fails closed** |
+| Architecture/import boundaries | **Passed** |
+| Constitutional non-reachability | **Passed** |
+| Provenance and immutable contract checks | **Passed** |
+| Strict MyPy on analytical source | **39 files passed** |
+| Ruff on complete sprint source/tests | **Passed** |
+| Lean entrypoint and governance integrity | **Passed** |
+| Lean pre-push | **All 5 checks passed** |
+| `git diff --check` | **Passed** |
+
+The single skip is the established POS test for preserving legacy `project/generated/` mtimes;
+that archived directory is absent in this environment. Repository-wide historical Ruff/MyPy
+baseline outside the analytical scope remains tracked by Issue #77 and is unchanged.
+
+## Complexity and change summary
+
+The implementation replaces one underspecified combined path with five bounded packages:
+Position Proposal, Portfolio, Risk, Execution Planning, and Simulation. New abstractions directly
+correspond to frozen ARCH-006 contracts. The atomic EXEC-001–006 cohort reduced total code by
+removing legacy policy/registry and compatibility-shaped tests; simulation and replay add only
+pure in-memory deterministic behavior. No API, database schema, deployment, queue, provider,
+broker adapter, credential, or external service was added.
+
+## Risks and follow-on work
+
+Simulation v1 is intentionally analytical, not a market-microstructure or performance model. It
+uses explicit finite liquidity, zero fees, and no slippage, latency, or queue model. USD-only and
+single-account semantics are deliberate v1 limits. Any multi-currency design, persistence,
+external execution subsystem, or live brokerage operation requires separate architecture and,
+for operational execution, a constitutional amendment plus Founder authorization.
+
+## Final disposition
+
+SPRINT-004 is complete. The default branch contains the frozen architecture, atomic contract
+migration, deterministic Simulation Engine, canonical replay integration, and complete validation
+evidence. The bounded sprint delegation expires with completion. Founder verification is required
+before another sprint begins.

--- a/tests/architecture/test_analytical_execution_validation.py
+++ b/tests/architecture/test_analytical_execution_validation.py
@@ -1,0 +1,41 @@
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+PACKAGES = ("position_proposals", "portfolio", "risk", "execution_planning", "simulation")
+
+
+def test_analytical_execution_source_has_no_live_capability() -> None:
+    source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for package in PACKAGES
+        for path in (ROOT / package).glob("*.py")
+    ).lower()
+    for prohibited in (
+        "submit_order", "cancel_order", "modify_order", "place_order",
+        "broker_auth", "robin_stocks", "requests.", "httpx.", "sqlalchemy",
+    ):
+        assert prohibited not in source
+
+
+def test_cross_package_import_matrix_matches_arch_006() -> None:
+    allowed = {
+        "position_proposals": {"domain", "position_proposals", "ranking"},
+        "portfolio": {"domain", "portfolio"},
+        "risk": {"domain", "risk"},
+        "execution_planning": {"domain", "execution_planning"},
+        "simulation": {"domain", "portfolio", "simulation"},
+    }
+    standard = {
+        "__future__", "collections", "dataclasses", "datetime", "decimal", "enum", "hashlib",
+    }
+    for package in PACKAGES:
+        for path in (ROOT / package).glob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            roots: set[str] = set()
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    roots.update(alias.name.split(".")[0] for alias in node.names)
+                elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                    roots.add(node.module.split(".")[0])
+            assert roots <= allowed[package] | standard, (path, roots - allowed[package] - standard)

--- a/tests/simulation/test_analytical_execution_validation.py
+++ b/tests/simulation/test_analytical_execution_validation.py
@@ -1,0 +1,65 @@
+"""EXEC-009 complete analytical execution validation."""
+
+from execution_planning.engine import build_planning_lifecycle, plan_execution
+from portfolio.engine import apply_simulation, evaluate_portfolio, reduction_candidates
+from risk.engine import evaluate_risk
+from simulation.engine import simulate
+from simulation.lifecycle import complete_lifecycle
+from simulation.replay import record_replay, verify_replay
+from tests.portfolio.helpers import request
+from tests.simulation.test_engine import market_data
+
+
+def _run_path():  # type: ignore[no-untyped-def]
+    evaluation_request = request()
+    result = evaluate_portfolio(evaluation_request)[0]
+    risk = evaluate_risk(
+        result,
+        evaluation_request.portfolio_snapshot,
+        evaluation_request.proposed_positions[0].strategy_risk_policies,
+        reduction_candidates(result, evaluation_request.portfolio_snapshot),
+    )
+    plan = plan_execution(risk, evaluation_request.portfolio_snapshot)
+    data = market_data()
+    simulation = simulate(plan, data)
+    delta, snapshot = apply_simulation(plan, simulation, data)
+    lifecycle = complete_lifecycle(
+        build_planning_lifecycle(risk, plan), simulation, delta, snapshot
+    )
+    replay = record_replay(plan, data, simulation, delta, snapshot, lifecycle)
+    return result, risk, plan, simulation, delta, snapshot, lifecycle, replay
+
+
+def test_complete_path_is_deterministic_and_replay_verified() -> None:
+    first = _run_path()
+    second = _run_path()
+    assert first == second
+    assert verify_replay(first[-1]).verified
+
+
+def test_complete_path_has_identity_and_provenance_at_every_boundary() -> None:
+    result, risk, plan, simulation, delta, snapshot, lifecycle, replay = _run_path()
+    identified = (
+        result.portfolio_evaluation_result_id,
+        risk.risk_decision_id,
+        plan.execution_plan_id,
+        simulation.simulation_result_id,
+        delta.portfolio_delta_id,
+        snapshot.portfolio_snapshot_id,
+        lifecycle.execution_planning_lifecycle_id,
+        replay.execution_replay_id,
+    )
+    assert all(identified)
+    assert all(
+        value.evidence
+        for value in (result, risk, plan, simulation, delta, snapshot, lifecycle, replay)
+    )
+
+
+def test_simulation_never_mutates_plan_or_source_snapshot() -> None:
+    _, _, plan, _, _, _, _, _ = _run_path()
+    before = (plan, plan.source_snapshot)
+    data = market_data()
+    simulation = simulate(plan, data)
+    apply_simulation(plan, simulation, data)
+    assert (plan, plan.source_snapshot) == before


### PR DESCRIPTION
## Summary

- adds integrated analytical execution, provenance, immutability, and replay validation
- records SPRINT-004 completion and updates canonical Lean POS state
- preserves the constitutional no-brokerage-mutation boundary

## Validation

- 1,722 passed, 1 established conditional POS skip
- strict MyPy: 39 analytical source files
- Ruff: complete changed scope
- Lean entrypoint, integrity, validator, and pre-push checks passed
- git diff --check passed

## Scope

No broker integration, network execution, persistence, API, schema, deployment, credential, or frozen-governance change.

Delegated SPRINT-004 merge authority applies after all required checks pass.