### PR TITLE
MD-002: add provider configuration boundary

### DIFF
--- a/market_data/__init__.py
+++ b/market_data/__init__.py
@@ -1,0 +1,27 @@
+"""Market Data Platform application services."""
+
+from market_data.config import (
+    ConfigurationError,
+    MarketDataConfig,
+    ProviderConfig,
+    ProviderEndpointEnvironment,
+    RequestBudgetConfig,
+    RetryConfig,
+    SecretValue,
+    ValidationBudgetConfig,
+    load_market_data_config,
+    load_market_data_config_from_environment,
+)
+
+__all__ = [
+    "ConfigurationError",
+    "MarketDataConfig",
+    "ProviderConfig",
+    "ProviderEndpointEnvironment",
+    "RequestBudgetConfig",
+    "RetryConfig",
+    "SecretValue",
+    "ValidationBudgetConfig",
+    "load_market_data_config",
+    "load_market_data_config_from_environment",
+]

--- a/market_data/config.py
+++ b/market_data/config.py
@@ -1,0 +1,301 @@
+"""Centralized, secret-safe Market Data provider configuration (MD-002)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ConfigurationError(ValueError):
+    """Safe actionable configuration failure that never reproduces input values."""
+
+
+class ProviderEndpointEnvironment(str, Enum):
+    SANDBOX = "sandbox"
+    PRODUCTION = "production"
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class SecretValue:
+    """In-memory secret wrapper whose display representations are always redacted."""
+
+    _value: str
+
+    def __post_init__(self) -> None:
+        if not self._value or self._value != self._value.strip():
+            raise ConfigurationError("Provider credential must be non-empty normalized text")
+
+    def __repr__(self) -> str:
+        return "SecretValue('[REDACTED]')"
+
+    def __str__(self) -> str:
+        return "[REDACTED]"
+
+    def reveal(self) -> str:
+        """Return the value only to an explicitly constructed adapter dependency."""
+        return self._value
+
+
+@dataclass(frozen=True, slots=True)
+class RequestBudgetConfig:
+    max_requests_per_run: int = 100
+    burst_limit: int = 1
+
+    def __post_init__(self) -> None:
+        _positive(self.max_requests_per_run, "max_requests_per_run")
+        _positive(self.burst_limit, "burst_limit")
+        if self.burst_limit > self.max_requests_per_run:
+            raise ConfigurationError("Provider burst limit cannot exceed request budget")
+
+
+@dataclass(frozen=True, slots=True)
+class RetryConfig:
+    max_retries: int = 1
+    backoff_seconds: tuple[int, ...] = (1,)
+
+    def __post_init__(self) -> None:
+        if type(self.max_retries) is not int or self.max_retries < 0:
+            raise ConfigurationError("Provider retry count must be a non-negative integer")
+        if len(self.backoff_seconds) != self.max_retries:
+            raise ConfigurationError("Provider backoff schedule must match retry count")
+        if any(type(value) is not int or value < 0 for value in self.backoff_seconds):
+            raise ConfigurationError("Provider backoff values must be non-negative integers")
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationBudgetConfig:
+    max_requests_per_provider_run: int = 12
+    max_requests_per_capability_check: int = 3
+    max_retries_per_request: int = 1
+    timeout_seconds: int = 10
+    concurrency_per_provider: int = 1
+
+    def __post_init__(self) -> None:
+        for name in (
+            "max_requests_per_provider_run",
+            "max_requests_per_capability_check",
+            "timeout_seconds",
+            "concurrency_per_provider",
+        ):
+            _positive(getattr(self, name), name)
+        if type(self.max_retries_per_request) is not int or self.max_retries_per_request < 0:
+            raise ConfigurationError("Validation retry count must be a non-negative integer")
+        if self.max_requests_per_capability_check > self.max_requests_per_provider_run:
+            raise ConfigurationError("Capability validation budget cannot exceed provider budget")
+        if self.max_requests_per_provider_run > 12:
+            raise ConfigurationError("Validation request budget exceeds the authorized safety ceiling")
+        if self.max_requests_per_capability_check > 3:
+            raise ConfigurationError("Capability request budget exceeds the authorized safety ceiling")
+        if self.max_retries_per_request > 1:
+            raise ConfigurationError("Validation retry budget exceeds the authorized safety ceiling")
+        if self.timeout_seconds > 10:
+            raise ConfigurationError("Validation timeout exceeds the authorized safety ceiling")
+        if self.concurrency_per_provider != 1:
+            raise ConfigurationError("Validation provider concurrency must equal one")
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderConfig:
+    provider_id: str
+    adapter_type: str
+    adapter_version: str
+    enabled: bool
+    endpoint_environment: ProviderEndpointEnvironment
+    credential: SecretValue | None
+    timeout_seconds: int
+    request_budget: RequestBudgetConfig
+    retry: RetryConfig
+    validation_budget: ValidationBudgetConfig
+
+    def __post_init__(self) -> None:
+        for name in ("provider_id", "adapter_type", "adapter_version"):
+            value = getattr(self, name)
+            if not value or value != value.strip():
+                raise ConfigurationError(f"Provider {name} must be non-empty normalized text")
+        if type(self.enabled) is not bool:
+            raise ConfigurationError("Provider enabled flag must be boolean")
+        _positive(self.timeout_seconds, "timeout_seconds")
+        if self.timeout_seconds > 60:
+            raise ConfigurationError("Provider timeout exceeds the configured safety ceiling")
+        if self.enabled and self.provider_id != "deterministic_fixture" and self.credential is None:
+            raise ConfigurationError(
+                f"Enabled provider {self.provider_id!r} requires its configured credential"
+            )
+
+    @property
+    def safe_identity(self) -> str:
+        payload = {
+            "adapter_type": self.adapter_type,
+            "adapter_version": self.adapter_version,
+            "enabled": self.enabled,
+            "endpoint_environment": self.endpoint_environment.value,
+            "provider_id": self.provider_id,
+            "request_budget": {
+                "burst_limit": self.request_budget.burst_limit,
+                "max_requests_per_run": self.request_budget.max_requests_per_run,
+            },
+            "retry": {
+                "backoff_seconds": self.retry.backoff_seconds,
+                "max_retries": self.retry.max_retries,
+            },
+            "timeout_seconds": self.timeout_seconds,
+            "validation_budget": {
+                "concurrency_per_provider": self.validation_budget.concurrency_per_provider,
+                "max_requests_per_capability_check": (
+                    self.validation_budget.max_requests_per_capability_check
+                ),
+                "max_requests_per_provider_run": (
+                    self.validation_budget.max_requests_per_provider_run
+                ),
+                "max_retries_per_request": self.validation_budget.max_retries_per_request,
+                "timeout_seconds": self.validation_budget.timeout_seconds,
+            },
+            "credential_reference": f"{self.provider_id}:configured"
+            if self.credential is not None
+            else None,
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class MarketDataConfig:
+    providers: tuple[ProviderConfig, ...]
+    compatibility_diagnostics: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        providers = tuple(sorted(self.providers, key=lambda value: value.provider_id))
+        ids = tuple(value.provider_id for value in providers)
+        if len(ids) != len(set(ids)):
+            raise ConfigurationError("Market Data providers must have unique identities")
+        object.__setattr__(self, "providers", providers)
+        object.__setattr__(
+            self, "compatibility_diagnostics", tuple(sorted(set(self.compatibility_diagnostics)))
+        )
+
+    @property
+    def safe_identity(self) -> str:
+        encoded = json.dumps(
+            [value.safe_identity for value in self.providers],
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        return hashlib.sha256(encoded).hexdigest()
+
+
+def _positive(value: object, field_name: str) -> None:
+    if type(value) is not int or cast_int(value) <= 0:
+        raise ConfigurationError(f"Provider {field_name} must be a positive integer")
+
+
+def cast_int(value: object) -> int:
+    return value if type(value) is int else 0
+
+
+def _integer(values: Mapping[str, str], name: str, default: int) -> int:
+    raw = values.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ConfigurationError(f"Provider configuration {name} must be an integer") from exc
+
+
+def _boolean(values: Mapping[str, str], name: str, default: bool) -> bool:
+    raw = values.get(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ConfigurationError(f"Provider configuration {name} must be boolean")
+
+
+def _credential(
+    values: Mapping[str, str],
+    preferred: str,
+    alias: str,
+    diagnostics: list[str],
+) -> SecretValue | None:
+    preferred_value = values.get(preferred)
+    alias_value = values.get(alias)
+    if preferred_value is not None:
+        return SecretValue(preferred_value.strip())
+    if alias_value is not None:
+        diagnostics.append(f"{alias} is deprecated; use {preferred}")
+        return SecretValue(alias_value.strip())
+    return None
+
+
+def _provider(
+    values: Mapping[str, str],
+    provider_id: str,
+    credential: SecretValue | None,
+    *,
+    default_enabled: bool = False,
+    endpoint_environment: ProviderEndpointEnvironment = ProviderEndpointEnvironment.PRODUCTION,
+) -> ProviderConfig:
+    prefix = f"ASA_{provider_id.upper()}"
+    enabled = _boolean(values, f"{prefix}_ENABLED", default_enabled)
+    timeout = _integer(values, f"{prefix}_TIMEOUT_SECONDS", 10)
+    requests = _integer(values, f"{prefix}_MAX_REQUESTS_PER_RUN", 100)
+    burst = _integer(values, f"{prefix}_BURST_LIMIT", 1)
+    retries = _integer(values, f"{prefix}_MAX_RETRIES", 1)
+    return ProviderConfig(
+        provider_id,
+        provider_id,
+        "v1",
+        enabled,
+        endpoint_environment,
+        credential,
+        timeout,
+        RequestBudgetConfig(requests, burst),
+        RetryConfig(retries, tuple(range(1, retries + 1))),
+        ValidationBudgetConfig(),
+    )
+
+
+def load_market_data_config(values: Mapping[str, str]) -> MarketDataConfig:
+    """Build complete immutable configuration from one explicit environment mapping."""
+    diagnostics: list[str] = []
+    tradier = _credential(
+        values, "ASA_TRADIER_ACCESS_TOKEN", "TRADIER_ACCESS_TOKEN", diagnostics
+    )
+    finnhub = _credential(values, "ASA_FINNHUB_API_KEY", "FINNHUB_API_KEY", diagnostics)
+    alpha = _credential(
+        values, "ASA_ALPHA_VANTAGE_API_KEY", "ALPHA_VANTAGE_API_KEY", diagnostics
+    )
+    raw_tradier_environment = values.get("ASA_TRADIER_ENV", "sandbox").strip().lower()
+    try:
+        tradier_environment = ProviderEndpointEnvironment(raw_tradier_environment)
+    except ValueError as exc:
+        raise ConfigurationError(
+            "Provider configuration ASA_TRADIER_ENV must be sandbox or production"
+        ) from exc
+    return MarketDataConfig(
+        (
+            _provider(
+                values,
+                "deterministic_fixture",
+                None,
+                default_enabled=True,
+                endpoint_environment=ProviderEndpointEnvironment.SANDBOX,
+            ),
+            _provider(values, "tradier", tradier, endpoint_environment=tradier_environment),
+            _provider(values, "finnhub", finnhub),
+            _provider(values, "alpha_vantage", alpha),
+        ),
+        tuple(diagnostics),
+    )
+
+
+def load_market_data_config_from_environment() -> MarketDataConfig:
+    """The sole Market Data environment boundary; providers never read environment state."""
+    return load_market_data_config(os.environ)

--- a/tests/architecture/test_market_data_config_boundary.py
+++ b/tests/architecture/test_market_data_config_boundary.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_only_market_data_config_reads_environment() -> None:
+    config = (ROOT / "market_data" / "config.py").read_text()
+    assert "os.environ" in config
+    for path in (ROOT / "providers").rglob("*.py"):
+        source = path.read_text()
+        assert "os.getenv" not in source
+        assert "os.environ" not in source
+
+
+def test_market_data_config_contains_no_provider_sdk_imports() -> None:
+    source = (ROOT / "market_data" / "config.py").read_text()
+    for name in ("tradier", "finnhub", "alpha_vantage", "requests", "httpx"):
+        assert f"import {name}" not in source

--- a/tests/market_data/test_config.py
+++ b/tests/market_data/test_config.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from market_data.config import (
+    ConfigurationError,
+    ProviderEndpointEnvironment,
+    SecretValue,
+    load_market_data_config,
+)
+
+
+def by_id(config: object, provider_id: str) -> object:
+    return next(value for value in config.providers if value.provider_id == provider_id)  # type: ignore[attr-defined]
+
+
+def test_offline_configuration_requires_no_live_credentials() -> None:
+    config = load_market_data_config({})
+    fixture = by_id(config, "deterministic_fixture")
+    assert fixture.enabled  # type: ignore[attr-defined]
+    assert all(
+        not value.enabled
+        for value in config.providers
+        if value.provider_id != "deterministic_fixture"
+    )
+
+
+def test_enabled_provider_requires_credential_before_network() -> None:
+    with pytest.raises(ConfigurationError, match="requires its configured credential"):
+        load_market_data_config({"ASA_FINNHUB_ENABLED": "true"})
+
+
+def test_valid_configuration_is_immutable_and_explicit() -> None:
+    config = load_market_data_config(
+        {
+            "ASA_TRADIER_ENABLED": "true",
+            "ASA_TRADIER_ACCESS_TOKEN": "tradier-secret",
+            "ASA_TRADIER_ENV": "sandbox",
+            "ASA_FINNHUB_ENABLED": "true",
+            "ASA_FINNHUB_API_KEY": "finnhub-secret",
+        }
+    )
+    tradier = by_id(config, "tradier")
+    assert tradier.endpoint_environment is ProviderEndpointEnvironment.SANDBOX  # type: ignore[attr-defined]
+    assert tradier.credential.reveal() == "tradier-secret"  # type: ignore[attr-defined]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        tradier.enabled = False  # type: ignore[attr-defined,misc]
+
+
+def test_secrets_never_enter_repr_str_or_safe_hash() -> None:
+    secret = SecretValue("top-secret-value")
+    config = load_market_data_config(
+        {"ASA_FINNHUB_ENABLED": "true", "ASA_FINNHUB_API_KEY": secret.reveal()}
+    )
+    rendered = f"{config!r} {secret!r} {secret!s} {config.safe_identity}"
+    assert "top-secret-value" not in rendered
+    assert "[REDACTED]" in rendered
+
+
+def test_compatibility_alias_is_centralized_and_secret_free() -> None:
+    config = load_market_data_config(
+        {"ASA_FINNHUB_ENABLED": "true", "FINNHUB_API_KEY": "legacy-secret"}
+    )
+    assert config.compatibility_diagnostics == (
+        "FINNHUB_API_KEY is deprecated; use ASA_FINNHUB_API_KEY",
+    )
+    assert "legacy-secret" not in repr(config)
+
+
+@pytest.mark.parametrize(
+    ("values", "message"),
+    [
+        ({"ASA_TRADIER_ENV": "invalid"}, "sandbox or production"),
+        ({"ASA_FINNHUB_ENABLED": "maybe"}, "must be boolean"),
+        ({"ASA_FINNHUB_TIMEOUT_SECONDS": "slow"}, "must be an integer"),
+        ({"ASA_FINNHUB_TIMEOUT_SECONDS": "0"}, "positive integer"),
+        ({"ASA_FINNHUB_MAX_REQUESTS_PER_RUN": "0"}, "positive integer"),
+        (
+            {"ASA_FINNHUB_MAX_REQUESTS_PER_RUN": "1", "ASA_FINNHUB_BURST_LIMIT": "2"},
+            "cannot exceed request budget",
+        ),
+    ],
+)
+def test_malformed_configuration_fails_actionably(
+    values: dict[str, str], message: str
+) -> None:
+    with pytest.raises(ConfigurationError, match=message):
+        load_market_data_config(values)


### PR DESCRIPTION
## Ticket

MD-002 — Provider Configuration and Secret Boundary

## Summary

- adds immutable provider, request-budget, retry, and validation-budget configuration
- centralizes environment loading and compatibility aliases
- fails enabled live providers before network when credentials are absent
- redacts secrets from repr, diagnostics, and configuration identities

## Frozen architecture compliance

Providers receive injected configuration only; no provider reads environment state.

## Security and secret handling

Secret values are wrapped, display-redacted, excluded from hashes, and absent from diagnostics.

## Network behavior

No network behavior is introduced.

## Request budget behavior

Configuration validates bounded request/retry/validation budgets; enforcement remains MD-006.

## Tests

- full repository: 1,758 passed, 1 established conditional POS skip
- focused MD-002: 13 passed
- strict MyPy: passed
- Ruff: passed
- Lean integrity and pre-push: passed

## Live validation status

Not applicable; no provider implementation.

## Explicit exclusions

No adapters, factory, registry, persistence, Strategy, Execution, or live calls.

## Auto-merge authority

Founder-authorized SPRINT-005B delegated implementation merge.
