### PR TITLE
ARCH-007B: define canonical Market Data subjects

### DIFF
--- a/architecture/ASA-ARCH-007-Market-Data-Platform.md
+++ b/architecture/ASA-ARCH-007-Market-Data-Platform.md
@@ -1,10 +1,10 @@
 # ASA-ARCH-007: Market Data Platform Contracts
 
-**Status:** Accepted by Founder merge of PR #110; ARCH-007A clarification proposed
+**Status:** Accepted by Founder merges of PRs #110 and #112; ARCH-007B clarification proposed
 **Date:** 2026-07-22
 **Sprint:** SPRINT-005A
 **Risk:** R3 architecture and public-contract change
-**Clarified by:** ARCH-007A (Issue #111; Founder merge required)
+**Clarified by:** ARCH-007A (Issue #111) and proposed ARCH-007B (Issue #119)
 
 ## 1. Decision and boundary
 
@@ -146,11 +146,99 @@ capabilities. Likewise, a Provider may describe additional source features in bo
 but those descriptions are not registry keys and are not visible to Strategies as capabilities.
 Adding a capability requires a separate Founder-approved architecture change.
 
-`CapabilityRequest` includes capability, canonical subjects, semantic time/window, required fields,
-and freshness/completeness requirements. It never includes a provider name. The immutable registry
+`CapabilityRequest` includes capability, canonical Market Data Subjects, semantic time/window,
+required fields, and freshness/completeness requirements. It never selects a provider. The immutable registry
 maps capabilities to eligible registered provider IDs and declared constraints. Lookup returns a
 canonically ordered candidate tuple; it does not contact providers or choose using hidden health.
 Selection uses explicit versioned policy outside Strategy code.
+
+### 7.1 MarketDataSubject
+
+Every request subject is an immutable, canonically serializable `MarketDataSubject`:
+
+```text
+MarketDataSubject
+  canonical_instrument       complete provider-neutral Instrument
+  subject_type               closed v1 subject classification
+  requested_capability       one canonical MarketCapability
+  request_context            complete MarketDataRequestContext
+
+MarketDataRequestContext
+  semantic_start
+  semantic_end
+  required_fields
+  provider_address_projections
+  evidence
+```
+
+V1 implemented subject types are `INSTRUMENT`, `OPTION_UNDERLYING`, and `EARNINGS_SECURITY`.
+Every subject carries the complete canonical `Instrument`. Trading-calendar subject semantics stay
+deferred with trading-calendar implementation; no synthetic venue Instrument or new Instrument kind
+is invented by this amendment. Required fields use the ARCH-007A projection rules. The subject's
+requested capability must equal its enclosing `CapabilityRequest.capability`. Strategy code may
+supply or preserve the canonical Instrument and requested capability, but never constructs,
+selects, or interprets provider addresses.
+
+The Instrument's existing `CanonicalInstrumentIdentity` remains the sole analytical instrument
+identity and never changes because a Provider or address changes. `MarketDataSubject` additionally
+has a deterministic content identity in `asa.market_data_subject/v1` over all four required fields,
+including the ordered address projections and their Evidence. This content identity protects the
+complete request/replay artifact; it is not a replacement Instrument identity.
+
+### 7.2 ProviderAddressProjection
+
+```text
+ProviderAddressProjection
+  provider_id
+  projection_schema_version
+  address_type
+  address_value
+  effective_from
+  effective_until?
+  evidence
+  projection_identity
+```
+
+A projection is immutable request-address data, never canonical analytical identity. `address_type`
+is provider-defined metadata such as `symbol`, `option_symbol`, or `venue_code`; it is not a new
+capability. `address_value` contains the explicit credential-free transport identifier. Secrets,
+account identifiers, URLs, headers, payload fragments, and session material are prohibited.
+
+Projection identity uses `asa.provider_address_projection/v1` and includes provider ID, projection
+schema version, type, value, semantic validity window, and Evidence. Projections are canonically
+ordered by provider ID, schema version, address type, effective start, and projection identity.
+There is at most one effective projection for a `(provider_id, address_type)` pair at a request's
+semantic time; absence or ambiguity fails closed.
+
+Provider projections are produced upstream from explicit, immutable, versioned Instrument Reference
+evidence. “Derived from the canonical Instrument” means the mapping record names that complete
+Instrument identity and its Evidence; it never means parsing identity strings, copying display text,
+guessing vendor syntax, or consulting an adapter-local map. The mapping owner and persistence model
+remain outside SPRINT-005B, so v1 callers and deterministic fixtures must inject the complete
+projection tuple explicitly.
+
+### 7.3 Addressed request lifecycle
+
+```text
+Strategy or analytical caller
+        |
+        v
+CapabilityRequest with MarketDataSubject
+        |
+Capability Registry selects Provider
+        |
+Address projection selection (pure, exact, effective-time checked)
+        |
+Provider Adapter receives request + its one explicit projection
+        |
+Canonical Observation retains MarketDataSubject identity and projection provenance
+```
+
+The adapter neither infers nor resolves an address. It accepts only the selected projection whose
+`provider_id` matches the adapter. Provider selection remains capability-driven; an analytical
+caller cannot select a Provider by adding or ordering projections. Replay preserves and verifies
+the complete original `MarketDataSubject`, request context, and projections but never invokes an
+adapter or re-resolves an address.
 
 ## 8. ARCH-MD-005 — Provider Registry and lifecycle
 

--- a/docs/sprints/ARCH-007B.yaml
+++ b/docs/sprints/ARCH-007B.yaml
@@ -1,0 +1,39 @@
+---
+id: ARCH-007B
+name: Market Data Subject Architecture
+version: 1.0
+status: FOUNDER_MERGE_REQUIRED
+kind: architecture_amendment
+trigger: issue_119
+contract: architecture/ASA-ARCH-007-Market-Data-Platform.md
+
+clarifications:
+  subject:
+    complete_canonical_instrument_required: true
+    provider_neutral: true
+    immutable_and_replay_safe: true
+  address_projection:
+    explicit_and_versioned: true
+    analytical_identity_unchanged: true
+    hidden_or_inferred_mapping: prohibited
+  request_lifecycle:
+    strategy_constructs_provider_address: false
+    adapter_infers_provider_address: false
+    replay_preserves_original_subject: true
+
+prohibitions:
+  - runtime_changes
+  - provider_changes
+  - live_provider_calls
+  - capability_changes
+  - persistence_changes
+  - governance_changes
+
+merge:
+  founder_required: true
+  self_merge: false
+
+successor:
+  id: SPRINT-005B
+  resume_ticket: MD-007
+  delegation_reactivation_requires_founder_merge: true

--- a/tests/architecture/test_market_data_platform_contract.py
+++ b/tests/architecture/test_market_data_platform_contract.py
@@ -55,3 +55,38 @@ def test_arch_007a_prohibits_statistical_resolution() -> None:
     assert "Median, mean, weighted aggregation, voting, statistical fusion" in text
     assert "never manufactures a consensus value" in text
     assert "separate Founder-approved architecture amendment" in text
+
+
+def test_arch_007b_defines_complete_market_data_subject() -> None:
+    text = CONTRACT.read_text()
+    for field in (
+        "canonical_instrument",
+        "subject_type",
+        "requested_capability",
+        "request_context",
+    ):
+        assert field in text
+    assert "complete provider-neutral Instrument" in text
+    assert "asa.market_data_subject/v1" in text
+
+
+def test_arch_007b_requires_explicit_versioned_provider_projection() -> None:
+    text = CONTRACT.read_text()
+    for field in (
+        "provider_id",
+        "projection_schema_version",
+        "address_type",
+        "address_value",
+        "projection_identity",
+    ):
+        assert field in text
+    assert "asa.provider_address_projection/v1" in text
+    assert "adapter-local map" in text
+    assert "Secrets,\naccount identifiers, URLs, headers" in text
+
+
+def test_arch_007b_freezes_request_and_replay_lifecycle() -> None:
+    text = CONTRACT.read_text()
+    assert "Provider Adapter receives request + its one explicit projection" in text
+    assert "adapter neither infers nor resolves an address" in text
+    assert "Replay preserves and verifies\nthe complete original `MarketDataSubject`" in text


### PR DESCRIPTION
## Summary

- resolves Issue #119 with immutable MarketDataSubject and ProviderAddressProjection contracts
- separates canonical Instrument identity from versioned provider request addressing
- freezes the addressed request path and replay preservation rules
- explicitly prohibits identity parsing, inferred symbols, adapter-local maps, and Strategy provider addressing

## Architecture review

- every implemented subject carries the complete existing Instrument
- subject content identity includes complete request context and projections without replacing Instrument identity
- provider selection remains capability-driven and projection order cannot select a provider
- speculative venue Instrument semantics remain deferred with trading-calendar implementation

## Validation

- architecture contract tests: 9 passed
- sprint YAML parse: passed
- Ruff: passed
- Lean entrypoint and frozen-governance integrity: passed
- git diff --check: passed

## Security and network behavior

No credentials, runtime code, provider changes, live calls, persistence, or network behavior.

## Merge authority

Founder merge is required by frozen governance. That merge explicitly reactivates SPRINT-005B delegation at MD-007.
