### PR TITLE
MD-009: add read-only Tradier market-data provider

### DIFF
--- a/market_data/__init__.py
+++ b/market_data/__init__.py
@@ -75,6 +75,14 @@ from market_data.validation import (
     render_validation_result,
     validation_result_to_data,
 )
+from market_data.tradier import TradierProvider, tradier_provider_registration
+from market_data.transport import (
+    ReadOnlyHttpRequest,
+    ReadOnlyHttpResponse,
+    ReadOnlyHttpTransport,
+    ReadOnlyTransportError,
+    ReadOnlyTransportTimeout,
+)
 
 __all__ = [
     "ConfigurationError",
@@ -138,4 +146,11 @@ __all__ = [
     "redact_diagnostic_text",
     "render_validation_result",
     "validation_result_to_data",
+    "TradierProvider",
+    "tradier_provider_registration",
+    "ReadOnlyHttpRequest",
+    "ReadOnlyHttpResponse",
+    "ReadOnlyHttpTransport",
+    "ReadOnlyTransportError",
+    "ReadOnlyTransportTimeout",
 ]

--- a/market_data/providers.py
+++ b/market_data/providers.py
@@ -320,6 +320,7 @@ class ProviderValidationPlan:
     maximum_requests: int
     maximum_request_units: int
     timeout_seconds: int
+    subjects: tuple[MarketDataSubject, ...] = ()
 
     def __post_init__(self) -> None:
         _text(self.plan_id, "ProviderValidationPlan", "plan_id")
@@ -331,6 +332,10 @@ class ProviderValidationPlan:
             if type(getattr(self, name)) is not int or getattr(self, name) <= 0:
                 raise DomainInvariantError(f"ProviderValidationPlan.{name} must be positive")
         object.__setattr__(self, "capabilities", capabilities)
+        subjects = tuple(sorted(set(self.subjects), key=lambda item: item.subject_identity))
+        if any(subject.requested_capability not in capabilities for subject in subjects):
+            raise DomainInvariantError("ProviderValidationPlan subject capability is not planned")
+        object.__setattr__(self, "subjects", subjects)
 
 
 @dataclass(frozen=True, slots=True)

--- a/market_data/tradier.py
+++ b/market_data/tradier.py
@@ -1,0 +1,540 @@
+"""Read-only Tradier Market Data adapter (MD-009)."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from typing import cast
+
+from domain import (
+    CompletenessMetadata,
+    EvidenceKind,
+    EvidenceReference,
+    ExpirationCycle,
+    FreshnessMetadata,
+    FreshnessStatus,
+    MarketCapability,
+    MarketDataSubject,
+    MarketObservation,
+    OHLCVBar,
+    OptionChain,
+    OptionContract,
+    OptionType,
+    ProviderProvenance,
+    Quote,
+    Security,
+    SecurityAssetType,
+    market_observation_identity,
+)
+from domain.operational import CanonicalInstrumentIdentity
+from domain.market_data import MarketObservationValue
+from domain.values import DomainInvariantError
+from market_data.config import ProviderConfig
+from market_data.factory import ProviderDependencies, ProviderRegistration
+from market_data.providers import (
+    CapabilityRequest,
+    HealthProbe,
+    ProviderAttemptMetadata,
+    ProviderErrorCode,
+    ProviderFetchResult,
+    ProviderHealthReport,
+    ProviderIdentity,
+    ProviderLimitDeclaration,
+    ProviderMetadata,
+    ProviderResponseMetadata,
+    ProviderShutdownReport,
+    ProviderStatus,
+    ProviderValidationPlan,
+    ProviderValidationReport,
+    RequestBudgetAuthorization,
+    ValidationCheckResult,
+    ValidationCheckStatus,
+    normalized_provider_error,
+)
+from market_data.transport import (
+    ReadOnlyHttpRequest,
+    ReadOnlyHttpResponse,
+    ReadOnlyHttpTransport,
+    ReadOnlyTransportError,
+    ReadOnlyTransportTimeout,
+)
+
+TRADIER_CAPABILITIES = (
+    MarketCapability.REAL_TIME_QUOTE_V1,
+    MarketCapability.HISTORICAL_BARS_V1,
+    MarketCapability.OPTION_CHAIN_V1,
+)
+
+
+class _EmptyPayload(ValueError):
+    pass
+
+
+class TradierProvider:
+    """Official documented `/v1/markets` reads only; no account or order surface."""
+
+    def __init__(self, config: ProviderConfig, dependencies: ProviderDependencies) -> None:
+        if config.provider_id != "tradier" or config.credential is None:
+            raise ValueError("Tradier requires its explicit enabled credential configuration")
+        if not isinstance(dependencies.transport, ReadOnlyHttpTransport):
+            raise ValueError("Tradier requires an injected read-only HTTP transport")
+        self._config = config
+        self._credential = config.credential
+        self._dependencies = dependencies
+        self._transport = dependencies.transport
+        self._metadata = ProviderMetadata(
+            ProviderIdentity("tradier", "tradier", config.adapter_version),
+            TRADIER_CAPABILITIES,
+            (
+                ProviderLimitDeclaration("market_data_per_minute_production", "120", "documented"),
+                ProviderLimitDeclaration("market_data_per_minute_sandbox", "60", "documented"),
+            ),
+            TRADIER_CAPABILITIES,
+            "v1",
+        )
+
+    @property
+    def provider_id(self) -> str:
+        return "tradier"
+
+    @property
+    def metadata(self) -> ProviderMetadata:
+        return self._metadata
+
+    @property
+    def capabilities(self) -> tuple[MarketCapability, ...]:
+        return self.metadata.capabilities
+
+    def fetch(
+        self, request: CapabilityRequest, budget: RequestBudgetAuthorization
+    ) -> ProviderFetchResult:
+        if budget.provider_id != self.provider_id:
+            raise DomainInvariantError("Tradier request budget provider mismatch")
+        if request.capability not in self.capabilities:
+            return self._failure(request, ProviderErrorCode.UNSUPPORTED_CAPABILITY, None, None)
+        observations: list[MarketObservation] = []
+        attempts: list[ProviderAttemptMetadata] = []
+        for subject in request.subjects:
+            projection = subject.projection_for("tradier", "symbol", request.effective_end)
+            path, query, endpoint_class = self._endpoint(request, subject, projection.address_value)
+            try:
+                response = self._transport.get(
+                    ReadOnlyHttpRequest(
+                        self._config.endpoint_environment.value,
+                        endpoint_class,
+                        path,
+                        query,
+                        (
+                            ("Accept", "application/json"),
+                            ("Authorization", f"Bearer {self._credential.reveal()}"),
+                        ),
+                        self._config.timeout_seconds,
+                    )
+                )
+            except ReadOnlyTransportTimeout:
+                return self._failure(
+                    request, ProviderErrorCode.TIMEOUT, None, tuple(attempts) or None
+                )
+            except ReadOnlyTransportError:
+                return self._failure(
+                    request, ProviderErrorCode.TRANSPORT_ERROR, None, tuple(attempts) or None
+                )
+            response_metadata = self._response_metadata(response)
+            attempts.append(
+                ProviderAttemptMetadata(
+                    "tradier", request.capability, len(attempts) + 1, 1, response_metadata
+                )
+            )
+            error_code = self._response_error(response)
+            if error_code is not None:
+                return self._failure(request, error_code, response, tuple(attempts))
+            try:
+                observations.extend(self._normalize(request, subject, response))
+            except _EmptyPayload:
+                return self._failure(
+                    request, ProviderErrorCode.EMPTY_PAYLOAD, response, tuple(attempts)
+                )
+            except (KeyError, TypeError, ValueError, InvalidOperation, DomainInvariantError):
+                return self._failure(
+                    request, ProviderErrorCode.SCHEMA_MISMATCH, response, tuple(attempts)
+                )
+        if not observations:
+            return self._failure(request, ProviderErrorCode.EMPTY_PAYLOAD, None, tuple(attempts))
+        return ProviderFetchResult(tuple(observations), None, tuple(attempts))
+
+    def health(self, probe: HealthProbe) -> ProviderHealthReport:
+        return ProviderHealthReport(
+            "tradier", ProviderStatus.UNKNOWN, probe.requested_at, "NOT_PROBED", None
+        )
+
+    def validate(self, plan: ProviderValidationPlan) -> ProviderValidationReport:
+        started = self._dependencies.clock.now()
+        checks: list[ValidationCheckResult] = []
+        attempts: list[ProviderAttemptMetadata] = []
+        subjects = {subject.requested_capability: subject for subject in plan.subjects}
+        for capability in plan.capabilities:
+            subject = subjects.get(capability)
+            if subject is None:
+                checks.append(
+                    ValidationCheckResult(
+                        capability.value,
+                        ValidationCheckStatus.SKIPPED,
+                        "INCONCLUSIVE",
+                        "explicit validation subject was not supplied",
+                    )
+                )
+                continue
+            authorization = self._dependencies.budget_authorizer.authorize("tradier", capability, 1)
+            context = subject.request_context
+            result = self.fetch(
+                CapabilityRequest(
+                    capability,
+                    (subject,),
+                    context.semantic_start,
+                    context.semantic_end,
+                    context.required_fields,
+                    300,
+                ),
+                authorization,
+            )
+            attempts.extend(result.attempts)
+            checks.append(
+                ValidationCheckResult(
+                    capability.value,
+                    ValidationCheckStatus.PASS
+                    if result.error is None
+                    else ValidationCheckStatus.FAIL,
+                    "VALID_DATA" if result.error is None else result.error.code.value.upper(),
+                    "bounded Tradier capability check completed",
+                )
+            )
+        completed = self._dependencies.clock.now()
+        report_id = hashlib.sha256(
+            f"{plan.plan_id}:{started.isoformat()}:{completed.isoformat()}".encode()
+        ).hexdigest()
+        return ProviderValidationReport(
+            report_id,
+            plan.plan_id,
+            "tradier",
+            self._config.adapter_version,
+            started,
+            completed,
+            tuple(checks),
+            tuple(attempts),
+        )
+
+    def shutdown(self) -> ProviderShutdownReport:
+        return ProviderShutdownReport("tradier", self._dependencies.clock.now())
+
+    def _endpoint(
+        self, request: CapabilityRequest, subject: MarketDataSubject, symbol: str
+    ) -> tuple[str, tuple[tuple[str, str], ...], str]:
+        if request.capability is MarketCapability.REAL_TIME_QUOTE_V1:
+            return "/v1/markets/quotes", (("greeks", "false"), ("symbols", symbol)), "quotes"
+        if request.capability is MarketCapability.HISTORICAL_BARS_V1:
+            return (
+                "/v1/markets/history",
+                (
+                    ("end", request.effective_end.date().isoformat()),
+                    ("interval", "daily"),
+                    ("start", request.effective_start.date().isoformat()),
+                    ("symbol", symbol),
+                ),
+                "history",
+            )
+        if "expirations" in request.required_fields and "contracts" not in request.required_fields:
+            return (
+                "/v1/markets/options/expirations",
+                (("includeAllRoots", "false"), ("symbol", symbol)),
+                "option_expirations",
+            )
+        expiration = subject.projection_for("tradier", "expiration", request.effective_end)
+        return (
+            "/v1/markets/options/chains",
+            (("expiration", expiration.address_value), ("greeks", "true"), ("symbol", symbol)),
+            "option_chain",
+        )
+
+    def _normalize(
+        self, request: CapabilityRequest, subject: MarketDataSubject, response: ReadOnlyHttpResponse
+    ) -> tuple[MarketObservation, ...]:
+        if request.capability is MarketCapability.REAL_TIME_QUOTE_V1:
+            rows = _rows(_mapping(response.json_body, "quotes").get("quote"))
+            return tuple(
+                self._observation(request, subject, _quote(subject, row), response, row)
+                for row in rows
+            )
+        if request.capability is MarketCapability.HISTORICAL_BARS_V1:
+            rows = _rows(_mapping(response.json_body, "history").get("day"))
+            return tuple(
+                self._observation(request, subject, _bar(subject, row), response, row)
+                for row in rows
+            )
+        if "expirations" in request.required_fields and "contracts" not in request.required_fields:
+            values = _mapping(response.json_body, "expirations").get("date")
+            dates = values if isinstance(values, list) else [values]
+            as_of = request.effective_end.date()
+            return tuple(
+                self._observation(
+                    request,
+                    subject,
+                    ExpirationCycle(
+                        parsed,
+                        (parsed - as_of).days,
+                        _is_monthly_expiration(parsed),
+                        not _is_monthly_expiration(parsed),
+                        as_of,
+                        _evidence(response),
+                    ),
+                    response,
+                    {},
+                )
+                for parsed in (_date(item) for item in dates)
+            )
+        rows = _rows(_mapping(response.json_body, "options").get("option"))
+        chain = _chain(subject, rows, response, self._dependencies.clock.now())
+        return (self._observation(request, subject, chain, response, rows[0] if rows else {}),)
+
+    def _observation(
+        self,
+        request: CapabilityRequest,
+        subject: MarketDataSubject,
+        value: MarketObservationValue,
+        response: ReadOnlyHttpResponse,
+        row: Mapping[str, object],
+    ) -> MarketObservation:
+        received = self._dependencies.clock.now().astimezone(timezone.utc)
+        if isinstance(value, OHLCVBar):
+            effective = value.end_at
+        elif isinstance(value, OptionChain):
+            effective = value.observed_at
+        else:
+            effective = _observed_at(row, received)
+        evidence = _evidence(response)
+        present = tuple(field for field in request.required_fields if _field_present(field, value))
+        missing = tuple(field for field in request.required_fields if field not in present)
+        age = max(0, int((received - effective).total_seconds()))
+        freshness = FreshnessMetadata(
+            received,
+            effective,
+            request.maximum_age_seconds,
+            age,
+            FreshnessStatus.FRESH if age <= request.maximum_age_seconds else FreshnessStatus.STALE,
+        )
+        provenance = ProviderProvenance("tradier", response.request_reference, evidence)
+        identity = market_observation_identity(
+            "tradier", request.capability, subject, effective, value, "v1"
+        )
+        return MarketObservation(
+            identity,
+            request.capability,
+            subject,
+            effective,
+            received,
+            value,
+            "v1",
+            provenance,
+            freshness,
+            CompletenessMetadata(request.required_fields, present, missing),
+        )
+
+    def _response_metadata(self, response: ReadOnlyHttpResponse) -> ProviderResponseMetadata:
+        quota = tuple(
+            (key.lower(), value)
+            for key, value in response.headers
+            if key.lower().startswith("x-ratelimit-")
+        )
+        return ProviderResponseMetadata(
+            "tradier",
+            response.request_reference,
+            self._dependencies.clock.now(),
+            str(response.status_code),
+            response.latency_milliseconds,
+            0,
+            quota,
+        )
+
+    def _response_error(self, response: ReadOnlyHttpResponse) -> ProviderErrorCode | None:
+        return {
+            400: ProviderErrorCode.INVALID_REQUEST,
+            401: ProviderErrorCode.AUTHENTICATION_FAILED,
+            403: ProviderErrorCode.ENTITLEMENT_MISSING,
+            429: ProviderErrorCode.RATE_LIMITED,
+        }.get(
+            response.status_code,
+            ProviderErrorCode.PROVIDER_UNAVAILABLE if response.status_code >= 500 else None,
+        )
+
+    def _failure(
+        self,
+        request: CapabilityRequest,
+        code: ProviderErrorCode,
+        response: ReadOnlyHttpResponse | None,
+        attempts: tuple[ProviderAttemptMetadata, ...] | None,
+    ) -> ProviderFetchResult:
+        reference = response.request_reference if response is not None else None
+        error = normalized_provider_error(
+            code, f"Tradier {code.value}", "tradier", request.capability, reference
+        )
+        if attempts is None:
+            metadata = ProviderResponseMetadata(
+                "tradier",
+                reference or "no-request",
+                self._dependencies.clock.now(),
+                "not_sent",
+                0,
+                0,
+            )
+            attempts = (ProviderAttemptMetadata("tradier", request.capability, 1, 1, metadata),)
+        return ProviderFetchResult((), error, attempts)
+
+
+def _mapping(value: Mapping[str, object], key: str) -> Mapping[str, object]:
+    nested = value[key]
+    if not isinstance(nested, Mapping):
+        raise TypeError("expected object")
+    return cast(Mapping[str, object], nested)
+
+
+def _rows(value: object) -> tuple[Mapping[str, object], ...]:
+    values: Sequence[object] = value if isinstance(value, list) else [value]
+    if not values or values == [None] or not all(isinstance(item, Mapping) for item in values):
+        raise _EmptyPayload("expected non-empty rows")
+    return tuple(cast(Mapping[str, object], item) for item in values)
+
+
+def _decimal(value: object) -> Decimal:
+    return Decimal(str(value))
+
+
+def _date(value: object) -> date:
+    return date.fromisoformat(str(value))
+
+
+def _is_monthly_expiration(value: date) -> bool:
+    return value.weekday() == 4 and 15 <= value.day <= 21
+
+
+def _observed_at(row: Mapping[str, object], fallback: datetime) -> datetime:
+    raw = row.get("trade_date") or row.get("timestamp")
+    if isinstance(raw, (int, float)):
+        divisor = 1000 if raw > 10_000_000_000 else 1
+        return datetime.fromtimestamp(raw / divisor, tz=timezone.utc)
+    if isinstance(raw, str):
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+    return fallback
+
+
+def _evidence(response: ReadOnlyHttpResponse) -> tuple[EvidenceReference, ...]:
+    return (EvidenceReference(EvidenceKind.OBSERVATION, f"tradier:{response.request_reference}"),)
+
+
+def _quote(subject: MarketDataSubject, row: Mapping[str, object]) -> Quote:
+    return Quote(
+        subject.canonical_instrument,
+        _decimal(row["bid"]),
+        _decimal(row["ask"]),
+        _decimal(row["last"]),
+        _decimal(row["bidsize"]) if row.get("bidsize") is not None else None,
+        _decimal(row["asksize"]) if row.get("asksize") is not None else None,
+        _decimal(row["volume"]) if row.get("volume") is not None else None,
+        subject.canonical_instrument.currency,
+    )
+
+
+def _bar(subject: MarketDataSubject, row: Mapping[str, object]) -> OHLCVBar:
+    day = _date(row["date"])
+    start = datetime.combine(day, time.min, tzinfo=timezone.utc)
+    return OHLCVBar(
+        subject.canonical_instrument,
+        86400,
+        start,
+        start + timedelta(days=1),
+        _decimal(row["open"]),
+        _decimal(row["high"]),
+        _decimal(row["low"]),
+        _decimal(row["close"]),
+        _decimal(row["volume"]),
+    )
+
+
+def _security(subject: MarketDataSubject, symbol: str) -> Security:
+    return Security(subject.canonical_instrument, symbol.upper(), SecurityAssetType.EQUITY, "US")
+
+
+def _chain(
+    subject: MarketDataSubject,
+    rows: tuple[Mapping[str, object], ...],
+    response: ReadOnlyHttpResponse,
+    received_at: datetime,
+) -> OptionChain:
+    if not rows:
+        raise ValueError("empty option chain")
+    observed = _observed_at(rows[0], received_at)
+    evidence = _evidence(response)
+    symbol = str(rows[0].get("underlying") or subject.canonical_instrument.display_symbol)
+    security = _security(subject, symbol)
+    contracts = tuple(_option(security, row, observed, evidence) for row in rows)
+    return OptionChain(
+        f"tradier:{response.request_reference}", security, observed, contracts, evidence
+    )
+
+
+def _option(
+    security: Security,
+    row: Mapping[str, object],
+    observed: datetime,
+    evidence: tuple[EvidenceReference, ...],
+) -> OptionContract:
+    greeks = row.get("greeks") if isinstance(row.get("greeks"), Mapping) else {}
+    values = cast(Mapping[str, object], greeks)
+    option_type = OptionType.CALL if str(row["option_type"]).lower() == "call" else OptionType.PUT
+
+    def optional(name: str) -> Decimal | None:
+        raw = values.get(name, row.get(name))
+        return None if raw is None else _decimal(raw)
+
+    return OptionContract(
+        CanonicalInstrumentIdentity("occ", str(row["symbol"])),
+        security,
+        _date(row["expiration_date"]),
+        _decimal(row["strike"]),
+        option_type,
+        optional("bid"),
+        optional("ask"),
+        optional("last"),
+        int(str(row["volume"])) if row.get("volume") is not None else None,
+        int(str(row["open_interest"])) if row.get("open_interest") is not None else None,
+        optional("delta"),
+        optional("gamma"),
+        optional("theta"),
+        optional("vega"),
+        optional("rho"),
+        optional("mid_iv"),
+        observed,
+        evidence,
+    )
+
+
+def _field_present(field: str, value: object) -> bool:
+    if field == "expirations":
+        return isinstance(value, ExpirationCycle)
+    if field == "contracts":
+        return isinstance(value, OptionChain) and bool(value.contracts)
+    if field in {"greeks", "implied_volatility", "volume", "open_interest"} and isinstance(
+        value, OptionChain
+    ):
+        attribute = {
+            "greeks": "delta",
+            "implied_volatility": "implied_volatility",
+            "volume": "volume",
+            "open_interest": "open_interest",
+        }[field]
+        return all(getattr(contract, attribute) is not None for contract in value.contracts)
+    return hasattr(value, field) and getattr(value, field) is not None
+
+
+def tradier_provider_registration() -> ProviderRegistration:
+    return ProviderRegistration("tradier", "v1", TradierProvider)

--- a/market_data/transport.py
+++ b/market_data/transport.py
@@ -1,0 +1,52 @@
+"""Injected read-only HTTP transport contracts for Market Data adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Protocol, runtime_checkable
+
+
+class ReadOnlyTransportError(RuntimeError):
+    """Safe transport failure without response or credential material."""
+
+
+class ReadOnlyTransportTimeout(ReadOnlyTransportError):
+    """The configured read timeout elapsed."""
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class ReadOnlyHttpRequest:
+    endpoint_environment: str
+    endpoint_class: str
+    path: str
+    query: tuple[tuple[str, str], ...]
+    headers: tuple[tuple[str, str], ...]
+    timeout_seconds: int
+
+    def __post_init__(self) -> None:
+        if self.path.startswith("http") or not self.path.startswith("/"):
+            raise ValueError("ReadOnlyHttpRequest requires a relative path")
+        if self.timeout_seconds <= 0:
+            raise ValueError("ReadOnlyHttpRequest timeout must be positive")
+
+    def __repr__(self) -> str:
+        return (
+            "ReadOnlyHttpRequest(endpoint_environment="
+            f"{self.endpoint_environment!r}, endpoint_class={self.endpoint_class!r}, "
+            f"path={self.path!r}, query_count={len(self.query)}, headers='[REDACTED]', "
+            f"timeout_seconds={self.timeout_seconds})"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ReadOnlyHttpResponse:
+    status_code: int
+    json_body: Mapping[str, object]
+    headers: tuple[tuple[str, str], ...]
+    latency_milliseconds: int
+    request_reference: str
+
+
+@runtime_checkable
+class ReadOnlyHttpTransport(Protocol):
+    def get(self, request: ReadOnlyHttpRequest) -> ReadOnlyHttpResponse: ...

--- a/tests/market_data/test_tradier.py
+++ b/tests/market_data/test_tradier.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from domain import (
+    CanonicalInstrumentIdentity,
+    EvidenceKind,
+    EvidenceReference,
+    Instrument,
+    InstrumentKind,
+    MarketCapability,
+    MarketDataRequestContext,
+    MarketDataSubject,
+    MarketDataSubjectType,
+    OHLCVBar,
+    OptionChain,
+    ProviderAddressProjection,
+    Quote,
+)
+from market_data import (
+    CapabilityRequest,
+    ProviderDependencies,
+    RequestBudgetAuthorization,
+    load_market_data_config,
+)
+from market_data.providers import ProviderErrorCode
+from market_data.tradier import TradierProvider
+from market_data.transport import ReadOnlyHttpRequest, ReadOnlyHttpResponse
+
+NOW = datetime(2026, 7, 21, 16, 0, tzinfo=timezone.utc)
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "instrument-reference:AAPL"),)
+INSTRUMENT = Instrument(
+    CanonicalInstrumentIdentity("figi", "BBG000B9XRY4"), InstrumentKind.EQUITY, "AAPL", "USD"
+)
+
+
+@dataclass(frozen=True)
+class Clock:
+    def now(self) -> datetime:
+        return NOW
+
+
+class Budget:
+    def authorize(
+        self, provider_id: str, capability: MarketCapability, request_units: int
+    ) -> RequestBudgetAuthorization:
+        return RequestBudgetAuthorization("validation-budget", provider_id, request_units, 1)
+
+
+class Transport:
+    def __init__(self, responses: tuple[ReadOnlyHttpResponse, ...]) -> None:
+        self.responses = list(responses)
+        self.requests: list[ReadOnlyHttpRequest] = []
+
+    def get(self, request: ReadOnlyHttpRequest) -> ReadOnlyHttpResponse:
+        self.requests.append(request)
+        return self.responses.pop(0)
+
+
+def response(body: dict[str, object], status: int = 200) -> ReadOnlyHttpResponse:
+    return ReadOnlyHttpResponse(
+        status, body, (("X-Ratelimit-Available", "119"),), 12, "tradier-request-1"
+    )
+
+
+def subject(
+    capability: MarketCapability, fields: tuple[str, ...], *, expiration: bool = False
+) -> MarketDataSubject:
+    projections = [
+        ProviderAddressProjection(
+            "tradier", "v1", "symbol", "AAPL", NOW - timedelta(days=30), None, EVIDENCE
+        )
+    ]
+    if expiration:
+        projections.append(
+            ProviderAddressProjection(
+                "tradier",
+                "v1",
+                "expiration",
+                "2026-08-21",
+                NOW - timedelta(days=30),
+                None,
+                EVIDENCE,
+            )
+        )
+    kind = {MarketCapability.OPTION_CHAIN_V1: MarketDataSubjectType.OPTION_UNDERLYING}.get(
+        capability, MarketDataSubjectType.INSTRUMENT
+    )
+    return MarketDataSubject(
+        INSTRUMENT,
+        kind,
+        capability,
+        MarketDataRequestContext(
+            NOW - timedelta(days=5), NOW, fields, tuple(projections), EVIDENCE
+        ),
+    )
+
+
+def request(
+    capability: MarketCapability, fields: tuple[str, ...], *, expiration: bool = False
+) -> CapabilityRequest:
+    item = subject(capability, fields, expiration=expiration)
+    return CapabilityRequest(
+        capability,
+        (item,),
+        item.request_context.semantic_start,
+        item.request_context.semantic_end,
+        fields,
+        86400 * 10,
+    )
+
+
+def provider(transport: Transport) -> TradierProvider:
+    config = load_market_data_config(
+        {"ASA_TRADIER_ENABLED": "true", "ASA_TRADIER_ACCESS_TOKEN": "test-token"}
+    )
+    tradier = next(item for item in config.providers if item.provider_id == "tradier")
+    return TradierProvider(tradier, ProviderDependencies(transport, Clock(), Budget()))
+
+
+def authorization() -> RequestBudgetAuthorization:
+    return RequestBudgetAuthorization("budget", "tradier", 1, 1)
+
+
+def test_quote_normalization_uses_only_read_market_endpoint_and_redacts_repr() -> None:
+    transport = Transport(
+        (
+            response(
+                {
+                    "quotes": {
+                        "quote": {
+                            "symbol": "AAPL",
+                            "bid": 209.9,
+                            "ask": 210.1,
+                            "last": 210,
+                            "bidsize": 100,
+                            "asksize": 120,
+                            "volume": 1000000,
+                        }
+                    }
+                }
+            ),
+        )
+    )
+    result = provider(transport).fetch(
+        request(MarketCapability.REAL_TIME_QUOTE_V1, ("bid", "ask", "last")), authorization()
+    )
+    assert result.error is None and isinstance(result.observations[0].value, Quote)
+    assert transport.requests[0].path == "/v1/markets/quotes"
+    assert transport.requests[0].query == (("greeks", "false"), ("symbols", "AAPL"))
+    assert "test-token" not in repr(transport.requests[0])
+
+
+def test_daily_history_normalizes_decimal_ohlcv() -> None:
+    transport = Transport(
+        (
+            response(
+                {
+                    "history": {
+                        "day": [
+                            {
+                                "date": "2026-07-20",
+                                "open": "205.00",
+                                "high": "212",
+                                "low": "204",
+                                "close": "210",
+                                "volume": 50000000,
+                            }
+                        ]
+                    }
+                }
+            ),
+        )
+    )
+    result = provider(transport).fetch(
+        request(MarketCapability.HISTORICAL_BARS_V1, ("open", "high", "low", "close", "volume")),
+        authorization(),
+    )
+    assert result.error is None and isinstance(result.observations[0].value, OHLCVBar)
+    assert transport.requests[0].path == "/v1/markets/history"
+
+
+def test_option_chain_preserves_greeks_iv_and_liquidity() -> None:
+    row = {
+        "symbol": "AAPL260821C00210000",
+        "underlying": "AAPL",
+        "expiration_date": "2026-08-21",
+        "strike": "210",
+        "option_type": "call",
+        "bid": "4.9",
+        "ask": "5.1",
+        "last": "5",
+        "volume": 1000,
+        "open_interest": 5000,
+        "greeks": {
+            "delta": "0.5",
+            "gamma": "0.03",
+            "theta": "-0.1",
+            "vega": "0.2",
+            "rho": "0.01",
+            "mid_iv": "0.25",
+        },
+    }
+    transport = Transport((response({"options": {"option": [row]}}),))
+    fields = ("contracts", "greeks", "implied_volatility", "volume", "open_interest")
+    result = provider(transport).fetch(
+        request(MarketCapability.OPTION_CHAIN_V1, fields, expiration=True), authorization()
+    )
+    chain = result.observations[0].value
+    assert isinstance(chain, OptionChain) and chain.contracts[0].delta is not None
+    assert result.observations[0].completeness.missing_fields == ()
+    assert transport.requests[0].path == "/v1/markets/options/chains"
+
+
+@pytest.mark.parametrize(
+    ("status", "code"),
+    (
+        (401, ProviderErrorCode.AUTHENTICATION_FAILED),
+        (403, ProviderErrorCode.ENTITLEMENT_MISSING),
+        (429, ProviderErrorCode.RATE_LIMITED),
+        (503, ProviderErrorCode.PROVIDER_UNAVAILABLE),
+    ),
+)
+def test_http_failures_are_normalized(status: int, code: ProviderErrorCode) -> None:
+    result = provider(Transport((response({}, status),))).fetch(
+        request(MarketCapability.REAL_TIME_QUOTE_V1, ("last",)), authorization()
+    )
+    assert result.error is not None and result.error.code is code
+
+
+def test_malformed_and_empty_payloads_fail_closed() -> None:
+    malformed = provider(Transport((response({"quotes": {"quote": {"last": "bad"}}}),))).fetch(
+        request(MarketCapability.REAL_TIME_QUOTE_V1, ("last",)), authorization()
+    )
+    assert malformed.error is not None and malformed.error.code is ProviderErrorCode.SCHEMA_MISMATCH
+    empty = provider(Transport((response({"quotes": {"quote": None}}),))).fetch(
+        request(MarketCapability.REAL_TIME_QUOTE_V1, ("last",)), authorization()
+    )
+    assert empty.error is not None and empty.error.code is ProviderErrorCode.EMPTY_PAYLOAD
+
+
+def test_adapter_has_no_write_or_brokerage_surface() -> None:
+    names = set(TradierProvider.__dict__)
+    assert not names & {
+        "submit",
+        "post",
+        "place_order",
+        "cancel",
+        "modify",
+        "accounts",
+        "positions",
+    }


