### PR TITLE
SCREEN-004: target strategy adapters

### DIFF
--- a/screening/__init__.py
+++ b/screening/__init__.py
@@ -6,6 +6,7 @@ through one common bounded contract, without changing their trading logic.
 
 from __future__ import annotations
 
+from screening.adapters import TARGET_STRATEGY_ADAPTERS, TARGET_STRATEGY_REGISTRY
 from screening.clock import Clock
 from screening.errors import (
     DuplicateScreeningRegistrationError,
@@ -17,6 +18,8 @@ from screening.results import ScreeningOutcomeStatus, ScreeningResult, bounded_f
 from screening.runner import StrategyAdapter, StrategyAdapterError, run_screening
 
 __all__ = [
+    "TARGET_STRATEGY_ADAPTERS",
+    "TARGET_STRATEGY_REGISTRY",
     "Clock",
     "DuplicateScreeningRegistrationError",
     "ScreeningError",

--- a/screening/adapters.py
+++ b/screening/adapters.py
@@ -1,0 +1,216 @@
+"""Target strategy adapters (SCREEN-004).
+
+Connects each ready target strategy (Forward Factor, Earnings Calendar,
+Skew Momentum -- confirmed present and fully implemented by SCREEN-001) to
+the screening framework, without changing any threshold, formula, entry
+logic, or scoring. Every adapter here is pure composition glue: it builds
+the manifest's required execution context from fixed, deterministic
+screening/fixtures.py data, executes the existing, unmodified manifest via
+strategies.compile_strategy_graph/execute_strategy_graph, and wraps the
+strategy-native verdict/score/evidence into a canonical ScreeningResult --
+it re-implements none of the strategy's own logic.
+
+A strategy's own PASS/WATCH/FAIL verdict is always preserved verbatim in
+ScreeningResult.signal_classification. outcome_status is a coarser,
+framework-level view: PASS/WATCH both mean "worth reporting" (PASS);
+FAIL means nothing actionable for this run (NO_SIGNAL). No exception
+handling is done here -- an unexpected failure propagates to the runner's
+own STRATEGY_EXCEPTION isolation boundary (SCREEN-003), which is exactly
+where that isolation is supposed to happen.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from domain import ExpirationCollection, MarketCapability, OptionType
+from screening import fixtures
+from screening.clock import Clock
+from screening.registry import ScreeningRegistry, ScreeningStrategyDefinition
+from screening.results import ScreeningOutcomeStatus, ScreeningResult
+from strategies import (
+    CORE_COMPONENTS,
+    EARNINGS_CALENDAR_MANIFEST,
+    FORWARD_FACTOR_CALENDAR_MANIFEST,
+    SKEW_MOMENTUM_VERTICAL_MANIFEST,
+    STONK_STRATEGY_PLUGINS,
+    compile_strategy_graph,
+    execute_strategy_graph,
+)
+from strategies.plugins import build_plugin_registry
+from strategies.stonk_components import (
+    D,
+    DATE,
+    DECIMAL_LIST,
+    EARNINGS_EVENT,
+    EXPIRATION_COLLECTION,
+    EXPIRATION_CYCLE,
+    OPTION_CHAIN,
+    OPTION_CONTRACT,
+)
+from strategies.type_system import ComponentValues, StrategyTypeReference, TypedValue
+
+_COMPONENT_REGISTRY = build_plugin_registry(CORE_COMPONENTS, STONK_STRATEGY_PLUGINS)
+_SUBJECT_IDENTITY = f"figi:figi-{fixtures.SAFE_SYMBOL}"
+
+_NON_FAIL_VERDICTS = frozenset({"PASS", "WATCH"})
+
+
+def _context(**items: tuple[StrategyTypeReference, object]) -> ComponentValues:
+    return ComponentValues(
+        tuple((name, TypedValue(type_ref, value)) for name, (type_ref, value) in items.items())
+    )
+
+
+def _outcome_status_for_verdict(verdict: str) -> ScreeningOutcomeStatus:
+    return (
+        ScreeningOutcomeStatus.PASS
+        if verdict in _NON_FAIL_VERDICTS
+        else ScreeningOutcomeStatus.NO_SIGNAL
+    )
+
+
+def run_forward_factor(
+    definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
+) -> ScreeningResult:
+    chain = fixtures.forward_factor_chain()
+    expirations = fixtures.forward_factor_expirations()
+    context = _context(
+        **{
+            "expiration_select.expirations": (EXPIRATION_COLLECTION, expirations),
+            "double_calendar.chain": (OPTION_CHAIN, chain),
+            "forward_iv.front_iv": (D, Decimal("0.48")),
+            "forward_iv.back_iv": (D, Decimal("0.4548992562461861547567860943472296")),
+            "forward_iv.front_dte": (D, 61),
+            "forward_iv.back_dte": (D, 91),
+            "factor.front_ex_earnings_iv": (D, Decimal("0.48")),
+        }
+    )
+    graph = compile_strategy_graph(FORWARD_FACTOR_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
+    result = execute_strategy_graph(graph, context)
+    verdict = str(result.outputs.get("verdict").value)
+    score = result.outputs.get("forward_factor").value
+    return ScreeningResult(
+        run_id,
+        definition.strategy_id,
+        definition.strategy_version,
+        _SUBJECT_IDENTITY,
+        clock.now(),
+        _outcome_status_for_verdict(verdict),
+        verdict,
+        score if isinstance(score, Decimal) else None,
+        fixtures.EVIDENCE,
+        fixtures.EVIDENCE,
+        None,
+        None,
+    )
+
+
+def run_earnings_calendar(
+    definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
+) -> ScreeningResult:
+    front, back = fixtures.earnings_calendar_expirations()
+    event = fixtures.earnings_calendar_event()
+    chain = fixtures.earnings_calendar_chain()
+    context = _context(
+        **{
+            "event_window.event": (EARNINGS_EVENT, event),
+            "event_window.front": (EXPIRATION_CYCLE, front),
+            "event_window.back": (EXPIRATION_CYCLE, back),
+            "expiration_select.expirations": (
+                EXPIRATION_COLLECTION,
+                ExpirationCollection(fixtures.AS_OF_DATE, (back, front)),
+            ),
+            "expiration_select.event": (EARNINGS_EVENT, event),
+            "calendar.chain": (OPTION_CHAIN, chain),
+            "calendar.target_strike": (D, Decimal("100")),
+            "score.values": (DECIMAL_LIST, (Decimal("80"), Decimal("60"))),
+            "score.weights": (DECIMAL_LIST, (Decimal("3"), Decimal("1"))),
+        }
+    )
+    graph = compile_strategy_graph(EARNINGS_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
+    result = execute_strategy_graph(graph, context)
+    verdict = str(result.outputs.get("verdict").value)
+    score = result.outputs.get("score").value
+    return ScreeningResult(
+        run_id,
+        definition.strategy_id,
+        definition.strategy_version,
+        _SUBJECT_IDENTITY,
+        clock.now(),
+        _outcome_status_for_verdict(verdict),
+        verdict,
+        score if isinstance(score, Decimal) else None,
+        fixtures.EVIDENCE,
+        fixtures.EVIDENCE,
+        None,
+        None,
+    )
+
+
+def run_skew_momentum(
+    definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
+) -> ScreeningResult:
+    chain = fixtures.skew_momentum_chain()
+    (call_contract,) = chain.find(
+        expiration=fixtures.SKEW_EXPIRATION,
+        strike=Decimal("100"),
+        option_type=OptionType.CALL,
+    )
+    context = _context(
+        **{
+            "vertical.chain": (OPTION_CHAIN, chain),
+            "vertical.expiration": (DATE, fixtures.SKEW_EXPIRATION),
+            "liquidity.contract": (OPTION_CONTRACT, call_contract),
+            "score.values": (DECIMAL_LIST, (Decimal("80"), Decimal("70"))),
+            "score.weights": (DECIMAL_LIST, (Decimal("2"), Decimal("1"))),
+        }
+    )
+    graph = compile_strategy_graph(SKEW_MOMENTUM_VERTICAL_MANIFEST, _COMPONENT_REGISTRY)
+    result = execute_strategy_graph(graph, context)
+    verdict = str(result.outputs.get("verdict").value)
+    score = result.outputs.get("score").value
+    return ScreeningResult(
+        run_id,
+        definition.strategy_id,
+        definition.strategy_version,
+        _SUBJECT_IDENTITY,
+        clock.now(),
+        _outcome_status_for_verdict(verdict),
+        verdict,
+        score if isinstance(score, Decimal) else None,
+        fixtures.EVIDENCE,
+        fixtures.EVIDENCE,
+        None,
+        None,
+    )
+
+
+TARGET_STRATEGY_DEFINITIONS: tuple[ScreeningStrategyDefinition, ...] = (
+    ScreeningStrategyDefinition(
+        "forward_factor",
+        FORWARD_FACTOR_CALENDAR_MANIFEST.strategy_version,
+        FORWARD_FACTOR_CALENDAR_MANIFEST.manifest_id,
+        (MarketCapability.OPTION_CHAIN_V1,),
+    ),
+    ScreeningStrategyDefinition(
+        "earnings_calendar",
+        EARNINGS_CALENDAR_MANIFEST.strategy_version,
+        EARNINGS_CALENDAR_MANIFEST.manifest_id,
+        (MarketCapability.EARNINGS_CALENDAR_V1, MarketCapability.OPTION_CHAIN_V1),
+    ),
+    ScreeningStrategyDefinition(
+        "skew_momentum",
+        SKEW_MOMENTUM_VERTICAL_MANIFEST.strategy_version,
+        SKEW_MOMENTUM_VERTICAL_MANIFEST.manifest_id,
+        (MarketCapability.OPTION_CHAIN_V1,),
+    ),
+)
+
+TARGET_STRATEGY_REGISTRY = ScreeningRegistry(TARGET_STRATEGY_DEFINITIONS)
+
+TARGET_STRATEGY_ADAPTERS = {
+    "forward_factor": run_forward_factor,
+    "earnings_calendar": run_earnings_calendar,
+    "skew_momentum": run_skew_momentum,
+}

--- a/screening/fixtures.py
+++ b/screening/fixtures.py
@@ -1,0 +1,176 @@
+"""Fixed, deterministic canonical fixture data for screening adapters (SCREEN-004).
+
+No symbol, provider, or live market-data access is involved -- every value
+here is a hard-coded, previously-reviewed, safe fixture, matching the same
+pattern already used for live Market Data Platform validation subjects
+(asa.market_data_ops.subjects). Live acquisition is explicitly deferred to
+a successor sprint (SPRINT-007); this sprint's screening runs are
+fixture-backed only, per SCREEN-004's own scope.
+
+Each target strategy's manifest enforces its own DTE (days-to-expiration)
+window, so each gets its own fixture expirations/chain rather than sharing
+one -- forcing one generic pair to satisfy every manifest's constraints
+would be fragile and less legible than naming each explicitly.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from domain import (
+    AnnouncementTime,
+    CanonicalInstrumentIdentity,
+    EarningsEvent,
+    EvidenceKind,
+    EvidenceReference,
+    ExpirationCollection,
+    ExpirationCycle,
+    Instrument,
+    InstrumentKind,
+    OptionChain,
+    OptionContract,
+    OptionType,
+    Security,
+    SecurityAssetType,
+)
+
+SAFE_SYMBOL = "AAPL"
+OBSERVED_AT = datetime(2026, 7, 22, 16, 0, tzinfo=UTC)
+AS_OF_DATE = date(2026, 7, 22)
+
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, f"screening:fixture:{SAFE_SYMBOL}"),)
+
+
+def fixture_security(symbol: str = SAFE_SYMBOL) -> Security:
+    return Security(
+        Instrument(
+            CanonicalInstrumentIdentity("figi", f"figi-{symbol}"),
+            InstrumentKind.EQUITY,
+            symbol,
+            "USD",
+        ),
+        symbol,
+        SecurityAssetType.EQUITY,
+        "XNAS",
+    )
+
+
+def fixture_contract(
+    option_id: str,
+    expiration: date,
+    strike: str,
+    option_type: OptionType,
+    delta: str,
+    mark: str,
+) -> OptionContract:
+    mark_value = Decimal(mark)
+    return OptionContract(
+        CanonicalInstrumentIdentity("asa-option-v1", option_id),
+        fixture_security(),
+        expiration,
+        Decimal(strike),
+        option_type,
+        mark_value - Decimal("0.10"),
+        mark_value + Decimal("0.10"),
+        mark_value,
+        100,
+        500,
+        Decimal(delta),
+        Decimal("0.01"),
+        Decimal("-0.02"),
+        Decimal("0.03"),
+        Decimal("0.01"),
+        Decimal("0.30"),
+        OBSERVED_AT,
+        EVIDENCE,
+    )
+
+
+# --- earnings_calendar: front_min/max_dte=7/21, back_min/max_dte=22/75, and the
+# front expiration must fall before the earnings date while back falls after it --
+
+EARNINGS_EVENT_DATE = date(2026, 8, 5)  # +14 days from AS_OF_DATE
+EARNINGS_FRONT_EXPIRATION = date(2026, 7, 31)  # +9 days; before the earnings date
+EARNINGS_BACK_EXPIRATION = date(2026, 9, 18)  # +58 days; after the earnings date
+
+
+def earnings_calendar_chain() -> OptionChain:
+    contracts = (
+        fixture_contract(
+            "ec-front-call-100", EARNINGS_FRONT_EXPIRATION, "100", OptionType.CALL, "0.55", "2"
+        ),
+        fixture_contract(
+            "ec-back-call-100", EARNINGS_BACK_EXPIRATION, "100", OptionType.CALL, "0.58", "3"
+        ),
+    )
+    return OptionChain(
+        "screening-fixture-earnings-chain", fixture_security(), OBSERVED_AT, contracts, EVIDENCE
+    )
+
+
+def earnings_calendar_expirations() -> tuple[ExpirationCycle, ExpirationCycle]:
+    front = ExpirationCycle(EARNINGS_FRONT_EXPIRATION, 9, True, False, AS_OF_DATE, EVIDENCE)
+    back = ExpirationCycle(EARNINGS_BACK_EXPIRATION, 58, True, False, AS_OF_DATE, EVIDENCE)
+    return front, back
+
+
+def earnings_calendar_event(*, confirmed: bool = True) -> EarningsEvent:
+    return EarningsEvent(
+        "screening-fixture-earnings-event",
+        fixture_security(),
+        EARNINGS_EVENT_DATE,
+        AnnouncementTime.AFTER_CLOSE,
+        Decimal("0.05"),
+        confirmed,
+        (),
+        OBSERVED_AT,
+        EVIDENCE,
+    )
+
+
+# --- skew_momentum: no DTE selector node; caller supplies an explicit expiration --
+
+SKEW_EXPIRATION = date(2026, 8, 7)  # +16 days
+
+
+def skew_momentum_chain() -> OptionChain:
+    contracts = (
+        fixture_contract("sm-call-100", SKEW_EXPIRATION, "100", OptionType.CALL, "0.55", "2"),
+        fixture_contract("sm-call-105", SKEW_EXPIRATION, "105", OptionType.CALL, "0.25", "1"),
+    )
+    return OptionChain(
+        "screening-fixture-skew-chain", fixture_security(), OBSERVED_AT, contracts, EVIDENCE
+    )
+
+
+# --- forward_factor: dte_pair_selector front_min/max=35/90, back_min/max=49/139 ---
+
+FORWARD_FRONT_EXPIRATION = date(2026, 9, 21)  # +61 days
+FORWARD_BACK_EXPIRATION = date(2026, 10, 21)  # +91 days
+
+
+def forward_factor_chain() -> OptionChain:
+    contracts = (
+        fixture_contract(
+            "ff-front-call", FORWARD_FRONT_EXPIRATION, "105", OptionType.CALL, "0.35", "2"
+        ),
+        fixture_contract(
+            "ff-back-call", FORWARD_BACK_EXPIRATION, "105", OptionType.CALL, "0.38", "3"
+        ),
+        fixture_contract(
+            "ff-front-put", FORWARD_FRONT_EXPIRATION, "95", OptionType.PUT, "-0.35", "2"
+        ),
+        fixture_contract(
+            "ff-back-put", FORWARD_BACK_EXPIRATION, "95", OptionType.PUT, "-0.38", "3"
+        ),
+    )
+    return OptionChain(
+        "screening-fixture-forward-chain", fixture_security(), OBSERVED_AT, contracts, EVIDENCE
+    )
+
+
+def forward_factor_expirations() -> ExpirationCollection:
+    front = ExpirationCycle(FORWARD_FRONT_EXPIRATION, 61, True, False, AS_OF_DATE, EVIDENCE)
+    back = ExpirationCycle(FORWARD_BACK_EXPIRATION, 91, True, False, AS_OF_DATE, EVIDENCE)
+    return ExpirationCollection(AS_OF_DATE, (front, back))

