### PR TITLE
MD-014: add immutable market snapshot builder

### DIFF
--- a/market_data/__init__.py
+++ b/market_data/__init__.py
@@ -93,6 +93,18 @@ from market_data.resolution import (
     ResolutionPolicy,
     ResolutionResult,
 )
+from market_data.snapshot import (
+    MarketSnapshot,
+    MarketSnapshotBuilder,
+    SNAPSHOT_IDENTITY_NAMESPACE,
+    SNAPSHOT_SCHEMA_VERSION,
+    SnapshotCompleteness,
+    SnapshotRequest,
+    SnapshotValidationMetadata,
+    market_snapshot_digest,
+    market_snapshot_to_data,
+    serialize_market_snapshot,
+)
 from market_data.transport import (
     ReadOnlyHttpRequest,
     ReadOnlyHttpResponse,
@@ -185,4 +197,14 @@ __all__ = [
     "ResolutionMethod",
     "ResolutionPolicy",
     "ResolutionResult",
+    "MarketSnapshot",
+    "MarketSnapshotBuilder",
+    "SNAPSHOT_IDENTITY_NAMESPACE",
+    "SNAPSHOT_SCHEMA_VERSION",
+    "SnapshotCompleteness",
+    "SnapshotRequest",
+    "SnapshotValidationMetadata",
+    "market_snapshot_digest",
+    "market_snapshot_to_data",
+    "serialize_market_snapshot",
 ]

--- a/market_data/snapshot.py
+++ b/market_data/snapshot.py
@@ -1,0 +1,269 @@
+"""Immutable, self-contained Market Snapshot construction (MD-014)."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from enum import Enum
+from typing import cast
+from domain import EvidenceReference, MarketCapability, MarketObservation
+from domain.values import DomainInvariantError, require_tz_aware
+from market_data.budget import RequestAccountingEntry
+from market_data.fulfillment import CapabilityFulfillmentResult
+from market_data.providers import ProviderMetadata
+from market_data.resolution import ResolutionMethod, ResolutionResult
+
+SNAPSHOT_SCHEMA_VERSION = "v1"
+SNAPSHOT_IDENTITY_NAMESPACE = "asa.market_snapshot/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotRequest:
+    as_of: datetime
+    requested_capabilities: tuple[MarketCapability, ...]
+    required_capabilities: tuple[MarketCapability, ...]
+    schema_version: str = SNAPSHOT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        require_tz_aware(self.as_of, "SnapshotRequest", "as_of")
+        requested = tuple(sorted(set(self.requested_capabilities), key=lambda item: item.value))
+        required = tuple(sorted(set(self.required_capabilities), key=lambda item: item.value))
+        if not requested or not set(required).issubset(requested):
+            raise DomainInvariantError("SnapshotRequest capability sets are inconsistent")
+        if self.schema_version != SNAPSHOT_SCHEMA_VERSION:
+            raise DomainInvariantError("SnapshotRequest schema version is unsupported")
+        object.__setattr__(self, "requested_capabilities", requested)
+        object.__setattr__(self, "required_capabilities", required)
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotValidationMetadata:
+    report_id: str
+    provider_id: str
+    disposition: str
+
+    def __post_init__(self) -> None:
+        for name in ("report_id", "provider_id", "disposition"):
+            value = getattr(self, name)
+            if not value or value != value.strip():
+                raise DomainInvariantError(f"SnapshotValidationMetadata {name} must be normalized")
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotCompleteness:
+    requested_capabilities: tuple[MarketCapability, ...]
+    resolved_capabilities: tuple[MarketCapability, ...]
+    unresolved_capabilities: tuple[MarketCapability, ...]
+    missing_required_capabilities: tuple[MarketCapability, ...]
+
+    def __post_init__(self) -> None:
+        requested = set(self.requested_capabilities)
+        if set(self.resolved_capabilities) | set(self.unresolved_capabilities) != requested:
+            raise DomainInvariantError("SnapshotCompleteness does not cover every request")
+        if set(self.resolved_capabilities) & set(self.unresolved_capabilities):
+            raise DomainInvariantError("SnapshotCompleteness resolution sets overlap")
+        if not set(self.missing_required_capabilities).issubset(self.unresolved_capabilities):
+            raise DomainInvariantError("SnapshotCompleteness required failures are inconsistent")
+
+
+@dataclass(frozen=True, slots=True)
+class MarketSnapshot:
+    snapshot_id: str
+    snapshot_digest: str
+    schema_version: str
+    as_of: datetime
+    requested_capabilities: tuple[MarketCapability, ...]
+    observations: tuple[MarketObservation, ...]
+    resolution_results: tuple[ResolutionResult, ...]
+    provider_metadata: tuple[ProviderMetadata, ...]
+    validation_metadata: tuple[SnapshotValidationMetadata, ...]
+    request_accounting: tuple[RequestAccountingEntry, ...]
+    completeness: SnapshotCompleteness
+    evidence: tuple[EvidenceReference, ...]
+
+    def __post_init__(self) -> None:
+        require_tz_aware(self.as_of, "MarketSnapshot", "as_of")
+        if self.schema_version != SNAPSHOT_SCHEMA_VERSION:
+            raise DomainInvariantError("MarketSnapshot schema version is unsupported")
+        if any(item.recorded_time > self.as_of for item in self.observations):
+            raise DomainInvariantError("MarketSnapshot as_of precedes included recording")
+        expected = market_snapshot_digest(self)
+        if (
+            self.snapshot_digest != expected
+            or self.snapshot_id != f"{SNAPSHOT_IDENTITY_NAMESPACE}:{expected}"
+        ):
+            raise DomainInvariantError("MarketSnapshot identity is not content-derived")
+
+
+class MarketSnapshotBuilder:
+    def build(
+        self,
+        request: SnapshotRequest,
+        fulfillments: tuple[CapabilityFulfillmentResult, ...],
+        resolutions: tuple[ResolutionResult, ...],
+        provider_metadata: tuple[ProviderMetadata, ...],
+        validation_metadata: tuple[SnapshotValidationMetadata, ...],
+        request_accounting: tuple[RequestAccountingEntry, ...],
+    ) -> MarketSnapshot:
+        fulfillment_by_capability = {item.request.capability: item for item in fulfillments}
+        resolution_by_capability = {item.capability: item for item in resolutions}
+        requested = set(request.requested_capabilities)
+        if (
+            len(fulfillment_by_capability) != len(fulfillments)
+            or set(fulfillment_by_capability) != requested
+        ):
+            raise DomainInvariantError("Snapshot requires one fulfillment per capability")
+        if len(resolution_by_capability) != len(resolutions) or not set(
+            resolution_by_capability
+        ).issubset(requested):
+            raise DomainInvariantError("Snapshot resolutions must be unique requested capabilities")
+
+        observations = tuple(
+            sorted(
+                {
+                    observation.observation_id: observation
+                    for fulfillment in fulfillments
+                    for attempt in fulfillment.attempts
+                    for observation in attempt.observations
+                }.values(),
+                key=lambda item: (
+                    item.capability.value,
+                    item.subject.subject_identity,
+                    item.effective_time,
+                    item.provenance.provider_id,
+                    item.observation_id,
+                ),
+            )
+        )
+        included_providers = {item.provenance.provider_id for item in observations}
+        metadata = tuple(
+            sorted(
+                (
+                    item
+                    for item in provider_metadata
+                    if item.identity.provider_id in included_providers
+                ),
+                key=lambda item: item.identity.provider_id,
+            )
+        )
+        if {item.identity.provider_id for item in metadata} != included_providers:
+            raise DomainInvariantError("Snapshot lacks bounded metadata for an included provider")
+        ordered_resolutions = tuple(sorted(resolutions, key=lambda item: item.capability.value))
+        resolved = tuple(
+            item.capability
+            for item in ordered_resolutions
+            if item.method is not ResolutionMethod.UNRESOLVED
+        )
+        resolved_set = set(resolved)
+        unresolved = tuple(
+            item for item in request.requested_capabilities if item not in resolved_set
+        )
+        missing_required = tuple(
+            item for item in unresolved if item in request.required_capabilities
+        )
+        completeness = SnapshotCompleteness(
+            request.requested_capabilities, resolved, unresolved, missing_required
+        )
+        evidence = tuple(
+            sorted(
+                {
+                    (item.kind.value, item.referenced_id): item
+                    for observation in observations
+                    for item in observation.provenance.evidence
+                }.values(),
+                key=lambda item: (item.kind.value, item.referenced_id),
+            )
+        )
+        ordered_validation = tuple(
+            sorted(validation_metadata, key=lambda item: (item.provider_id, item.report_id))
+        )
+        ordered_accounting = tuple(
+            sorted(request_accounting, key=lambda item: item.authorization_id)
+        )
+        values: dict[str, object] = {
+            "schema_version": request.schema_version,
+            "as_of": request.as_of,
+            "requested_capabilities": request.requested_capabilities,
+            "observations": observations,
+            "resolution_results": ordered_resolutions,
+            "provider_metadata": metadata,
+            "validation_metadata": ordered_validation,
+            "request_accounting": ordered_accounting,
+            "completeness": completeness,
+            "evidence": evidence,
+        }
+        digest = _digest(values)
+        return MarketSnapshot(
+            f"{SNAPSHOT_IDENTITY_NAMESPACE}:{digest}",
+            digest,
+            request.schema_version,
+            request.as_of,
+            request.requested_capabilities,
+            observations,
+            ordered_resolutions,
+            metadata,
+            ordered_validation,
+            ordered_accounting,
+            completeness,
+            evidence,
+        )
+
+
+def market_snapshot_digest(snapshot: MarketSnapshot) -> str:
+    return _digest(
+        {
+            "schema_version": snapshot.schema_version,
+            "as_of": snapshot.as_of,
+            "requested_capabilities": snapshot.requested_capabilities,
+            "observations": snapshot.observations,
+            "resolution_results": snapshot.resolution_results,
+            "provider_metadata": snapshot.provider_metadata,
+            "validation_metadata": snapshot.validation_metadata,
+            "request_accounting": snapshot.request_accounting,
+            "completeness": snapshot.completeness,
+            "evidence": snapshot.evidence,
+        }
+    )
+
+
+def market_snapshot_to_data(snapshot: MarketSnapshot) -> dict[str, object]:
+    return cast(dict[str, object], _canonical(snapshot))
+
+
+def serialize_market_snapshot(snapshot: MarketSnapshot) -> str:
+    return json.dumps(_canonical(snapshot), sort_keys=True, separators=(",", ":"))
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(_canonical(value), sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _canonical(value: object) -> object:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _canonical(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        }
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return {"$decimal": format(value, "f")}
+    if isinstance(value, dict):
+        return {
+            str(key): _canonical(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (tuple, list)):
+        return [_canonical(item) for item in value]
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    raise TypeError(f"Unsupported snapshot value type: {type(value).__name__}")

--- a/tests/market_data/test_snapshot.py
+++ b/tests/market_data/test_snapshot.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from domain import MarketCapability
+from market_data import (
+    FulfillmentStatus,
+    CapabilityFulfillmentResult,
+    MarketSnapshotBuilder,
+    ObservationResolver,
+    ProviderErrorCode,
+    ResolutionPolicy,
+    ResolutionResult,
+    RequestBudgetManager,
+    SnapshotRequest,
+    SnapshotValidationMetadata,
+    market_snapshot_digest,
+    serialize_market_snapshot,
+)
+from market_data.fixture import FixtureScenario
+from tests.market_data.test_fulfillment import ScriptedProvider, provider, request, service
+
+NOW = datetime(2026, 7, 21, 16, 0, tzinfo=timezone.utc)
+CAPABILITY = MarketCapability.REAL_TIME_QUOTE_V1
+
+
+def successful_inputs() -> tuple[
+    ScriptedProvider,
+    CapabilityFulfillmentResult,
+    ResolutionResult,
+    RequestBudgetManager,
+]:
+    source = provider("tradier")
+    fulfillment_service, budgets = service(source)
+    fulfillment = fulfillment_service.fulfill(request())
+    resolution = ObservationResolver().resolve(
+        fulfillment.observations,
+        ResolutionPolicy("v1", ("tradier",), 60, ("last",)),
+        as_of=NOW,
+    )
+    return source, fulfillment, resolution, budgets
+
+
+def test_snapshot_is_deterministic_canonical_and_self_contained() -> None:
+    source, fulfillment, resolution, budgets = successful_inputs()
+    builder = MarketSnapshotBuilder()
+    snapshot_request = SnapshotRequest(NOW, (CAPABILITY,), (CAPABILITY,))
+    arguments = (
+        snapshot_request,
+        (fulfillment,),
+        (resolution,),
+        (source.metadata,),
+        (SnapshotValidationMetadata("report-1", "tradier", "passed"),),
+        budgets.accounting,
+    )
+    first = builder.build(*arguments)
+    second = builder.build(*arguments)
+    assert first == second
+    assert first.snapshot_digest == market_snapshot_digest(first)
+    assert first.snapshot_id.endswith(first.snapshot_digest)
+    assert first.completeness.missing_required_capabilities == ()
+    assert first.observations == fulfillment.observations
+
+
+def test_semantically_equivalent_input_order_has_same_digest() -> None:
+    first_provider = provider("tradier")
+    second_provider = provider("finnhub")
+    fulfillment_service, budgets = service(first_provider, second_provider)
+    fulfillment = fulfillment_service.fulfill(request())
+    resolution = ObservationResolver().resolve(
+        fulfillment.observations,
+        ResolutionPolicy("v1", ("tradier", "finnhub"), 60, ("last",)),
+        as_of=NOW,
+    )
+    builder = MarketSnapshotBuilder()
+    snapshot_request = SnapshotRequest(NOW, (CAPABILITY,), ())
+    first = builder.build(
+        snapshot_request,
+        (fulfillment,),
+        (resolution,),
+        (second_provider.metadata, first_provider.metadata),
+        (),
+        tuple(reversed(budgets.accounting)),
+    )
+    second = builder.build(
+        snapshot_request,
+        (fulfillment,),
+        (resolution,),
+        (first_provider.metadata, second_provider.metadata),
+        (),
+        budgets.accounting,
+    )
+    assert first.snapshot_digest == second.snapshot_digest
+
+
+def test_missing_required_capability_is_explicit_without_fabricated_observation() -> None:
+    failed_provider = provider(
+        "tradier", FixtureScenario(failures=((CAPABILITY, ProviderErrorCode.NO_DATA),))
+    )
+    fulfillment_service, budgets = service(failed_provider)
+    failed = fulfillment_service.fulfill(request())
+    assert failed.status is FulfillmentStatus.FAILED
+    snapshot = MarketSnapshotBuilder().build(
+        SnapshotRequest(NOW, (CAPABILITY,), (CAPABILITY,)),
+        (failed,),
+        (),
+        (failed_provider.metadata,),
+        (),
+        budgets.accounting,
+    )
+    assert snapshot.observations == ()
+    assert snapshot.completeness.missing_required_capabilities == (CAPABILITY,)
+
+
+def test_serialized_snapshot_contains_no_secret_material() -> None:
+    source, fulfillment, resolution, budgets = successful_inputs()
+    snapshot = MarketSnapshotBuilder().build(
+        SnapshotRequest(NOW, (CAPABILITY,), (CAPABILITY,)),
+        (fulfillment,),
+        (resolution,),
+        (source.metadata,),
+        (),
+        budgets.accounting,
+    )
+    encoded = serialize_market_snapshot(snapshot)
+    assert "password" not in encoded.lower()
+    assert "authorization_header" not in encoded.lower()
+    assert "test-only-placeholder" not in encoded


### PR DESCRIPTION
## Ticket\n\nMD-014 — Immutable Market Snapshot Builder\n\n## Summary\n\nAdds the canonical immutable MarketSnapshot envelope and builder, including ordered observations, resolution results, bounded provider metadata, validation dispositions, request accounting, completeness, evidence, canonical serialization, and a content-derived digest.\n\n## Frozen architecture compliance\n\n- Snapshot identity uses the asa.market_snapshot/v1 namespace.\n- as_of is caller supplied and cannot precede included recording times.\n- Ordering is canonical and provider-neutral.\n- Required capability failures remain explicit and never fabricate observations.\n- No persistence, current-pointer semantics, or strategy execution is introduced.\n\n## Security and secret handling\n\nThe snapshot schema admits only canonical observations and bounded non-secret metadata. Tests verify serialized output excludes secret and authorization-header material.\n\n## Network behavior\n\nSnapshot construction is entirely offline and has no provider, registry, factory, transport, or network dependency.\n\n## Request budget behavior\n\nImmutable request-accounting records are included in canonical snapshot identity; the builder performs no requests.\n\n## Tests\n\n- 4 focused snapshot tests passed.\n- 619 domain, market-data, and architecture tests passed.\n- Full repository suite: 1883 passed, 1 existing skip.\n- Ruff passed.\n- Strict mypy passed for 33 domain/market-data source files.\n- Lean entrypoint, integrity, and pre-push checks passed.\n- git diff --check passed.\n\n## Live validation status\n\nNot applicable; snapshot construction is deterministic and offline.\n\n## Explicit exclusions\n\nNo database, cache, live provider call, strategy execution, statistical resolution, or architecture change.\n\n## Auto-merge authority\n\nSPRINT-005B delegated merge authority is active. This PR is eligible for automatic merge after repository requirements pass.