### PR TITLE
ANALYTICS-002: Forward Factor derived analytics

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -14,19 +14,36 @@ from analytics.engine import FeatureComputation, compute_feature
 from analytics.errors import (
     AnalyticsError,
     DuplicateFeatureRegistrationError,
+    MissingImpliedVolatilityError,
+    NoMatchingContractError,
     UnknownFeatureIdError,
 )
+from analytics.expiration_selection import ExpirationCandidate, select_expiration_pair
 from analytics.features import DerivedFeatureResult
+from analytics.forward_factor import (
+    FORWARD_FACTOR_ANALYTICS_COMPUTATIONS,
+    FORWARD_FACTOR_ANALYTICS_REGISTRY,
+    compute_days_to_expiration,
+    compute_option_implied_volatility,
+)
 from analytics.registry import AnalyticsFeatureDefinition, AnalyticsRegistry
 
 __all__ = [
+    "FORWARD_FACTOR_ANALYTICS_COMPUTATIONS",
+    "FORWARD_FACTOR_ANALYTICS_REGISTRY",
     "AnalyticsError",
     "AnalyticsFeatureDefinition",
     "AnalyticsRegistry",
     "Clock",
     "DerivedFeatureResult",
     "DuplicateFeatureRegistrationError",
+    "ExpirationCandidate",
     "FeatureComputation",
+    "MissingImpliedVolatilityError",
+    "NoMatchingContractError",
     "UnknownFeatureIdError",
+    "compute_days_to_expiration",
     "compute_feature",
+    "compute_option_implied_volatility",
+    "select_expiration_pair",
 ]

--- a/analytics/errors.py
+++ b/analytics/errors.py
@@ -21,3 +21,22 @@ class UnknownFeatureIdError(AnalyticsError):
     def __init__(self, feature_id: str) -> None:
         super().__init__(f"no derived feature registered for id: {feature_id!r}")
         self.feature_id = feature_id
+
+
+class MissingImpliedVolatilityError(AnalyticsError):
+    """A matched option contract has no implied_volatility value."""
+
+    def __init__(self, expiration: str, strike: str) -> None:
+        super().__init__(
+            f"no implied_volatility on the contract matching expiration={expiration!r} "
+            f"strike={strike!r}"
+        )
+
+
+class NoMatchingContractError(AnalyticsError):
+    """No contract in the chain matched the requested expiration/strike/type."""
+
+    def __init__(self, expiration: str, strike: str) -> None:
+        super().__init__(
+            f"no contract found matching expiration={expiration!r} strike={strike!r}"
+        )

