### PR TITLE
MD-015: add offline market snapshot replay

### DIFF
--- a/market_data/__init__.py
+++ b/market_data/__init__.py
@@ -105,6 +105,12 @@ from market_data.snapshot import (
     market_snapshot_to_data,
     serialize_market_snapshot,
 )
+from market_data.replay import (
+    SnapshotFixtureLibrary,
+    SnapshotReplayRecord,
+    SnapshotReplayResult,
+    replay_market_snapshot,
+)
 from market_data.transport import (
     ReadOnlyHttpRequest,
     ReadOnlyHttpResponse,
@@ -207,4 +213,8 @@ __all__ = [
     "market_snapshot_digest",
     "market_snapshot_to_data",
     "serialize_market_snapshot",
+    "SnapshotFixtureLibrary",
+    "SnapshotReplayRecord",
+    "SnapshotReplayResult",
+    "replay_market_snapshot",
 ]

--- a/market_data/replay.py
+++ b/market_data/replay.py
@@ -1,0 +1,83 @@
+"""Offline-only Market Snapshot replay integration (MD-015)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+from domain import MarketObservation
+from domain.values import DomainInvariantError
+from market_data.resolution import ResolutionResult
+from market_data.snapshot import MarketSnapshot, market_snapshot_digest
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotReplayRecord:
+    snapshot: MarketSnapshot
+    expected_digest: str
+    replay_algorithm_version: str = "asa.market_data_replay/v1"
+
+    def __post_init__(self) -> None:
+        if not self.expected_digest or self.expected_digest != self.expected_digest.strip():
+            raise DomainInvariantError("SnapshotReplayRecord expected digest must be normalized")
+        if self.replay_algorithm_version != "asa.market_data_replay/v1":
+            raise DomainInvariantError("SnapshotReplayRecord algorithm version is unsupported")
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotReplayResult:
+    replay_id: str
+    snapshot_id: str
+    snapshot_digest: str
+    observations: tuple[MarketObservation, ...]
+    resolution_results: tuple[ResolutionResult, ...]
+    verified: bool
+
+    def __post_init__(self) -> None:
+        if not self.verified:
+            raise DomainInvariantError("SnapshotReplayResult must represent verified replay")
+
+
+class SnapshotFixtureLibrary:
+    """Immutable in-memory inventory of explicit snapshot fixtures."""
+
+    __slots__ = ("_snapshots",)
+
+    def __init__(self, snapshots: tuple[MarketSnapshot, ...]) -> None:
+        ordered = tuple(sorted(snapshots, key=lambda item: item.snapshot_id))
+        if not ordered or len({item.snapshot_id for item in ordered}) != len(ordered):
+            raise DomainInvariantError("SnapshotFixtureLibrary requires unique snapshots")
+        self._snapshots = ordered
+
+    def load(self, snapshot_id: str) -> MarketSnapshot:
+        matches = tuple(item for item in self._snapshots if item.snapshot_id == snapshot_id)
+        if len(matches) != 1:
+            raise DomainInvariantError("Snapshot fixture was not found")
+        return matches[0]
+
+
+def replay_market_snapshot(record: SnapshotReplayRecord) -> SnapshotReplayResult:
+    """Verify and replay sealed content; no injectable acquisition dependency exists."""
+
+    actual_digest = market_snapshot_digest(record.snapshot)
+    if actual_digest != record.snapshot.snapshot_digest or actual_digest != record.expected_digest:
+        raise DomainInvariantError("Market Snapshot replay digest verification failed")
+    payload = json.dumps(
+        {
+            "algorithm": record.replay_algorithm_version,
+            "snapshot_digest": actual_digest,
+            "snapshot_id": record.snapshot.snapshot_id,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    replay_id = f"asa.market_data_replay/v1:{hashlib.sha256(payload).hexdigest()}"
+    return SnapshotReplayResult(
+        replay_id,
+        record.snapshot.snapshot_id,
+        actual_digest,
+        record.snapshot.observations,
+        record.snapshot.resolution_results,
+        True,
+    )

--- a/tests/architecture/test_market_data_replay_boundary.py
+++ b/tests/architecture/test_market_data_replay_boundary.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_market_data_replay_cannot_import_acquisition_dependencies() -> None:
+    source = (Path(__file__).parents[2] / "market_data" / "replay.py").read_text().lower()
+    prohibited = (
+        "providerfactory",
+        "providerregistry",
+        "marketdataprovider",
+        "readonlyhttptransport",
+        "load_market_data_config",
+        "socket",
+        "requests",
+        "httpx",
+        "urllib",
+    )
+    assert not tuple(item for item in prohibited if item in source)

--- a/tests/market_data/test_replay.py
+++ b/tests/market_data/test_replay.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from domain.values import DomainInvariantError
+from market_data import (
+    MarketSnapshotBuilder,
+    MarketSnapshot,
+    SnapshotFixtureLibrary,
+    SnapshotReplayRecord,
+    SnapshotRequest,
+    replay_market_snapshot,
+)
+from tests.market_data.test_snapshot import CAPABILITY, NOW, successful_inputs
+
+
+def snapshot() -> MarketSnapshot:
+    source, fulfillment, resolution, budgets = successful_inputs()
+    return MarketSnapshotBuilder().build(
+        SnapshotRequest(NOW, (CAPABILITY,), (CAPABILITY,)),
+        (fulfillment,),
+        (resolution,),
+        (source.metadata,),
+        (),
+        budgets.accounting,
+    )
+
+
+def test_offline_replay_is_deterministic_and_reconstructs_observations() -> None:
+    source = snapshot()
+    record = SnapshotReplayRecord(source, source.snapshot_digest)
+    first = replay_market_snapshot(record)
+    second = replay_market_snapshot(record)
+    assert first == second
+    assert first.observations == source.observations
+    assert first.resolution_results == source.resolution_results
+
+
+def test_tampered_expected_digest_fails_closed() -> None:
+    source = snapshot()
+    with pytest.raises(DomainInvariantError, match="digest verification"):
+        replay_market_snapshot(SnapshotReplayRecord(source, "0" * 64))
+
+
+def test_fixture_library_loads_only_explicit_sealed_snapshot() -> None:
+    source = snapshot()
+    library = SnapshotFixtureLibrary((source,))
+    assert library.load(source.snapshot_id) is source
+    with pytest.raises(DomainInvariantError, match="not found"):
+        library.load("missing")
+
+
+def test_replay_signature_has_no_provider_factory_or_transport_path() -> None:
+    source = snapshot()
+    record = SnapshotReplayRecord(source, source.snapshot_digest)
+    with pytest.raises(TypeError):
+        replay_market_snapshot(record, object())  # type: ignore[call-arg]
+
+
+def test_snapshot_contract_rejects_internal_digest_tampering() -> None:
+    source = snapshot()
+    with pytest.raises(DomainInvariantError, match="content-derived"):
+        dataclasses.replace(source, snapshot_digest="f" * 64)


### PR DESCRIPTION
## Ticket\n\nMD-015 — Market Data Replay Integration\n\n## Summary\n\nAdds offline-only MarketSnapshot replay records, digest verification, deterministic replay results, tamper detection, and an immutable fixture library.\n\n## Frozen architecture compliance\n\n- Replay accepts only a sealed MarketSnapshot record.\n- No Provider Factory, Provider Registry, provider adapter, transport, configuration loader, credential, clock, or network dependency can be supplied.\n- Replay returns snapshot content only and never fills missing data.\n- Snapshot and expected digests are verified before output.\n\n## Security and secret handling\n\nReplay consumes already-sanitized canonical snapshots and introduces no credential or environment surface.\n\n## Network behavior\n\nNetwork access is impossible through the replay API by construction. An architecture regression test rejects acquisition and networking imports in the replay module.\n\n## Request budget behavior\n\nNot applicable; replay cannot acquire data.\n\n## Tests\n\n- 6 focused replay and boundary tests passed.\n- 625 domain, market-data, and architecture tests passed.\n- Full repository regression command completed successfully with the existing skip preserved.\n- Ruff and changed-file format checks passed.\n- Strict mypy passed for 34 domain/market-data source files.\n- Lean entrypoint, integrity, and pre-push checks passed.\n- git diff --check passed.\n\n## Live validation status\n\nNot applicable; replay is strictly offline.\n\n## Explicit exclusions\n\nNo live provider construction, network access, persistence, strategy changes, execution-constitution changes, or architecture changes.\n\n## Auto-merge authority\n\nSPRINT-005B delegated merge authority is active. This PR is eligible for automatic merge after repository requirements pass.