### PR TITLE
Fix uncaught DomainInvariantError from empty-valued ratelimit headers

### DIFF
--- a/backend/src/market_data/finnhub.py
+++ b/backend/src/market_data/finnhub.py
@@ -378,7 +378,9 @@ class FinnhubProvider:
 
     def _response_metadata(self, response: ReadOnlyHttpResponse) -> ProviderResponseMetadata:
         quota = tuple(
-            (key.lower(), value) for key, value in response.headers if "ratelimit" in key.lower()
+            (key.lower(), value)
+            for key, value in response.headers
+            if "ratelimit" in key.lower() and value
         )
         return ProviderResponseMetadata(
             "finnhub",

--- a/backend/src/market_data/tradier.py
+++ b/backend/src/market_data/tradier.py
@@ -344,7 +344,7 @@ class TradierProvider:
         quota = tuple(
             (key.lower(), value)
             for key, value in response.headers
-            if key.lower().startswith("x-ratelimit-")
+            if key.lower().startswith("x-ratelimit-") and value
         )
         return ProviderResponseMetadata(
             "tradier",

--- a/market_data/finnhub.py
+++ b/market_data/finnhub.py
@@ -378,7 +378,9 @@ class FinnhubProvider:
 
     def _response_metadata(self, response: ReadOnlyHttpResponse) -> ProviderResponseMetadata:
         quota = tuple(
-            (key.lower(), value) for key, value in response.headers if "ratelimit" in key.lower()
+            (key.lower(), value)
+            for key, value in response.headers
+            if "ratelimit" in key.lower() and value
         )
         return ProviderResponseMetadata(
             "finnhub",

--- a/market_data/tradier.py
+++ b/market_data/tradier.py
@@ -344,7 +344,7 @@ class TradierProvider:
         quota = tuple(
             (key.lower(), value)
             for key, value in response.headers
-            if key.lower().startswith("x-ratelimit-")
+            if key.lower().startswith("x-ratelimit-") and value
         )
         return ProviderResponseMetadata(
             "tradier",

--- a/tests/market_data/test_finnhub.py
+++ b/tests/market_data/test_finnhub.py
@@ -210,6 +210,26 @@ def test_provider_http_failures_are_normalized(status: int, expected: ProviderEr
     assert result.error is not None and result.error.code is expected
 
 
+def test_empty_valued_ratelimit_header_is_dropped_instead_of_crashing() -> None:
+    """An empty-valued *ratelimit* header must never reach ProviderResponseMetadata,
+    which rejects empty quota values -- it must be dropped, not raised uncaught.
+    """
+    transport = Transport(
+        (
+            ReadOnlyHttpResponse(
+                200,
+                {"c": 210.25, "t": int(NOW.timestamp())},
+                (("X-Ratelimit-Remaining", ""),),
+                9,
+                "finnhub-request-1",
+            ),
+        )
+    )
+    adapter, _ = provider(transport)
+    result = adapter.fetch(request(MarketCapability.REAL_TIME_QUOTE_V1, ("last",)), authorization())
+    assert result.error is None and isinstance(result.observations[0].value, Quote)
+
+
 def test_entitlement_failure_is_distinct_even_on_http_200() -> None:
     adapter, _ = provider(Transport((response({"error": "Premium subscription required"}),)))
     result = adapter.fetch(

--- a/tests/market_data/test_tradier.py
+++ b/tests/market_data/test_tradier.py
@@ -242,6 +242,39 @@ def test_malformed_and_empty_payloads_fail_closed() -> None:
     assert empty.error is not None and empty.error.code is ProviderErrorCode.EMPTY_PAYLOAD
 
 
+def test_empty_valued_ratelimit_header_is_dropped_instead_of_crashing() -> None:
+    """An empty-valued X-Ratelimit-* header must never reach ProviderResponseMetadata,
+    which rejects empty quota values -- it must be dropped, not raised uncaught.
+    """
+    transport = Transport(
+        (
+            ReadOnlyHttpResponse(
+                200,
+                {
+                    "quotes": {
+                        "quote": {
+                            "symbol": "AAPL",
+                            "bid": 209.9,
+                            "ask": 210.1,
+                            "last": 210,
+                            "bidsize": 100,
+                            "asksize": 120,
+                            "volume": 1000000,
+                        }
+                    }
+                },
+                (("X-Ratelimit-Available", ""),),
+                12,
+                "tradier-request-1",
+            ),
+        )
+    )
+    result = provider(transport).fetch(
+        request(MarketCapability.REAL_TIME_QUOTE_V1, ("bid", "ask", "last")), authorization()
+    )
+    assert result.error is None and isinstance(result.observations[0].value, Quote)
+
+
 def test_adapter_has_no_write_or_brokerage_surface() -> None:
     names = set(TradierProvider.__dict__)
     assert not names & {


### PR DESCRIPTION
## Summary
- Discovered during POST-005B-LIVE-VALIDATION Phase 4, testing the fixed (#137) `/ops/market-data/validate` endpoint live against real Tradier/Finnhub/Alpha Vantage APIs. Alpha Vantage validated cleanly (real requests, correctly classified `RATE_LIMITED`/`NO_DATA`), but a run including Tradier/Finnhub returned a raw `500 Internal Server Error`.
- Root cause: `TradierProvider._response_metadata()` and `FinnhubProvider._response_metadata()` collect every response header matching their ratelimit-header filter into `ProviderResponseMetadata.quota_metadata`, without checking for an empty value. `ProviderResponseMetadata.__post_init__` (`providers.py:198`) rejects any quota entry with an empty key or value. A real provider response carrying an empty-valued rate-limit header (e.g. `X-Ratelimit-Available: ""`) therefore raises `DomainInvariantError` from inside `fetch()`, outside any try/except in the call chain up through `run_bounded_validation()` -- crashing the whole request, the same failure shape as the `ConfigurationError` bug fixed in #137, but triggered by live provider response headers instead of environment config.
- Confirmed locally with a secret-free repro (scripted transport returning a 200 response with an empty-valued `X-Ratelimit-Available` header) -- reproduced the exact `DomainInvariantError` before the fix, resolved after.
- Fix: skip ratelimit headers with an empty value when building quota metadata, in both the backend vendor copy (`backend/src/market_data/`) and the root source of truth (`market_data/`), kept in sync per `tests/market_data_ops/test_vendor_sync.py`.
- Scope: minimal fix for the discovered defect only, in both adapters where the same pattern existed. No refactoring, no architecture or feature changes.

## Test plan
- [x] Reproduced the uncaught `DomainInvariantError` locally (secret-free repro).
- [x] Confirmed fix resolves it -- validation now completes normally.
- [x] Added one regression test per adapter (`test_tradier.py`, `test_finnhub.py`) reproducing the exact empty-header response.
- [x] `pytest tests/market_data/` (root) -- 140 passed, 1 skipped (up from 138/1 baseline, +2 new tests).
- [x] `pytest tests/market_data_ops/test_vendor_sync.py` -- vendor copies confirmed in sync.
- [x] `pytest tests/` (backend) -- 63 passed, 7 skipped (pre-existing Postgres-only skips, unrelated).
- [x] `ruff check` -- clean, both root and backend.
- [x] `mypy` -- clean, both root and backend (34 backend source files; tradier.py/finnhub.py checked directly since backend excludes vendored files from its own mypy config, deferring to root's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)