### PR DESCRIPTION
## Ticket

MD-009

## Summary

Adds a read-only Tradier adapter for canonical quotes, daily OHLCV bars, option expirations, option chains, Greeks, implied volatility, volume, and open interest. All provider responses normalize into frozen Market Data and financial contracts.

## Frozen architecture compliance

The adapter consumes complete MarketDataSubject values plus explicit Tradier symbol and expiration projections. It performs no symbol parsing, inference, hidden lookup, strategy selection, or provider-object leakage.

## Security and secret handling

Credentials enter only the redacted injected request envelope; request repr never displays headers. Errors, observations, attempts, validation reports, and provenance contain no credential, raw payload, full URL, cookie, or session material.

## Network behavior

Only injected GET transport is reachable. Implemented official documented market endpoints: /v1/markets/quotes, /v1/markets/history, /v1/markets/options/expirations, and /v1/markets/options/chains. There is no account, order, POST, mutation, or brokerage surface.

Official references:
- https://docs.tradier.com/reference/brokerage-api-markets-get-quotes
- https://docs.tradier.com/reference/brokerage-api-markets-get-history
- https://docs.tradier.com/reference/brokerage-api-markets-get-options-expirations
- https://docs.tradier.com/reference/brokerage-api-markets-get-options-chains
- https://docs.tradier.com/docs/rate-limiting

## Request budget behavior

Every fetch requires an explicit authorization matching Tradier. Validation acquires one authorization per requested capability. Provider quota headers are normalized into bounded metadata; the adapter performs no retries itself.

## Tests

- 578 domain, market-data, and architecture tests passed
- Strict mypy passed for domain and market_data (28 source files)
- Ruff and format checks passed for changed scope
- Lean entrypoint, governance integrity, validator, conflict, and pre-push gates passed
- git diff --check passed

## Live validation status

Externally blocked: ASA_TRADIER_ACCESS_TOKEN is not configured in this authorized worker environment. No live request was attempted and no success was fabricated. Fixture normalization, failures, schema mismatch, empty payload, decimal precision, quota metadata, and write-surface isolation are covered offline.

## Explicit exclusions

No account access, positions, order endpoint, brokerage mutation, persistence, schema, strategy behavior, execution behavior, or production cutover.

## Auto-merge authority

Authorized under SPRINT-005B delegated merge authority; the missing credential is a documented external live-validation gap and normal PR CI remains deterministic and network-free.