### PR TITLE
MD-005: add provider and capability registries

### DIFF
--- a/market_data/__init__.py
+++ b/market_data/__init__.py
@@ -42,6 +42,13 @@ from market_data.factory import (
     ProviderFactoryError,
     ProviderRegistration,
 )
+from market_data.registry import (
+    CapabilityRegistry,
+    ProviderCandidate,
+    ProviderPriority,
+    ProviderPriorityPolicy,
+    ProviderRegistry,
+)
 
 __all__ = [
     "ConfigurationError",
@@ -80,4 +87,9 @@ __all__ = [
     "ProviderFactory",
     "ProviderFactoryError",
     "ProviderRegistration",
+    "CapabilityRegistry",
+    "ProviderCandidate",
+    "ProviderPriority",
+    "ProviderPriorityPolicy",
+    "ProviderRegistry",
 ]

--- a/market_data/registry.py
+++ b/market_data/registry.py
@@ -1,0 +1,168 @@
+"""Closed Provider inventory and capability-driven discovery (MD-005)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from domain import MarketCapability
+from domain.values import DomainInvariantError
+from market_data.providers import (
+    HealthProbe,
+    MarketDataProvider,
+    ProviderHealthReport,
+    ProviderMetadata,
+    ProviderShutdownReport,
+    ProviderStatus,
+    ProviderValidationPlan,
+    ProviderValidationReport,
+)
+
+
+def _text(value: str, owner: str, field_name: str) -> None:
+    if not value or value != value.strip():
+        raise DomainInvariantError(f"{owner}.{field_name} must be normalized text")
+
+
+class ProviderRegistry:
+    """Immutable inventory closed before acquisition begins."""
+
+    __slots__ = ("_providers",)
+
+    def __init__(self, providers: tuple[MarketDataProvider, ...]) -> None:
+        ordered = tuple(sorted(providers, key=lambda value: value.provider_id))
+        ids = tuple(value.provider_id for value in ordered)
+        if not ordered:
+            raise DomainInvariantError("ProviderRegistry requires providers")
+        if len(ids) != len(set(ids)):
+            raise DomainInvariantError("ProviderRegistry provider IDs must be unique")
+        if any(value.provider_id != value.metadata.identity.provider_id for value in ordered):
+            raise DomainInvariantError("ProviderRegistry metadata identity mismatch")
+        self._providers = ordered
+
+    @property
+    def providers(self) -> tuple[MarketDataProvider, ...]:
+        return self._providers
+
+    def provider(self, provider_id: str) -> MarketDataProvider:
+        matches = tuple(value for value in self._providers if value.provider_id == provider_id)
+        if len(matches) != 1:
+            raise DomainInvariantError(f"Unknown Provider {provider_id!r}")
+        return matches[0]
+
+    def metadata(self) -> tuple[ProviderMetadata, ...]:
+        return tuple(value.metadata for value in self._providers)
+
+    def providers_for(self, capability: MarketCapability) -> tuple[MarketDataProvider, ...]:
+        return tuple(value for value in self._providers if capability in value.capabilities)
+
+    def health(self, probe: HealthProbe) -> tuple[ProviderHealthReport, ...]:
+        return tuple(value.health(probe) for value in self._providers)
+
+    def validate(
+        self, plans: tuple[ProviderValidationPlan, ...]
+    ) -> tuple[ProviderValidationReport, ...]:
+        ordered = tuple(sorted(plans, key=lambda value: value.provider_id))
+        if len({value.provider_id for value in ordered}) != len(ordered):
+            raise DomainInvariantError("Provider validation plans must be unique by provider")
+        return tuple(self.provider(plan.provider_id).validate(plan) for plan in ordered)
+
+    def shutdown(self) -> tuple[ProviderShutdownReport, ...]:
+        return tuple(value.shutdown() for value in self._providers)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderPriority:
+    capability: MarketCapability
+    provider_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.provider_ids:
+            raise DomainInvariantError("ProviderPriority requires provider IDs")
+        if any(not value or value != value.strip() for value in self.provider_ids):
+            raise DomainInvariantError("ProviderPriority IDs must be normalized")
+        if len(self.provider_ids) != len(set(self.provider_ids)):
+            raise DomainInvariantError("ProviderPriority IDs must be unique")
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderPriorityPolicy:
+    policy_version: str
+    priorities: tuple[ProviderPriority, ...]
+
+    def __post_init__(self) -> None:
+        _text(self.policy_version, "ProviderPriorityPolicy", "policy_version")
+        priorities = tuple(sorted(self.priorities, key=lambda value: value.capability.value))
+        capabilities = tuple(value.capability for value in priorities)
+        if not priorities or len(capabilities) != len(set(capabilities)):
+            raise DomainInvariantError("ProviderPriorityPolicy capabilities must be unique")
+        object.__setattr__(self, "priorities", priorities)
+
+    def for_capability(self, capability: MarketCapability) -> ProviderPriority:
+        matches = tuple(value for value in self.priorities if value.capability is capability)
+        if len(matches) != 1:
+            raise DomainInvariantError(f"No priority policy for {capability.value}")
+        return matches[0]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderCandidate:
+    provider_id: str
+    capability: MarketCapability
+    priority: int
+    status: ProviderStatus
+    status_detail_code: str
+
+    def __post_init__(self) -> None:
+        _text(self.provider_id, "ProviderCandidate", "provider_id")
+        _text(self.status_detail_code, "ProviderCandidate", "status_detail_code")
+        if type(self.priority) is not int or self.priority < 1:
+            raise DomainInvariantError("ProviderCandidate.priority must be positive")
+
+
+class CapabilityRegistry:
+    """Deterministic lookup from canonical capability to visible candidates."""
+
+    __slots__ = ("_providers", "_policy")
+
+    def __init__(
+        self, provider_registry: ProviderRegistry, priority_policy: ProviderPriorityPolicy
+    ) -> None:
+        registered = {value.provider_id for value in provider_registry.providers}
+        for priority in priority_policy.priorities:
+            unknown = set(priority.provider_ids) - registered
+            if unknown:
+                raise DomainInvariantError("Capability priority references unknown Provider")
+            declared = {
+                value.provider_id
+                for value in provider_registry.providers_for(priority.capability)
+            }
+            if not set(priority.provider_ids).issubset(declared):
+                raise DomainInvariantError("Capability priority contradicts Provider declarations")
+        self._providers = provider_registry
+        self._policy = priority_policy
+
+    @property
+    def policy(self) -> ProviderPriorityPolicy:
+        return self._policy
+
+    def lookup(
+        self,
+        capability: MarketCapability,
+        health_reports: tuple[ProviderHealthReport, ...] = (),
+    ) -> tuple[ProviderCandidate, ...]:
+        statuses = {value.provider_id: value for value in health_reports}
+        if len(statuses) != len(health_reports):
+            raise DomainInvariantError("Health reports must be unique by provider")
+        priority = self._policy.for_capability(capability)
+        return tuple(
+            ProviderCandidate(
+                provider_id,
+                capability,
+                index,
+                statuses[provider_id].status
+                if provider_id in statuses
+                else ProviderStatus.UNKNOWN,
+                statuses[provider_id].detail_code if provider_id in statuses else "NOT_CHECKED",
+            )
+            for index, provider_id in enumerate(priority.provider_ids, start=1)
+        )

--- a/tests/architecture/test_market_data_registry_boundary.py
+++ b/tests/architecture/test_market_data_registry_boundary.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_registry_is_provider_neutral_and_has_no_runtime_registration() -> None:
+    source = (ROOT / "market_data" / "registry.py").read_text()
+    for token in ("tradier", "finnhub", "alpha_vantage", "importlib", "entry_points"):
+        assert token not in source
+    assert "def register(" not in source
+
+
+def test_strategies_do_not_import_registries() -> None:
+    for path in (ROOT / "strategies").rglob("*.py"):
+        assert "market_data.registry" not in path.read_text()

--- a/tests/market_data/__init__.py
+++ b/tests/market_data/__init__.py
@@ -1,0 +1,1 @@
+"""Market Data Platform test package."""

--- a/tests/market_data/test_registry.py
+++ b/tests/market_data/test_registry.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from domain import MarketCapability
+from domain.values import DomainInvariantError
+from market_data.providers import (
+    CapabilityRequest,
+    HealthProbe,
+    ProviderFetchResult,
+    ProviderHealthReport,
+    ProviderIdentity,
+    ProviderMetadata,
+    ProviderShutdownReport,
+    ProviderStatus,
+    ProviderValidationPlan,
+    ProviderValidationReport,
+    RequestBudgetAuthorization,
+)
+from market_data.registry import (
+    CapabilityRegistry,
+    ProviderPriority,
+    ProviderPriorityPolicy,
+    ProviderRegistry,
+)
+
+NOW = datetime(2026, 7, 21, tzinfo=timezone.utc)
+
+
+class FakeProvider:
+    def __init__(self, provider_id: str, capabilities: tuple[MarketCapability, ...]) -> None:
+        self._provider_id = provider_id
+        self._metadata = ProviderMetadata(
+            ProviderIdentity(provider_id, provider_id, "v1"), capabilities, (), capabilities, "v1"
+        )
+
+    @property
+    def provider_id(self) -> str:
+        return self._provider_id
+
+    @property
+    def metadata(self) -> ProviderMetadata:
+        return self._metadata
+
+    @property
+    def capabilities(self) -> tuple[MarketCapability, ...]:
+        return self.metadata.capabilities
+
+    def fetch(
+        self, request: CapabilityRequest, budget: RequestBudgetAuthorization
+    ) -> ProviderFetchResult:
+        raise NotImplementedError
+
+    def health(self, probe: HealthProbe) -> ProviderHealthReport:
+        return ProviderHealthReport(self.provider_id, ProviderStatus.AVAILABLE, NOW, "OK", None)
+
+    def validate(self, plan: ProviderValidationPlan) -> ProviderValidationReport:
+        raise NotImplementedError
+
+    def shutdown(self) -> ProviderShutdownReport:
+        return ProviderShutdownReport(self.provider_id, NOW)
+
+
+def providers() -> ProviderRegistry:
+    quote = MarketCapability.REAL_TIME_QUOTE_V1
+    bars = MarketCapability.HISTORICAL_BARS_V1
+    return ProviderRegistry(
+        (
+            FakeProvider("finnhub", (quote, bars)),
+            FakeProvider("tradier", (quote, bars, MarketCapability.OPTION_CHAIN_V1)),
+            FakeProvider("alpha_vantage", (bars,)),
+        )
+    )
+
+
+def policy() -> ProviderPriorityPolicy:
+    return ProviderPriorityPolicy(
+        "v1",
+        (
+            ProviderPriority(MarketCapability.REAL_TIME_QUOTE_V1, ("tradier", "finnhub")),
+            ProviderPriority(
+                MarketCapability.HISTORICAL_BARS_V1,
+                ("tradier", "finnhub", "alpha_vantage"),
+            ),
+            ProviderPriority(MarketCapability.OPTION_CHAIN_V1, ("tradier",)),
+        ),
+    )
+
+
+def test_provider_inventory_is_canonical_and_closed() -> None:
+    registry = providers()
+    assert tuple(value.provider_id for value in registry.providers) == (
+        "alpha_vantage",
+        "finnhub",
+        "tradier",
+    )
+    with pytest.raises(AttributeError):
+        registry.register  # type: ignore[attr-defined]
+
+
+def test_capability_lookup_uses_configured_priority_not_registration_order() -> None:
+    registry = CapabilityRegistry(providers(), policy())
+    candidates = registry.lookup(MarketCapability.HISTORICAL_BARS_V1)
+    assert tuple(value.provider_id for value in candidates) == (
+        "tradier",
+        "finnhub",
+        "alpha_vantage",
+    )
+    assert tuple(value.priority for value in candidates) == (1, 2, 3)
+
+
+def test_unavailable_provider_remains_visible() -> None:
+    registry = CapabilityRegistry(providers(), policy())
+    reports = (
+        ProviderHealthReport("tradier", ProviderStatus.UNAVAILABLE, NOW, "OUTAGE", None),
+    )
+    candidates = registry.lookup(MarketCapability.REAL_TIME_QUOTE_V1, reports)
+    assert candidates[0].provider_id == "tradier"
+    assert candidates[0].status is ProviderStatus.UNAVAILABLE
+    assert candidates[1].status is ProviderStatus.UNKNOWN
+
+
+def test_duplicate_provider_and_unknown_priority_fail_closed() -> None:
+    fixture = FakeProvider("fixture", (MarketCapability.REAL_TIME_QUOTE_V1,))
+    with pytest.raises(DomainInvariantError, match="unique"):
+        ProviderRegistry((fixture, fixture))
+    bad = ProviderPriorityPolicy(
+        "v1", (ProviderPriority(MarketCapability.REAL_TIME_QUOTE_V1, ("missing",)),)
+    )
+    with pytest.raises(DomainInvariantError, match="unknown"):
+        CapabilityRegistry(providers(), bad)
+
+
+def test_missing_capability_policy_fails_explicitly() -> None:
+    registry = CapabilityRegistry(providers(), policy())
+    with pytest.raises(DomainInvariantError, match="No priority policy"):
+        registry.lookup(MarketCapability.EARNINGS_CALENDAR_V1)


### PR DESCRIPTION
## Ticket

MD-005 — Provider Registry and Capability Registry

## Summary

- adds immutable closed ProviderRegistry lifecycle inventory
- adds versioned capability priority policy and deterministic candidate lookup
- keeps unavailable and unchecked providers visible with explicit status metadata
- rejects duplicate providers, unknown priorities, and declaration conflicts

## Frozen architecture compliance

Strategies request canonical capabilities only; no provider names or SDKs enter Strategy code.

## Security and network behavior

Registry contains no credentials or network implementation. Health and validation are explicit calls.

## Request budget behavior

No request execution is implemented.

## Tests

- full repository: 1,797 passed, 1 established conditional POS skip
- focused MD-005: 7 passed
- MyPy, Ruff, Lean integrity, and pre-push: passed

## Live validation status

Not applicable.

## Explicit exclusions

No adapters, fallback execution, live calls, persistence, or dynamic registration.

## Auto-merge authority

Founder-authorized SPRINT-005B delegated implementation merge.
