### PR TITLE
LIVE-001: live market data integration

### DIFF
--- a/screening/__init__.py
+++ b/screening/__init__.py
@@ -13,6 +13,13 @@ from screening.errors import (
     ScreeningError,
     UnknownScreeningStrategyIdError,
 )
+from screening.live_acquisition import (
+    acquire_capability,
+    build_capability_registry,
+    build_fulfillment_service,
+    build_request_budget_manager,
+    enabled_provider_configs,
+)
 from screening.registry import ScreeningRegistry, ScreeningStrategyDefinition
 from screening.results import ScreeningOutcomeStatus, ScreeningResult, bounded_failure_detail
 from screening.runner import StrategyAdapter, StrategyAdapterError, run_screening
@@ -30,6 +37,11 @@ __all__ = [
     "StrategyAdapter",
     "StrategyAdapterError",
     "UnknownScreeningStrategyIdError",
+    "acquire_capability",
     "bounded_failure_detail",
+    "build_capability_registry",
+    "build_fulfillment_service",
+    "build_request_budget_manager",
+    "enabled_provider_configs",
     "run_screening",
 ]

--- a/screening/live_acquisition.py
+++ b/screening/live_acquisition.py
@@ -1,0 +1,150 @@
+"""Live market data integration (LIVE-001).
+
+Reuses the completed Market Data Platform (market_data/) to acquire only
+the canonical capability a requested strategy actually needs, through a
+capability-driven, provider-independent API that respects existing
+request-budget ceilings. Builds no new acquisition machinery -- every
+piece here composes market_data's own ProviderFactory / ProviderRegistry /
+CapabilityRegistry / RequestBudgetManager / CapabilityFulfillmentService
+exactly as market_data/'s own tests already prove correct
+(tests/market_data/test_sprint_005b_integration.py).
+
+No editorial provider preference is encoded here: every enabled provider
+that declares a capability serves it, in deterministic provider_id order.
+Which provider *should* be preferred for a given capability is a Founder/
+business decision, not this ticket's to invent.
+
+Transport construction is injected, never hardcoded here: this package
+cannot import backend/ (a separate deployable service that vendors its own
+copies of market_data/domain), so a real network transport is the
+caller's responsibility to supply -- this module only orchestrates.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+
+from domain import MarketCapability, MarketDataSubject
+from market_data import (
+    BudgetScope,
+    CapabilityFulfillmentResult,
+    CapabilityFulfillmentService,
+    CapabilityRegistry,
+    CapabilityRequest,
+    MarketDataConfig,
+    ProviderConfig,
+    ProviderDependencies,
+    ProviderFactory,
+    ProviderPriority,
+    ProviderPriorityPolicy,
+    ProviderRegistry,
+    RequestBudgetManager,
+    RequestBudgetPolicy,
+    alpha_vantage_provider_registration,
+    finnhub_provider_registration,
+    fixture_provider_registration,
+    tradier_provider_registration,
+)
+from screening.clock import Clock
+
+PRIORITY_POLICY_VERSION = "screening-live-v1"
+BUDGET_POLICY_VERSION = "screening-live-v1"
+
+
+def _provider_factory() -> ProviderFactory:
+    return ProviderFactory(
+        (
+            tradier_provider_registration(),
+            finnhub_provider_registration(),
+            alpha_vantage_provider_registration(),
+            fixture_provider_registration(),
+        )
+    )
+
+
+def enabled_provider_configs(config: MarketDataConfig) -> tuple[ProviderConfig, ...]:
+    return tuple(item for item in config.providers if item.enabled)
+
+
+def build_capability_registry(provider_registry: ProviderRegistry) -> CapabilityRegistry:
+    """Every enabled provider serves every capability it declares, in
+    deterministic provider_id order.
+    """
+    capabilities: dict[MarketCapability, list[str]] = {}
+    for provider in provider_registry.providers:
+        for capability in provider.capabilities:
+            capabilities.setdefault(capability, []).append(provider.provider_id)
+    priorities = tuple(
+        ProviderPriority(capability, tuple(sorted(provider_ids)))
+        for capability, provider_ids in sorted(capabilities.items(), key=lambda item: item[0].value)
+    )
+    policy = ProviderPriorityPolicy(PRIORITY_POLICY_VERSION, priorities)
+    return CapabilityRegistry(provider_registry, policy)
+
+
+def build_request_budget_manager(
+    enabled_configs: tuple[ProviderConfig, ...], clock: Clock
+) -> RequestBudgetManager:
+    """One RequestBudgetPolicy per enabled provider, derived from its own
+    ProviderConfig.request_budget -- never widened, never invented.
+    """
+    policies = tuple(
+        RequestBudgetPolicy(
+            item.provider_id,
+            BudgetScope.RUNTIME,
+            item.request_budget.max_requests_per_run,
+            item.request_budget.burst_limit,
+            item.retry.max_retries,
+            BUDGET_POLICY_VERSION,
+        )
+        for item in enabled_configs
+    )
+    return RequestBudgetManager(policies, clock)
+
+
+def build_fulfillment_service(
+    config: MarketDataConfig,
+    transport_factory: Callable[[str], object],
+    clock: Clock,
+) -> CapabilityFulfillmentService:
+    """Construct a fully-wired CapabilityFulfillmentService for every
+    enabled provider in ``config``. The same RequestBudgetManager instance
+    is shared by every provider's dependencies, so budget consumption is
+    tracked correctly across all of them, not per-provider in isolation.
+    """
+    enabled_configs = enabled_provider_configs(config)
+    budget_manager = build_request_budget_manager(enabled_configs, clock)
+    factory = _provider_factory()
+    providers = tuple(
+        factory.create(
+            item,
+            ProviderDependencies(transport_factory(item.provider_id), clock, budget_manager),
+        )
+        for item in enabled_configs
+    )
+    provider_registry = ProviderRegistry(providers)
+    capability_registry = build_capability_registry(provider_registry)
+    return CapabilityFulfillmentService(provider_registry, capability_registry, budget_manager)
+
+
+def acquire_capability(
+    fulfillment: CapabilityFulfillmentService,
+    capability: MarketCapability,
+    subject: MarketDataSubject,
+    *,
+    effective_start: datetime,
+    effective_end: datetime,
+    required_fields: tuple[str, ...],
+    maximum_age_seconds: int,
+    required: bool = True,
+) -> CapabilityFulfillmentResult:
+    """Acquire exactly one capability for one subject -- the only
+    acquisition surface a caller needs; provider selection, budget
+    authorization, and fallback all happen inside CapabilityFulfillmentService
+    itself, unchanged.
+    """
+    request = CapabilityRequest(
+        capability, (subject,), effective_start, effective_end, required_fields, maximum_age_seconds
+    )
+    return fulfillment.fulfill(request, required=required)

--- a/tests/architecture/test_screening_boundaries.py
+++ b/tests/architecture/test_screening_boundaries.py
@@ -43,19 +43,26 @@ def _screening_files() -> list[Path]:
 
 
 class TestScreeningImportScope:
-    """screening/ imports only screening, domain, strategies, and analytics
-    (SCREEN-004 adapters wrap existing strategies; ANALYTICS-003 context
-    builders use analytics/ for Forward Factor's derived inputs) -- these
-    dependencies are intentional and one-directional: neither strategies/
-    nor analytics/ is permitted to import screening, enforced separately by
-    their own allowlists (test_strategy_boundaries.py,
-    test_analytics_boundaries.py). Never a provider-facing or
-    infrastructure module.
+    """screening/ imports only screening, domain, strategies, analytics, and
+    market_data (SCREEN-004 adapters wrap existing strategies; ANALYTICS-003
+    context builders use analytics/ for Forward Factor's derived inputs;
+    LIVE-001 reuses market_data/'s own canonical, provider-neutral
+    acquisition pipeline instead of building a new one) -- these
+    dependencies are intentional and one-directional: none of strategies/,
+    analytics/, or market_data/ is permitted to import screening, enforced
+    separately by their own allowlists (test_strategy_boundaries.py,
+    test_analytics_boundaries.py, and market_data/'s own existing
+    boundary tests). market_data/ is the sanctioned canonical acquisition
+    layer, not a raw provider SDK -- the raw providers/ package stays
+    prohibited below; no provider-specific code may enter screening/
+    directly.
     """
 
     @pytest.mark.parametrize("py_file", _screening_files())
     def test_only_permitted_roots(self, py_file: Path) -> None:
-        permitted = {"screening", "domain", "strategies", "analytics"} | STDLIB_ALLOWED
+        permitted = (
+            {"screening", "domain", "strategies", "analytics", "market_data"} | STDLIB_ALLOWED
+        )
         imported = _imported_roots(py_file)
         assert imported <= permitted, (
             f"{py_file.name} imports outside {permitted}: {imported - permitted}"
@@ -64,7 +71,7 @@ class TestScreeningImportScope:
     @pytest.mark.parametrize("py_file", _screening_files())
     def test_prohibited_imports_absent(self, py_file: Path) -> None:
         prohibited = {
-            "market_data", "providers", "observation", "ranking",
+            "providers", "observation", "ranking",
             "guardrails", "presentation", "simulation", "execution_planning",
         }
         imported = _imported_roots(py_file)

--- a/tests/screening/test_live_acquisition.py
+++ b/tests/screening/test_live_acquisition.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from domain import (
+    CanonicalInstrumentIdentity,
+    EvidenceKind,
+    EvidenceReference,
+    Instrument,
+    InstrumentKind,
+    MarketCapability,
+    MarketDataRequestContext,
+    MarketDataSubject,
+    MarketDataSubjectType,
+    ProviderAddressProjection,
+)
+from market_data import (
+    BudgetExhaustedError,
+    FulfillmentStatus,
+    ProviderDependencies,
+    ProviderRegistry,
+    RequestBudgetAuthorization,
+    load_market_data_config,
+)
+from market_data.fixture import fixture_provider_registration
+from screening.live_acquisition import (
+    acquire_capability,
+    build_capability_registry,
+    build_fulfillment_service,
+    build_request_budget_manager,
+    enabled_provider_configs,
+)
+
+NOW = datetime(2026, 7, 22, 16, 0, tzinfo=UTC)
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "live-acquisition-test"),)
+INSTRUMENT = Instrument(
+    CanonicalInstrumentIdentity("figi", "BBG000B9XRY4"), InstrumentKind.EQUITY, "AAPL", "USD"
+)
+
+
+@dataclass(frozen=True)
+class FixedClock:
+    fixed_at: datetime = NOW
+
+    def now(self) -> datetime:
+        return self.fixed_at
+
+
+class _NoBudgetChecks:
+    def authorize(
+        self, provider_id: str, capability: MarketCapability, request_units: int
+    ) -> RequestBudgetAuthorization:
+        return RequestBudgetAuthorization("no-budget-check", provider_id, request_units, 1)
+
+
+def _no_transport(_provider_id: str) -> object:
+    """deterministic_fixture never touches its transport, so a placeholder
+    is sufficient -- these tests exercise the orchestration wiring only,
+    never real network access.
+    """
+    return object()
+
+
+def _subject(capability: MarketCapability, required_fields: tuple[str, ...]) -> MarketDataSubject:
+    subject_type = {
+        MarketCapability.OPTION_CHAIN_V1: MarketDataSubjectType.OPTION_UNDERLYING,
+        MarketCapability.EARNINGS_CALENDAR_V1: MarketDataSubjectType.EARNINGS_SECURITY,
+    }.get(capability, MarketDataSubjectType.INSTRUMENT)
+    projection = ProviderAddressProjection(
+        "deterministic_fixture", "v1", "symbol", "AAPL", NOW - timedelta(days=2), None, EVIDENCE
+    )
+    return MarketDataSubject(
+        INSTRUMENT,
+        subject_type,
+        capability,
+        MarketDataRequestContext(NOW, NOW, required_fields, (projection,), EVIDENCE),
+    )
+
+
+class TestEnabledProviderConfigs:
+    def test_deterministic_fixture_is_enabled_with_no_environment_variables(self) -> None:
+        config = load_market_data_config({})
+        enabled = enabled_provider_configs(config)
+        assert {item.provider_id for item in enabled} == {"deterministic_fixture"}
+
+
+class TestBuildCapabilityRegistry:
+    def test_every_declared_capability_is_registered(self) -> None:
+        config = load_market_data_config({})
+        (fixture_config,) = enabled_provider_configs(config)
+        registration = fixture_provider_registration()
+        provider = registration.constructor(
+            fixture_config, ProviderDependencies(object(), FixedClock(), _NoBudgetChecks())
+        )
+        registry = ProviderRegistry((provider,))
+        capability_registry = build_capability_registry(registry)
+        for capability in provider.capabilities:
+            candidates = capability_registry.lookup(capability)
+            assert candidates and candidates[0].provider_id == "deterministic_fixture"
+
+
+class TestBuildRequestBudgetManager:
+    def test_one_policy_per_enabled_provider(self) -> None:
+        config = load_market_data_config({})
+        enabled = enabled_provider_configs(config)
+        manager = build_request_budget_manager(enabled, FixedClock())
+        authorization = manager.authorize(
+            "deterministic_fixture", MarketCapability.OPTION_CHAIN_V1, 1
+        )
+        assert authorization.provider_id == "deterministic_fixture"
+
+    def test_unconfigured_provider_is_rejected(self) -> None:
+        config = load_market_data_config({})
+        enabled = enabled_provider_configs(config)
+        manager = build_request_budget_manager(enabled, FixedClock())
+        with pytest.raises(BudgetExhaustedError):
+            manager.authorize("tradier", MarketCapability.OPTION_CHAIN_V1, 1)
+
+
+_REQUIRED_FIELDS = {
+    MarketCapability.REAL_TIME_QUOTE_V1: ("last",),
+    MarketCapability.HISTORICAL_BARS_V1: ("close",),
+    MarketCapability.OPTION_CHAIN_V1: ("contracts",),
+    MarketCapability.EARNINGS_CALENDAR_V1: ("earnings_date",),
+}
+
+
+class TestBuildFulfillmentServiceAndAcquireCapability:
+    def test_acquires_every_fixture_capability_successfully(self) -> None:
+        # A fresh service per capability, matching realistic usage where a
+        # real (advancing) clock is used -- FixedClock never advances, and
+        # RequestBudgetPolicy's default burst_limit=1 keys bursts by exact
+        # timestamp, so reusing one service across same-timestamp calls
+        # would hit the burst limit after the first, not a bug in the
+        # acquisition wiring itself.
+        config = load_market_data_config({})
+        for capability, fields in _REQUIRED_FIELDS.items():
+            fulfillment = build_fulfillment_service(config, _no_transport, FixedClock())
+            result = acquire_capability(
+                fulfillment,
+                capability,
+                _subject(capability, fields),
+                effective_start=NOW,
+                effective_end=NOW,
+                required_fields=fields,
+                maximum_age_seconds=3600,
+            )
+            assert result.status is FulfillmentStatus.FULFILLED
+            assert result.selected_provider == "deterministic_fixture"
+            assert result.observations
+
+    def test_request_budget_is_enforced_within_the_same_clock_tick(self) -> None:
+        """Demonstrates real request-budget enforcement, not just that it's
+        wired: a second, *distinct* request (a different capability -- an
+        identical repeated request is memoized by CapabilityFulfillmentService
+        and never re-authorized) in the same instant hits the provider's
+        burst_limit=1 default and is refused, exactly as RequestBudgetPolicy
+        is designed to do -- LIVE-001's request_budget_compliance deliverable
+        proven, not merely assumed.
+        """
+        config = load_market_data_config({})
+        fulfillment = build_fulfillment_service(config, _no_transport, FixedClock())
+        first_capability = MarketCapability.REAL_TIME_QUOTE_V1
+        second_capability = MarketCapability.HISTORICAL_BARS_V1
+        first = acquire_capability(
+            fulfillment,
+            first_capability,
+            _subject(first_capability, _REQUIRED_FIELDS[first_capability]),
+            effective_start=NOW,
+            effective_end=NOW,
+            required_fields=_REQUIRED_FIELDS[first_capability],
+            maximum_age_seconds=3600,
+        )
+        second = acquire_capability(
+            fulfillment,
+            second_capability,
+            _subject(second_capability, _REQUIRED_FIELDS[second_capability]),
+            effective_start=NOW,
+            effective_end=NOW,
+            required_fields=_REQUIRED_FIELDS[second_capability],
+            maximum_age_seconds=3600,
+        )
+        assert first.status is FulfillmentStatus.FULFILLED
+        assert second.status is FulfillmentStatus.FAILED
+
+    def test_is_deterministic_for_identical_inputs_and_clock(self) -> None:
+        config = load_market_data_config({})
+        first_service = build_fulfillment_service(config, _no_transport, FixedClock())
+        second_service = build_fulfillment_service(config, _no_transport, FixedClock())
+        capability = MarketCapability.REAL_TIME_QUOTE_V1
+        fields = _REQUIRED_FIELDS[capability]
+        first = acquire_capability(
+            first_service,
+            capability,
+            _subject(capability, fields),
+            effective_start=NOW,
+            effective_end=NOW,
+            required_fields=fields,
+            maximum_age_seconds=3600,
+        )
+        second = acquire_capability(
+            second_service,
+            capability,
+            _subject(capability, fields),
+            effective_start=NOW,
+            effective_end=NOW,
+            required_fields=fields,
+            maximum_age_seconds=3600,
+        )
+        assert first.status == second.status
+        assert first.selected_provider == second.selected_provider