--- a/analytics/expiration_selection.py
+++ b/analytics/expiration_selection.py
@@ -1,0 +1,86 @@
+"""Reusable expiration-pair selection (ANALYTICS-002).
+
+Selects one front/back ExpirationCycle pair from a pool by an explicit DTE
+and gap policy. This is deliberately independent of
+strategies/stonk_components.py's DtePairSelector component -- that
+component is wired inside the frozen Forward Factor manifest graph for its
+own calendar-structure-building branch, but the manifest's separate
+implied_forward_volatility node has no incoming graph edges at all (SPRINT-
+006's discovered gap): its front_iv/back_iv/front_dte/back_dte inputs must
+be supplied from outside the graph entirely. This selector serves that
+external, pre-graph step, using the same selection semantics so the two
+branches choose consistent expirations, without importing strategies/ (this
+package cannot -- see tests/architecture/test_analytics_boundaries.py) or
+modifying the manifest itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass(frozen=True, slots=True)
+class ExpirationCandidate:
+    """The minimal shape this selector needs from a canonical expiration
+    cycle -- decoupled from domain.ExpirationCycle's own constructor shape
+    so callers can adapt any compatible source.
+    """
+
+    expiration_date: date
+    days_to_expiration: int
+
+
+def select_expiration_pair(
+    candidates: tuple[ExpirationCandidate, ...],
+    *,
+    front_min_dte: int,
+    front_max_dte: int,
+    back_min_dte: int,
+    back_max_dte: int,
+    minimum_gap_days: int,
+    maximum_gap_days: int,
+    target_front_dte: int,
+    target_gap_days: int,
+) -> tuple[ExpirationCandidate, ExpirationCandidate] | None:
+    """Select the front/back pair closest to the target front DTE and gap,
+    among all pairs satisfying the DTE-window and gap bounds. Returns None
+    when no candidate pair satisfies the policy -- an expected, non-
+    exceptional outcome the caller must handle explicitly, not a defect.
+    """
+    if (
+        min(
+            front_min_dte,
+            front_max_dte,
+            back_min_dte,
+            back_max_dte,
+            minimum_gap_days,
+            maximum_gap_days,
+        )
+        < 0
+        or front_min_dte > front_max_dte
+        or back_min_dte > back_max_dte
+        or minimum_gap_days > maximum_gap_days
+    ):
+        raise ValueError("expiration selection policy is invalid")
+
+    pairs = tuple(
+        (front, back)
+        for front in candidates
+        for back in candidates
+        if front_min_dte <= front.days_to_expiration <= front_max_dte
+        and back_min_dte <= back.days_to_expiration <= back_max_dte
+        and minimum_gap_days
+        <= back.days_to_expiration - front.days_to_expiration
+        <= maximum_gap_days
+    )
+    return min(
+        pairs,
+        key=lambda pair: (
+            abs(pair[0].days_to_expiration - target_front_dte)
+            + abs(pair[1].days_to_expiration - pair[0].days_to_expiration - target_gap_days),
+            pair[0].expiration_date,
+            pair[1].expiration_date,
+        ),
+        default=None,
+    )

--- a/analytics/forward_factor.py
+++ b/analytics/forward_factor.py
@@ -1,0 +1,77 @@
+"""Forward Factor derived analytics (ANALYTICS-002).
+
+Implements the two derived features SPRINT-006 found missing from this
+codebase: per-contract implied volatility extraction and days-to-expiration
+computation, ready to feed the existing, frozen Forward Factor manifest's
+implied_forward_volatility node (front_iv/back_iv/front_dte/back_dte)
+without any further calculation. Deliberately does NOT reimplement that
+node's own forward-variance blending formula
+(strategies/stonk_components.py::ImpliedForwardVolatility) -- it already
+exists, is already correct, and duplicating it here would only risk drift.
+
+implied_volatility is read directly from the canonical
+domain.OptionContract field the Market Data Platform already populates from
+the live provider (see market_data/tradier.py) -- no Black-Scholes solving
+is implemented or needed here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date
+from decimal import Decimal
+from typing import cast
+
+from domain import MarketCapability, OptionChain, OptionType
+from analytics.engine import FeatureComputation
+from analytics.errors import MissingImpliedVolatilityError, NoMatchingContractError
+from analytics.registry import AnalyticsFeatureDefinition, AnalyticsRegistry
+
+DAYS_TO_EXPIRATION_FEATURE_ID = "days_to_expiration"
+OPTION_IMPLIED_VOLATILITY_FEATURE_ID = "option_implied_volatility"
+
+
+def compute_days_to_expiration(inputs: Mapping[str, object]) -> Decimal:
+    expiration = cast(date, inputs["expiration"])
+    as_of = cast(date, inputs["as_of"])
+    if expiration < as_of:
+        raise ValueError("expiration cannot precede as_of")
+    return Decimal((expiration - as_of).days)
+
+
+def compute_option_implied_volatility(inputs: Mapping[str, object]) -> Decimal:
+    chain = cast(OptionChain, inputs["chain"])
+    expiration = cast(date, inputs["expiration"])
+    strike = cast(Decimal, inputs["strike"])
+    option_type = cast(OptionType, inputs["option_type"])
+    matches = chain.find(expiration=expiration, strike=strike, option_type=option_type)
+    if not matches:
+        raise NoMatchingContractError(expiration.isoformat(), str(strike))
+    contract = matches[0]
+    if contract.implied_volatility is None:
+        raise MissingImpliedVolatilityError(expiration.isoformat(), str(strike))
+    return contract.implied_volatility
+
+
+FORWARD_FACTOR_ANALYTICS_DEFINITIONS: tuple[AnalyticsFeatureDefinition, ...] = (
+    AnalyticsFeatureDefinition(
+        DAYS_TO_EXPIRATION_FEATURE_ID,
+        "1.0.0",
+        "Calendar days between as_of and a given expiration date.",
+        (MarketCapability.OPTION_CHAIN_V1,),
+    ),
+    AnalyticsFeatureDefinition(
+        OPTION_IMPLIED_VOLATILITY_FEATURE_ID,
+        "1.0.0",
+        "Canonical implied_volatility of the option contract matching an "
+        "expiration/strike/type, as already reported by the Market Data Platform.",
+        (MarketCapability.OPTION_CHAIN_V1,),
+    ),
+)
+
+FORWARD_FACTOR_ANALYTICS_REGISTRY = AnalyticsRegistry(FORWARD_FACTOR_ANALYTICS_DEFINITIONS)
+
+FORWARD_FACTOR_ANALYTICS_COMPUTATIONS: dict[str, FeatureComputation] = {
+    DAYS_TO_EXPIRATION_FEATURE_ID: compute_days_to_expiration,
+    OPTION_IMPLIED_VOLATILITY_FEATURE_ID: compute_option_implied_volatility,
+}

