### PR TITLE
MD-013: add deterministic observation resolution

### DIFF
--- a/market_data/__init__.py
+++ b/market_data/__init__.py
@@ -84,6 +84,15 @@ from market_data.fulfillment import (
     FulfillmentStatus,
     ProviderFulfillmentAttempt,
 )
+from market_data.resolution import (
+    ConfidenceClassification,
+    FieldDisagreement,
+    ObservationResolver,
+    ResolutionConfidence,
+    ResolutionMethod,
+    ResolutionPolicy,
+    ResolutionResult,
+)
 from market_data.transport import (
     ReadOnlyHttpRequest,
     ReadOnlyHttpResponse,
@@ -169,4 +178,11 @@ __all__ = [
     "CapabilityFulfillmentService",
     "FulfillmentStatus",
     "ProviderFulfillmentAttempt",
+    "ConfidenceClassification",
+    "FieldDisagreement",
+    "ObservationResolver",
+    "ResolutionConfidence",
+    "ResolutionMethod",
+    "ResolutionPolicy",
+    "ResolutionResult",
 ]

--- a/market_data/resolution.py
+++ b/market_data/resolution.py
@@ -1,0 +1,252 @@
+"""Provider-neutral, non-statistical observation resolution (MD-013)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from domain import (
+    EarningsEvent,
+    ExpirationCycle,
+    MarketCapability,
+    MarketObservation,
+    OptionChain,
+    OptionContract,
+    financial_contract_to_data,
+    market_data_to_data,
+)
+from domain.values import DomainInvariantError, require_tz_aware
+
+
+class ResolutionMethod(str, Enum):
+    SINGLE_AVAILABLE = "single_available"
+    EXACT_AGREEMENT = "exact_agreement"
+    PROVIDER_PRIORITY = "provider_priority"
+    UNRESOLVED = "unresolved"
+
+
+class ConfidenceClassification(str, Enum):
+    SINGLE_SOURCE = "single_source"
+    EXACT_AGREEMENT = "exact_agreement"
+    DISAGREEMENT = "disagreement"
+    INSUFFICIENT_QUALITY = "insufficient_quality"
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionPolicy:
+    policy_version: str
+    provider_priority: tuple[str, ...]
+    freshness_threshold_seconds: int
+    required_fields: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.policy_version or self.policy_version != self.policy_version.strip():
+            raise DomainInvariantError("ResolutionPolicy policy_version must be normalized")
+        if not self.provider_priority or len(set(self.provider_priority)) != len(
+            self.provider_priority
+        ):
+            raise DomainInvariantError("ResolutionPolicy requires unique provider priority")
+        if any(not item or item != item.strip() for item in self.provider_priority):
+            raise DomainInvariantError("ResolutionPolicy provider IDs must be normalized")
+        if (
+            type(self.freshness_threshold_seconds) is not int
+            or self.freshness_threshold_seconds < 0
+        ):
+            raise DomainInvariantError("ResolutionPolicy freshness threshold must be non-negative")
+        fields = tuple(sorted(set(self.required_fields)))
+        if not fields or any(not item or item != item.strip() for item in fields):
+            raise DomainInvariantError("ResolutionPolicy requires normalized fields")
+        object.__setattr__(self, "required_fields", fields)
+
+
+@dataclass(frozen=True, slots=True)
+class FieldDisagreement:
+    field_path: str
+    values_by_provider: tuple[tuple[str, str], ...]
+
+    def __post_init__(self) -> None:
+        if not self.field_path or self.field_path != self.field_path.strip():
+            raise DomainInvariantError("FieldDisagreement path must be normalized")
+        if len(self.values_by_provider) < 2:
+            raise DomainInvariantError("FieldDisagreement requires multiple contributors")
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionConfidence:
+    classification: ConfidenceClassification
+    contributor_count: int
+    fresh_contributor_count: int
+    complete_contributor_count: int
+    exact_agreement: bool
+
+    def __post_init__(self) -> None:
+        for name in ("contributor_count", "fresh_contributor_count", "complete_contributor_count"):
+            value = getattr(self, name)
+            if type(value) is not int or value < 0 or value > self.contributor_count:
+                raise DomainInvariantError(f"ResolutionConfidence {name} is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionResult:
+    capability: MarketCapability
+    selected_observation: MarketObservation | None
+    consumed_observation_ids: tuple[str, ...]
+    contributors: tuple[str, ...]
+    method: ResolutionMethod
+    disagreements: tuple[FieldDisagreement, ...]
+    confidence: ResolutionConfidence
+    policy_version: str
+    policy_parameters: tuple[tuple[str, str], ...]
+    rationale: str
+
+    def __post_init__(self) -> None:
+        if not self.consumed_observation_ids or not self.contributors:
+            raise DomainInvariantError("ResolutionResult requires consumed evidence")
+        if (self.method is ResolutionMethod.UNRESOLVED) != (self.selected_observation is None):
+            raise DomainInvariantError("ResolutionResult selection and method are inconsistent")
+        if not self.rationale or self.rationale != self.rationale.strip():
+            raise DomainInvariantError("ResolutionResult rationale must be normalized")
+
+
+class ObservationResolver:
+    """Selects one reported value by frozen priority or leaves the conflict unresolved."""
+
+    def resolve(
+        self,
+        observations: tuple[MarketObservation, ...],
+        policy: ResolutionPolicy,
+        *,
+        as_of: datetime,
+    ) -> ResolutionResult:
+        require_tz_aware(as_of, "ObservationResolver", "as_of")
+        ordered = tuple(sorted(observations, key=lambda item: item.observation_id))
+        if not ordered:
+            raise DomainInvariantError("Observation resolution requires observations")
+        capability = ordered[0].capability
+        subject = ordered[0].subject
+        if any(item.capability is not capability or item.subject != subject for item in ordered):
+            raise DomainInvariantError("Observation resolution requires one capability and subject")
+        providers = tuple(item.provenance.provider_id for item in ordered)
+        if len(providers) != len(set(providers)):
+            raise DomainInvariantError("Observation resolution requires one value per provider")
+
+        by_provider = {item.provenance.provider_id: item for item in ordered}
+        eligible = tuple(item for item in policy.provider_priority if item in by_provider)
+        consumed_ids = tuple(item.observation_id for item in ordered)
+        contributors = tuple(sorted(providers))
+        values = {item.provenance.provider_id: self._value_data(item) for item in ordered}
+        disagreements = self._disagreements(values)
+        fresh = tuple(
+            item
+            for item in ordered
+            if max(0, int((as_of - item.effective_time).total_seconds()))
+            <= policy.freshness_threshold_seconds
+        )
+        complete = tuple(
+            item
+            for item in ordered
+            if not (set(policy.required_fields) - set(item.completeness.present_fields))
+        )
+        exact = not disagreements
+        confidence = ResolutionConfidence(
+            ConfidenceClassification.EXACT_AGREEMENT
+            if exact and len(ordered) > 1
+            else ConfidenceClassification.SINGLE_SOURCE
+            if len(ordered) == 1
+            else ConfidenceClassification.DISAGREEMENT,
+            len(ordered),
+            len(fresh),
+            len(complete),
+            exact,
+        )
+        parameters = (
+            ("freshness_threshold_seconds", str(policy.freshness_threshold_seconds)),
+            ("provider_priority", ",".join(policy.provider_priority)),
+            ("required_fields", ",".join(policy.required_fields)),
+        )
+
+        selected = by_provider[eligible[0]] if eligible else None
+        if selected is None or selected not in fresh or selected not in complete:
+            return ResolutionResult(
+                capability,
+                None,
+                consumed_ids,
+                contributors,
+                ResolutionMethod.UNRESOLVED,
+                disagreements,
+                ResolutionConfidence(
+                    ConfidenceClassification.INSUFFICIENT_QUALITY,
+                    len(ordered),
+                    len(fresh),
+                    len(complete),
+                    exact,
+                ),
+                policy.policy_version,
+                parameters,
+                "highest-priority available observation did not satisfy explicit quality inputs",
+            )
+        method = (
+            ResolutionMethod.SINGLE_AVAILABLE
+            if len(ordered) == 1
+            else ResolutionMethod.EXACT_AGREEMENT
+            if exact
+            else ResolutionMethod.PROVIDER_PRIORITY
+        )
+        return ResolutionResult(
+            capability,
+            selected,
+            consumed_ids,
+            contributors,
+            method,
+            disagreements,
+            confidence,
+            policy.policy_version,
+            parameters,
+            "selected one complete reported value using frozen provider priority",
+        )
+
+    @staticmethod
+    def _value_data(observation: MarketObservation) -> dict[str, object]:
+        if isinstance(
+            observation.value, (OptionContract, OptionChain, ExpirationCycle, EarningsEvent)
+        ):
+            data = financial_contract_to_data(observation.value)
+        else:
+            data = market_data_to_data(observation.value)
+        if not isinstance(data, dict):
+            raise DomainInvariantError("Market observation value must serialize as an object")
+        return data
+
+    @classmethod
+    def _disagreements(cls, values: dict[str, dict[str, object]]) -> tuple[FieldDisagreement, ...]:
+        flattened = {provider: cls._flatten(value) for provider, value in values.items()}
+        paths = sorted({path for value in flattened.values() for path in value})
+        output: list[FieldDisagreement] = []
+        for path in paths:
+            contributors = tuple(
+                sorted(
+                    (provider, value.get(path, "<missing>"))
+                    for provider, value in flattened.items()
+                )
+            )
+            if len({value for _, value in contributors}) > 1:
+                output.append(FieldDisagreement(path, contributors))
+        return tuple(output)
+
+    @staticmethod
+    def _flatten(value: object, prefix: str = "") -> dict[str, str]:
+        if isinstance(value, dict):
+            output: dict[str, str] = {}
+            for key in sorted(value):
+                child = f"{prefix}.{key}" if prefix else str(key)
+                output.update(ObservationResolver._flatten(value[key], child))
+            return output
+        if isinstance(value, list):
+            output = {}
+            for index, item in enumerate(value):
+                child = f"{prefix}[{index}]"
+                output.update(ObservationResolver._flatten(item, child))
+            return output
+        return {prefix: json.dumps(value, sort_keys=True, separators=(",", ":"))}

--- a/tests/market_data/test_resolution.py
+++ b/tests/market_data/test_resolution.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from domain import (
+    FreshnessStatus,
+    MarketObservation,
+    ProviderProvenance,
+    Quote,
+    market_observation_identity,
+)
+from domain.values import DomainInvariantError
+from market_data import (
+    ConfidenceClassification,
+    ObservationResolver,
+    RequestBudgetAuthorization,
+    ResolutionMethod,
+    ResolutionPolicy,
+)
+from tests.market_data.test_fulfillment import provider, request
+
+NOW = datetime(2026, 7, 21, 16, 0, tzinfo=timezone.utc)
+
+
+def observation(provider_id: str) -> MarketObservation:
+    return (
+        provider(provider_id)
+        .fetch(request(), RequestBudgetAuthorization("test", provider_id, 1, 1))
+        .observations[0]
+    )
+
+
+def changed_price(source: MarketObservation, provider_id: str, price: str) -> MarketObservation:
+    assert isinstance(source.value, Quote)
+    value = dataclasses.replace(source.value, last=Decimal(price))
+    provenance = ProviderProvenance(
+        provider_id, f"{provider_id}-request", source.provenance.evidence
+    )
+    return dataclasses.replace(
+        source,
+        value=value,
+        provenance=provenance,
+        observation_id=market_observation_identity(
+            provider_id,
+            source.capability,
+            source.subject,
+            source.effective_time,
+            value,
+            source.schema_version,
+        ),
+    )
+
+
+def policy(*providers: str) -> ResolutionPolicy:
+    return ResolutionPolicy("v1", providers, 60, ("last",))
+
+
+def test_single_observation_is_selected() -> None:
+    item = observation("tradier")
+    result = ObservationResolver().resolve((item,), policy("tradier"), as_of=NOW)
+    assert result.method is ResolutionMethod.SINGLE_AVAILABLE
+    assert result.selected_observation == item
+    assert result.confidence.classification is ConfidenceClassification.SINGLE_SOURCE
+
+
+def test_exact_agreement_selects_configured_priority_independent_of_input_order() -> None:
+    tradier = observation("tradier")
+    finnhub = changed_price(tradier, "finnhub", str(tradier.value.last))  # type: ignore[union-attr]
+    resolver = ObservationResolver()
+    first = resolver.resolve((finnhub, tradier), policy("tradier", "finnhub"), as_of=NOW)
+    second = resolver.resolve((tradier, finnhub), policy("tradier", "finnhub"), as_of=NOW)
+    assert first == second
+    assert first.method is ResolutionMethod.EXACT_AGREEMENT
+    assert first.selected_observation == tradier
+    assert first.disagreements == ()
+
+
+def test_disagreement_is_field_level_and_priority_selects_reported_value() -> None:
+    tradier = observation("tradier")
+    finnhub = changed_price(tradier, "finnhub", "999.25")
+    result = ObservationResolver().resolve(
+        (finnhub, tradier), policy("tradier", "finnhub"), as_of=NOW
+    )
+    assert result.method is ResolutionMethod.PROVIDER_PRIORITY
+    assert result.selected_observation == tradier
+    assert any(".last" in item.field_path for item in result.disagreements)
+    assert result.confidence.classification is ConfidenceClassification.DISAGREEMENT
+    assert result.contributors == ("finnhub", "tradier")
+
+
+def test_stale_highest_priority_remains_unresolved_without_hidden_fallback() -> None:
+    tradier = observation("tradier")
+    stale_freshness = dataclasses.replace(
+        tradier.freshness,
+        as_of=NOW + timedelta(seconds=120),
+        age_seconds=120,
+        status=FreshnessStatus.STALE,
+    )
+    stale = dataclasses.replace(tradier, freshness=stale_freshness)
+    finnhub = changed_price(tradier, "finnhub", "999.25")
+    result = ObservationResolver().resolve(
+        (stale, finnhub), policy("tradier", "finnhub"), as_of=NOW + timedelta(seconds=120)
+    )
+    assert result.method is ResolutionMethod.UNRESOLVED
+    assert result.selected_observation is None
+    assert result.confidence.classification is ConfidenceClassification.INSUFFICIENT_QUALITY
+
+
+def test_resolution_rejects_mixed_subjects_and_duplicate_provider_values() -> None:
+    item = observation("tradier")
+    with pytest.raises(DomainInvariantError, match="one value per provider"):
+        ObservationResolver().resolve((item, item), policy("tradier"), as_of=NOW)


### PR DESCRIPTION
## Ticket\n\nMD-013 — Observation Resolution and Confidence Metadata\n\n## Summary\n\nAdds immutable provider-neutral observation resolution. It preserves all contributors, computes field-level disagreement, records multidimensional quality inputs, selects one provider-reported value by the frozen priority policy, and leaves insufficient-quality cases unresolved.\n\n## Frozen architecture compliance\n\n- Implements Market Data Platform v1 provider-priority selection only.\n- Supports single-available and exact-agreement input cases.\n- Does not implement median, averaging, voting, blending, probabilistic, or statistical resolution.\n- Freshness and completeness are explicit policy inputs and never hidden fallback heuristics.\n- Input ordering cannot affect the result.\n\n## Security and secret handling\n\nResolution consumes canonical observations only and retains no configuration, credentials, provider payloads, or URLs.\n\n## Network behavior\n\nNo provider, registry, transport, or network dependency exists in the resolver.\n\n## Request budget behavior\n\nNot applicable; resolution performs no acquisition.\n\n## Tests\n\n- 5 focused resolution regressions passed.\n- 615 domain, market-data, and architecture tests passed.\n- Full repository suite: 1879 passed, 1 existing skip.\n- Ruff passed.\n- Strict mypy passed for 32 domain/market-data source files.\n- Lean entrypoint, integrity, and pre-push checks passed.\n- git diff --check passed.\n\n## Live validation status\n\nNot applicable; resolution is deterministic and offline.\n\n## Explicit exclusions\n\nNo statistical fusion, synthesized values, strategy signals, provider calls, persistence, snapshot changes, or frozen architecture changes.\n\n## Auto-merge authority\n\nSPRINT-005B delegated merge authority is active. This PR is eligible for automatic merge after repository requirements pass.