### PR TITLE
SCREEN-005: bounded screening entrypoint

### DIFF
--- a/screening/__main__.py
+++ b/screening/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from screening.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/screening/cli.py
+++ b/screening/cli.py
@@ -1,0 +1,210 @@
+"""Bounded, deterministic screening entrypoint (SCREEN-005).
+
+    python -m screening [--strategies ID[,ID...]] [--universe SYMBOL[,...]]
+                         [--as-of ISO8601] [--dry-run] [--live] [--json]
+
+Exit codes: 0 for a completed orchestration run -- regardless of individual
+strategy outcomes (PASS/NO_SIGNAL/MISSING_DATA/MALFORMED_OUTPUT/
+STRATEGY_EXCEPTION are all isolated per-strategy results, not orchestration
+failures); 2 for an orchestration-level failure (unknown strategy_id,
+unsupported universe symbol, a malformed --as-of value, or --live -- not yet
+available, deferred to a successor sprint).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from dataclasses import dataclass
+
+from screening.adapters import TARGET_STRATEGY_ADAPTERS, TARGET_STRATEGY_REGISTRY
+from screening.errors import UnknownScreeningStrategyIdError
+from screening.fixtures import SAFE_SYMBOL
+from screening.registry import ScreeningStrategyDefinition
+from screening.results import ScreeningResult
+from screening.runner import run_screening
+from screening.serialization import results_to_json_payload
+
+APPROVED_FIXTURE_UNIVERSE = (SAFE_SYMBOL,)
+
+_ORCHESTRATION_FAILURE_EXIT_CODE = 2
+
+
+@dataclass(frozen=True)
+class SystemClock:
+    def now(self) -> datetime:
+        return datetime.now(UTC)
+
+
+@dataclass(frozen=True)
+class FixedClock:
+    fixed_at: datetime
+
+    def now(self) -> datetime:
+        return self.fixed_at
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m screening",
+        description=(
+            "Bounded, deterministic screening entrypoint for ready target strategies "
+            "(forward_factor, earnings_calendar, skew_momentum)."
+        ),
+    )
+    parser.add_argument(
+        "--strategies",
+        default=None,
+        help="Comma-separated strategy_ids to run (default: all registered).",
+    )
+    parser.add_argument(
+        "--universe",
+        default=",".join(APPROVED_FIXTURE_UNIVERSE),
+        help=(
+            "Comma-separated symbol universe. Only the approved fixture universe "
+            f"({', '.join(APPROVED_FIXTURE_UNIVERSE)}) is supported this sprint -- "
+            "live, arbitrary universes are deferred to a successor sprint."
+        ),
+    )
+    parser.add_argument(
+        "--as-of",
+        default=None,
+        help="Timezone-aware ISO8601 timestamp for the run clock (default: current time).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Plan mode: show which strategies and canonical capabilities would run, "
+        "without executing any strategy.",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Bounded live acquisition. NOT YET AVAILABLE this sprint -- deferred to "
+        "SPRINT-007; passing this flag fails closed.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit only the machine-readable JSON payload (suppresses the human summary).",
+    )
+    return parser
+
+
+def _parse_csv(value: str) -> tuple[str, ...]:
+    return tuple(item.strip() for item in value.split(",") if item.strip())
+
+
+def _print_dry_run_summary(plan: Sequence[ScreeningStrategyDefinition]) -> None:
+    print("DRY RUN -- plan only, no strategy was executed.")
+    for entry in plan:
+        capabilities = ", ".join(capability.value for capability in entry.required_capabilities)
+        print(f"  would run: {entry.strategy_id} (capabilities: {capabilities})")
+
+
+def _print_results_summary(results: Sequence[ScreeningResult]) -> None:
+    print("SCREENING RUN")
+    for result in results:
+        print(
+            f"  {result.strategy_id:<18} {result.outcome_status.value:<18} "
+            f"classification={result.signal_classification!r} "
+            f"score={result.strategy_native_score!r}"
+        )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.live:
+        print(
+            "error: --live is not yet available. Live acquisition is explicitly deferred "
+            "to a successor sprint (SPRINT-007); this sprint's screening runs are "
+            "fixture-backed only.",
+            file=sys.stderr,
+        )
+        return _ORCHESTRATION_FAILURE_EXIT_CODE
+
+    requested_universe = _parse_csv(args.universe)
+    unsupported = set(requested_universe) - set(APPROVED_FIXTURE_UNIVERSE)
+    if not requested_universe or unsupported:
+        print(
+            f"error: unsupported universe symbol(s) {sorted(unsupported) or list(requested_universe)}. "
+            f"Only {APPROVED_FIXTURE_UNIVERSE} is supported this sprint.",
+            file=sys.stderr,
+        )
+        return _ORCHESTRATION_FAILURE_EXIT_CODE
+
+    requested_strategy_ids: tuple[str, ...] | None
+    if args.strategies is None:
+        requested_strategy_ids = None
+    else:
+        requested_strategy_ids = _parse_csv(args.strategies)
+        unknown = set(requested_strategy_ids) - set(TARGET_STRATEGY_REGISTRY.registered_ids())
+        if not requested_strategy_ids or unknown:
+            print(
+                f"error: unknown strategy_id(s) {sorted(unknown) or list(requested_strategy_ids)}. "
+                f"Registered: {TARGET_STRATEGY_REGISTRY.registered_ids()}.",
+                file=sys.stderr,
+            )
+            return _ORCHESTRATION_FAILURE_EXIT_CODE
+
+    if args.as_of is None:
+        clock: SystemClock | FixedClock = SystemClock()
+    else:
+        try:
+            parsed = datetime.fromisoformat(args.as_of)
+        except ValueError:
+            print(f"error: --as-of is not a valid ISO8601 timestamp: {args.as_of!r}", file=sys.stderr)
+            return _ORCHESTRATION_FAILURE_EXIT_CODE
+        if parsed.tzinfo is None:
+            print("error: --as-of must be timezone-aware", file=sys.stderr)
+            return _ORCHESTRATION_FAILURE_EXIT_CODE
+        clock = FixedClock(parsed)
+
+    effective_ids = requested_strategy_ids or TARGET_STRATEGY_REGISTRY.registered_ids()
+
+    if args.dry_run:
+        plan = [TARGET_STRATEGY_REGISTRY.get(strategy_id) for strategy_id in sorted(effective_ids)]
+        if not args.json:
+            _print_dry_run_summary(plan)
+        print(
+            json.dumps(
+                {
+                    "dry_run": True,
+                    "as_of": clock.now().isoformat(),
+                    "plan": [
+                        {
+                            "strategy_id": entry.strategy_id,
+                            "strategy_version": entry.strategy_version,
+                            "required_capabilities": [c.value for c in entry.required_capabilities],
+                        }
+                        for entry in plan
+                    ],
+                }
+            )
+        )
+        return 0
+
+    try:
+        results = run_screening(
+            TARGET_STRATEGY_REGISTRY,
+            TARGET_STRATEGY_ADAPTERS,
+            clock,
+            strategy_ids=requested_strategy_ids,
+        )
+    except UnknownScreeningStrategyIdError as exc:
+        print(f"error: orchestration failure: {exc}", file=sys.stderr)
+        return _ORCHESTRATION_FAILURE_EXIT_CODE
+
+    if not args.json:
+        _print_results_summary(results)
+    print(json.dumps(results_to_json_payload(results, dry_run=False)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/screening/serialization.py
+++ b/screening/serialization.py
@@ -1,0 +1,54 @@
+"""Canonical, secret-free JSON serialization for ScreeningResult (SCREEN-005)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from domain import EvidenceReference
+from domain.market_data import CompletenessMetadata
+from screening.results import ScreeningResult
+
+
+def _evidence_to_dict(reference: EvidenceReference) -> dict[str, Any]:
+    return {"kind": reference.kind.value, "referenced_id": reference.referenced_id}
+
+
+def _completeness_to_dict(completeness: CompletenessMetadata | None) -> dict[str, Any] | None:
+    if completeness is None:
+        return None
+    return {
+        "required_fields": list(completeness.required_fields),
+        "present_fields": list(completeness.present_fields),
+        "missing_fields": list(completeness.missing_fields),
+    }
+
+
+def result_to_dict(result: ScreeningResult) -> dict[str, Any]:
+    """Convert one ScreeningResult into a canonical, JSON-safe mapping.
+
+    Never includes a raw provider payload or secret -- every field here is
+    already one of ScreeningResult's own bounded, redacted, canonical
+    fields.
+    """
+    return {
+        "run_id": result.run_id,
+        "strategy_id": result.strategy_id,
+        "strategy_version": result.strategy_version,
+        "subject_identity": result.subject_identity,
+        "as_of": result.as_of.isoformat(),
+        "outcome_status": result.outcome_status.value,
+        "signal_classification": result.signal_classification,
+        "strategy_native_score": (
+            str(result.strategy_native_score) if result.strategy_native_score is not None else None
+        ),
+        "evidence": [_evidence_to_dict(item) for item in result.evidence],
+        "input_provenance": [_evidence_to_dict(item) for item in result.input_provenance],
+        "completeness": _completeness_to_dict(result.completeness),
+        "failure_detail": result.failure_detail,
+    }
+
+
+def results_to_json_payload(
+    results: tuple[ScreeningResult, ...], *, dry_run: bool
+) -> dict[str, Any]:
+    return {"dry_run": dry_run, "results": [result_to_dict(result) for result in results]}

