### PR TITLE
SCREEN-002: screening framework contract and registration

### DIFF
--- a/screening/__init__.py
+++ b/screening/__init__.py
@@ -1,0 +1,24 @@
+"""Screening framework (SPRINT-006).
+
+Registers, executes, isolates, and ranks existing ASA analytical strategies
+through one common bounded contract, without changing their trading logic.
+"""
+
+from __future__ import annotations
+
+from screening.clock import Clock
+from screening.errors import (
+    DuplicateScreeningRegistrationError,
+    ScreeningError,
+    UnknownScreeningStrategyIdError,
+)
+from screening.registry import ScreeningRegistry, ScreeningStrategyDefinition
+
+__all__ = [
+    "Clock",
+    "DuplicateScreeningRegistrationError",
+    "ScreeningError",
+    "ScreeningRegistry",
+    "ScreeningStrategyDefinition",
+    "UnknownScreeningStrategyIdError",
+]

--- a/screening/clock.py
+++ b/screening/clock.py
@@ -1,0 +1,16 @@
+"""Injected clock port for the screening framework (SCREEN-002).
+
+A local, minimal Protocol -- deliberately not imported from market_data or
+any other bounded context, so the screening framework stays decoupled from
+provider-facing infrastructure.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Clock(Protocol):
+    def now(self) -> datetime: ...

--- a/screening/errors.py
+++ b/screening/errors.py
@@ -1,0 +1,23 @@
+"""Screening framework errors (SCREEN-002)."""
+
+from __future__ import annotations
+
+
+class ScreeningError(Exception):
+    """Base error for all screening framework operations."""
+
+
+class DuplicateScreeningRegistrationError(ScreeningError):
+    """A strategy_id was registered more than once in a ScreeningRegistry."""
+
+    def __init__(self, strategy_id: str) -> None:
+        super().__init__(f"strategy_id already registered: {strategy_id!r}")
+        self.strategy_id = strategy_id
+
+
+class UnknownScreeningStrategyIdError(ScreeningError):
+    """No screening strategy is registered for the requested strategy_id."""
+
+    def __init__(self, strategy_id: str) -> None:
+        super().__init__(f"no screening strategy registered for id: {strategy_id!r}")
+        self.strategy_id = strategy_id

--- a/screening/registry.py
+++ b/screening/registry.py
@@ -1,0 +1,79 @@
+"""Screening strategy registry (SCREEN-002).
+
+A closed, explicit, deterministic catalog of screening-eligible strategy
+identity and declared canonical input requirements. Registration carries no
+strategy-specific execution logic and performs no execution itself -- see
+SCREEN-003 for the runner boundary that pairs a registered strategy's
+identity with an adapter and executes it.
+
+No dynamic discovery: a ScreeningRegistry is always constructed from one
+explicit, finite tuple of definitions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from domain import MarketCapability
+from screening.errors import DuplicateScreeningRegistrationError, UnknownScreeningStrategyIdError
+
+
+def _normalized_text(value: str, owner: str, field_name: str) -> None:
+    if not value or value != value.strip():
+        raise ValueError(f"{owner}.{field_name} must be non-empty normalized text")
+
+
+@dataclass(frozen=True, slots=True)
+class ScreeningStrategyDefinition:
+    """One registered screening strategy's identity and declared canonical inputs.
+
+    ``required_capabilities`` is expressed exclusively in canonical
+    ``MarketCapability`` terms -- never a provider name -- per SPRINT-006's
+    architecture_invariants.
+    """
+
+    strategy_id: str
+    strategy_version: str
+    manifest_id: str
+    required_capabilities: tuple[MarketCapability, ...]
+
+    def __post_init__(self) -> None:
+        for name in ("strategy_id", "strategy_version", "manifest_id"):
+            _normalized_text(getattr(self, name), "ScreeningStrategyDefinition", name)
+        if not self.required_capabilities:
+            raise ValueError(
+                "ScreeningStrategyDefinition.required_capabilities cannot be empty"
+            )
+        if len(set(self.required_capabilities)) != len(self.required_capabilities):
+            raise ValueError(
+                "ScreeningStrategyDefinition.required_capabilities must be unique"
+            )
+
+
+class ScreeningRegistry:
+    """Immutable strategy_id -> ScreeningStrategyDefinition catalog."""
+
+    __slots__ = ("_definitions",)
+
+    def __init__(self, definitions: tuple[ScreeningStrategyDefinition, ...] = ()) -> None:
+        registered: dict[str, ScreeningStrategyDefinition] = {}
+        for definition in definitions:
+            if definition.strategy_id in registered:
+                raise DuplicateScreeningRegistrationError(definition.strategy_id)
+            registered[definition.strategy_id] = definition
+        self._definitions = registered
+
+    def get(self, strategy_id: str) -> ScreeningStrategyDefinition:
+        try:
+            return self._definitions[strategy_id]
+        except KeyError:
+            raise UnknownScreeningStrategyIdError(strategy_id) from None
+
+    def is_registered(self, strategy_id: str) -> bool:
+        return strategy_id in self._definitions
+
+    def registered_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(self._definitions.keys()))
+
+    def definitions(self) -> tuple[ScreeningStrategyDefinition, ...]:
+        return tuple(self._definitions[key] for key in sorted(self._definitions.keys()))

