### PR TITLE
MD-008: add bounded provider validation framework

### DIFF
--- a/market_data/__init__.py
+++ b/market_data/__init__.py
@@ -63,6 +63,18 @@ from market_data.fixture import (
     FixtureScenario,
     fixture_provider_registration,
 )
+from market_data.validation import (
+    DiagnosticFinding,
+    ProviderValidationRunner,
+    ValidationOverallStatus,
+    ValidationRequest,
+    ValidationRequestPlan,
+    ValidationRunResult,
+    command_main,
+    redact_diagnostic_text,
+    render_validation_result,
+    validation_result_to_data,
+)
 
 __all__ = [
     "ConfigurationError",
@@ -116,4 +128,14 @@ __all__ = [
     "DeterministicFixtureProvider",
     "FixtureScenario",
     "fixture_provider_registration",
+    "DiagnosticFinding",
+    "ProviderValidationRunner",
+    "ValidationOverallStatus",
+    "ValidationRequest",
+    "ValidationRequestPlan",
+    "ValidationRunResult",
+    "command_main",
+    "redact_diagnostic_text",
+    "render_validation_result",
+    "validation_result_to_data",
 ]

--- a/market_data/validation.py
+++ b/market_data/validation.py
@@ -1,0 +1,222 @@
+"""Bounded, opt-in Provider validation orchestration (MD-008)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Sequence
+
+from domain import MarketCapability
+from domain.values import DomainInvariantError
+from market_data.config import ProviderConfig
+from market_data.providers import (
+    ProviderValidationPlan,
+    ProviderValidationReport,
+    ValidationCheckStatus,
+)
+from market_data.registry import ProviderRegistry
+
+
+class ValidationOverallStatus(str, Enum):
+    PASSED = "passed"
+    FAILED = "failed"
+    PARTIAL = "partial"
+    DRY_RUN = "dry_run"
+
+
+class DiagnosticFinding(str, Enum):
+    LIKELY_CONFIGURATION_ISSUE = "likely_configuration_issue"
+    LIKELY_AUTHENTICATION_ISSUE = "likely_authentication_issue"
+    LIKELY_ENTITLEMENT_ISSUE = "likely_entitlement_issue"
+    LIKELY_REQUEST_PARAMETER_ISSUE = "likely_request_parameter_issue"
+    LIKELY_SYMBOL_ISSUE = "likely_symbol_issue"
+    LIKELY_TIME_RANGE_ISSUE = "likely_time_range_issue"
+    LIKELY_RESOLUTION_ISSUE = "likely_resolution_issue"
+    PROVIDER_RETURNED_NO_DATA = "provider_returned_no_data"
+    PROVIDER_RETURNED_EMPTY_PAYLOAD = "provider_returned_empty_payload"
+    PROVIDER_SCHEMA_CHANGED = "provider_schema_changed"
+    PROVIDER_RATE_LIMITED = "provider_rate_limited"
+    PROVIDER_UNAVAILABLE = "provider_unavailable"
+    LOCAL_TRANSPORT_ISSUE = "local_transport_issue"
+    UNKNOWN_ISSUE = "unknown_issue"
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationRequest:
+    provider_ids: tuple[str, ...]
+    capabilities: tuple[MarketCapability, ...] = ()
+    dry_run: bool = True
+    allow_live: bool = False
+
+    def __post_init__(self) -> None:
+        providers = tuple(sorted(set(self.provider_ids)))
+        capabilities = tuple(sorted(set(self.capabilities), key=lambda item: item.value))
+        if not providers or any(not item or item != item.strip() for item in providers):
+            raise DomainInvariantError("ValidationRequest requires normalized provider IDs")
+        object.__setattr__(self, "provider_ids", providers)
+        object.__setattr__(self, "capabilities", capabilities)
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationRequestPlan:
+    plans: tuple[ProviderValidationPlan, ...]
+    total_request_ceiling: int
+    live_providers: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationRunResult:
+    request_plan: ValidationRequestPlan
+    reports: tuple[ProviderValidationReport, ...]
+    overall_status: ValidationOverallStatus
+
+    @property
+    def exit_code(self) -> int:
+        return (
+            0
+            if self.overall_status
+            in {ValidationOverallStatus.PASSED, ValidationOverallStatus.DRY_RUN}
+            else 1
+        )
+
+
+class ProviderValidationRunner:
+    """Build and execute immutable plans without bypassing configured ceilings."""
+
+    def __init__(
+        self, registry: ProviderRegistry, provider_configs: tuple[ProviderConfig, ...]
+    ) -> None:
+        self._registry = registry
+        self._configs = {item.provider_id: item for item in provider_configs}
+
+    def plan(self, request: ValidationRequest) -> ValidationRequestPlan:
+        plans: list[ProviderValidationPlan] = []
+        live: list[str] = []
+        for provider_id in request.provider_ids:
+            provider = self._registry.provider(provider_id)
+            config = self._configs.get(provider_id)
+            if config is None:
+                raise DomainInvariantError(
+                    f"Provider {provider_id!r} lacks validation configuration"
+                )
+            capabilities = request.capabilities or provider.capabilities
+            maximum = min(
+                config.validation_budget.max_requests_per_provider_run,
+                len(capabilities) * config.validation_budget.max_requests_per_capability_check,
+            )
+            plans.append(
+                ProviderValidationPlan(
+                    f"validate:{provider_id}:{config.adapter_version}",
+                    provider_id,
+                    capabilities,
+                    maximum,
+                    maximum,
+                    config.validation_budget.timeout_seconds,
+                )
+            )
+            if provider_id != "deterministic_fixture":
+                live.append(provider_id)
+        ordered = tuple(sorted(plans, key=lambda item: item.provider_id))
+        return ValidationRequestPlan(
+            ordered, sum(item.maximum_requests for item in ordered), tuple(sorted(live))
+        )
+
+    def run(self, request: ValidationRequest) -> ValidationRunResult:
+        request_plan = self.plan(request)
+        if request.dry_run:
+            return ValidationRunResult(request_plan, (), ValidationOverallStatus.DRY_RUN)
+        if request_plan.live_providers and not request.allow_live:
+            raise DomainInvariantError("Live Provider validation requires explicit opt-in")
+        reports = self._registry.validate(request_plan.plans)
+        statuses = tuple(check.status for report in reports for check in report.checks)
+        if any(status is ValidationCheckStatus.FAIL for status in statuses):
+            overall = ValidationOverallStatus.FAILED
+        elif any(
+            status in {ValidationCheckStatus.SKIPPED, ValidationCheckStatus.NOT_SUPPORTED}
+            for status in statuses
+        ):
+            overall = ValidationOverallStatus.PARTIAL
+        else:
+            overall = ValidationOverallStatus.PASSED
+        return ValidationRunResult(request_plan, reports, overall)
+
+
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)bearer\s+\S+"),
+    re.compile(r"(?i)(token|password|api[_-]?key|authorization)\s*[=:]\s*\S+"),
+    re.compile(r"https?://\S+"),
+)
+
+
+def redact_diagnostic_text(value: str) -> str:
+    redacted = value
+    for pattern in _SECRET_PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+    return redacted
+
+
+def validation_result_to_data(result: ValidationRunResult) -> dict[str, object]:
+    return {
+        "overall_status": result.overall_status.value,
+        "exit_code": result.exit_code,
+        "request_plan": {
+            "total_request_ceiling": result.request_plan.total_request_ceiling,
+            "live_providers": list(result.request_plan.live_providers),
+            "providers": [
+                {
+                    "provider_id": plan.provider_id,
+                    "capabilities": [item.value for item in plan.capabilities],
+                    "maximum_requests": plan.maximum_requests,
+                    "maximum_request_units": plan.maximum_request_units,
+                    "timeout_seconds": plan.timeout_seconds,
+                }
+                for plan in result.request_plan.plans
+            ],
+        },
+        "reports": [
+            {
+                "provider_id": report.provider_id,
+                "adapter_version": report.adapter_version,
+                "checks": [
+                    {
+                        "check_id": check.check_id,
+                        "status": check.status.value,
+                        "detail_code": check.detail_code,
+                        "safe_summary": redact_diagnostic_text(check.safe_summary),
+                    }
+                    for check in report.checks
+                ],
+            }
+            for report in result.reports
+        ],
+    }
+
+
+def render_validation_result(result: ValidationRunResult) -> str:
+    return json.dumps(validation_result_to_data(result), sort_keys=True, indent=2)
+
+
+def command_main(
+    argv: Sequence[str], runner_factory: Callable[[], ProviderValidationRunner]
+) -> int:
+    parser = argparse.ArgumentParser(description="Run bounded Market Data Provider validation")
+    parser.add_argument("--provider", action="append", required=True)
+    parser.add_argument(
+        "--capability", action="append", choices=[item.value for item in MarketCapability]
+    )
+    parser.add_argument(
+        "--execute", action="store_true", help="execute instead of showing a dry-run plan"
+    )
+    parser.add_argument(
+        "--allow-live", action="store_true", help="explicitly authorize bounded live checks"
+    )
+    args = parser.parse_args(tuple(argv))
+    capabilities = tuple(MarketCapability(item) for item in (args.capability or ()))
+    result = runner_factory().run(
+        ValidationRequest(tuple(args.provider), capabilities, not args.execute, args.allow_live)
+    )
+    print(render_validation_result(result))
+    return result.exit_code

--- a/tests/market_data/test_validation.py
+++ b/tests/market_data/test_validation.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+
+from domain import MarketCapability
+from market_data import (
+    DeterministicFixtureProvider,
+    ProviderDependencies,
+    ProviderFactory,
+    ProviderRegistry,
+    ProviderValidationRunner,
+    RequestBudgetAuthorization,
+    ValidationOverallStatus,
+    ValidationRequest,
+    command_main,
+    fixture_provider_registration,
+    load_market_data_config,
+    redact_diagnostic_text,
+    validation_result_to_data,
+)
+
+NOW = datetime(2026, 7, 21, 16, 0, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class Clock:
+    def now(self) -> datetime:
+        return NOW
+
+
+class NoBudgetCalls:
+    def authorize(
+        self, provider_id: str, capability: MarketCapability, request_units: int
+    ) -> RequestBudgetAuthorization:
+        raise AssertionError("validation orchestration cannot bypass its plan")
+
+
+def runner() -> ProviderValidationRunner:
+    config = load_market_data_config({})
+    provider_config = next(
+        item for item in config.providers if item.provider_id == "deterministic_fixture"
+    )
+    provider = ProviderFactory((fixture_provider_registration(),)).create(
+        provider_config, ProviderDependencies(object(), Clock(), NoBudgetCalls())
+    )
+    assert isinstance(provider, DeterministicFixtureProvider)
+    return ProviderValidationRunner(ProviderRegistry((provider,)), config.providers)
+
+
+def test_dry_run_exposes_bounded_request_plan_without_execution() -> None:
+    result = runner().run(ValidationRequest(("deterministic_fixture",)))
+    assert result.overall_status is ValidationOverallStatus.DRY_RUN
+    assert result.reports == ()
+    assert result.request_plan.total_request_ceiling == 12
+    assert result.request_plan.live_providers == ()
+    data = validation_result_to_data(result)
+    assert data["request_plan"] == {
+        "total_request_ceiling": 12,
+        "live_providers": [],
+        "providers": [
+            {
+                "provider_id": "deterministic_fixture",
+                "capabilities": [
+                    item.value
+                    for item in sorted(provider_capabilities(), key=lambda item: item.value)
+                ],
+                "maximum_requests": 12,
+                "maximum_request_units": 12,
+                "timeout_seconds": 10,
+            }
+        ],
+    }
+
+
+def provider_capabilities() -> tuple[MarketCapability, ...]:
+    return (
+        MarketCapability.EARNINGS_CALENDAR_V1,
+        MarketCapability.HISTORICAL_BARS_V1,
+        MarketCapability.OPTION_CHAIN_V1,
+        MarketCapability.REAL_TIME_QUOTE_V1,
+    )
+
+
+def test_offline_fixture_validation_executes_and_reports_pass() -> None:
+    result = runner().run(
+        ValidationRequest(
+            ("deterministic_fixture",),
+            (MarketCapability.REAL_TIME_QUOTE_V1,),
+            dry_run=False,
+        )
+    )
+    assert result.overall_status is ValidationOverallStatus.PASSED
+    assert result.exit_code == 0
+    assert result.reports[0].checks[0].status.value == "pass"
+
+
+def test_unsupported_capability_is_partial_not_a_new_check_status() -> None:
+    result = runner().run(
+        ValidationRequest(
+            ("deterministic_fixture",),
+            (MarketCapability.TRADING_CALENDAR_V1,),
+            dry_run=False,
+        )
+    )
+    assert result.overall_status is ValidationOverallStatus.PARTIAL
+    assert result.exit_code == 1
+    assert result.reports[0].checks[0].status.value == "not_supported"
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "Authorization: Bearer abc123",
+        "api_key=supersecret",
+        "token:secret-value",
+        "https://user:pass@example.test/private",
+    ),
+)
+def test_diagnostic_output_redacts_secret_like_values_and_urls(value: str) -> None:
+    result = redact_diagnostic_text(value)
+    assert "secret" not in result.lower()
+    assert "abc123" not in result
+    assert "example.test" not in result
+    assert "[REDACTED]" in result
+
+
+def test_command_defaults_to_dry_run_and_prints_machine_readable_plan(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    code = command_main(("--provider", "deterministic_fixture"), runner)
+    output = capsys.readouterr().out
+    assert code == 0
+    assert '"overall_status": "dry_run"' in output
+    assert '"total_request_ceiling": 12' in output
+
+
+def test_validation_request_is_deterministically_normalized() -> None:
+    request = ValidationRequest(
+        ("deterministic_fixture", "deterministic_fixture"),
+        (MarketCapability.REAL_TIME_QUOTE_V1, MarketCapability.REAL_TIME_QUOTE_V1),
+    )
+    assert request.provider_ids == ("deterministic_fixture",)
+    assert request.capabilities == (MarketCapability.REAL_TIME_QUOTE_V1,)


### PR DESCRIPTION
## Ticket

MD-008

## Summary

Adds immutable provider-validation requests and request plans, deterministic plan generation, dry-run-by-default orchestration, explicit bounded live opt-in, aggregate validation outcomes, machine-readable rendering, and a reusable command entrypoint.

## Frozen architecture compliance

Per-check statuses remain exactly PASS, FAIL, SKIPPED, and NOT_SUPPORTED. NOT_CONFIGURED, INCONCLUSIVE, and BUDGET_EXHAUSTED remain diagnostic detail codes; aggregate outcomes do not alter check semantics.

## Security and secret handling

Rendered diagnostics redact authorization material, tokens, passwords, API keys, and full URLs. No environment values, raw payloads, or credentials enter reports.

## Network behavior

Dry-run is the default. Fixture execution is offline. Non-fixture providers require explicit allow_live authorization and remain constrained by immutable configured validation ceilings.

## Request budget behavior

Plans expose the complete request ceiling before execution and cap each provider at the lower of its configured provider-run ceiling and capability-check ceiling. No CLI option can raise those limits.

## Tests

- 569 domain, market-data, and architecture tests passed
- Strict mypy passed for domain and market_data (26 source files)
- Ruff and format checks passed for the changed scope
- Lean entrypoint, governance integrity, validator, conflict, and pre-push gates passed
- git diff --check passed

## Live validation status

Not run. Live adapters and credentials are outside MD-008; live validation remains opt-in for MD-009 through MD-011.

## Explicit exclusions

No provider adapter, live call, persistence, schema, strategy, execution, brokerage, or production behavior was added.

## Auto-merge authority

Authorized under SPRINT-005B delegated merge authority.