--- a/tests/analytics/test_expiration_selection.py
+++ b/tests/analytics/test_expiration_selection.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from analytics.expiration_selection import ExpirationCandidate, select_expiration_pair
+
+_POLICY = {
+    "front_min_dte": 35,
+    "front_max_dte": 90,
+    "back_min_dte": 49,
+    "back_max_dte": 139,
+    "minimum_gap_days": 14,
+    "maximum_gap_days": 49,
+    "target_front_dte": 60,
+    "target_gap_days": 30,
+}
+
+
+def _candidate(days: int, expiration: date) -> ExpirationCandidate:
+    return ExpirationCandidate(expiration, days)
+
+
+class TestSelectExpirationPair:
+    def test_selects_the_pair_closest_to_target(self) -> None:
+        candidates = (
+            _candidate(61, date(2026, 9, 21)),
+            _candidate(91, date(2026, 10, 21)),
+            _candidate(35, date(2026, 8, 26)),
+            _candidate(139, date(2026, 12, 8)),
+        )
+        selected = select_expiration_pair(candidates, **_POLICY)
+        assert selected is not None
+        front, back = selected
+        assert front.days_to_expiration == 61
+        assert back.days_to_expiration == 91
+
+    def test_returns_none_when_no_pair_satisfies_the_policy(self) -> None:
+        candidates = (_candidate(5, date(2026, 7, 27)),)
+        assert select_expiration_pair(candidates, **_POLICY) is None
+
+    def test_returns_none_for_empty_candidates(self) -> None:
+        assert select_expiration_pair((), **_POLICY) is None
+
+    def test_gap_constraint_is_enforced(self) -> None:
+        # front and back both individually valid, but gap (139-35=104) exceeds max 49.
+        candidates = (
+            _candidate(35, date(2026, 8, 26)),
+            _candidate(139, date(2026, 12, 8)),
+        )
+        assert select_expiration_pair(candidates, **_POLICY) is None
+
+    def test_is_deterministic(self) -> None:
+        candidates = (
+            _candidate(61, date(2026, 9, 21)),
+            _candidate(91, date(2026, 10, 21)),
+        )
+        first = select_expiration_pair(candidates, **_POLICY)
+        second = select_expiration_pair(candidates, **_POLICY)
+        assert first == second
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"front_min_dte": 100, "front_max_dte": 50},
+            {"minimum_gap_days": 100, "maximum_gap_days": 10},
+            {"front_min_dte": -1},
+        ],
+    )
+    def test_invalid_policy_rejected(self, overrides: dict[str, int]) -> None:
+        policy = dict(_POLICY)
+        policy.update(overrides)
+        with pytest.raises(ValueError, match="policy is invalid"):
+            select_expiration_pair((), **policy)