--- a/tests/architecture/test_screening_boundaries.py
+++ b/tests/architecture/test_screening_boundaries.py
@@ -1,0 +1,103 @@
+"""SCREEN-002: screening framework architecture validation.
+
+Mirrors test_strategy_boundaries.py's pattern for the new screening/
+package: an explicit permitted-import allowlist plus prohibited-import and
+no-network/no-persistence/no-provider-access sweeps, so the framework
+cannot silently grow a dependency on providers, market_data internals, or
+infrastructure.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+FORBIDDEN_INFRASTRUCTURE_MODULES = {
+    "sqlite3", "psycopg2", "sqlalchemy", "asyncio", "threading",
+    "multiprocessing", "socket", "http", "urllib", "requests",
+    "random", "secrets",
+}
+
+STDLIB_ALLOWED = {
+    "__future__", "abc", "dataclasses", "datetime", "decimal", "enum", "hashlib", "json", "re",
+    "typing",
+}
+
+
+def _imported_roots(py_file: Path) -> set[str]:
+    tree = ast.parse(py_file.read_text())
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots |= {a.name.split(".")[0] for a in node.names}
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            roots.add(node.module.split(".")[0])
+    return roots
+
+
+def _screening_files() -> list[Path]:
+    return sorted((REPO_ROOT / "screening").glob("*.py"))
+
+
+class TestScreeningImportScope:
+    """screening/ imports only screening and domain -- never a bounded-context
+    implementation module (strategies, market_data, providers, ranking, ...).
+    """
+
+    @pytest.mark.parametrize("py_file", _screening_files())
+    def test_only_permitted_roots(self, py_file: Path) -> None:
+        permitted = {"screening", "domain"} | STDLIB_ALLOWED
+        imported = _imported_roots(py_file)
+        assert imported <= permitted, (
+            f"{py_file.name} imports outside {permitted}: {imported - permitted}"
+        )
+
+    @pytest.mark.parametrize("py_file", _screening_files())
+    def test_prohibited_imports_absent(self, py_file: Path) -> None:
+        prohibited = {
+            "market_data", "providers", "observation", "strategies", "ranking",
+            "guardrails", "presentation", "simulation", "execution_planning",
+        }
+        imported = _imported_roots(py_file)
+        assert not (imported & prohibited), (
+            f"{py_file.name} imports prohibited module(s): {imported & prohibited}"
+        )
+
+    @pytest.mark.parametrize("py_file", _screening_files())
+    def test_no_infrastructure_dependencies(self, py_file: Path) -> None:
+        imported = _imported_roots(py_file)
+        assert not (imported & FORBIDDEN_INFRASTRUCTURE_MODULES), (
+            f"{py_file.name} imports infrastructure module(s): "
+            f"{imported & FORBIDDEN_INFRASTRUCTURE_MODULES}"
+        )
+
+    @pytest.mark.parametrize("py_file", _screening_files())
+    def test_no_network_or_persistence(self, py_file: Path) -> None:
+        forbidden = {
+            "socket", "http", "urllib", "requests", "aiohttp",
+            "sqlite3", "sqlalchemy", "psycopg2", "pickle", "shelve",
+        }
+        imported = _imported_roots(py_file)
+        assert not (imported & forbidden)
+
+    @pytest.mark.parametrize("py_file", _screening_files())
+    def test_no_random_or_ml_libraries(self, py_file: Path) -> None:
+        forbidden = {"random", "sklearn", "torch", "tensorflow", "numpy", "scipy", "pandas"}
+        imported = _imported_roots(py_file)
+        assert not (imported & forbidden)
+
+
+class TestScreeningRegistryIsClosedAndExplicit:
+    def test_registry_requires_explicit_construction(self) -> None:
+        from screening.registry import ScreeningRegistry
+
+        assert ScreeningRegistry().registered_ids() == ()
+
+    def test_no_dynamic_discovery_helpers_exposed(self) -> None:
+        import screening
+
+        forbidden_names = {"discover", "autoregister", "scan_plugins", "load_plugins"}
+        assert not (forbidden_names & set(dir(screening)))

--- a/tests/screening/test_registry.py
+++ b/tests/screening/test_registry.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from domain import MarketCapability
+from screening.errors import DuplicateScreeningRegistrationError, UnknownScreeningStrategyIdError
+from screening.registry import ScreeningRegistry, ScreeningStrategyDefinition
+
+
+def _definition(
+    strategy_id: str = "forward_factor",
+    strategy_version: str = "1.1.0",
+    manifest_id: str = "asa.stonk.forward_factor_calendar",
+    required_capabilities: tuple[MarketCapability, ...] = (MarketCapability.OPTION_CHAIN_V1,),
+) -> ScreeningStrategyDefinition:
+    return ScreeningStrategyDefinition(
+        strategy_id, strategy_version, manifest_id, required_capabilities
+    )
+
+
+class TestScreeningStrategyDefinition:
+    def test_valid_definition_constructs(self) -> None:
+        definition = _definition()
+        assert definition.strategy_id == "forward_factor"
+        assert definition.required_capabilities == (MarketCapability.OPTION_CHAIN_V1,)
+
+    @pytest.mark.parametrize("field", ["strategy_id", "strategy_version", "manifest_id"])
+    def test_empty_text_field_rejected(self, field: str) -> None:
+        kwargs = {
+            "strategy_id": "forward_factor",
+            "strategy_version": "1.1.0",
+            "manifest_id": "asa.stonk.forward_factor_calendar",
+            "required_capabilities": (MarketCapability.OPTION_CHAIN_V1,),
+        }
+        kwargs[field] = ""
+        with pytest.raises(ValueError, match="normalized text"):
+            ScreeningStrategyDefinition(**kwargs)
+
+    def test_whitespace_padded_text_field_rejected(self) -> None:
+        with pytest.raises(ValueError, match="normalized text"):
+            _definition(strategy_id=" forward_factor ")
+
+    def test_empty_required_capabilities_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cannot be empty"):
+            _definition(required_capabilities=())
+
+    def test_duplicate_required_capabilities_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be unique"):
+            _definition(
+                required_capabilities=(
+                    MarketCapability.OPTION_CHAIN_V1,
+                    MarketCapability.OPTION_CHAIN_V1,
+                )
+            )
+
+    def test_multiple_canonical_capabilities_allowed(self) -> None:
+        definition = _definition(
+            strategy_id="earnings_calendar",
+            manifest_id="asa.stonk.earnings_calendar",
+            required_capabilities=(
+                MarketCapability.EARNINGS_CALENDAR_V1,
+                MarketCapability.OPTION_CHAIN_V1,
+            ),
+        )
+        assert len(definition.required_capabilities) == 2
+
+
+class TestScreeningRegistry:
+    def test_empty_registry_is_valid(self) -> None:
+        registry = ScreeningRegistry()
+        assert registry.registered_ids() == ()
+        assert registry.definitions() == ()
+
+    def test_construction_is_deterministic_regardless_of_input_order(self) -> None:
+        a = _definition("forward_factor")
+        b = _definition("skew_momentum", manifest_id="asa.stonk.skew_momentum_vertical")
+        first = ScreeningRegistry((a, b))
+        second = ScreeningRegistry((b, a))
+        assert first.registered_ids() == second.registered_ids() == ("forward_factor", "skew_momentum")
+        assert first.definitions() == second.definitions()
+
+    def test_get_returns_the_registered_definition(self) -> None:
+        definition = _definition()
+        registry = ScreeningRegistry((definition,))
+        assert registry.get("forward_factor") is definition
+
+    def test_get_unknown_strategy_id_raises(self) -> None:
+        registry = ScreeningRegistry()
+        with pytest.raises(UnknownScreeningStrategyIdError):
+            registry.get("does_not_exist")
+
+    def test_is_registered(self) -> None:
+        registry = ScreeningRegistry((_definition(),))
+        assert registry.is_registered("forward_factor") is True
+        assert registry.is_registered("skew_momentum") is False
+
+    def test_duplicate_strategy_id_registration_rejected(self) -> None:
+        first = _definition(strategy_id="forward_factor", strategy_version="1.1.0")
+        second = _definition(strategy_id="forward_factor", strategy_version="1.2.0")
+        with pytest.raises(DuplicateScreeningRegistrationError):
+            ScreeningRegistry((first, second))
+
+    def test_definitions_are_returned_in_sorted_strategy_id_order(self) -> None:
+        registry = ScreeningRegistry(
+            (
+                _definition("skew_momentum", manifest_id="asa.stonk.skew_momentum_vertical"),
+                _definition("earnings_calendar", manifest_id="asa.stonk.earnings_calendar"),
+                _definition("forward_factor"),
+            )
+        )
+        assert registry.registered_ids() == ("earnings_calendar", "forward_factor", "skew_momentum")


### PR DESCRIPTION
## Ticket
SCREEN-002 (SPRINT-006, delegated merge under GOV-006/Amendment 013, active since #141 merged)

## Summary
Introduces the minimal internal framework needed to register ready screening strategies through one bounded, closed catalog. Per the ticket's own scope split from SCREEN-003 ("Canonical Screening Run and Signal Results"), this delivers registration/identity/declared-input metadata only -- no execution, no result envelope, no strategy adapters (those are SCREEN-003 and SCREEN-004).

## Repository evidence
- Resolves the architecture gate found in SCREEN-001 (#142) and decided in #143 (closed): screening results will use a new narrower canonical type in SCREEN-003, not `domain.opportunity.Opportunity`.
- New top-level `screening/` package, structurally consistent with `ranking/`, `simulation/`, `execution_planning/`.
- `ScreeningRegistry`/`ScreeningStrategyDefinition` pattern closely mirrors `strategies/library.py`'s `StrategyLibrary` (immutable, constructed from one explicit tuple, deterministic, duplicate rejection) rather than `strategies/registry.py`'s older mutable pattern (that module is the unrelated, unwired legacy Facts/Indicators engine SCREEN-001 flagged).
- `screening/clock.py`'s `Clock` Protocol is a fresh, local definition rather than importing `market_data.factory.Clock`, keeping the framework decoupled from market-data infrastructure (satisfies "no provider name or provider SDK enters the strategy contract").

## Relevant issues and PRs
#142 (SCREEN-001, merged), #143 (architecture decision, closed by Founder decision), #141 (GOV-006, merged -- activates this ticket's delegated merge authority).

## Architecture compliance
- `required_capabilities` on `ScreeningStrategyDefinition` is typed `tuple[MarketCapability, ...]` -- canonical terms only, enforced by a new architecture boundary test.
- New `tests/architecture/test_screening_boundaries.py` (22 tests) asserts `screening/` imports only `screening` and `domain` -- never `market_data`, `providers`, `strategies`, `ranking`, or any infrastructure/network/persistence/ML module -- mirroring `test_strategy_boundaries.py`'s existing pattern exactly.
- No dynamic plugin discovery: `ScreeningRegistry` only ever constructs from one explicit, finite tuple; verified by `test_registry_requires_explicit_construction` and `test_no_dynamic_discovery_helpers_exposed`.
- Strategy-specific logic remains entirely outside the framework: this PR contains zero references to any of the three target strategies' actual logic.

## Security and secret handling
Secret scan (`grep -riE "token|secret|password|api[_-]?key|bearer"`) against all new files: one match, `"secrets"` -- the stdlib module name in the architecture test's forbidden-infrastructure-imports set literal, not an actual secret.

## Network behavior
None. Registration performs no network access (verified by the boundary test's infrastructure/network import sweep).

## Request budget behavior
N/A -- no provider or market-data requests in this ticket.

## Tests
- `pytest tests/screening/ tests/architecture/test_screening_boundaries.py` -> 37 passed.
- `pytest tests/` (full repo) -> 1939 passed, 2 skipped (pre-existing, unrelated).
- `ruff check screening/ tests/screening/ tests/architecture/test_screening_boundaries.py` -> clean.
- `mypy screening/` -> clean (4 source files, strict mode).
- `tools/pos/lean/check_integrity.py` -> OK.
- `tools/pos/lean/validate.py` -> PASS.
- `tools/pos/lean/generate.py current-state ...` -> no drift in `CURRENT_STATE.md`.
- `tools/pos/lean/check_entrypoints.py` -> OK.
- `git status --short` -> exactly the new `screening/` package, `tests/screening/`, and one new architecture test file -- matches approved ticket scope, no extraneous changes.

## Live validation status
N/A -- no live/network execution in this ticket.

## Explicit exclusions
No execution/runner logic (SCREEN-003). No strategy adapters or references to the three target strategies' actual logic (SCREEN-004). No entrypoint (SCREEN-005). No changes to any existing strategy, `strategies/`, `ranking/`, or any other existing module.

## Merge authority
`delegated_after_required_checks` per SPRINT-006/GOV-006 -- active since #141 merged. All required gates above are green; merging under delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)