### PR TITLE
SCREEN-001: strategy inventory and readiness audit

### DIFF
--- a/project/reports/SCREEN-001-strategy-inventory.json
+++ b/project/reports/SCREEN-001-strategy-inventory.json
@@ -1,0 +1,144 @@
+{
+  "ticket": "SCREEN-001",
+  "sprint": "SPRINT-006",
+  "audited_at": "2026-07-22",
+  "repository_commit": "1d3483e",
+  "base_branch": "main",
+  "strategies": [
+    {
+      "name": "forward_factor",
+      "ticket_name": "Forward Factor",
+      "status": "partial",
+      "status_reason": "fully implemented and tested; zero production integration",
+      "manifest_id": "asa.stonk.forward_factor_calendar",
+      "manifest_version": "1.1.0",
+      "files": [
+        "strategies/stonk_manifests.py",
+        "strategies/stonk_components.py"
+      ],
+      "components": [
+        "ForwardFactor",
+        "ImpliedForwardVolatility",
+        "DoubleCalendarStructure",
+        "DteSelector"
+      ],
+      "canonical_inputs": ["OptionChain", "OptionContract", "ExpirationCollection"],
+      "market_data_capability_origin": ["option_chain_v1"],
+      "output_fields": ["factor", "verdict"],
+      "clock_dependency": "none direct; ExpirationCollection.as_of / chain.observed_at",
+      "canonical_boundary_compliant": true,
+      "provider_imports_found": false,
+      "wall_clock_usage_found": false,
+      "tests": [
+        "tests/strategies/test_stonk_manifests.py::test_forward_factor_manifest_requires_source_iv_and_builds_double_calendar",
+        "tests/strategies/test_stonk_behavioral_equivalence.py::test_forward_factor_matches_legacy_reference_vector_and_replays"
+      ],
+      "tests_passing": true
+    },
+    {
+      "name": "earnings_calendar",
+      "ticket_name": "Earnings Calendar",
+      "status": "partial",
+      "status_reason": "fully implemented and tested; zero production integration",
+      "manifest_id": "asa.stonk.earnings_calendar",
+      "manifest_version": "1.0.0",
+      "files": [
+        "strategies/stonk_manifests.py",
+        "strategies/stonk_components.py"
+      ],
+      "components": [
+        "EarningsEventWindow",
+        "ExpirationPairSelector",
+        "NearestCommonStrikeCalendar",
+        "OptionStructureDebit"
+      ],
+      "canonical_inputs": ["EarningsEvent", "ExpirationCycle"],
+      "market_data_capability_origin": ["earnings_calendar_v1", "option_chain_v1"],
+      "output_fields": ["eligible", "structure", "debit", "score", "verdict"],
+      "clock_dependency": "none direct; ExpirationCollection.as_of",
+      "canonical_boundary_compliant": true,
+      "provider_imports_found": false,
+      "wall_clock_usage_found": false,
+      "tests": [
+        "tests/strategies/test_stonk_manifests.py::test_earnings_calendar_manifest_executes_and_replays"
+      ],
+      "tests_passing": true,
+      "note": "Distinct from MarketCapability.EARNINGS_CALENDAR_V1, which is a market-data capability, not a strategy."
+    },
+    {
+      "name": "skew_momentum",
+      "ticket_name": "Skew Momentum",
+      "status": "partial",
+      "status_reason": "fully implemented and tested; zero production integration",
+      "manifest_id": "asa.stonk.skew_momentum_vertical",
+      "manifest_version": "1.0.0",
+      "files": [
+        "strategies/stonk_manifests.py",
+        "strategies/stonk_components.py"
+      ],
+      "components": [
+        "VerticalStructure",
+        "OptionLegLiquidity",
+        "OptionStructureDebit"
+      ],
+      "canonical_inputs": ["OptionChain"],
+      "market_data_capability_origin": ["option_chain_v1"],
+      "output_fields": ["structure", "liquid", "score", "verdict"],
+      "clock_dependency": "none direct; chain.observed_at",
+      "canonical_boundary_compliant": true,
+      "provider_imports_found": false,
+      "wall_clock_usage_found": false,
+      "tests": [
+        "tests/strategies/test_stonk_manifests.py (parametrized)",
+        "tests/strategies/test_stonk_behavioral_equivalence.py (parametrized)",
+        "tests/strategies/test_stonk_production_validation.py (parametrized)"
+      ],
+      "tests_passing": true,
+      "note": "No dedicated per-name test file; exercised via suites parametrized across all three manifests."
+    }
+  ],
+  "test_verification": {
+    "command": "PYTHONPATH=. python -m pytest -q tests/strategies/ tests/architecture/test_stonk_decommissioning.py",
+    "passed": 259,
+    "failed": 0,
+    "skipped": 0
+  },
+  "shared_infrastructure": {
+    "strategies_dir": "component/registry/manifest/graph-runtime machinery; runtime.py::execute_strategy_graph returns GraphExecutionResult",
+    "ranking_dir": "engine.py/models.py/scorers.py/registry.py; consumes domain.opportunity.Opportunity and GuardrailDecision",
+    "unused_legacy_engine": "strategies/engine.py + registry.py (evaluate_strategy) produces Opportunity from Facts/Indicators directly; unrelated to and not wired to the manifest/graph runtime used by the three target strategies",
+    "production_callers_of_manifest_runtime": []
+  },
+  "architecture_gate": {
+    "triggered": true,
+    "condition": "No existing analytical execution contract can support screening without a new public interface.",
+    "evidence": [
+      "domain/execution.py (ASA-ARCH-006, PR #109) covers portfolio delta, risk decision, planned orders, and simulation only -- downstream of an approved position, not a scoring surface.",
+      "No file outside strategies/ and its own tests references STONK_STRATEGY_LIBRARY or execute_strategy_graph.",
+      "ranking/*.py consumes domain.opportunity.Opportunity, which requires expected_outcome_metrics and evidence_confidence -- fields a manifest's raw factor/score/verdict output does not map to mechanically."
+    ],
+    "required_action": "Issue one bounded Architect ticket before SCREEN-002 proceeds; do not improvise a public framework contract.",
+    "open_questions": [
+      "Should screening results be represented as domain.opportunity.Opportunity, or a new, narrower canonical type?",
+      "If Opportunity, how does manifest verdict/score map to expected_outcome_metrics and evidence_confidence?",
+      "Where does that mapping live -- strategies/, a new module, or ranking/?"
+    ]
+  },
+  "github_search": {
+    "relevant_open_issues_found": [],
+    "adjacent_open_issues": [54, 55, 46],
+    "claim_in_sprint_doc_confirmed": true
+  },
+  "migration_history": {
+    "source_repository": "jaiaFoster/Stonk",
+    "pinned_commit": "5f3fec8",
+    "ported_via_ticket": "STONK-001",
+    "ported_via_prs": [92, 96, 97, 98],
+    "record_files": [
+      "docs/migration/stonk-strategy-inventory.md",
+      "docs/migration/stonk-strategy-catalog.yaml"
+    ],
+    "legacy_archive_mentions": false,
+    "note": "Ranking/portfolio integration was intentionally left to existing ASA engines at port time, not duplicated."
+  }
+}

