### PR TITLE
ANALYTICS-003: strategy input builders

### DIFF
--- a/screening/adapters.py
+++ b/screening/adapters.py
@@ -1,14 +1,18 @@
-"""Target strategy adapters (SCREEN-004).
+"""Target strategy adapters (SCREEN-004, updated by ANALYTICS-003).
 
 Connects each ready target strategy (Forward Factor, Earnings Calendar,
 Skew Momentum -- confirmed present and fully implemented by SCREEN-001) to
 the screening framework, without changing any threshold, formula, entry
 logic, or scoring. Every adapter here is pure composition glue: it builds
-the manifest's required execution context from fixed, deterministic
-screening/fixtures.py data, executes the existing, unmodified manifest via
-strategies.compile_strategy_graph/execute_strategy_graph, and wraps the
-strategy-native verdict/score/evidence into a canonical ScreeningResult --
-it re-implements none of the strategy's own logic.
+the manifest's required execution context (via screening.context_builders,
+using screening/fixtures.py data), executes the existing, unmodified
+manifest via strategies.compile_strategy_graph/execute_strategy_graph, and
+wraps the strategy-native verdict/score/evidence into a canonical
+ScreeningResult -- it re-implements none of the strategy's own logic.
+
+Forward Factor's context now comes from real analytics computation
+(ANALYTICS-002) instead of a hardcoded external implied-volatility
+constant -- see screening/context_builders.py.
 
 A strategy's own PASS/WATCH/FAIL verdict is always preserved verbatim in
 ScreeningResult.signal_classification. outcome_status is a coarser,
@@ -23,9 +27,14 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from domain import ExpirationCollection, MarketCapability, OptionType
+from domain import MarketCapability, OptionType
 from screening import fixtures
 from screening.clock import Clock
+from screening.context_builders import (
+    build_earnings_calendar_context,
+    build_forward_factor_context,
+    build_skew_momentum_context,
+)
 from screening.registry import ScreeningRegistry, ScreeningStrategyDefinition
 from screening.results import ScreeningOutcomeStatus, ScreeningResult
 from strategies import (
@@ -38,28 +47,11 @@ from strategies import (
     execute_strategy_graph,
 )
 from strategies.plugins import build_plugin_registry
-from strategies.stonk_components import (
-    D,
-    DATE,
-    DECIMAL_LIST,
-    EARNINGS_EVENT,
-    EXPIRATION_COLLECTION,
-    EXPIRATION_CYCLE,
-    OPTION_CHAIN,
-    OPTION_CONTRACT,
-)
-from strategies.type_system import ComponentValues, StrategyTypeReference, TypedValue
 
 _COMPONENT_REGISTRY = build_plugin_registry(CORE_COMPONENTS, STONK_STRATEGY_PLUGINS)
 _SUBJECT_IDENTITY = f"figi:figi-{fixtures.SAFE_SYMBOL}"
 
 _NON_FAIL_VERDICTS = frozenset({"PASS", "WATCH"})
-
-
-def _context(**items: tuple[StrategyTypeReference, object]) -> ComponentValues:
-    return ComponentValues(
-        tuple((name, TypedValue(type_ref, value)) for name, (type_ref, value) in items.items())
-    )
 
 
 def _outcome_status_for_verdict(verdict: str) -> ScreeningOutcomeStatus:
@@ -70,39 +62,46 @@ def _outcome_status_for_verdict(verdict: str) -> ScreeningOutcomeStatus:
     )
 
 