### PR DESCRIPTION
## Ticket
LIVE-001 (SPRINT-007, delegated merge under GOV-007/Amendment 013, active since #150 merged)

## Summary
Reuses the completed Market Data Platform (`market_data/`) to acquire only the canonical capability a requested strategy actually needs, through a capability-driven, provider-independent API respecting existing request-budget ceilings. Builds no new acquisition machinery.

## Repository evidence -- investigated before implementing
- Dedicated research pass (Explore agent) confirmed: **no production code anywhere in this repository currently constructs a `ProviderPriorityPolicy` or calls `CapabilityFulfillmentService.fulfill()`**. The existing `/ops/market-data/validate` endpoint only exercises `ProviderRegistry.validate()` for fixed diagnostic checks (a different, narrower path); the live web app's own quote path (`backend/src/asa/application/use_cases.py`) is wired to `DeterministicFakeQuoteProvider`, not `market_data/` at all. This is genuinely new integration work, not a rewire of something that already existed.
- `screening/live_acquisition.py::build_fulfillment_service()` composes `market_data`'s own `ProviderFactory`/`ProviderRegistry`/`CapabilityRegistry`/`RequestBudgetManager`/`CapabilityFulfillmentService` exactly as `tests/market_data/test_sprint_005b_integration.py` already proves correct -- same construction pattern, not a new one.
- `build_capability_registry()` declares **no editorial provider preference**: every enabled provider that declares a capability serves it, in deterministic `provider_id` order. Which provider *should* be preferred for a given capability is a Founder/business decision this ticket does not invent.
- A single shared `RequestBudgetManager` is passed to every provider's `ProviderDependencies`, so budget consumption is tracked correctly *across* providers, not per-provider in isolation.
- Transport construction is injected, never hardcoded: `screening/` cannot import `backend/` (a separate deployable service that vendors its own copies of `market_data`/`domain`), so a real network transport stays the caller's responsibility -- the same injection pattern `market_data_ops/service.py` already uses.

## Relevant issues and PRs
None directly relevant beyond this sprint's own chain (#150-#153).

## Architecture compliance
- `tests/architecture/test_screening_boundaries.py` extended to permit `screening/` importing `market_data/` (the sanctioned canonical, provider-neutral acquisition layer) while keeping the raw `providers/` package prohibited -- no provider-specific code may enter `screening/` directly.
- No new acquisition logic duplicated: every function here is a thin, well-documented composition of existing `market_data/` primitives.
- Tested exclusively against `market_data`'s always-available, zero-network `deterministic_fixture` provider -- **no real credentials or live network access anywhere in this PR**, consistent with this sprint's `live_execution_policy` (real provider credentials are LIVE-003's Founder-gated concern).

## Security and secret handling
Secret scan (`grep -riE "token|secret|password|api[_-]?key|bearer"`) against all new/changed files: one match, the pre-existing false positive (stdlib module name `"secrets"` in the forbidden-imports test set).

## Network behavior
None. Every test uses `deterministic_fixture` (a complete, zero-network offline provider by design -- `market_data/fixture.py` declares `ProviderLimitDeclaration("network_requests", "0", "fixture")`).

## Request budget behavior
Explicitly tested, not merely wired: `test_request_budget_is_enforced_within_the_same_clock_tick` proves a second, distinct capability request in the same clock instant is refused by the provider's `burst_limit=1` default -- genuine enforcement, demonstrated.

## Tests
- `pytest tests/screening/test_live_acquisition.py` -> 7 passed.
- `pytest tests/screening/ tests/analytics/ tests/architecture/ tests/market_data/` -> 667 passed, 1 skipped (pre-existing, unrelated).
- `pytest tests/` (full repo) -> 2141 passed, 2 skipped (pre-existing, unrelated).
- `ruff check` -> clean.
- `mypy screening/live_acquisition.py` -> zero errors attributed to this file itself (confirmed via direct grep of mypy's own output); the same 22 pre-existing `strategies`/`indicators` findings (tracked in #147) surface transitively because `screening/__init__.py` imports the whole package, unchanged from prior PRs.
- `tools/pos/lean/check_integrity.py` / `validate.py` / `generate.py current-state` / `check_entrypoints.py` / `pre_push_check.py` -> all green (5/5).
- `git status --short` -> exactly the new `live_acquisition.py`, its test, and the `__init__.py`/boundary-test updates -- matches approved ticket scope.

## Live validation status
N/A -- deterministic-fixture-backed only, per this ticket's own scope and this sprint's `live_execution_policy`.

## Explicit exclusions
No real provider credentials used or required. No screening runner integration (LIVE-002). No operational live validation (LIVE-003, Founder-gated). No changes to `market_data/` itself, `strategies/`, or `analytics/`.

## Merge authority
`delegated_after_required_checks` per SPRINT-007/GOV-007 -- active since #150 merged. All required gates above are green; merging under delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)