--- a/project/reports/SCREEN-001-strategy-inventory.md
+++ b/project/reports/SCREEN-001-strategy-inventory.md
@@ -1,0 +1,160 @@
+# SCREEN-001 — Strategy Inventory and Readiness Audit
+
+Status: Complete. Discovery only — no strategy semantics, framework code, or architecture
+contracts were changed or introduced.
+
+Activity type: repository audit for SPRINT-006 (Screening Framework v1), preceding any
+framework design or implementation work.
+
+Audit time (UTC): 2026-07-22
+Repository commit: `1d3483e` (`main`, post-PR-#140)
+Sprint reference: SPRINT-006, ticket SCREEN-001
+
+## 1. Method
+
+Source, tests, docs, migration records, and git/PR history were searched for each target
+strategy under its ticket name and plausible aliases. Located implementations were read
+directly and their test suites were run (`PYTHONPATH=. python -m pytest -q tests/strategies/
+tests/architecture/test_stonk_decommissioning.py`). GitHub issues and PRs were searched via
+`gh issue list` / `gh pr list`. No network access was used other than the GitHub issue/PR
+search; no code was executed against live providers.
+
+## 2. Per-strategy findings
+
+### Forward Factor
+- **Status: partial** (fully implemented and tested; zero production integration)
+- **Files:** `strategies/stonk_manifests.py` (`FORWARD_FACTOR_CALENDAR_MANIFEST`, id
+  `asa.stonk.forward_factor_calendar`, v1.1.0), `strategies/stonk_components.py`
+  (`ForwardFactor`, `ImpliedForwardVolatility`, `DoubleCalendarStructure`, `DteSelector`).
+- **Input:** canonical `OptionChain` / `OptionContract` / `ExpirationCollection` from
+  `domain/` only.
+- **Output:** `factor` (Decimal), routed through `VerdictClassifier` to PASS/WATCH/FAIL, with
+  `EvidenceReference` / `observed_at` provenance.
+- **Clock:** none direct — all timing derives from `ExpirationCollection.as_of` / chain
+  `observed_at`.
+- **Tests:** `tests/strategies/test_stonk_manifests.py::test_forward_factor_manifest_*`,
+  `tests/strategies/test_stonk_behavioral_equivalence.py::test_forward_factor_matches_legacy_reference_vector_and_replays`
+  — pass.
+
+### Earnings Calendar (strategy)
+Distinct from `MarketCapability.EARNINGS_CALENDAR_V1`, which is a market-data capability, not
+a strategy.
+- **Status: partial** (fully implemented and tested; zero production integration)
+- **Files:** `strategies/stonk_manifests.py` (`EARNINGS_CALENDAR_MANIFEST`, id
+  `asa.stonk.earnings_calendar`, v1.0.0), `strategies/stonk_components.py`
+  (`EarningsEventWindow`, `ExpirationPairSelector`, `NearestCommonStrikeCalendar`,
+  `OptionStructureDebit`).
+- **Input:** canonical `EarningsEvent`, `ExpirationCycle` from `domain/`; confirms
+  `event.confirmed`, `announcement_time`, and `front.as_of == back.as_of`.
+- **Output:** `eligible` (bool), `structure`, mid/conservative `debit`, `score`, PASS/WATCH/FAIL
+  `verdict`.
+- **Clock:** none direct — uses `as_of` on the domain `ExpirationCollection`.
+- **Tests:** `tests/strategies/test_stonk_manifests.py::test_earnings_calendar_manifest_executes_and_replays`
+  — pass.
+
+### Skew Momentum
+- **Status: partial** (fully implemented and tested; zero production integration)
+- **Files:** `strategies/stonk_manifests.py` (`SKEW_MOMENTUM_VERTICAL_MANIFEST`, id
+  `asa.stonk.skew_momentum_vertical`, v1.0.0), `strategies/stonk_components.py`
+  (`VerticalStructure`, `OptionLegLiquidity`, `OptionStructureDebit`).
+- **Input:** canonical `OptionChain`, delta-target parameters; liquidity gates use
+  `open_interest` / `volume` / `spread_ratio` from the chain.
+- **Output:** `structure` (vertical), `liquid` (bool), `score`, `verdict`.
+- **Clock:** none direct — uses `chain.observed_at`.
+- **Tests:** exercised in `tests/strategies/test_stonk_manifests.py`,
+  `test_stonk_behavioral_equivalence.py`, `test_stonk_production_validation.py` (parametrized
+  across all three manifests, no dedicated per-name test file) — pass.
+
+## 3. Canonical-boundary compliance
+
+Verified directly (not solely from the initial search): `grep -rln "market_data\.\|providers\."
+strategies/*.py` and `grep -rn "datetime.now()\|date.today()" strategies/*.py` both return no
+matches. All three strategies consume canonical `domain/` types exclusively and use no
+wall-clock time. **Compliance: yes, for all three.**
+
+## 4. Test verification
+
+Independently re-run: `PYTHONPATH=. python -m pytest -q tests/strategies/
+tests/architecture/test_stonk_decommissioning.py` → **259 passed**, 0 failed, 0 skipped.
+
+## 5. Input-to-canonical-capability matrix
+
+| Strategy | Canonical domain types consumed | Market data capability origin |
+|---|---|---|
+| Forward Factor | `OptionChain`, `OptionContract`, `ExpirationCollection` | `OPTION_CHAIN_V1` |
+| Earnings Calendar | `EarningsEvent`, `ExpirationCycle` | `EARNINGS_CALENDAR_V1`, `OPTION_CHAIN_V1` |
+| Skew Momentum | `OptionChain` (leg liquidity, deltas) | `OPTION_CHAIN_V1` |
+
+## 6. Shared infrastructure
+
+- **`strategies/`**: component/registry/manifest/graph-runtime machinery
+  (`runtime.py::execute_strategy_graph` → `GraphExecutionResult(outputs: ComponentValues,
+  trace: ExecutionTrace)`), plus `stonk_components.py`, `stonk_manifests.py`,
+  `stonk_plugins.py`, `library.py` (`STONK_STRATEGY_LIBRARY`). A separate, older
+  `engine.py` / `registry.py` (`evaluate_strategy`) produces `domain.opportunity.Opportunity`
+  from Facts/Indicators directly — **unrelated to, and not wired to, the manifest/graph
+  runtime the three target strategies use.**
+- **`ranking/`**: `engine.py`, `models.py`, `scorers.py`, `registry.py` — consumes
+  `domain.opportunity.Opportunity` and `GuardrailDecision`. Per SPRINT-003's own report:
+  "Ranking remains owned by the Ranking Engine" (`project/reports/SPRINT-003.md:47`) —
+  ranking/allocation was explicitly deferred to existing ASA engines when the three
+  strategies were ported, not duplicated inside `strategies/`.
+- **`simulation/`, `execution_planning/`**: order/portfolio simulation and planning,
+  downstream of Risk decisions — unrelated to scoring/screening.
+
+## 7. Integration-surface assessment (architecture gate finding)
+
+`domain/execution.py` ("Immutable analytical execution contracts frozen by ASA-ARCH-006",
+SPRINT-004 / PR #109) defines contracts for **portfolio delta, risk decision, planned orders,
+and simulation** — strictly downstream of an already-approved position. It is not a
+scoring/screening surface and was not designed to be one.
+
+Independently confirmed: no file outside `strategies/` and its own tests references
+`STONK_STRATEGY_LIBRARY` or `execute_strategy_graph`. `ranking/*.py` all reference
+`domain.opportunity.Opportunity`, confirming `ranking/` is built to consume `Opportunity`
+records, not `GraphExecutionResult`. `domain.opportunity.Opportunity` requires
+`expected_outcome_metrics` (an `ExpectedOutcomeMetrics` record) and `evidence_confidence`
+(a `Confidence` value) — neither of which a manifest's raw `factor`/`score`/PASS-WATCH-FAIL
+`verdict` output maps to mechanically. Deciding that mapping (e.g. what confidence value a
+"WATCH" verdict implies, what `ExpectedOutcomeMetrics` a Forward Factor score implies) is a
+product/architecture decision, not a wiring task.
+
+**This triggers SPRINT-006's own architecture_gate condition**: *"No existing analytical
+execution contract can support screening without a new public interface."* Per the sprint's
+own required action, implementation must stop here rather than improvise a public framework
+contract; a bounded Architect ticket is required before SCREEN-002 proceeds.
+
+## 8. GitHub issues and PRs
+
+`gh issue list` / `gh pr list` searches for screening/screener/signal/strategy/"forward
+factor"/earnings/"skew momentum" returned no open issue or PR matching screening or screener.
+The sprint document's claim of zero relevant open issues found via code search is confirmed.
+Adjacent (not directly relevant) open issues: #54 (Opportunity lacks a liquidity metric for
+Ranking), #55 (Ranking v1 weights need calibration), #46 (placeholder outcome metrics) — these
+concern eventual ranking calibration, not this discovery ticket.
+
+## 9. Migration history
+
+`project/lean/migration/legacy-inventory.yaml` and `capability-map.yaml` contain no mentions
+of the three strategy names. The authoritative migration record is
+`docs/migration/stonk-strategy-inventory.md` and `stonk-strategy-catalog.yaml` (ticket
+STONK-001, PR #92): all three were ported from the `jaiaFoster/Stonk` legacy repository
+(pinned commit `5f3fec8`) via SPRINT-003 (PRs #92, #96, #97, #98), with an explicit note that
+ranking/portfolio integration was intentionally left to existing ASA engines rather than
+duplicated. `project/lean/archive/legacy/` has no related content — the strategies are not
+legacy/dead code, they are genuinely complete but unintegrated.
+
+## 10. Recommendation
+
+**Architecture gate.** SCREEN-002 through SCREEN-006 should not proceed by improvising a
+`GraphExecutionResult` → `Opportunity` adapter inside a worker ticket. A bounded Architect
+ticket is needed to decide: (a) whether screening results should be represented as
+`domain.opportunity.Opportunity` records at all, or as a new, narrower canonical type; (b) if
+`Opportunity`, how manifest verdict/score maps to `expected_outcome_metrics` and
+`evidence_confidence`; (c) whether that mapping lives in `strategies/`, a new module, or
+`ranking/`.
+
+## 11. Deliverables
+
+- `project/reports/SCREEN-001-strategy-inventory.md` — this report.
+- `project/reports/SCREEN-001-strategy-inventory.json` — machine-readable inventory.


### PR DESCRIPTION
## Ticket
SCREEN-001 (SPRINT-006, depends on GOV-006 delegation activation -- see below)

## Summary
Determines the exact current state of Forward Factor, Earnings Calendar, and Skew Momentum before any framework design or code changes, as required before SCREEN-002 proceeds.

## Repository evidence
- All three strategies located in `strategies/stonk_manifests.py` + `strategies/stonk_components.py`, ported from `jaiaFoster/Stonk` (pinned commit `5f3fec8`) via STONK-001 (PRs #92/#96/#97/#98).
- Canonical-boundary compliance verified directly: `grep -rln "market_data\.\|providers\." strategies/*.py` and `grep -rn "datetime.now()\|date.today()" strategies/*.py` both return zero matches.
- Test suite independently re-run: `PYTHONPATH=. python -m pytest -q tests/strategies/ tests/architecture/test_stonk_decommissioning.py` -> 259 passed, 0 failed.
- Zero production callers confirmed: no file outside `strategies/` and its own tests references `STONK_STRATEGY_LIBRARY` or `execute_strategy_graph`.
- `ranking/*.py` confirmed to consume `domain.opportunity.Opportunity`, not `GraphExecutionResult` -- the two are not currently bridged anywhere.

## Relevant issues and PRs
`gh issue list` / `gh pr list` searches for screening/screener/signal/strategy/"forward factor"/earnings/"skew momentum" found no matching open issue or PR -- confirms the sprint doc's own claim. Adjacent (not directly relevant) open issues: #54, #55, #46 (ranking calibration, not this audit).

## Architecture compliance
**This audit itself introduces no framework, contract, or code change** -- discovery only. It **identifies** that SPRINT-006's own `architecture_gate` condition is triggered ("No existing analytical execution contract can support screening without a new public interface"): `domain/execution.py` (ASA-ARCH-006, PR #109) is a portfolio-delta/risk/order/simulation contract, not a scoring surface, and `domain.opportunity.Opportunity` requires `expected_outcome_metrics`/`evidence_confidence` fields a manifest's raw score/verdict doesn't map to mechanically. Per the sprint's own required action, this ticket does **not** attempt that mapping -- it stops and reports the finding, per Section 10 of the attached report.

## Security and secret handling
Both new files are reports only, no code changes. Secret scan (`grep -iE "token|secret|password|api[_-]?key|bearer"`) against both new files: zero matches.

## Network behavior
Read-only local repository search plus `gh issue list`/`gh pr list` (GitHub API, read-only). No provider or live network access.

## Request budget behavior
N/A -- no live market-data or provider requests made.

## Tests
- `pytest tests/strategies/ tests/architecture/test_stonk_decommissioning.py` -> 259 passed.
- `pytest tests/pos` -> 574 passed, 1 skipped (pre-existing, unrelated).
- `pytest tests/architecture tests/domain tests/strategies tests/ranking tests/market_data` -> 927 passed, 1 skipped (pre-existing, unrelated).
- `tools/pos/lean/check_integrity.py` -> OK.
- `tools/pos/lean/validate.py --file project/lean/state/project-state.yaml --schema project_state` -> PASS.
- `tools/pos/lean/generate.py current-state ...` -> no drift in `CURRENT_STATE.md`.
- `tools/pos/lean/check_entrypoints.py` -> OK.
- `git status --short` -> exactly two new files, matching approved ticket scope.

## Live validation status
N/A -- offline audit only, per SCREEN-001's own acceptance criteria ("Audit is deterministic and network-free" for the codebase portion; the GitHub issue/PR search necessarily used the GitHub API).

## Explicit exclusions
No strategy semantics changed. No framework, registry, or contract code introduced. No architecture decision made -- only reported.

## Merge authority
`delegated_after_required_checks` per SPRINT-006 -- **contingent on #141 (GOV-006) merging first**, since Founder Sprint Delegation isn't active until that merge. I will not merge this PR before #141 merges, regardless of standing authorization for this sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)