--- a/tests/architecture/test_screening_boundaries.py
+++ b/tests/architecture/test_screening_boundaries.py
@@ -22,8 +22,8 @@ FORBIDDEN_INFRASTRUCTURE_MODULES = {
 }
 
 STDLIB_ALLOWED = {
-    "__future__", "abc", "collections", "dataclasses", "datetime", "decimal", "enum", "hashlib",
-    "json", "re", "typing",
+    "__future__", "abc", "argparse", "collections", "dataclasses", "datetime", "decimal", "enum",
+    "hashlib", "json", "re", "sys", "typing",
 }
 
 

--- a/tests/screening/test_cli.py
+++ b/tests/screening/test_cli.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from screening.cli import main
+
+AS_OF = "2026-07-22T16:00:00+00:00"
+
+
+class TestDryRun:
+    def test_dry_run_lists_all_registered_strategies_and_exits_zero(self, capsys) -> None:
+        exit_code = main(["--dry-run", "--as-of", AS_OF, "--json"])
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["dry_run"] is True
+        assert {entry["strategy_id"] for entry in payload["plan"]} == {
+            "earnings_calendar",
+            "forward_factor",
+            "skew_momentum",
+        }
+
+    def test_dry_run_executes_nothing(self, capsys, monkeypatch) -> None:
+        def _fail(*_args, **_kwargs):
+            raise AssertionError("dry_run must never execute a strategy")
+
+        monkeypatch.setattr("screening.cli.run_screening", _fail)
+        exit_code = main(["--dry-run", "--as-of", AS_OF])
+        assert exit_code == 0
+
+    def test_dry_run_can_be_scoped_to_one_strategy(self, capsys) -> None:
+        exit_code = main(["--dry-run", "--as-of", AS_OF, "--json", "--strategies", "forward_factor"])
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert [entry["strategy_id"] for entry in payload["plan"]] == ["forward_factor"]
+
+
+class TestRealRun:
+    def test_all_ready_strategies_run_by_default_and_exit_zero(self, capsys) -> None:
+        exit_code = main(["--as-of", AS_OF, "--json"])
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["dry_run"] is False
+        assert {result["strategy_id"] for result in payload["results"]} == {
+            "earnings_calendar",
+            "forward_factor",
+            "skew_momentum",
+        }
+        assert all(result["outcome_status"] == "pass" for result in payload["results"])
+
+    def test_json_flag_suppresses_the_human_summary(self, capsys) -> None:
+        main(["--as-of", AS_OF, "--json"])
+        out = capsys.readouterr().out
+        assert "SCREENING RUN" not in out
+        json.loads(out)  # the whole stdout is valid JSON, nothing else was printed
+
+    def test_default_mode_prints_a_human_summary_before_the_json(self, capsys) -> None:
+        main(["--as-of", AS_OF])
+        out = capsys.readouterr().out
+        assert "SCREENING RUN" in out
+        last_line = out.strip().splitlines()[-1]
+        json.loads(last_line)
+
+    def test_output_contains_no_evidence_of_a_raw_provider_payload(self, capsys) -> None:
+        main(["--as-of", AS_OF, "--json"])
+        out = capsys.readouterr().out
+        assert "http://" not in out and "https://" not in out
+        assert "Bearer" not in out and "Authorization" not in out
+
+
+class TestFailClosed:
+    def test_live_flag_fails_closed_and_never_reaches_the_runner(self, capsys, monkeypatch) -> None:
+        def _fail(*_args, **_kwargs):
+            raise AssertionError("--live must never reach run_screening")
+
+        monkeypatch.setattr("screening.cli.run_screening", _fail)
+        exit_code = main(["--live"])
+        assert exit_code == 2
+        assert "not yet available" in capsys.readouterr().err
+
+    def test_unknown_strategy_id_fails_closed(self, capsys) -> None:
+        exit_code = main(["--strategies", "does_not_exist", "--as-of", AS_OF])
+        assert exit_code == 2
+        assert "unknown strategy_id" in capsys.readouterr().err
+
+    def test_unsupported_universe_symbol_fails_closed(self, capsys) -> None:
+        exit_code = main(["--universe", "TSLA", "--as-of", AS_OF])
+        assert exit_code == 2
+        assert "unsupported universe" in capsys.readouterr().err
+
+    def test_empty_universe_fails_closed(self, capsys) -> None:
+        exit_code = main(["--universe", "", "--as-of", AS_OF])
+        assert exit_code == 2
+
+    def test_naive_as_of_fails_closed(self, capsys) -> None:
+        exit_code = main(["--as-of", "2026-07-22T16:00:00"])
+        assert exit_code == 2
+        assert "timezone-aware" in capsys.readouterr().err
+
+    def test_malformed_as_of_fails_closed(self, capsys) -> None:
+        exit_code = main(["--as-of", "not-a-date"])
+        assert exit_code == 2
+        assert "not a valid ISO8601" in capsys.readouterr().err
+
+    def test_bad_arguments_exit_nonzero_via_argparse(self) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            main(["--not-a-real-flag"])
+        assert excinfo.value.code != 0
+
+
+class TestDeterminism:
+    def test_identical_as_of_produces_identical_json_output(self, capsys) -> None:
+        main(["--as-of", AS_OF, "--json"])
+        first = capsys.readouterr().out
+        main(["--as-of", AS_OF, "--json"])
+        second = capsys.readouterr().out
+        assert first == second
+
+    def test_no_as_of_still_completes_and_uses_the_real_clock(self, capsys) -> None:
+        exit_code = main(["--json"])
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["results"][0]["as_of"]


