### PR TITLE
Fix Tradier option-chain validation subject missing expiration projection

### DIFF
--- a/backend/src/asa/market_data_ops/subjects.py
+++ b/backend/src/asa/market_data_ops/subjects.py
@@ -6,7 +6,7 @@ hard-coded, previously-reviewed, safe read (a single well-known liquid equity).
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from domain import (
     CanonicalInstrumentIdentity,
@@ -63,19 +63,47 @@ _REQUIRED_FIELDS_BY_CAPABILITY = {
 }
 
 
+def _next_monthly_expiration(as_of: datetime) -> date:
+    """The next third-Friday-of-the-month strictly after as_of (a standard, liquid
+    equity option expiration cycle), matching tradier._is_monthly_expiration.
+    """
+    year, month = as_of.year, as_of.month
+    while True:
+        third_friday = date(year, month, 15)
+        third_friday += timedelta(days=(4 - third_friday.weekday()) % 7)
+        if third_friday > as_of.date():
+            return third_friday
+        month, year = (1, year + 1) if month == 12 else (month + 1, year)
+
+
 def build_validation_subject(
     provider_id: str, capability: MarketCapability, *, as_of: datetime
 ) -> MarketDataSubject:
     subject_type = _SUBJECT_TYPE_BY_CAPABILITY[capability]
     window_start = as_of - timedelta(days=30)
-    projection = ProviderAddressProjection(
-        provider_id, "v1", "symbol", _SAFE_SYMBOL, window_start, None, _EVIDENCE
-    )
+    projections = [
+        ProviderAddressProjection(
+            provider_id, "v1", "symbol", _SAFE_SYMBOL, window_start, None, _EVIDENCE
+        )
+    ]
+    if capability is MarketCapability.OPTION_CHAIN_V1:
+        expiration = _next_monthly_expiration(as_of)
+        projections.append(
+            ProviderAddressProjection(
+                provider_id,
+                "v1",
+                "expiration",
+                expiration.isoformat(),
+                window_start,
+                None,
+                _EVIDENCE,
+            )
+        )
     context = MarketDataRequestContext(
         window_start,
         as_of,
         _REQUIRED_FIELDS_BY_CAPABILITY[capability],
-        (projection,),
+        tuple(projections),
         _EVIDENCE,
     )
     return MarketDataSubject(_SAFE_INSTRUMENT, subject_type, capability, context)

--- a/backend/tests/market_data_ops/test_market_data_validate.py
+++ b/backend/tests/market_data_ops/test_market_data_validate.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 from asa.bootstrap import DependencyOverrides, build_application
 from asa.config import Settings
+from market_data.transport import ReadOnlyHttpResponse
 from tests.fakes import InMemoryObservationRepository
 from tests.market_data_ops.fakes import ScriptedTransport
 
@@ -94,6 +95,98 @@ def test_valid_token_with_no_live_credentials_is_accepted_and_blocked_closed() -
 
 def _raise_if_called(_provider_id: str) -> None:
     raise AssertionError("dry_run must never construct a live transport")
+
+
+def test_tradier_option_chain_live_run_completes_instead_of_crashing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for POST-005B-LIVE-VALIDATION Phase 4: the fixed OPTION_CHAIN_V1
+    validation subject previously carried no "expiration" projection, so Tradier's
+    endpoint routing raised DomainInvariantError before any transport call, crashing
+    the whole request with a raw 500. This exercises the full live (non-dry-run) path
+    for all three of Tradier's capabilities, in the sorted order TradierProvider
+    processes them (historical_bars_v1, option_chain_v1, real_time_quote_v1).
+    """
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    option_row = {
+        "symbol": "AAPL260821C00210000",
+        "underlying": "AAPL",
+        "expiration_date": "2026-08-21",
+        "strike": "210",
+        "option_type": "call",
+        "bid": "4.9",
+        "ask": "5.1",
+        "last": "5",
+        "volume": 1000,
+        "open_interest": 5000,
+        "greeks": {"delta": "0.5", "gamma": "0.03", "theta": "-0.1", "vega": "0.2", "rho": "0.01"},
+    }
+    responses = [
+        ReadOnlyHttpResponse(
+            200,
+            {
+                "history": {
+                    "day": [
+                        {
+                            "date": "2026-07-20",
+                            "open": "205.00",
+                            "high": "212",
+                            "low": "204",
+                            "close": "210",
+                            "volume": 50000000,
+                        }
+                    ]
+                }
+            },
+            (),
+            12,
+            "tradier-request-1",
+        ),
+        ReadOnlyHttpResponse(
+            200, {"options": {"option": [option_row]}}, (), 12, "tradier-request-2"
+        ),
+        ReadOnlyHttpResponse(
+            200,
+            {
+                "quotes": {
+                    "quote": {
+                        "symbol": "AAPL",
+                        "bid": "189.10",
+                        "ask": "189.20",
+                        "last": "189.15",
+                        "bidsize": 1,
+                        "asksize": 1,
+                        "volume": 100,
+                    }
+                }
+            },
+            (),
+            12,
+            "tradier-request-3",
+        ),
+    ]
+    client = _client(
+        "correct-token", transport_factory=lambda _provider_id: ScriptedTransport(responses)
+    )
+    result = client.post(
+        "/ops/market-data/validate",
+        json={"providers": ["tradier"], "dry_run": False},
+        headers={"Authorization": "Bearer correct-token"},
+    )
+    assert result.status_code == 200
+    body = result.json()
+    (provider,) = body["providers"]
+    assert provider["configuration_status"] == "enabled"
+    checks_by_capability = {check["capability"]: check for check in provider["checks"]}
+    assert set(checks_by_capability) == {
+        "historical_bars_v1",
+        "option_chain_v1",
+        "real_time_quote_v1",
+    }
+    for check in checks_by_capability.values():
+        assert check["normalized_check_status"] == "pass"
+        assert check["diagnostic_detail_code"] == "VALID_DATA"
 
 
 def test_dry_run_with_enabled_provider_never_calls_transport(

--- a/backend/tests/market_data_ops/test_subjects.py
+++ b/backend/tests/market_data_ops/test_subjects.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from asa.market_data_ops.subjects import build_validation_subject
+from domain import MarketCapability
+
+AS_OF = datetime(2026, 7, 22, 6, 0, tzinfo=UTC)
+
+
+def test_option_chain_subject_carries_a_future_expiration_projection() -> None:
+    """TradierProvider._endpoint() requires an "expiration" projection for
+    OPTION_CHAIN_V1 whenever required_fields is ("contracts",) (the fixed
+    validation subject's required_fields). Without one, subject.projection_for()
+    raised DomainInvariantError uncaught before any transport call was made --
+    this reproduces the live crash discovered during POST-005B-LIVE-VALIDATION
+    Phase 4 and confirms the fix.
+    """
+    subject = build_validation_subject("tradier", MarketCapability.OPTION_CHAIN_V1, as_of=AS_OF)
+    projection = subject.projection_for("tradier", "expiration", AS_OF)
+    expiration = datetime.fromisoformat(projection.address_value).date()
+    assert expiration > AS_OF.date()
+    assert expiration.weekday() == 4  # Friday
+    assert 15 <= expiration.day <= 21  # third Friday of the month
+
+
+def test_non_option_capabilities_are_unaffected() -> None:
+    for capability in (
+        MarketCapability.REAL_TIME_QUOTE_V1,
+        MarketCapability.HISTORICAL_BARS_V1,
+        MarketCapability.EARNINGS_CALENDAR_V1,
+    ):
+        subject = build_validation_subject("tradier", capability, as_of=AS_OF)
+        assert len(subject.request_context.provider_address_projections) == 1


### PR DESCRIPTION
## Summary
- Discovered during POST-005B-LIVE-VALIDATION Phase 4, after #137 and #138 were merged and deployed: a live run of all three providers together still 500'd. Isolating providers one at a time showed Alpha Vantage clean, Finnhub clean (two legitimate provider-side failures, not bugs), but **Tradier alone crashed every time**, deterministically -- unrelated to any live response content.
- Root cause: `build_validation_subject()` builds every fixed validation subject with only a `"symbol"` projection. `TradierProvider._endpoint()` routes `OPTION_CHAIN_V1` requests (whose fixed `required_fields` is `("contracts",)`) to `subject.projection_for("tradier", "expiration", ...)`, which raises `DomainInvariantError` when no matching projection exists -- and this call happens *before* any transport call, outside every try/except in the chain up through `run_bounded_validation()`. Finnhub and Alpha Vantage were unaffected because neither is assigned `OPTION_CHAIN_V1` in `PROVIDER_CAPABILITIES`.
- Confirmed locally with a no-network repro: constructing the fixed `OPTION_CHAIN_V1` subject and calling `TradierProvider.validate()` against it raises `DomainInvariantError: MarketDataSubject requires one effective provider projection` before the transport is ever touched -- this is guaranteed to happen on every real attempt, not just an edge case.
- Fix: `build_validation_subject()` now attaches a second `"expiration"` projection for `OPTION_CHAIN_V1` subjects, computed as the next standard monthly (third-Friday) expiration strictly after `as_of` -- matching `tradier.py`'s own `_is_monthly_expiration` convention and the file's existing "fixed, safe, pre-reviewed" subject design intent.
- Scope: minimal fix for the discovered defect only, in the one place (`subjects.py`) responsible for building fixed validation subjects. No refactoring, no architecture or feature changes.

## Test plan
- [x] Reproduced the uncaught `DomainInvariantError` locally (no network, deterministic).
- [x] Confirmed fix resolves it -- `_endpoint()` now reaches the transport with a correct `/v1/markets/options/chains` request including a valid future `expiration` query param.
- [x] Added a unit test (`test_subjects.py`) confirming the `OPTION_CHAIN_V1` subject carries a future, correctly-dated expiration projection, and that other capabilities are unaffected.
- [x] Added an end-to-end regression test through the actual `/ops/market-data/validate` endpoint, exercising all three of Tradier's capabilities with scripted responses in their real processing order, confirming `200` + `pass` instead of a `500`.
- [x] `pytest tests/market_data_ops/` -- 19 passed (up from 17 baseline, +2 new tests).
- [x] `pytest tests/` (backend, full) -- 66 passed, 7 skipped (pre-existing Postgres-only skips, unrelated).
- [x] `ruff check .` -- clean.
- [x] `mypy` -- clean (34 source files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)