--- a/tests/architecture/test_screening_boundaries.py
+++ b/tests/architecture/test_screening_boundaries.py
@@ -43,13 +43,16 @@ def _screening_files() -> list[Path]:
 
 
 class TestScreeningImportScope:
-    """screening/ imports only screening and domain -- never a bounded-context
-    implementation module (strategies, market_data, providers, ranking, ...).
+    """screening/ imports only screening, domain, and strategies (SCREEN-004
+    adapters wrap existing strategies -- that dependency is intentional and
+    one-directional; strategies/ itself is not permitted to import screening,
+    enforced separately by test_strategy_boundaries.py's own allowlist).
+    Never a provider-facing or infrastructure module.
     """
 
     @pytest.mark.parametrize("py_file", _screening_files())
     def test_only_permitted_roots(self, py_file: Path) -> None:
-        permitted = {"screening", "domain"} | STDLIB_ALLOWED
+        permitted = {"screening", "domain", "strategies"} | STDLIB_ALLOWED
         imported = _imported_roots(py_file)
         assert imported <= permitted, (
             f"{py_file.name} imports outside {permitted}: {imported - permitted}"
@@ -58,7 +61,7 @@ class TestScreeningImportScope:
     @pytest.mark.parametrize("py_file", _screening_files())
     def test_prohibited_imports_absent(self, py_file: Path) -> None:
         prohibited = {
-            "market_data", "providers", "observation", "strategies", "ranking",
+            "market_data", "providers", "observation", "ranking",
             "guardrails", "presentation", "simulation", "execution_planning",
         }
         imported = _imported_roots(py_file)

--- a/tests/screening/test_adapters.py
+++ b/tests/screening/test_adapters.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from screening.adapters import (
+    TARGET_STRATEGY_ADAPTERS,
+    TARGET_STRATEGY_DEFINITIONS,
+    TARGET_STRATEGY_REGISTRY,
+    run_earnings_calendar,
+    run_forward_factor,
+    run_skew_momentum,
+)
+from screening.results import ScreeningOutcomeStatus
+from screening.runner import run_screening
+
+AS_OF = datetime(2026, 7, 22, 16, 0, tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class FixedClock:
+    fixed_at: datetime = AS_OF
+
+    def now(self) -> datetime:
+        return self.fixed_at
+
+
+def _definition(strategy_id: str):
+    return TARGET_STRATEGY_REGISTRY.get(strategy_id)
+
+
+class TestForwardFactorAdapter:
+    def test_produces_a_valid_pass_result(self) -> None:
+        result = run_forward_factor(_definition("forward_factor"), FixedClock(), "run-1")
+        assert result.strategy_id == "forward_factor"
+        assert result.outcome_status is ScreeningOutcomeStatus.PASS
+        assert result.signal_classification == "PASS"
+        assert result.strategy_native_score is not None
+        assert result.strategy_native_score > Decimal("0")
+
+    def test_is_deterministic(self) -> None:
+        first = run_forward_factor(_definition("forward_factor"), FixedClock(), "run-1")
+        second = run_forward_factor(_definition("forward_factor"), FixedClock(), "run-1")
+        assert first == second
+
+
+class TestEarningsCalendarAdapter:
+    def test_produces_a_valid_pass_result(self) -> None:
+        result = run_earnings_calendar(_definition("earnings_calendar"), FixedClock(), "run-1")
+        assert result.strategy_id == "earnings_calendar"
+        assert result.outcome_status is ScreeningOutcomeStatus.PASS
+        assert result.signal_classification == "PASS"
+        assert result.strategy_native_score == Decimal("75")
+
+    def test_is_deterministic(self) -> None:
+        first = run_earnings_calendar(_definition("earnings_calendar"), FixedClock(), "run-1")
+        second = run_earnings_calendar(_definition("earnings_calendar"), FixedClock(), "run-1")
+        assert first == second
+
+
+class TestSkewMomentumAdapter:
+    def test_produces_a_valid_pass_result(self) -> None:
+        result = run_skew_momentum(_definition("skew_momentum"), FixedClock(), "run-1")
+        assert result.strategy_id == "skew_momentum"
+        assert result.outcome_status is ScreeningOutcomeStatus.PASS
+        assert result.signal_classification == "PASS"
+        assert result.strategy_native_score is not None
+
+    def test_is_deterministic(self) -> None:
+        first = run_skew_momentum(_definition("skew_momentum"), FixedClock(), "run-1")
+        second = run_skew_momentum(_definition("skew_momentum"), FixedClock(), "run-1")
+        assert first == second
+
+
+class TestTargetStrategyRegistration:
+    def test_all_three_target_strategies_are_registered(self) -> None:
+        assert TARGET_STRATEGY_REGISTRY.registered_ids() == (
+            "earnings_calendar",
+            "forward_factor",
+            "skew_momentum",
+        )
+
+    def test_every_registered_definition_has_an_adapter(self) -> None:
+        for strategy_id in TARGET_STRATEGY_REGISTRY.registered_ids():
+            assert strategy_id in TARGET_STRATEGY_ADAPTERS
+
+    def test_strategy_versions_are_pinned_from_the_manifests_not_hardcoded(self) -> None:
+        from strategies import (
+            EARNINGS_CALENDAR_MANIFEST,
+            FORWARD_FACTOR_CALENDAR_MANIFEST,
+            SKEW_MOMENTUM_VERTICAL_MANIFEST,
+        )
+
+        expected = {
+            "forward_factor": FORWARD_FACTOR_CALENDAR_MANIFEST.strategy_version,
+            "earnings_calendar": EARNINGS_CALENDAR_MANIFEST.strategy_version,
+            "skew_momentum": SKEW_MOMENTUM_VERTICAL_MANIFEST.strategy_version,
+        }
+        for definition in TARGET_STRATEGY_DEFINITIONS:
+            assert definition.strategy_version == expected[definition.strategy_id]
+
+
+class TestFullRunThroughTheFramework:
+    def test_all_three_target_strategies_run_through_run_screening(self) -> None:
+        results = run_screening(TARGET_STRATEGY_REGISTRY, TARGET_STRATEGY_ADAPTERS, FixedClock())
+        assert [result.strategy_id for result in results] == [
+            "earnings_calendar",
+            "forward_factor",
+            "skew_momentum",
+        ]
+        assert all(result.outcome_status is ScreeningOutcomeStatus.PASS for result in results)
+        assert len({result.run_id for result in results}) == 1
+
+    def test_a_single_strategy_can_be_selected(self) -> None:
+        (result,) = run_screening(
+            TARGET_STRATEGY_REGISTRY,
+            TARGET_STRATEGY_ADAPTERS,
+            FixedClock(),
+            strategy_ids=("forward_factor",),
+        )
+        assert result.strategy_id == "forward_factor"


### PR DESCRIPTION
## Ticket
SCREEN-004 (SPRINT-006, delegated merge under GOV-006/Amendment 013)

## Summary
Connects all three ready target strategies (Forward Factor, Earnings Calendar, Skew Momentum) to the screening framework built in #144/#145, without changing any threshold, formula, entry logic, or scoring. Every adapter is pure composition glue: builds each manifest's required execution context from fixed fixture data, executes the existing unmodified manifest, and wraps the strategy-native output into a `ScreeningResult`.

## Repository evidence
- Verified all three adapters actually execute the real, unmodified manifests end-to-end and produce `PASS` verdicts, using `compile_strategy_graph`/`execute_strategy_graph` exactly as the existing `tests/strategies/test_stonk_manifests.py` does -- no strategy logic re-implemented anywhere.
- Fixture DTE windows are strategy-specific because each manifest enforces its own selector constraints (confirmed by reading each manifest's node parameters directly): earnings_calendar needs `front_min/max_dte=7/21`, `back_min/max_dte=22/75`, **and** the front expiration strictly before the earnings date (discovered the hard way -- my first attempt had this backwards and failed at the `pair` node with `ComponentContractError: expiration pair projection requires exactly two cycles`, traced to `expiration_pair_selector`'s date-relative-to-earnings-event filter in `strategies/stonk_components.py`); forward_factor needs `front_min/max_dte=35/90`, `back_min/max_dte=49/139`.
- Existing strategy regression suite re-run unmodified: `pytest tests/strategies/ tests/architecture/test_stonk_decommissioning.py` -> 259 passed (identical count to SCREEN-001's baseline).
- Fixed the SCREEN-002 architecture boundary test, which forbade `screening/` from importing `strategies/` entirely -- discovered while implementing this ticket to be too broad, since wrapping existing strategies is exactly SCREEN-004's purpose. `strategies/`'s own boundary test (`test_strategy_boundaries.py`) still does not permit importing `screening`, so the dependency stays one-directional (screening depends on strategies, never the reverse).

## Relevant issues and PRs
#144 (SCREEN-002), #145 (SCREEN-003), #142 (SCREEN-001, the audit this ticket directly implements).

## Architecture compliance
- No threshold, formula, entry logic, or scoring changed in any of the three strategies -- confirmed by the unchanged regression test count and by inspection (zero lines touched under `strategies/`).
- A verdict of PASS/WATCH maps to `outcome_status=PASS`; FAIL maps to `NO_SIGNAL`; the original verdict string is always preserved verbatim in `signal_classification` either way, satisfying "preserve existing strategy-native evidence and explanations."
- No exception handling inside the adapters by design -- an unexpected failure propagates to the runner's own `STRATEGY_EXCEPTION` isolation boundary (#145), which is exactly where that isolation belongs; adapters stay simple composition glue.
- `tests/architecture/test_screening_boundaries.py` extended and still enforces: no provider, market_data, or infrastructure import; only `screening`, `domain`, `strategies`, and stdlib.

## Security and secret handling
Secret scan (`grep -riE "token|secret|password|api[_-]?key|bearer"`) against all new/changed files: one match, the pre-existing false positive (stdlib module name `"secrets"` in the forbidden-imports test set).

## Network behavior
None. Every adapter uses fixed, hard-coded fixture data -- zero provider or live market-data access, matching the same "fixed, safe, pre-reviewed" design already used for live Market Data Platform validation subjects. Live acquisition is explicitly deferred to SPRINT-007 per this sprint's own scope (`successor_candidate.authorized: false`).

## Request budget behavior
N/A -- no provider or market-data requests.

## Tests
- `pytest tests/screening/ tests/architecture/test_screening_boundaries.py` -> 99 passed (up from 78 in #145).
- `pytest tests/` (full repo) -> 2001 passed, 2 skipped (pre-existing, unrelated).
- `pytest tests/strategies/ tests/architecture/test_stonk_decommissioning.py` -> 259 passed, unchanged from SCREEN-001's baseline -- confirms zero strategy semantic drift.
- `ruff check screening/ tests/screening/ tests/architecture/test_screening_boundaries.py` -> clean.
- `mypy screening/adapters.py` -> zero errors in this PR's own files. Reaching `strategies`/`indicators` transitively surfaces 22 **pre-existing** mypy errors (missing generic type args, `Decimal`/`object` operator mismatches, one broken re-export) in `strategies/calculations.py`, `strategies/registry.py`, `strategies/__init__.py`, `indicators/calculations.py`, `indicators/registry.py`, `indicators/engine.py` -- confirmed byte-identical with `git stash` (i.e. present on `main` before this PR, not introduced by it). No existing CI workflow runs root-level mypy today (`product-ci.yml` scopes mypy to `backend/src` only), so these were never previously surfaced. Fixing them is unrelated-refactoring risk to code this ticket must not touch (`strategies/` semantics), explicitly out of scope.
- `tools/pos/lean/check_integrity.py` -> OK. `validate.py` -> PASS. `generate.py current-state` -> no drift. `check_entrypoints.py` -> OK.
- `git status --short` -> exactly the new `screening/adapters.py`, `screening/fixtures.py`, their test, the `__init__.py` export update, and the boundary-test fix -- matches approved ticket scope.

## Live validation status
N/A -- fixture-backed only, per this ticket's own scope.

## Explicit exclusions
No entrypoint (SCREEN-005). No changes to `strategies/`, `ranking/`, or any existing module's semantics. No live market-data acquisition. No unrelated fixes to the pre-existing mypy findings noted above.

## Merge authority
`delegated_after_required_checks` per SPRINT-006/GOV-006 -- active since #141 merged. All required gates above are green (with the pre-existing mypy findings documented and out of scope); merging under delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)