--- a/tests/analytics/test_forward_factor.py
+++ b/tests/analytics/test_forward_factor.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+
+from analytics.errors import MissingImpliedVolatilityError, NoMatchingContractError
+from analytics.forward_factor import (
+    FORWARD_FACTOR_ANALYTICS_COMPUTATIONS,
+    FORWARD_FACTOR_ANALYTICS_REGISTRY,
+    compute_days_to_expiration,
+    compute_option_implied_volatility,
+)
+from domain import (
+    CanonicalInstrumentIdentity,
+    EvidenceKind,
+    EvidenceReference,
+    Instrument,
+    InstrumentKind,
+    OptionChain,
+    OptionContract,
+    OptionType,
+    Security,
+    SecurityAssetType,
+)
+
+OBSERVED_AT = datetime(2026, 7, 22, 16, 0, tzinfo=UTC)
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "test-evidence"),)
+
+
+def _security() -> Security:
+    return Security(
+        Instrument(CanonicalInstrumentIdentity("figi", "figi-AAPL"), InstrumentKind.EQUITY, "AAPL", "USD"),
+        "AAPL",
+        SecurityAssetType.EQUITY,
+        "XNAS",
+    )
+
+
+def _contract(expiration: date, strike: str, implied_volatility: Decimal | None) -> OptionContract:
+    return OptionContract(
+        CanonicalInstrumentIdentity("asa-option-v1", f"opt-{strike}"),
+        _security(),
+        expiration,
+        Decimal(strike),
+        OptionType.CALL,
+        Decimal("1.90"),
+        Decimal("2.10"),
+        Decimal("2.00"),
+        100,
+        500,
+        Decimal("0.35"),
+        Decimal("0.01"),
+        Decimal("-0.02"),
+        Decimal("0.03"),
+        Decimal("0.01"),
+        implied_volatility,
+        OBSERVED_AT,
+        EVIDENCE,
+    )
+
+
+def _chain(*contracts: OptionContract) -> OptionChain:
+    return OptionChain("test-chain", _security(), OBSERVED_AT, contracts, EVIDENCE)
+
+
+class TestComputeDaysToExpiration:
+    def test_computes_calendar_days(self) -> None:
+        value = compute_days_to_expiration(
+            {"expiration": date(2026, 9, 21), "as_of": date(2026, 7, 22)}
+        )
+        assert value == Decimal(61)
+
+    def test_same_day_is_zero(self) -> None:
+        value = compute_days_to_expiration({"expiration": date(2026, 7, 22), "as_of": date(2026, 7, 22)})
+        assert value == Decimal(0)
+
+    def test_expiration_before_as_of_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cannot precede"):
+            compute_days_to_expiration({"expiration": date(2026, 7, 1), "as_of": date(2026, 7, 22)})
+
+
+class TestComputeOptionImpliedVolatility:
+    def test_extracts_the_canonical_field_directly(self) -> None:
+        chain = _chain(_contract(date(2026, 9, 21), "105", Decimal("0.35")))
+        value = compute_option_implied_volatility(
+            {"chain": chain, "expiration": date(2026, 9, 21), "strike": Decimal("105"), "option_type": OptionType.CALL}
+        )
+        assert value == Decimal("0.35")
+
+    def test_no_matching_contract_raises(self) -> None:
+        chain = _chain(_contract(date(2026, 9, 21), "105", Decimal("0.35")))
+        with pytest.raises(NoMatchingContractError):
+            compute_option_implied_volatility(
+                {"chain": chain, "expiration": date(2026, 9, 21), "strike": Decimal("110"), "option_type": OptionType.CALL}
+            )
+
+    def test_missing_implied_volatility_raises(self) -> None:
+        chain = _chain(_contract(date(2026, 9, 21), "105", None))
+        with pytest.raises(MissingImpliedVolatilityError):
+            compute_option_implied_volatility(
+                {"chain": chain, "expiration": date(2026, 9, 21), "strike": Decimal("105"), "option_type": OptionType.CALL}
+            )
+
+    def test_no_black_scholes_solving_the_field_is_read_verbatim(self) -> None:
+        """Confirms this reads the provider-reported field directly rather
+        than deriving it -- the whole point of this ticket's scoping
+        decision (see analytics/forward_factor.py's module docstring).
+        """
+        chain = _chain(_contract(date(2026, 9, 21), "105", Decimal("0.9999")))
+        value = compute_option_implied_volatility(
+            {"chain": chain, "expiration": date(2026, 9, 21), "strike": Decimal("105"), "option_type": OptionType.CALL}
+        )
+        assert value == Decimal("0.9999")
+
+
+class TestRegistration:
+    def test_both_features_are_registered(self) -> None:
+        assert FORWARD_FACTOR_ANALYTICS_REGISTRY.registered_ids() == (
+            "days_to_expiration",
+            "option_implied_volatility",
+        )
+
+    def test_every_registered_feature_has_a_computation(self) -> None:
+        for feature_id in FORWARD_FACTOR_ANALYTICS_REGISTRY.registered_ids():
+            assert feature_id in FORWARD_FACTOR_ANALYTICS_COMPUTATIONS

