### PR TITLE
MD-004: add deterministic provider factory

### DIFF
--- a/market_data/__init__.py
+++ b/market_data/__init__.py
@@ -34,6 +34,14 @@ from market_data.providers import (
     ValidationCheckStatus,
     normalized_provider_error,
 )
+from market_data.factory import (
+    BudgetAuthorizer,
+    Clock,
+    ProviderDependencies,
+    ProviderFactory,
+    ProviderFactoryError,
+    ProviderRegistration,
+)
 
 __all__ = [
     "ConfigurationError",
@@ -66,4 +74,10 @@ __all__ = [
     "ValidationCheckResult",
     "ValidationCheckStatus",
     "normalized_provider_error",
+    "BudgetAuthorizer",
+    "Clock",
+    "ProviderDependencies",
+    "ProviderFactory",
+    "ProviderFactoryError",
+    "ProviderRegistration",
 ]

--- a/market_data/factory.py
+++ b/market_data/factory.py
@@ -1,0 +1,113 @@
+"""Deterministic dependency-injected Provider construction (MD-004)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Protocol, runtime_checkable
+
+from domain import MarketCapability
+from market_data.config import ConfigurationError, MarketDataConfig, ProviderConfig
+from market_data.providers import MarketDataProvider, RequestBudgetAuthorization
+
+
+class ProviderFactoryError(ConfigurationError):
+    """Provider construction failed before any network operation."""
+
+
+@runtime_checkable
+class Clock(Protocol):
+    def now(self) -> datetime: ...
+
+
+@runtime_checkable
+class BudgetAuthorizer(Protocol):
+    def authorize(
+        self, provider_id: str, capability: MarketCapability, request_units: int
+    ) -> RequestBudgetAuthorization: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderDependencies:
+    transport: object
+    clock: Clock
+    budget_authorizer: BudgetAuthorizer
+
+
+ProviderConstructor = Callable[[ProviderConfig, ProviderDependencies], MarketDataProvider]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderRegistration:
+    adapter_type: str
+    adapter_version: str
+    constructor: ProviderConstructor
+
+    def __post_init__(self) -> None:
+        for name in ("adapter_type", "adapter_version"):
+            value = getattr(self, name)
+            if not value or value != value.strip():
+                raise ProviderFactoryError(f"Provider registration {name} must be normalized")
+        if not callable(self.constructor):
+            raise ProviderFactoryError("Provider registration constructor must be callable")
+
+
+class ProviderFactory:
+    """Closed construction registry assembled once by the composition root."""
+
+    __slots__ = ("_registrations",)
+
+    def __init__(self, registrations: tuple[ProviderRegistration, ...]) -> None:
+        ordered = tuple(
+            sorted(registrations, key=lambda value: (value.adapter_type, value.adapter_version))
+        )
+        keys = tuple((value.adapter_type, value.adapter_version) for value in ordered)
+        if not ordered:
+            raise ProviderFactoryError("ProviderFactory requires static registrations")
+        if len(keys) != len(set(keys)):
+            raise ProviderFactoryError("Duplicate ProviderFactory registration")
+        self._registrations = ordered
+
+    @property
+    def registrations(self) -> tuple[ProviderRegistration, ...]:
+        return self._registrations
+
+    def create(
+        self,
+        config: ProviderConfig,
+        dependencies: ProviderDependencies,
+    ) -> MarketDataProvider:
+        if not config.enabled:
+            raise ProviderFactoryError(f"Provider {config.provider_id!r} is disabled")
+        if config.provider_id != "deterministic_fixture" and config.credential is None:
+            raise ProviderFactoryError(
+                f"Provider {config.provider_id!r} requires configured credentials"
+            )
+        matches = tuple(
+            value
+            for value in self._registrations
+            if (value.adapter_type, value.adapter_version)
+            == (config.adapter_type, config.adapter_version)
+        )
+        if len(matches) != 1:
+            raise ProviderFactoryError(
+                f"No unique constructor for adapter {config.adapter_type!r} version "
+                f"{config.adapter_version!r}"
+            )
+        provider = matches[0].constructor(config, dependencies)
+        if not isinstance(provider, MarketDataProvider):
+            raise ProviderFactoryError("Provider constructor did not satisfy MarketDataProvider")
+        if provider.provider_id != config.provider_id:
+            raise ProviderFactoryError("Constructed Provider identity does not match configuration")
+        return provider
+
+    def create_enabled(
+        self,
+        config: MarketDataConfig,
+        dependencies: ProviderDependencies,
+    ) -> tuple[MarketDataProvider, ...]:
+        return tuple(
+            self.create(provider_config, dependencies)
+            for provider_config in config.providers
+            if provider_config.enabled
+        )

--- a/tests/architecture/test_market_data_factory_boundary.py
+++ b/tests/architecture/test_market_data_factory_boundary.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_factory_has_no_environment_or_network_construction() -> None:
+    source = (ROOT / "market_data" / "factory.py").read_text()
+    for token in ("os.environ", "os.getenv", "requests", "httpx", "socket"):
+        assert token not in source
+
+
+def test_factory_has_no_module_level_provider_instances() -> None:
+    source = (ROOT / "market_data" / "factory.py").read_text()
+    assert "ProviderFactory(" not in source
+    assert "MarketDataProvider()" not in source

--- a/tests/market_data/test_factory.py
+++ b/tests/market_data/test_factory.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+
+from domain import MarketCapability
+from market_data.config import ProviderConfig, load_market_data_config
+from market_data.factory import (
+    ProviderDependencies,
+    ProviderFactory,
+    ProviderFactoryError,
+    ProviderRegistration,
+)
+from market_data.providers import (
+    CapabilityRequest,
+    HealthProbe,
+    ProviderFetchResult,
+    ProviderHealthReport,
+    ProviderIdentity,
+    ProviderMetadata,
+    ProviderShutdownReport,
+    ProviderStatus,
+    ProviderValidationPlan,
+    ProviderValidationReport,
+    RequestBudgetAuthorization,
+)
+
+NOW = datetime(2026, 7, 21, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class FakeClock:
+    def now(self) -> datetime:
+        return NOW
+
+
+@dataclass(frozen=True)
+class FakeBudgetAuthorizer:
+    def authorize(
+        self, provider_id: str, capability: MarketCapability, request_units: int
+    ) -> RequestBudgetAuthorization:
+        return RequestBudgetAuthorization("authorization", provider_id, request_units, 1)
+
+
+class FakeProvider:
+    def __init__(self, config: ProviderConfig, dependencies: ProviderDependencies) -> None:
+        self.config = config
+        self.dependencies = dependencies
+        self._metadata = ProviderMetadata(
+            ProviderIdentity(config.provider_id, config.adapter_type, config.adapter_version),
+            (MarketCapability.REAL_TIME_QUOTE_V1,),
+            (),
+            (MarketCapability.REAL_TIME_QUOTE_V1,),
+            "v1",
+        )
+
+    @property
+    def provider_id(self) -> str:
+        return self.config.provider_id
+
+    @property
+    def metadata(self) -> ProviderMetadata:
+        return self._metadata
+
+    @property
+    def capabilities(self) -> tuple[MarketCapability, ...]:
+        return self.metadata.capabilities
+
+    def fetch(
+        self, request: CapabilityRequest, budget: RequestBudgetAuthorization
+    ) -> ProviderFetchResult:
+        raise NotImplementedError
+
+    def health(self, probe: HealthProbe) -> ProviderHealthReport:
+        return ProviderHealthReport(self.provider_id, ProviderStatus.AVAILABLE, NOW, "OK", None)
+
+    def validate(self, plan: ProviderValidationPlan) -> ProviderValidationReport:
+        raise NotImplementedError
+
+    def shutdown(self) -> ProviderShutdownReport:
+        return ProviderShutdownReport(self.provider_id, NOW)
+
+
+def dependencies() -> ProviderDependencies:
+    return ProviderDependencies(object(), FakeClock(), FakeBudgetAuthorizer())
+
+
+def registrations() -> tuple[ProviderRegistration, ...]:
+    return tuple(
+        ProviderRegistration(name, "v1", FakeProvider)
+        for name in ("deterministic_fixture", "tradier", "finnhub", "alpha_vantage")
+    )
+
+
+def test_factory_constructs_enabled_fixture_with_injected_dependencies() -> None:
+    factory = ProviderFactory(registrations())
+    config = load_market_data_config({})
+    providers = factory.create_enabled(config, dependencies())
+    assert tuple(value.provider_id for value in providers) == ("deterministic_fixture",)
+    fixture = providers[0]
+    assert isinstance(fixture, FakeProvider)
+    assert fixture.dependencies.transport is not None
+    assert fixture.dependencies.clock.now() == NOW
+
+
+@pytest.mark.parametrize("provider_id", ("tradier", "finnhub", "alpha_vantage"))
+def test_factory_can_construct_each_initial_live_provider(provider_id: str) -> None:
+    prefix = provider_id.upper()
+    values = {
+        f"ASA_{prefix}_ENABLED": "true",
+        {
+            "tradier": "ASA_TRADIER_ACCESS_TOKEN",
+            "finnhub": "ASA_FINNHUB_API_KEY",
+            "alpha_vantage": "ASA_ALPHA_VANTAGE_API_KEY",
+        }[provider_id]: "secret",
+    }
+    config = load_market_data_config(values)
+    provider_config = next(item for item in config.providers if item.provider_id == provider_id)
+    provider = ProviderFactory(registrations()).create(provider_config, dependencies())
+    assert provider.provider_id == provider_id
+
+
+def test_disabled_provider_is_not_constructed() -> None:
+    config = load_market_data_config({})
+    disabled = next(item for item in config.providers if item.provider_id == "finnhub")
+    with pytest.raises(ProviderFactoryError, match="disabled"):
+        ProviderFactory(registrations()).create(disabled, dependencies())
+
+
+def test_duplicate_and_unknown_registrations_fail_closed() -> None:
+    registration = ProviderRegistration("fixture", "v1", FakeProvider)
+    with pytest.raises(ProviderFactoryError, match="Duplicate"):
+        ProviderFactory((registration, registration))
+    config = next(
+        item for item in load_market_data_config({}).providers if item.provider_id == "deterministic_fixture"
+    )
+    with pytest.raises(ProviderFactoryError, match="No unique constructor"):
+        ProviderFactory((registration,)).create(config, dependencies())
+
+
+def test_factory_does_not_probe_or_fetch_during_construction() -> None:
+    config = load_market_data_config({})
+    first = ProviderFactory(registrations()).create_enabled(config, dependencies())
+    second = ProviderFactory(tuple(reversed(registrations()))).create_enabled(config, dependencies())
+    assert tuple(value.provider_id for value in first) == tuple(value.provider_id for value in second)


### PR DESCRIPTION
## Ticket

MD-004 — Provider Factory

## Summary

- adds closed static ProviderRegistration and deterministic ProviderFactory
- injects transport, clock, and budget-authorizer dependencies
- rejects disabled, unknown, duplicate, credential-missing, or identity-mismatched construction
- constructs no clients and performs no health probe or fetch

## Frozen architecture compliance

One explicit factory path; no globals, environment reads, discovery, or dynamic plugins.

## Security and network behavior

Credentials are validated before construction; no network code or hidden client construction.

## Request budget behavior

Budget authorizer is mandatory and injected; enforcement follows in MD-006.

## Tests

- full repository: 1,790 passed, 1 established conditional POS skip
- focused MD-004: 9 passed
- MyPy, Ruff, Lean integrity, and pre-push: passed

## Live validation status

Not applicable.

## Explicit exclusions

No real adapter, SDK, registry, live provider call, or persistence.

## Auto-merge authority

Founder-authorized SPRINT-005B delegated implementation merge.