### PR DESCRIPTION
## Ticket
SCREEN-005 (SPRINT-006, delegated merge under GOV-006/Amendment 013)

## Summary
Adds `python -m screening`: one operator-facing local command running the three ready target strategies (#146) with explicit bounded inputs, dry-run/plan mode, and machine- and human-readable output.

## Repository evidence
- `--dry-run` never touches `run_screening` -- verified by a test that monkeypatches it to raise `AssertionError` if called, confirming plan mode is truly execution-free.
- `--universe` is validated against `screening/fixtures.py`'s `SAFE_SYMBOL` (AAPL) -- the only symbol any current adapter actually has fixture data for; anything else fails closed with exit code 2.
- `--live` is recognized and documented in `--help` (satisfying "help text clearly distinguishes dry-run, fixture, and bounded live modes") but fails closed immediately -- live acquisition is explicitly out of this sprint's scope (`successor_candidate.authorized: false` in `docs/sprints/SPRINT-006.yaml`), so this doesn't silently no-op or crash, it says so.
- Exit code semantics tested explicitly: 0 for any completed run regardless of individual strategy outcome (a `STRATEGY_EXCEPTION` or `MISSING_DATA` result does not fail the process -- that's the whole point of SCREEN-003's isolation), 2 only for genuine orchestration failures (unknown strategy_id, unsupported universe, malformed/naive `--as-of`, `--live`).

## Relevant issues and PRs
#146 (SCREEN-004, the adapters this entrypoint wires together), #145 (SCREEN-003, whose isolation semantics define the exit-code split), #147 (CI coverage gap, unrelated to this ticket's own correctness -- flagged separately for your review).

## Architecture compliance
- `tests/architecture/test_screening_boundaries.py` extended: added `argparse`/`sys` to the permitted stdlib set for the new CLI/serialization files; no new provider, market_data, or infrastructure import anywhere.
- `--json` output verified to contain no `http://`/`https://`/`Bearer`/`Authorization` substrings -- no raw provider payload or secret leakage, by construction (`serialization.py` only ever reads `ScreeningResult`'s own already-bounded/redacted fields).
- No background scheduling, no polling, no loop -- the command runs once and exits.

## Security and secret handling
Secret scan (`grep -riE "token|secret|password|api[_-]?key|bearer"`) against all new/changed files: four matches, all false positives -- two docstrings describing the serializer's secret-free design, a test assertion checking `"Bearer"`/`"Authorization"` are *absent* from output, and the pre-existing stdlib-module-name false positive in the boundary test.

## Network behavior
None. `--live` fails closed before any execution path is reached.

## Request budget behavior
N/A this sprint -- `--live` is not implemented; existing market-data request budgets are therefore untouched, and no command option can raise them (there's nothing live to raise a ceiling on yet).

## Tests
- `pytest tests/screening/test_cli.py` -> 16 passed, covering dry-run, real runs, both output modes, all four fail-closed paths, and determinism.
- `pytest tests/screening/ tests/architecture/test_screening_boundaries.py` -> 130 passed (up from 99 in #146).
- `pytest tests/` (full repo) -> 2032 passed, 2 skipped (pre-existing, unrelated).
- `ruff check screening/ tests/screening/ tests/architecture/test_screening_boundaries.py` -> clean.
- `mypy screening/cli.py screening/serialization.py screening/__main__.py` -> zero errors in these files (the same 22 pre-existing, unrelated `strategies`/`indicators` findings noted in #146 still surface transitively; not introduced or changed by this PR).
- `tools/pos/lean/check_integrity.py` -> OK. `validate.py` -> PASS. `generate.py current-state` -> no drift. `check_entrypoints.py` -> OK.
- Manual smoke test of `python -m screening --help`, `--dry-run`, a real run, and all four fail-closed paths -- all behave as documented (included in the commit history of this branch's development).
- `git status --short` -> exactly the new CLI/serialization files, their test, and the boundary-test stdlib allowlist update -- matches approved ticket scope.

## Live validation status
N/A -- `--live` is explicitly not implemented this sprint (see above).

## Explicit exclusions
No live acquisition. No scheduling, alerting, or background jobs. No change to request budget ceilings (none exist to change yet). No change to `screening/adapters.py`, `screening/runner.py`, or any prior ticket's code.

## Merge authority
`delegated_after_required_checks` per SPRINT-006/GOV-006 -- active since #141 merged. All required gates above are green; merging under delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)