-def run_forward_factor(
-    definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
+def _result_from_graph_execution(
+    definition: ScreeningStrategyDefinition,
+    clock: Clock,
+    run_id: str,
+    verdict: object,
+    score: object,
 ) -> ScreeningResult:
-    chain = fixtures.forward_factor_chain()
-    expirations = fixtures.forward_factor_expirations()
-    context = _context(
-        **{
-            "expiration_select.expirations": (EXPIRATION_COLLECTION, expirations),
-            "double_calendar.chain": (OPTION_CHAIN, chain),
-            "forward_iv.front_iv": (D, Decimal("0.48")),
-            "forward_iv.back_iv": (D, Decimal("0.4548992562461861547567860943472296")),
-            "forward_iv.front_dte": (D, 61),
-            "forward_iv.back_dte": (D, 91),
-            "factor.front_ex_earnings_iv": (D, Decimal("0.48")),
-        }
-    )
-    graph = compile_strategy_graph(FORWARD_FACTOR_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
-    result = execute_strategy_graph(graph, context)
-    verdict = str(result.outputs.get("verdict").value)
-    score = result.outputs.get("forward_factor").value
+    verdict_text = str(verdict)
     return ScreeningResult(
         run_id,
         definition.strategy_id,
         definition.strategy_version,
         _SUBJECT_IDENTITY,
         clock.now(),
-        _outcome_status_for_verdict(verdict),
-        verdict,
+        _outcome_status_for_verdict(verdict_text),
+        verdict_text,
         score if isinstance(score, Decimal) else None,
         fixtures.EVIDENCE,
         fixtures.EVIDENCE,
         None,
         None,
+    )
+
+
+def run_forward_factor(
+    definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
+) -> ScreeningResult:
+    chain = fixtures.forward_factor_chain()
+    expirations = fixtures.forward_factor_expirations()
+    context = build_forward_factor_context(
+        chain, expirations.cycles, fixtures.AS_OF_DATE, strike=Decimal("105")
+    )
+    graph = compile_strategy_graph(FORWARD_FACTOR_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
+    result = execute_strategy_graph(graph, context)
+    return _result_from_graph_execution(
+        definition,
+        clock,
+        run_id,
+        result.outputs.get("verdict").value,
+        result.outputs.get("forward_factor").value,
     )
 
 
@@ -112,39 +111,17 @@ def run_earnings_calendar(
     front, back = fixtures.earnings_calendar_expirations()
     event = fixtures.earnings_calendar_event()
     chain = fixtures.earnings_calendar_chain()
-    context = _context(
-        **{
-            "event_window.event": (EARNINGS_EVENT, event),
-            "event_window.front": (EXPIRATION_CYCLE, front),
-            "event_window.back": (EXPIRATION_CYCLE, back),
-            "expiration_select.expirations": (
-                EXPIRATION_COLLECTION,
-                ExpirationCollection(fixtures.AS_OF_DATE, (back, front)),
-            ),
-            "expiration_select.event": (EARNINGS_EVENT, event),
-            "calendar.chain": (OPTION_CHAIN, chain),
-            "calendar.target_strike": (D, Decimal("100")),
-            "score.values": (DECIMAL_LIST, (Decimal("80"), Decimal("60"))),
-            "score.weights": (DECIMAL_LIST, (Decimal("3"), Decimal("1"))),
-        }
+    context = build_earnings_calendar_context(
+        chain, event, front, back, fixtures.AS_OF_DATE, target_strike=Decimal("100")
     )
     graph = compile_strategy_graph(EARNINGS_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
     result = execute_strategy_graph(graph, context)
-    verdict = str(result.outputs.get("verdict").value)
-    score = result.outputs.get("score").value
-    return ScreeningResult(
+    return _result_from_graph_execution(
+        definition,
+        clock,
         run_id,
-        definition.strategy_id,
-        definition.strategy_version,
-        _SUBJECT_IDENTITY,
-        clock.now(),
-        _outcome_status_for_verdict(verdict),
-        verdict,
-        score if isinstance(score, Decimal) else None,
-        fixtures.EVIDENCE,
-        fixtures.EVIDENCE,
-        None,
-        None,
+        result.outputs.get("verdict").value,
+        result.outputs.get("score").value,
     )
 
 
@@ -152,37 +129,17 @@ def run_skew_momentum(
     definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
 ) -> ScreeningResult:
     chain = fixtures.skew_momentum_chain()
-    (call_contract,) = chain.find(
-        expiration=fixtures.SKEW_EXPIRATION,
-        strike=Decimal("100"),
-        option_type=OptionType.CALL,
-    )
-    context = _context(
-        **{
-            "vertical.chain": (OPTION_CHAIN, chain),
-            "vertical.expiration": (DATE, fixtures.SKEW_EXPIRATION),
-            "liquidity.contract": (OPTION_CONTRACT, call_contract),
-            "score.values": (DECIMAL_LIST, (Decimal("80"), Decimal("70"))),
-            "score.weights": (DECIMAL_LIST, (Decimal("2"), Decimal("1"))),
-        }
+    context = build_skew_momentum_context(
+        chain, fixtures.SKEW_EXPIRATION, strike=Decimal("100"), option_type=OptionType.CALL
     )
     graph = compile_strategy_graph(SKEW_MOMENTUM_VERTICAL_MANIFEST, _COMPONENT_REGISTRY)
     result = execute_strategy_graph(graph, context)
-    verdict = str(result.outputs.get("verdict").value)
-    score = result.outputs.get("score").value
-    return ScreeningResult(
+    return _result_from_graph_execution(
+        definition,
+        clock,
         run_id,
-        definition.strategy_id,
-        definition.strategy_version,
-        _SUBJECT_IDENTITY,
-        clock.now(),
-        _outcome_status_for_verdict(verdict),
-        verdict,
-        score if isinstance(score, Decimal) else None,
-        fixtures.EVIDENCE,
-        fixtures.EVIDENCE,
-        None,
-        None,
+        result.outputs.get("verdict").value,
+        result.outputs.get("score").value,
     )
 
 

--- a/screening/context_builders.py
+++ b/screening/context_builders.py
@@ -1,0 +1,170 @@
+"""Strategy execution context builders (ANALYTICS-003).
+
+Constructs each target strategy's frozen manifest execution context from
+canonical market data. Forward Factor's builder uses analytics/ for the
+implied-forward-volatility inputs SPRINT-006 found missing (ANALYTICS-002)
+instead of any hardcoded external constant; Earnings Calendar and Skew
+Momentum need no derived analytics, so their builders just isolate the
+context-construction logic previously inline in screening/adapters.py into
+separately testable functions.
+
+Adapters only: no strategy modification, no provider import. Every builder
+here takes already-canonical domain objects and produces a ComponentValues
+context for the existing, unmodified manifest to consume verbatim -- this
+is exactly what lets LIVE-001/002 later supply live-acquired canonical data
+to the same builders without changing anything here.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from analytics.expiration_selection import ExpirationCandidate, select_expiration_pair
+from analytics.forward_factor import compute_days_to_expiration, compute_option_implied_volatility
+from domain import EarningsEvent, ExpirationCollection, ExpirationCycle, OptionChain, OptionType
+from strategies.stonk_components import (
+    D,
+    DATE,
+    DECIMAL_LIST,
+    EARNINGS_EVENT,
+    EXPIRATION_COLLECTION,
+    EXPIRATION_CYCLE,
+    OPTION_CHAIN,
+    OPTION_CONTRACT,
+)
+from strategies.type_system import ComponentValues, StrategyTypeReference, TypedValue
+
+# Mirrors FORWARD_FACTOR_CALENDAR_MANIFEST's own frozen dte_pair_selector
+# node parameters (strategies/stonk_manifests.py). The manifest exposes no
+# queryable API for these, so the policy is deliberately duplicated here
+# to select a consistent pair for this separate, non-graph-connected branch
+# -- not invented, and not a modification of the manifest itself.
+FORWARD_FACTOR_DTE_POLICY = {
+    "front_min_dte": 35,
+    "front_max_dte": 90,
+    "back_min_dte": 49,
+    "back_max_dte": 139,
+    "minimum_gap_days": 14,
+    "maximum_gap_days": 49,
+    "target_front_dte": 60,
+    "target_gap_days": 30,
+}
+
+_INTEGER = StrategyTypeReference("Integer", "1.0.0")
+
+
+class NoValidExpirationPairError(ValueError):
+    """No front/back expiration pair in the available pool satisfies the
+    target strategy's DTE and gap policy.
+    """
+
+
+def _context(**items: tuple[StrategyTypeReference, object]) -> ComponentValues:
+    return ComponentValues(
+        tuple((name, TypedValue(type_ref, value)) for name, (type_ref, value) in items.items())
+    )
+
+
+def build_forward_factor_context(
+    chain: OptionChain,
+    available_expirations: tuple[ExpirationCycle, ...],
+    as_of: date,
+    *,
+    strike: Decimal,
+    option_type: OptionType = OptionType.CALL,
+) -> ComponentValues:
+    candidates = tuple(
+        ExpirationCandidate(cycle.expiration_date, cycle.days_to_expiration)
+        for cycle in available_expirations
+    )
+    selected = select_expiration_pair(candidates, **FORWARD_FACTOR_DTE_POLICY)
+    if selected is None:
+        raise NoValidExpirationPairError(
+            "no front/back expiration pair satisfies Forward Factor's DTE policy"
+        )
+    front, back = selected
+    front_cycle = next(
+        cycle for cycle in available_expirations if cycle.expiration_date == front.expiration_date
+    )
+    back_cycle = next(
+        cycle for cycle in available_expirations if cycle.expiration_date == back.expiration_date
+    )
+
+    front_dte = compute_days_to_expiration({"expiration": front.expiration_date, "as_of": as_of})
+    back_dte = compute_days_to_expiration({"expiration": back.expiration_date, "as_of": as_of})
+    front_iv = compute_option_implied_volatility(
+        {
+            "chain": chain,
+            "expiration": front.expiration_date,
+            "strike": strike,
+            "option_type": option_type,
+        }
+    )
+    back_iv = compute_option_implied_volatility(
+        {
+            "chain": chain,
+            "expiration": back.expiration_date,
+            "strike": strike,
+            "option_type": option_type,
+        }
+    )
+
+    expirations = ExpirationCollection(as_of, (front_cycle, back_cycle))
+    return _context(
+        **{
+            "expiration_select.expirations": (EXPIRATION_COLLECTION, expirations),
+            "double_calendar.chain": (OPTION_CHAIN, chain),
+            "forward_iv.front_iv": (D, front_iv),
+            "forward_iv.back_iv": (D, back_iv),
+            "forward_iv.front_dte": (_INTEGER, int(front_dte)),
+            "forward_iv.back_dte": (_INTEGER, int(back_dte)),
+            "factor.front_ex_earnings_iv": (D, front_iv),
+        }
+    )
+
+
+def build_earnings_calendar_context(
+    chain: OptionChain,
+    event: EarningsEvent,
+    front: ExpirationCycle,
+    back: ExpirationCycle,
+    as_of: date,
+    *,
+    target_strike: Decimal,
+) -> ComponentValues:
+    return _context(
+        **{
+            "event_window.event": (EARNINGS_EVENT, event),
+            "event_window.front": (EXPIRATION_CYCLE, front),
+            "event_window.back": (EXPIRATION_CYCLE, back),
+            "expiration_select.expirations": (
+                EXPIRATION_COLLECTION,
+                ExpirationCollection(as_of, (back, front)),
+            ),
+            "expiration_select.event": (EARNINGS_EVENT, event),
+            "calendar.chain": (OPTION_CHAIN, chain),
+            "calendar.target_strike": (D, target_strike),
+            "score.values": (DECIMAL_LIST, (Decimal("80"), Decimal("60"))),
+            "score.weights": (DECIMAL_LIST, (Decimal("3"), Decimal("1"))),
+        }
+    )
+
+
+def build_skew_momentum_context(
+    chain: OptionChain,
+    expiration: date,
+    *,
+    strike: Decimal,
+    option_type: OptionType = OptionType.CALL,
+) -> ComponentValues:
+    (contract,) = chain.find(expiration=expiration, strike=strike, option_type=option_type)
+    return _context(
+        **{
+            "vertical.chain": (OPTION_CHAIN, chain),
+            "vertical.expiration": (DATE, expiration),
+            "liquidity.contract": (OPTION_CONTRACT, contract),
+            "score.values": (DECIMAL_LIST, (Decimal("80"), Decimal("70"))),
+            "score.weights": (DECIMAL_LIST, (Decimal("2"), Decimal("1"))),
+        }
+    )

--- a/screening/fixtures.py
+++ b/screening/fixtures.py
@@ -63,6 +63,8 @@ def fixture_contract(
     option_type: OptionType,
     delta: str,
     mark: str,
+    *,
+    implied_volatility: str = "0.30",
 ) -> OptionContract:
     mark_value = Decimal(mark)
     return OptionContract(
@@ -81,7 +83,7 @@ def fixture_contract(
         Decimal("-0.02"),
         Decimal("0.03"),
         Decimal("0.01"),
-        Decimal("0.30"),
+        Decimal(implied_volatility),
         OBSERVED_AT,
         EVIDENCE,
     )
@@ -151,12 +153,29 @@ FORWARD_BACK_EXPIRATION = date(2026, 10, 21)  # +91 days
 
 
 def forward_factor_chain() -> OptionChain:
+    # front/back call implied_volatility values are the same known-good pair
+    # previously supplied as hardcoded external manifest context (SCREEN-004);
+    # they now live on the contracts themselves, where implied_volatility
+    # canonically belongs, so ANALYTICS-002's option_implied_volatility feature
+    # can extract them directly instead of anything being pre-baked upstream.
     contracts = (
         fixture_contract(
-            "ff-front-call", FORWARD_FRONT_EXPIRATION, "105", OptionType.CALL, "0.35", "2"
+            "ff-front-call",
+            FORWARD_FRONT_EXPIRATION,
+            "105",
+            OptionType.CALL,
+            "0.35",
+            "2",
+            implied_volatility="0.48",
         ),
         fixture_contract(
-            "ff-back-call", FORWARD_BACK_EXPIRATION, "105", OptionType.CALL, "0.38", "3"
+            "ff-back-call",
+            FORWARD_BACK_EXPIRATION,
+            "105",
+            OptionType.CALL,
+            "0.38",
+            "3",
+            implied_volatility="0.4548992562461861547567860943472296",
         ),
         fixture_contract(
             "ff-front-put", FORWARD_FRONT_EXPIRATION, "95", OptionType.PUT, "-0.35", "2"

--- a/tests/architecture/test_screening_boundaries.py
+++ b/tests/architecture/test_screening_boundaries.py
@@ -43,16 +43,19 @@ def _screening_files() -> list[Path]:
 
 
 class TestScreeningImportScope:
-    """screening/ imports only screening, domain, and strategies (SCREEN-004
-    adapters wrap existing strategies -- that dependency is intentional and
-    one-directional; strategies/ itself is not permitted to import screening,
-    enforced separately by test_strategy_boundaries.py's own allowlist).
-    Never a provider-facing or infrastructure module.
+    """screening/ imports only screening, domain, strategies, and analytics
+    (SCREEN-004 adapters wrap existing strategies; ANALYTICS-003 context
+    builders use analytics/ for Forward Factor's derived inputs) -- these
+    dependencies are intentional and one-directional: neither strategies/
+    nor analytics/ is permitted to import screening, enforced separately by
+    their own allowlists (test_strategy_boundaries.py,
+    test_analytics_boundaries.py). Never a provider-facing or
+    infrastructure module.
     """
 
     @pytest.mark.parametrize("py_file", _screening_files())
     def test_only_permitted_roots(self, py_file: Path) -> None:
-        permitted = {"screening", "domain", "strategies"} | STDLIB_ALLOWED
+        permitted = {"screening", "domain", "strategies", "analytics"} | STDLIB_ALLOWED
         imported = _imported_roots(py_file)
         assert imported <= permitted, (
             f"{py_file.name} imports outside {permitted}: {imported - permitted}"

--- a/tests/screening/test_context_builders.py
+++ b/tests/screening/test_context_builders.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+
+from domain import ExpirationCycle, OptionType
+from screening import fixtures
+from screening.context_builders import (
+    NoValidExpirationPairError,
+    build_earnings_calendar_context,
+    build_forward_factor_context,
+    build_skew_momentum_context,
+)
+
+
+class TestBuildForwardFactorContext:
+    def test_builds_a_context_with_analytics_derived_values(self) -> None:
+        chain = fixtures.forward_factor_chain()
+        expirations = fixtures.forward_factor_expirations()
+        context = build_forward_factor_context(
+            chain, expirations.cycles, fixtures.AS_OF_DATE, strike=Decimal("105")
+        )
+        values = dict(context.entries)
+        assert values["forward_iv.front_iv"].value == Decimal("0.48")
+        assert values["forward_iv.back_iv"].value == Decimal("0.4548992562461861547567860943472296")
+        assert values["forward_iv.front_dte"].value == 61
+        assert values["forward_iv.back_dte"].value == 91
+        assert values["factor.front_ex_earnings_iv"].value == Decimal("0.48")
+
+    def test_raises_when_no_pair_satisfies_the_dte_policy(self) -> None:
+        chain = fixtures.forward_factor_chain()
+        near_expiration = fixtures.AS_OF_DATE + timedelta(days=5)
+        too_short = (
+            ExpirationCycle(near_expiration, 5, True, False, fixtures.AS_OF_DATE, fixtures.EVIDENCE),
+        )
+        with pytest.raises(NoValidExpirationPairError):
+            build_forward_factor_context(chain, too_short, fixtures.AS_OF_DATE, strike=Decimal("105"))
+
+
+class TestBuildEarningsCalendarContext:
+    def test_builds_a_context(self) -> None:
+        front, back = fixtures.earnings_calendar_expirations()
+        event = fixtures.earnings_calendar_event()
+        chain = fixtures.earnings_calendar_chain()
+        context = build_earnings_calendar_context(
+            chain, event, front, back, fixtures.AS_OF_DATE, target_strike=Decimal("100")
+        )
+        values = dict(context.entries)
+        assert values["calendar.target_strike"].value == Decimal("100")
+        assert values["event_window.event"].value is event
+
+
+class TestBuildSkewMomentumContext:
+    def test_builds_a_context(self) -> None:
+        chain = fixtures.skew_momentum_chain()
+        context = build_skew_momentum_context(
+            chain, fixtures.SKEW_EXPIRATION, strike=Decimal("100"), option_type=OptionType.CALL
+        )
+        values = dict(context.entries)
+        assert values["vertical.expiration"].value == fixtures.SKEW_EXPIRATION
+        assert values["liquidity.contract"].value.strike == Decimal("100")


### PR DESCRIPTION
## Ticket
ANALYTICS-003 (SPRINT-007, delegated merge under GOV-007/Amendment 013, active since #150 merged)

## Summary
Constructs each target strategy's manifest execution context from canonical market data, extracted from `screening/adapters.py` into separately testable builder functions. Forward Factor's builder now uses ANALYTICS-002's real derived analytics instead of the hardcoded external IV constant SCREEN-004 originally used -- this is the actual point of the ticket, closing the loop SPRINT-006/ANALYTICS-002 opened.

## Repository evidence
- `screening/context_builders.py::build_forward_factor_context()` calls `analytics.expiration_selection.select_expiration_pair()`, `analytics.forward_factor.compute_days_to_expiration()`, and `analytics.forward_factor.compute_option_implied_volatility()` -- no hardcoded `Decimal("0.48")` anywhere anymore.
- To make that meaningful rather than a no-op, `screening/fixtures.py`'s `forward_factor_chain()` now carries the **same known-good IV pair** (`0.48` / `0.4548992562461861547567860943472296`) directly on the front/back call contracts themselves (where `implied_volatility` canonically belongs, per `domain.OptionContract`), instead of as separate hardcoded manifest context. `fixture_contract()` gained an optional `implied_volatility` parameter (default `"0.30"`, preserving every other existing caller -- earnings_calendar and skew_momentum fixtures -- exactly as before).
- `build_earnings_calendar_context()`/`build_skew_momentum_context()` need no derived analytics; they isolate context-construction logic that was previously inline inside `screening/adapters.py`'s `run_*` functions into independently testable functions, so the same builders can later take live-acquired canonical data (LIVE-001/002) without any change here.
- **Zero-regression proof**: all 223 screening+analytics tests pass unchanged after this refactor, including SCREEN-004's own `outcome_status is PASS` assertions and SCREEN-006's failure-isolation evidence test -- confirms replacing the hardcoded constant with genuine computation produces the identical PASS verdict.

## Relevant issues and PRs
#152 (ANALYTICS-002, the features this ticket wires in), #146/#148/#149 (SCREEN-004/005/006, whose existing tests are the regression proof above).

## Architecture compliance
- `tests/architecture/test_screening_boundaries.py`'s permitted-import allowlist extended to include `analytics` (`screening/context_builders.py` needs it) -- neither `strategies/` nor `analytics/` is permitted to import `screening/`, enforced separately by their own allowlists, so the dependency graph stays one-directional: `screening -> {strategies, analytics}`, never the reverse.
- No strategy semantics changed: `strategies/*.py` has zero lines touched in this PR.
- No provider import anywhere in the new builder module -- confirmed by the boundary test.

## Security and secret handling
Secret scan (`grep -riE "token|secret|password|api[_-]?key|bearer"`) against all new/changed files: one match, the pre-existing false positive (stdlib module name `"secrets"` in the forbidden-imports test set).

## Network behavior
None.

## Request budget behavior
N/A -- fixture-backed only; live acquisition is LIVE-001/002/003's scope.

## Tests
- `pytest tests/screening/ tests/analytics/ tests/architecture/test_screening_boundaries.py tests/architecture/test_analytics_boundaries.py` -> 223 passed (up from 218 pre-refactor across the two suites), zero regressions.
- `pytest tests/` (full repo) -> 2129 passed, 2 skipped (pre-existing, unrelated).
- `ruff check` -> clean.
- `mypy screening/` -> zero errors in `screening/` itself (same pre-existing `strategies`/`indicators` findings tracked in #147 surface transitively where `strategies` is imported, unchanged from prior PRs).
- `tools/pos/lean/check_integrity.py` / `validate.py` / `generate.py current-state` / `check_entrypoints.py` / `pre_push_check.py` -> all green (5/5).
- `git status --short` -> exactly `screening/adapters.py` (refactored), `screening/fixtures.py` (IV enrichment), the new `context_builders.py` + its test, and the boundary-test allowlist update -- matches approved ticket scope.

## Live validation status
N/A -- fixture-backed only.

## Explicit exclusions
No live market-data integration (LIVE-001/002/003). No changes to `strategies/`, `analytics/registry.py`/`engine.py`/`features.py`, or any prior ticket's own module beyond the `screening/` refactor described above.

## Merge authority
`delegated_after_required_checks` per SPRINT-007/GOV-007 -- active since #150 merged. All required gates above are green; merging under delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)