### PR TITLE
MD-016: add reusable provider compliance suite

### DIFF
--- a/market_data/__init__.py
+++ b/market_data/__init__.py
@@ -111,6 +111,11 @@ from market_data.replay import (
     SnapshotReplayResult,
     replay_market_snapshot,
 )
+from market_data.compliance import (
+    ProviderCapabilityCase,
+    ProviderComplianceReport,
+    evaluate_provider_compliance,
+)
 from market_data.transport import (
     ReadOnlyHttpRequest,
     ReadOnlyHttpResponse,
@@ -217,4 +222,7 @@ __all__ = [
     "SnapshotReplayRecord",
     "SnapshotReplayResult",
     "replay_market_snapshot",
+    "ProviderCapabilityCase",
+    "ProviderComplianceReport",
+    "evaluate_provider_compliance",
 ]

--- a/market_data/compliance.py
+++ b/market_data/compliance.py
@@ -1,0 +1,63 @@
+"""Reusable offline Provider compliance evaluation (MD-016)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from domain import MarketCapability
+from domain.values import DomainInvariantError
+from market_data.providers import MarketDataProvider, ProviderFetchResult
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderCapabilityCase:
+    capability: MarketCapability
+    result: ProviderFetchResult
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderComplianceReport:
+    provider_id: str
+    adapter_version: str
+    covered_capabilities: tuple[MarketCapability, ...]
+    passed: bool
+
+    def __post_init__(self) -> None:
+        if not self.provider_id or not self.adapter_version:
+            raise DomainInvariantError("ProviderComplianceReport identity must be non-empty")
+        if not self.covered_capabilities or not self.passed:
+            raise DomainInvariantError("ProviderComplianceReport represents passing coverage only")
+
+
+def evaluate_provider_compliance(
+    provider: MarketDataProvider,
+    cases: tuple[ProviderCapabilityCase, ...],
+) -> ProviderComplianceReport:
+    """Fail closed unless every declared capability has one canonical successful fixture."""
+
+    by_capability = {case.capability: case for case in cases}
+    if len(by_capability) != len(cases):
+        raise DomainInvariantError("Provider compliance cases must be unique by capability")
+    declared = set(provider.capabilities)
+    if set(by_capability) != declared:
+        raise DomainInvariantError("Provider compliance must cover every declared capability")
+    if set(provider.metadata.fixture_coverage) != declared:
+        raise DomainInvariantError("Provider fixture coverage must match declared capabilities")
+    for capability in sorted(declared, key=lambda item: item.value):
+        result = by_capability[capability].result
+        if result.error is not None or not result.observations or not result.attempts:
+            raise DomainInvariantError("Provider compliance requires a successful canonical result")
+        if any(item.capability is not capability for item in result.observations):
+            raise DomainInvariantError("Provider compliance result capability mismatch")
+        if any(item.provenance.provider_id != provider.provider_id for item in result.observations):
+            raise DomainInvariantError("Provider compliance provenance mismatch")
+        if any(item.completeness.missing_fields for item in result.observations):
+            raise DomainInvariantError("Provider compliance fixture is incomplete")
+        if any(item.provider_id != provider.provider_id for item in result.attempts):
+            raise DomainInvariantError("Provider compliance attempt identity mismatch")
+    return ProviderComplianceReport(
+        provider.provider_id,
+        provider.metadata.identity.adapter_version,
+        tuple(sorted(declared, key=lambda item: item.value)),
+        True,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,6 @@ strict = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests/deployment_observer"]
+markers = [
+  "live_provider: opt-in bounded provider validation requiring configured credentials",
+]

--- a/tests/market_data/conftest.py
+++ b/tests/market_data/conftest.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    if os.environ.get("ASA_LIVE_PROVIDER_VALIDATION") == "1":
+        return
+    skip = pytest.mark.skip(reason="live provider validation is opt-in and disabled by default")
+    for item in items:
+        if "live_provider" in item.keywords:
+            item.add_marker(skip)

--- a/tests/market_data/test_live_provider_isolation.py
+++ b/tests/market_data/test_live_provider_isolation.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.mark.live_provider
+def test_live_provider_collection_is_disabled_by_default() -> None:
+    """Sentinel: normal CI must skip this entire opt-in class of tests."""
+
+    pytest.fail("live provider tests require ASA_LIVE_PROVIDER_VALIDATION=1")

--- a/tests/market_data/test_provider_compliance.py
+++ b/tests/market_data/test_provider_compliance.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from domain import MarketCapability
+from domain.values import DomainInvariantError
+from market_data import ProviderCapabilityCase, evaluate_provider_compliance
+from tests.market_data import test_alpha_vantage as alpha
+from tests.market_data import test_finnhub as finnhub
+from tests.market_data import test_tradier as tradier
+from tests.market_data.test_fixture_provider import budget as fixture_budget
+from tests.market_data.test_fixture_provider import provider as fixture_provider
+from tests.market_data.test_fixture_provider import request as fixture_request
+
+
+def test_tradier_passes_shared_supported_capability_suite() -> None:
+    quote = tradier.provider(
+        tradier.Transport(
+            (
+                tradier.response(
+                    {"quotes": {"quote": {"symbol": "AAPL", "last": 210, "bid": 209, "ask": 211}}}
+                ),
+            )
+        )
+    )
+    bars = tradier.provider(
+        tradier.Transport(
+            (
+                tradier.response(
+                    {
+                        "history": {
+                            "day": [
+                                {
+                                    "date": "2026-07-20",
+                                    "open": 205,
+                                    "high": 212,
+                                    "low": 204,
+                                    "close": 210,
+                                    "volume": 50,
+                                }
+                            ]
+                        }
+                    }
+                ),
+            )
+        )
+    )
+    chain = tradier.provider(
+        tradier.Transport(
+            (
+                tradier.response(
+                    {
+                        "options": {
+                            "option": [
+                                {
+                                    "symbol": "AAPL260821C00210000",
+                                    "underlying": "AAPL",
+                                    "expiration_date": "2026-08-21",
+                                    "strike": 210,
+                                    "option_type": "call",
+                                    "bid": 4,
+                                    "ask": 5,
+                                    "last": 4.5,
+                                    "volume": 10,
+                                    "open_interest": 20,
+                                    "greeks": {
+                                        "delta": 0.5,
+                                        "gamma": 0.03,
+                                        "theta": -0.1,
+                                        "vega": 0.2,
+                                        "rho": 0.01,
+                                        "mid_iv": 0.25,
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ),
+            )
+        )
+    )
+    cases = (
+        ProviderCapabilityCase(
+            MarketCapability.REAL_TIME_QUOTE_V1,
+            quote.fetch(
+                tradier.request(MarketCapability.REAL_TIME_QUOTE_V1, ("last",)),
+                tradier.authorization(),
+            ),
+        ),
+        ProviderCapabilityCase(
+            MarketCapability.HISTORICAL_BARS_V1,
+            bars.fetch(
+                tradier.request(
+                    MarketCapability.HISTORICAL_BARS_V1, ("open", "high", "low", "close", "volume")
+                ),
+                tradier.authorization(),
+            ),
+        ),
+        ProviderCapabilityCase(
+            MarketCapability.OPTION_CHAIN_V1,
+            chain.fetch(
+                tradier.request(
+                    MarketCapability.OPTION_CHAIN_V1,
+                    ("contracts", "greeks", "implied_volatility", "volume", "open_interest"),
+                    expiration=True,
+                ),
+                tradier.authorization(),
+            ),
+        ),
+    )
+    assert evaluate_provider_compliance(quote, cases).passed
+
+
+def test_finnhub_passes_shared_supported_capability_suite() -> None:
+    stamp = int((finnhub.NOW - timedelta(days=2)).timestamp())
+    quote, _ = finnhub.provider(
+        finnhub.Transport((finnhub.response({"c": 210, "t": int(finnhub.NOW.timestamp())}),))
+    )
+    bars, _ = finnhub.provider(
+        finnhub.Transport(
+            (
+                finnhub.response(
+                    {
+                        "s": "ok",
+                        "o": [205],
+                        "h": [212],
+                        "l": [204],
+                        "c": [210],
+                        "v": [50],
+                        "t": [stamp],
+                    }
+                ),
+            )
+        )
+    )
+    earnings, _ = finnhub.provider(
+        finnhub.Transport(
+            (
+                finnhub.response(
+                    {"earningsCalendar": [{"symbol": "AAPL", "date": "2026-08-01", "hour": "amc"}]}
+                ),
+            )
+        )
+    )
+    cases = (
+        ProviderCapabilityCase(
+            MarketCapability.REAL_TIME_QUOTE_V1,
+            quote.fetch(
+                finnhub.request(MarketCapability.REAL_TIME_QUOTE_V1, ("last",)),
+                finnhub.authorization(),
+            ),
+        ),
+        ProviderCapabilityCase(
+            MarketCapability.HISTORICAL_BARS_V1,
+            bars.fetch(
+                finnhub.request(
+                    MarketCapability.HISTORICAL_BARS_V1, ("open", "high", "low", "close", "volume")
+                ),
+                finnhub.authorization(),
+            ),
+        ),
+        ProviderCapabilityCase(
+            MarketCapability.EARNINGS_CALENDAR_V1,
+            earnings.fetch(
+                finnhub.request(MarketCapability.EARNINGS_CALENDAR_V1, ("earnings_date",)),
+                finnhub.authorization(),
+            ),
+        ),
+    )
+    assert evaluate_provider_compliance(quote, cases).passed
+
+
+def test_alpha_vantage_passes_shared_supported_capability_suite() -> None:
+    bars, _ = alpha.provider(
+        alpha.Transport(
+            (
+                alpha.response(
+                    {
+                        "Time Series (Daily)": {
+                            "2026-07-20": {
+                                "1. open": "205",
+                                "2. high": "212",
+                                "3. low": "204",
+                                "4. close": "210",
+                                "5. volume": "50",
+                            }
+                        }
+                    }
+                ),
+            )
+        )
+    )
+    earnings, _ = alpha.provider(
+        alpha.Transport(
+            (
+                alpha.response(
+                    {
+                        "quarterlyEarnings": [
+                            {
+                                "fiscalDateEnding": "2026-06-30",
+                                "reportedDate": "2026-07-10",
+                                "reportedEPS": "1.5",
+                            }
+                        ]
+                    }
+                ),
+            )
+        )
+    )
+    cases = (
+        ProviderCapabilityCase(
+            MarketCapability.HISTORICAL_BARS_V1,
+            bars.fetch(
+                alpha.request(
+                    MarketCapability.HISTORICAL_BARS_V1, ("open", "high", "low", "close", "volume")
+                ),
+                alpha.authorization(),
+            ),
+        ),
+        ProviderCapabilityCase(
+            MarketCapability.EARNINGS_CALENDAR_V1,
+            earnings.fetch(
+                alpha.request(MarketCapability.EARNINGS_CALENDAR_V1, ("earnings_date",)),
+                alpha.authorization(),
+            ),
+        ),
+    )
+    assert evaluate_provider_compliance(bars, cases).passed
+
+
+def test_fixture_provider_passes_every_declared_capability() -> None:
+    provider = fixture_provider()
+    fields = {
+        MarketCapability.REAL_TIME_QUOTE_V1: ("last",),
+        MarketCapability.HISTORICAL_BARS_V1: ("open", "close"),
+        MarketCapability.OPTION_CHAIN_V1: (
+            "contracts",
+            "greeks",
+            "implied_volatility",
+            "volume",
+            "open_interest",
+        ),
+        MarketCapability.EARNINGS_CALENDAR_V1: ("earnings_date",),
+    }
+    cases = tuple(
+        ProviderCapabilityCase(
+            capability,
+            provider.fetch(fixture_request(capability, fields[capability]), fixture_budget()),
+        )
+        for capability in provider.capabilities
+    )
+    assert evaluate_provider_compliance(provider, cases).passed
+
+
+def test_compliance_fails_when_claimed_capability_lacks_coverage() -> None:
+    provider = fixture_provider()
+    with pytest.raises(DomainInvariantError, match="every declared capability"):
+        evaluate_provider_compliance(provider, ())


### PR DESCRIPTION
## Ticket\n\nMD-016 — Provider Compliance Test Suite\n\n## Summary\n\nAdds one reusable offline compliance evaluator and applies it to every declared capability of the deterministic fixture, Tradier, Finnhub, and Alpha Vantage adapters. It verifies capability coverage, canonical success results, provenance, completeness, attempt identity, and fixture declarations. Live provider tests are explicitly marked and disabled by default.\n\n## Frozen architecture compliance\n\n- Evaluates the existing provider-neutral interface and capability declarations.\n- Adds no capability, provider behavior, validation status, or public strategy/execution contract.\n- All fixtures use canonical observations and sanitized payload shapes.\n\n## Security and secret handling\n\nCompliance reports contain only provider identity, adapter version, capability coverage, and pass state. No credentials or raw payloads are retained.\n\n## Network behavior\n\nThe normal suite is fixture-only and network-free. Tests marked live_provider are skipped unless ASA_LIVE_PROVIDER_VALIDATION=1 is explicitly set.\n\n## Request budget behavior\n\nAdapter fixtures use explicit finite authorizations. The compliance evaluator itself makes no requests.\n\n## Tests\n\n- Shared compliance: 5 passed.\n- Scoped domain/market-data/architecture: 630 passed, 1 expected live-provider skip.\n- Full repository suite: 1894 passed, 2 expected skips.\n- Ruff and changed-file format checks passed.\n- Strict mypy passed for 35 domain/market-data source files.\n- Lean entrypoint, integrity, and pre-push checks passed.\n- git diff --check passed.\n\n## Live validation status\n\nDisabled by default and not run; no credentials were accessed.\n\n## Explicit exclusions\n\nNo live API calls, provider implementation changes, persistence, documentation generation, strategy changes, or architecture changes.\n\n## Auto-merge authority\n\nSPRINT-005B delegated merge authority is active. This PR is eligible for automatic merge after repository requirements pass.