### PR TITLE
Fix unhandled ConfigurationError crashing /ops/market-data/validate

### DIFF
--- a/backend/src/asa/market_data_ops/service.py
+++ b/backend/src/asa/market_data_ops/service.py
@@ -115,9 +115,35 @@ def run_bounded_validation(
     dry_run: bool,
     transport_factory: Callable[[str], object] = build_transport_for_provider,
 ) -> ValidationRunOutcome:
-    config = load_market_data_config_from_environment()
-    configs_by_id = {item.provider_id: item for item in config.providers}
     clock = Clock()
+    try:
+        config = load_market_data_config_from_environment()
+    except ConfigurationError as exc:
+        redacted = redact_diagnostic_text(str(exc))
+        configuration_error_results = tuple(
+            ProviderCheckResult(
+                provider_id,
+                "configuration_error",
+                (
+                    CapabilityCheckResult(
+                        provider_id,
+                        PROVIDER_CAPABILITIES[provider_id][0],
+                        "fail",
+                        "CONFIGURATION_ERROR",
+                        0,
+                        None,
+                        "unknown",
+                        "inconclusive",
+                        "unknown",
+                        None,
+                        redacted,
+                    ),
+                ),
+            )
+            for provider_id in requested_provider_ids
+        )
+        return ValidationRunOutcome("failed", dry_run, clock.now(), configuration_error_results)
+    configs_by_id = {item.provider_id: item for item in config.providers}
     factory = _provider_factory()
 
     provider_results: list[ProviderCheckResult] = []

--- a/backend/tests/market_data_ops/test_market_data_validate.py
+++ b/backend/tests/market_data_ops/test_market_data_validate.py
@@ -119,6 +119,43 @@ def test_dry_run_with_enabled_provider_never_calls_transport(
     assert "sandbox-secret-token" not in response.text
 
 
+# --- environment_configuration_error_tests --------------------------------------------
+
+
+def test_invalid_environment_configuration_fails_closed_instead_of_crashing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """load_market_data_config_from_environment() raises ConfigurationError for an
+    invalid ASA_TRADIER_ENV value; the endpoint must classify this per-provider
+    rather than propagate an unhandled 500, for both dry_run and live requests.
+    """
+    monkeypatch.setenv("ASA_TRADIER_ENV", "not-a-real-environment")
+    client = _client("correct-token")
+    response = client.post(
+        "/ops/market-data/validate",
+        json={"dry_run": True},
+        headers={"Authorization": "Bearer correct-token"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["overall_status"] == "failed"
+    assert {provider["provider"] for provider in body["providers"]} == {
+        "tradier",
+        "finnhub",
+        "alpha_vantage",
+    }
+    assert all(
+        provider["configuration_status"] == "configuration_error"
+        for provider in body["providers"]
+    )
+    for provider in body["providers"]:
+        (check,) = provider["checks"]
+        assert check["normalized_check_status"] == "fail"
+        assert check["diagnostic_detail_code"] == "CONFIGURATION_ERROR"
+        assert check["request_count"] == 0
+    assert "not-a-real-environment" not in response.text
+
+
 # --- provider_selection_tests --------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- POST-005B-LIVE-VALIDATION operational validation of the Railway-deployed `/ops/market-data/validate` endpoint (from #136) found that both dry-run and live requests return a raw `500 Internal Server Error` instead of the endpoint's designed fail-closed, redacted response.
- Root cause: `run_bounded_validation()` calls `load_market_data_config_from_environment()` with no exception handling. Any `ConfigurationError` from the config loader (e.g. an invalid `ASA_TRADIER_ENV` value, or an empty-string credential env var) propagates uncaught to a raw 500, for every request regardless of `dry_run` or which providers were requested. Only the later `_execute_live()` call was guarded against this class of error.
- Fix: wrap the config load in the same try/except pattern already used for per-provider `ProviderFactoryError`/`ConfigurationError` handling in `_execute_live`, returning a redacted `configuration_error` result per requested provider instead of crashing.
- Scope: this is the minimal fix for the discovered defect only — no refactoring, no architecture or feature changes.

## Test plan
- [x] Reproduced the exact 500 locally (secret-free repro: invalid `ASA_TRADIER_ENV`), matching the live Railway response byte-for-byte.
- [x] Confirmed fix converts the crash into a `200` with a redacted, classified `configuration_error` response.
- [x] Added a regression test covering this exact failure mode for both providers and dry_run.
- [x] `ruff check .` — all checks passed.
- [x] `mypy` — no issues found (34 source files).
- [x] `pytest tests/` — 62 passed, 7 skipped (pre-existing Postgres-only skips, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)