--- a/tests/analytics/test_forward_factor_manifest_integration.py
+++ b/tests/analytics/test_forward_factor_manifest_integration.py
@@ -1,0 +1,158 @@
+"""ANALYTICS-002 success criterion: "Forward Factor consumes analytics
+outputs without additional calculations."
+
+This proves it end-to-end against the real, unmodified Forward Factor
+manifest -- analytics/ computes front_iv/back_iv/front_dte/back_dte, and
+those values are passed directly into the manifest's execution context with
+no further math performed anywhere in this test.
+
+Lives under tests/ (not analytics/) because it imports strategies/ purely
+to validate against the real manifest -- analytics/ itself must not import
+strategies/ (tests/architecture/test_analytics_boundaries.py), and this
+file is exactly why: it's the integration seam between the two, not part
+of the reusable package.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from analytics.expiration_selection import ExpirationCandidate, select_expiration_pair
+from analytics.forward_factor import compute_days_to_expiration, compute_option_implied_volatility
+from domain import (
+    CanonicalInstrumentIdentity,
+    EvidenceKind,
+    EvidenceReference,
+    ExpirationCollection,
+    ExpirationCycle,
+    Instrument,
+    InstrumentKind,
+    OptionChain,
+    OptionContract,
+    OptionType,
+    Security,
+    SecurityAssetType,
+)
+from strategies import (
+    CORE_COMPONENTS,
+    FORWARD_FACTOR_CALENDAR_MANIFEST,
+    STONK_STRATEGY_PLUGINS,
+    compile_strategy_graph,
+    execute_strategy_graph,
+)
+from strategies.plugins import build_plugin_registry
+from strategies.stonk_components import D, EXPIRATION_COLLECTION, OPTION_CHAIN
+from strategies.type_system import ComponentValues, StrategyTypeReference, TypedValue
+
+AS_OF = date(2026, 7, 22)
+OBSERVED_AT = datetime(2026, 7, 22, 16, 0, tzinfo=UTC)
+FRONT_EXPIRATION = date(2026, 9, 21)  # 61 days out
+BACK_EXPIRATION = date(2026, 10, 21)  # 91 days out
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "integration-test"),)
+
+
+def _security() -> Security:
+    return Security(
+        Instrument(CanonicalInstrumentIdentity("figi", "figi-AAPL"), InstrumentKind.EQUITY, "AAPL", "USD"),
+        "AAPL",
+        SecurityAssetType.EQUITY,
+        "XNAS",
+    )
+
+
+def _contract(expiration: date, strike: str, option_type: OptionType, iv: str) -> OptionContract:
+    mark = Decimal("2.00")
+    return OptionContract(
+        CanonicalInstrumentIdentity("asa-option-v1", f"{expiration}-{strike}-{option_type.value}"),
+        _security(),
+        expiration,
+        Decimal(strike),
+        option_type,
+        mark - Decimal("0.10"),
+        mark + Decimal("0.10"),
+        mark,
+        100,
+        500,
+        Decimal("0.35"),
+        Decimal("0.01"),
+        Decimal("-0.02"),
+        Decimal("0.03"),
+        Decimal("0.01"),
+        Decimal(iv),
+        OBSERVED_AT,
+        EVIDENCE,
+    )
+
+
+def test_analytics_outputs_feed_the_real_manifest_with_zero_additional_math() -> None:
+    chain = OptionChain(
+        "integration-chain",
+        _security(),
+        OBSERVED_AT,
+        (
+            _contract(FRONT_EXPIRATION, "105", OptionType.CALL, "0.48"),
+            _contract(BACK_EXPIRATION, "105", OptionType.CALL, "0.4548992562461861547567860943472296"),
+            _contract(FRONT_EXPIRATION, "95", OptionType.PUT, "0.50"),
+            _contract(BACK_EXPIRATION, "95", OptionType.PUT, "0.47"),
+        ),
+        EVIDENCE,
+    )
+
+    # Step 1: analytics selects the front/back expiration pair -- the same
+    # DTE policy the manifest's own (separate, frozen) dte_pair_selector uses.
+    candidates = (
+        ExpirationCandidate(FRONT_EXPIRATION, 61),
+        ExpirationCandidate(BACK_EXPIRATION, 91),
+    )
+    selected = select_expiration_pair(
+        candidates,
+        front_min_dte=35,
+        front_max_dte=90,
+        back_min_dte=49,
+        back_max_dte=139,
+        minimum_gap_days=14,
+        maximum_gap_days=49,
+        target_front_dte=60,
+        target_gap_days=30,
+    )
+    assert selected is not None
+    front, back = selected
+
+    # Step 2: analytics computes DTE and extracts IV -- both read/derived
+    # directly, no further calculation performed here or afterward.
+    front_dte = compute_days_to_expiration({"expiration": front.expiration_date, "as_of": AS_OF})
+    back_dte = compute_days_to_expiration({"expiration": back.expiration_date, "as_of": AS_OF})
+    front_iv = compute_option_implied_volatility(
+        {"chain": chain, "expiration": front.expiration_date, "strike": Decimal("105"), "option_type": OptionType.CALL}
+    )
+    back_iv = compute_option_implied_volatility(
+        {"chain": chain, "expiration": back.expiration_date, "strike": Decimal("105"), "option_type": OptionType.CALL}
+    )
+
+    # Step 3: those four analytics outputs are passed directly into the
+    # real, unmodified manifest's execution context -- verbatim, no math.
+    expirations = ExpirationCollection(
+        AS_OF,
+        (
+            ExpirationCycle(front.expiration_date, front.days_to_expiration, True, False, AS_OF, EVIDENCE),
+            ExpirationCycle(back.expiration_date, back.days_to_expiration, True, False, AS_OF, EVIDENCE),
+        ),
+    )
+    context = ComponentValues(
+        (
+            ("expiration_select.expirations", TypedValue(EXPIRATION_COLLECTION, expirations)),
+            ("double_calendar.chain", TypedValue(OPTION_CHAIN, chain)),
+            ("forward_iv.front_iv", TypedValue(D, front_iv)),
+            ("forward_iv.back_iv", TypedValue(D, back_iv)),
+            ("forward_iv.front_dte", TypedValue(StrategyTypeReference("Integer", "1.0.0"), int(front_dte))),
+            ("forward_iv.back_dte", TypedValue(StrategyTypeReference("Integer", "1.0.0"), int(back_dte))),
+            ("factor.front_ex_earnings_iv", TypedValue(D, front_iv)),
+        )
+    )
+    registry = build_plugin_registry(CORE_COMPONENTS, STONK_STRATEGY_PLUGINS)
+    graph = compile_strategy_graph(FORWARD_FACTOR_CALENDAR_MANIFEST, registry)
+    result = execute_strategy_graph(graph, context)
+
+    assert result.outputs.get("verdict").value in {"PASS", "WATCH", "FAIL"}
+    assert result.outputs.get("forward_factor").value is not None


### PR DESCRIPTION
## Ticket
ANALYTICS-002 (SPRINT-007, delegated merge under GOV-007/Amendment 013, active since #150 merged)

## Summary
Closes the implied-forward-volatility gap SPRINT-006 discovered (`project/reports/SPRINT-006.md` section 8, item 2): the Forward Factor manifest's `implied_forward_volatility` node has no incoming graph edges -- `front_iv`/`back_iv`/`front_dte`/`back_dte` must be supplied from outside the graph entirely.

## Repository evidence -- what was actually missing (investigated before implementing anything)
- `domain.OptionContract` **already carries a canonical `implied_volatility` field** (`domain/financial.py:219`), and `market_data/tradier.py` already populates it from Tradier's live `greeks.mid_iv` response field. No Black-Scholes solving is needed or implemented -- the value is already provider-supplied and canonical.
- `strategies/stonk_components.py::ImpliedForwardVolatility` **already implements** the front/back-IV variance-blending formula correctly (`(back_iv^2 * back_dte - front_iv^2 * front_dte) / (back_dte - front_dte)`, then sqrt). Not touched, not reimplemented -- duplicating it would only risk drift between two copies of the same formula.
- What's genuinely missing, confirmed by reading the manifest's own edge list: everything *upstream* of that node -- selecting a front/back expiration pair outside the graph (the graph's own `dte_pair_selector` only feeds the separate calendar-structure branch, not this one), computing DTE, and extracting each contract's already-canonical IV.

## Relevant issues and PRs
#151 (ANALYTICS-001, the framework this ticket registers features into), #150 (GOV-007), `project/reports/SPRINT-006.md` (origin of the gap).

## Architecture compliance
- `analytics/expiration_selection.py`'s `select_expiration_pair()` is independent of `strategies/stonk_components.py::DtePairSelector` (this package cannot import `strategies/`, enforced by `test_analytics_boundaries.py`) but uses the identical DTE-window-and-gap selection semantics, so both branches of the manifest choose consistent expirations without this package depending on the graph system.
- Two new features registered into ANALYTICS-001's framework: `days_to_expiration`, `option_implied_volatility`. Zero new dependency on `market_data`, `providers`, or `strategies` in `analytics/*.py` itself -- boundary test still enforces this.
- **The ticket's own success criterion proven end-to-end**: `tests/analytics/test_forward_factor_manifest_integration.py` feeds these two features' outputs directly into the real, unmodified `FORWARD_FACTOR_CALENDAR_MANIFEST`'s execution context and executes it via `compile_strategy_graph`/`execute_strategy_graph` -- zero additional calculation performed anywhere in the test. This file imports `strategies/` (for validation only) and deliberately lives under `tests/`, not `analytics/`, since `analytics/` itself must not have that dependency.
- Existing strategy regression suite re-run unmodified: `pytest tests/strategies/ tests/architecture/test_stonk_decommissioning.py` -> 259 passed, unchanged from SCREEN-001's original baseline.

## Security and secret handling
Secret scan (`grep -riE "token|secret|password|api[_-]?key|bearer"`) against all new/changed files: zero matches.

## Network behavior
None.

## Request budget behavior
N/A -- no provider or market-data requests; these features only compute from canonical domain objects a caller already supplies.

## Tests
- `pytest tests/analytics/ tests/architecture/test_analytics_boundaries.py` -> 86 passed (up from 58 in #151).
- `pytest tests/` (full repo) -> 2120 passed, 2 skipped (pre-existing, unrelated).
- `pytest tests/strategies/ tests/architecture/test_stonk_decommissioning.py` -> 259 passed, unchanged.
- `ruff check` -> clean.
- `mypy analytics/` -> clean (8 source files, strict), zero errors -- unaffected by the pre-existing `strategies`/`indicators` findings (#147) since `analytics/*.py` itself doesn't import `strategies`. `mypy tests/analytics/` -> zero errors in this PR's own test files; the integration test transitively surfaces the same 22 pre-existing findings tracked in #147 (confirmed identical, not new).
- `tools/pos/lean/check_integrity.py` / `validate.py` / `generate.py current-state` / `check_entrypoints.py` / `pre_push_check.py` -> all green (5/5).
- `git status --short` -> exactly the two new `analytics/` modules, their tests, the integration test, and the `__init__.py`/`errors.py` export updates -- matches approved ticket scope.

## Live validation status
N/A -- no live/network execution.

## Explicit exclusions
No reimplementation of the forward-IV blending formula (already exists, untouched). No strategy input builders (ANALYTICS-003). No live market-data integration (LIVE-001/002/003). No changes to `strategies/`, `screening/`, or any existing module.

## Merge authority
`delegated_after_required_checks` per SPRINT-007/GOV-007 -- active since #150 merged. All required gates above are green; merging under delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)