### PR TITLE
LIVE-002: live screening runner

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -9,6 +9,7 @@ whatever canonical inputs a caller supplies.
 
 from __future__ import annotations
 
+from analytics.atm_selection import select_atm_strike
 from analytics.clock import Clock
 from analytics.engine import FeatureComputation, compute_feature
 from analytics.errors import (
@@ -18,7 +19,11 @@ from analytics.errors import (
     NoMatchingContractError,
     UnknownFeatureIdError,
 )
-from analytics.expiration_selection import ExpirationCandidate, select_expiration_pair
+from analytics.expiration_selection import (
+    ExpirationCandidate,
+    select_earnings_relative_expiration_pair,
+    select_expiration_pair,
+)
 from analytics.features import DerivedFeatureResult
 from analytics.forward_factor import (
     FORWARD_FACTOR_ANALYTICS_COMPUTATIONS,
@@ -45,5 +50,7 @@ __all__ = [
     "compute_days_to_expiration",
     "compute_feature",
     "compute_option_implied_volatility",
+    "select_atm_strike",
+    "select_earnings_relative_expiration_pair",
     "select_expiration_pair",
 ]

--- a/analytics/atm_selection.py
+++ b/analytics/atm_selection.py
@@ -1,0 +1,21 @@
+"""At-the-money strike selection (LIVE-002).
+
+Standard, provider-neutral option-analytics utility: given the set of
+available strikes at one expiration and a spot price, return the strike
+closest to spot. This is a textbook-defined, deterministic algorithm, not
+a business policy choice -- unlike provider preference (see
+screening/live_acquisition.py's own docstring), there is one universally
+accepted definition of "at the money."
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+
+def select_atm_strike(available_strikes: tuple[Decimal, ...], spot_price: Decimal) -> Decimal:
+    if not available_strikes:
+        raise ValueError("select_atm_strike requires at least one available strike")
+    if spot_price <= 0:
+        raise ValueError("select_atm_strike requires a positive spot_price")
+    return min(available_strikes, key=lambda strike: (abs(strike - spot_price), strike))

--- a/analytics/expiration_selection.py
+++ b/analytics/expiration_selection.py
@@ -31,6 +31,65 @@ class ExpirationCandidate:
     days_to_expiration: int
 
 
+def select_earnings_relative_expiration_pair(
+    candidates: tuple[ExpirationCandidate, ...],
+    earnings_date: date,
+    *,
+    front_min_dte: int,
+    front_max_dte: int,
+    back_min_dte: int,
+    back_max_dte: int,
+    front_must_be_before_earnings: bool = True,
+) -> tuple[ExpirationCandidate, ExpirationCandidate] | None:
+    """Select the front/back pair spanning an earnings event: independent
+    of strategies/stonk_components.py::ExpirationPairSelector (this
+    package cannot import strategies/), using the same earnings-relative
+    selection semantics -- front strictly before the earnings date, back
+    strictly after, both within their own DTE windows -- so a consistent
+    pair is chosen without depending on the graph system. Returns None
+    when no candidate pair satisfies the policy -- an expected,
+    non-exceptional outcome the caller must handle explicitly.
+    """
+    if (
+        min(front_min_dte, front_max_dte, back_min_dte, back_max_dte) < 0
+        or front_min_dte > front_max_dte
+        or back_min_dte > back_max_dte
+    ):
+        raise ValueError("earnings-relative expiration selection policy is invalid")
+
+    fronts = tuple(
+        candidate
+        for candidate in candidates
+        if front_min_dte <= candidate.days_to_expiration <= front_max_dte
+        and (
+            candidate.expiration_date < earnings_date
+            or not front_must_be_before_earnings
+        )
+    )
+    backs = tuple(
+        candidate
+        for candidate in candidates
+        if back_min_dte <= candidate.days_to_expiration <= back_max_dte
+        and candidate.expiration_date > earnings_date
+    )
+    pairs = tuple(
+        (front, back)
+        for front in fronts
+        for back in backs
+        if back.expiration_date > front.expiration_date
+    )
+    return min(
+        pairs,
+        key=lambda pair: (
+            (earnings_date - pair[0].expiration_date).days
+            + (pair[1].expiration_date - earnings_date).days,
+            pair[0].expiration_date,
+            pair[1].expiration_date,
+        ),
+        default=None,
+    )
+
+
 def select_expiration_pair(
     candidates: tuple[ExpirationCandidate, ...],
     *,

--- a/market_data/live_transport.py
+++ b/market_data/live_transport.py
@@ -1,0 +1,99 @@
+"""Stdlib-only live HTTP transport (LIVE-002).
+
+An independent copy of backend/src/asa/market_data_ops/transport.py's
+UrllibReadOnlyHttpTransport, for callers of the root-level market_data/
+package (e.g. screening/'s --live CLI path) -- backend/ is a separate
+deployable service that itself vendors independent copies of market_data/
+domain (per its own pyproject.toml comment), so root-level callers cannot
+import backend/'s transport and need their own. Same behavior: fixed,
+provider-official documented base URLs only, never inferred from the
+request; no logic beyond translating the ReadOnlyHttpTransport port to
+stdlib urllib.
+
+Deliberately not in screening/: that package's own architecture boundary
+tests (tests/architecture/test_screening_boundaries.py) forbid it from
+importing urllib or performing network I/O directly -- transport
+implementations must be supplied to it from outside, never written inside
+it. market_data/ carries no such restriction (only its narrower replay/
+fixture submodule does), so this lives alongside market_data/transport.py,
+the port it implements.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from urllib.parse import urlencode
+
+from market_data.transport import (
+    ReadOnlyHttpRequest,
+    ReadOnlyHttpResponse,
+    ReadOnlyTransportError,
+    ReadOnlyTransportTimeout,
+)
+
+_TRADIER_BASE_URLS = {
+    "sandbox": "https://sandbox.tradier.com",
+    "production": "https://api.tradier.com",
+}
+_FINNHUB_BASE_URL = "https://finnhub.io"
+_ALPHA_VANTAGE_BASE_URL = "https://www.alphavantage.co"
+
+
+class UrllibReadOnlyHttpTransport:
+    """One instance per provider; the base URL is fixed at construction time."""
+
+    def __init__(self, base_urls: dict[str, str]) -> None:
+        self._base_urls = dict(base_urls)
+
+    def get(self, request: ReadOnlyHttpRequest) -> ReadOnlyHttpResponse:
+        base_url = self._base_urls.get(request.endpoint_environment)
+        if base_url is None:
+            raise ReadOnlyTransportError(
+                f"No configured base URL for endpoint_environment={request.endpoint_environment!r}"
+            )
+        query = f"?{urlencode(request.query)}" if request.query else ""
+        url = f"{base_url}{request.path}{query}"
+        http_request = urllib.request.Request(url, headers=dict(request.headers), method="GET")
+        started = time.monotonic()
+        try:
+            with urllib.request.urlopen(  # noqa: S310 - fixed https provider hosts only
+                http_request, timeout=request.timeout_seconds
+            ) as raw_response:
+                status_code = raw_response.status
+                body_bytes = raw_response.read()
+                response_headers = tuple(raw_response.getheaders())
+        except urllib.error.HTTPError as exc:
+            status_code = exc.code
+            body_bytes = exc.read()
+            response_headers = tuple(exc.headers.items()) if exc.headers else ()
+        except TimeoutError as exc:
+            raise ReadOnlyTransportTimeout("Provider request timed out") from exc
+        except urllib.error.URLError as exc:
+            raise ReadOnlyTransportError("Provider transport failed") from exc
+        latency_milliseconds = int((time.monotonic() - started) * 1000)
+        try:
+            json_body = json.loads(body_bytes) if body_bytes else {}
+        except json.JSONDecodeError as exc:
+            raise ReadOnlyTransportError("Provider response was not valid JSON") from exc
+        if not isinstance(json_body, dict):
+            json_body = {"data": json_body}
+        return ReadOnlyHttpResponse(
+            status_code,
+            json_body,
+            response_headers,
+            latency_milliseconds,
+            f"live-request-{started:.6f}",
+        )
+
+
+def build_live_transport(provider_id: str) -> UrllibReadOnlyHttpTransport:
+    if provider_id == "tradier":
+        return UrllibReadOnlyHttpTransport(_TRADIER_BASE_URLS)
+    if provider_id == "finnhub":
+        return UrllibReadOnlyHttpTransport({"production": _FINNHUB_BASE_URL})
+    if provider_id == "alpha_vantage":
+        return UrllibReadOnlyHttpTransport({"production": _ALPHA_VANTAGE_BASE_URL})
+    raise ValueError(f"No live transport configured for provider {provider_id!r}")

--- a/screening/__init__.py
+++ b/screening/__init__.py
@@ -20,6 +20,7 @@ from screening.live_acquisition import (
     build_request_budget_manager,
     enabled_provider_configs,
 )
+from screening.live_adapters import build_live_adapters
 from screening.registry import ScreeningRegistry, ScreeningStrategyDefinition
 from screening.results import ScreeningOutcomeStatus, ScreeningResult, bounded_failure_detail
 from screening.runner import StrategyAdapter, StrategyAdapterError, run_screening
@@ -41,6 +42,7 @@ __all__ = [
     "bounded_failure_detail",
     "build_capability_registry",
     "build_fulfillment_service",
+    "build_live_adapters",
     "build_request_budget_manager",
     "enabled_provider_configs",
     "run_screening",

--- a/screening/cli.py
+++ b/screening/cli.py
@@ -1,4 +1,4 @@
-"""Bounded, deterministic screening entrypoint (SCREEN-005).
+"""Bounded, deterministic screening entrypoint (SCREEN-005, LIVE-002).
 
     python -m screening [--strategies ID[,ID...]] [--universe SYMBOL[,...]]
                          [--as-of ISO8601] [--dry-run] [--live] [--json]
@@ -7,8 +7,17 @@ Exit codes: 0 for a completed orchestration run -- regardless of individual
 strategy outcomes (PASS/NO_SIGNAL/MISSING_DATA/MALFORMED_OUTPUT/
 STRATEGY_EXCEPTION are all isolated per-strategy results, not orchestration
 failures); 2 for an orchestration-level failure (unknown strategy_id,
-unsupported universe symbol, a malformed --as-of value, or --live -- not yet
-available, deferred to a successor sprint).
+unsupported universe symbol, a malformed --as-of value).
+
+--live runs against real, network-connected providers (per
+market_data.load_market_data_config_from_environment()'s configured, enabled
+providers) instead of the offline deterministic fixture, one symbol at a
+time across the requested universe. Without --live, --universe stays bounded
+to APPROVED_FIXTURE_UNIVERSE (SAFE_SYMBOL only); with --live, it accepts
+APPROVED_LIVE_UNIVERSE -- the SPRINT-007 validation_universe (AAPL, MSFT,
+NVDA, AMD, SPY, QQQ). Actually exercising this against real provider
+credentials for the first time is LIVE-003's explicitly Founder-gated
+concern, not this flag's -- this flag only makes the capability real.
 """
 
 from __future__ import annotations
@@ -18,19 +27,41 @@ import json
 import sys
 from collections.abc import Sequence
 from datetime import UTC, datetime
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
+from market_data import MarketDataConfig, load_market_data_config_from_environment
+from market_data.live_transport import build_live_transport
 from screening.adapters import TARGET_STRATEGY_ADAPTERS, TARGET_STRATEGY_REGISTRY
 from screening.errors import UnknownScreeningStrategyIdError
 from screening.fixtures import SAFE_SYMBOL
+from screening.live_acquisition import build_fulfillment_service, enabled_provider_configs
+from screening.live_adapters import build_live_adapters
 from screening.registry import ScreeningStrategyDefinition
 from screening.results import ScreeningResult
 from screening.runner import run_screening
 from screening.serialization import results_to_json_payload
 
 APPROVED_FIXTURE_UNIVERSE = (SAFE_SYMBOL,)
+APPROVED_LIVE_UNIVERSE = ("AAPL", "MSFT", "NVDA", "AMD", "SPY", "QQQ")
 
 _ORCHESTRATION_FAILURE_EXIT_CODE = 2
+_FIXTURE_PROVIDER_ID = "deterministic_fixture"
+
+
+def _live_only_config(config: MarketDataConfig) -> MarketDataConfig:
+    """deterministic_fixture defaults to enabled (market_data/config.py's own
+    safety default) and, being alphabetically first among enabled providers,
+    would otherwise be tried before any real provider by
+    CapabilityRegistry's deterministic priority order -- silently serving
+    every --live request from offline fixture data instead of a real
+    provider. --live must mean live, so the fixture provider is always
+    force-disabled here, regardless of environment configuration.
+    """
+    providers = tuple(
+        replace(item, enabled=False) if item.provider_id == _FIXTURE_PROVIDER_ID else item
+        for item in config.providers
+    )
+    return replace(config, providers=providers)
 
 
 @dataclass(frozen=True)
@@ -62,11 +93,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--universe",
-        default=",".join(APPROVED_FIXTURE_UNIVERSE),
+        default=None,
         help=(
-            "Comma-separated symbol universe. Only the approved fixture universe "
-            f"({', '.join(APPROVED_FIXTURE_UNIVERSE)}) is supported this sprint -- "
-            "live, arbitrary universes are deferred to a successor sprint."
+            "Comma-separated symbol universe. Without --live: the approved fixture "
+            f"universe ({', '.join(APPROVED_FIXTURE_UNIVERSE)}). With --live: the "
+            f"approved live validation universe ({', '.join(APPROVED_LIVE_UNIVERSE)}). "
+            "Arbitrary, unbounded universes are not supported."
         ),
     )
     parser.add_argument(
@@ -83,8 +115,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--live",
         action="store_true",
-        help="Bounded live acquisition. NOT YET AVAILABLE this sprint -- deferred to "
-        "SPRINT-007; passing this flag fails closed.",
+        help="Bounded live acquisition against real, network-connected providers "
+        f"for the approved live universe ({', '.join(APPROVED_LIVE_UNIVERSE)}), "
+        "instead of the offline fixture.",
     )
     parser.add_argument(
         "--json",
@@ -119,21 +152,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
-    if args.live:
-        print(
-            "error: --live is not yet available. Live acquisition is explicitly deferred "
-            "to a successor sprint (SPRINT-007); this sprint's screening runs are "
-            "fixture-backed only.",
-            file=sys.stderr,
-        )
-        return _ORCHESTRATION_FAILURE_EXIT_CODE
-
-    requested_universe = _parse_csv(args.universe)
-    unsupported = set(requested_universe) - set(APPROVED_FIXTURE_UNIVERSE)
+    approved_universe = APPROVED_LIVE_UNIVERSE if args.live else APPROVED_FIXTURE_UNIVERSE
+    universe_arg = args.universe if args.universe is not None else ",".join(approved_universe)
+    requested_universe = _parse_csv(universe_arg)
+    unsupported = set(requested_universe) - set(approved_universe)
     if not requested_universe or unsupported:
         print(
             f"error: unsupported universe symbol(s) {sorted(unsupported) or list(requested_universe)}. "
-            f"Only {APPROVED_FIXTURE_UNIVERSE} is supported this sprint.",
+            f"Only {approved_universe} is supported "
+            f"{'in --live mode' if args.live else 'without --live'}.",
             file=sys.stderr,
         )
         return _ORCHESTRATION_FAILURE_EXIT_CODE
@@ -190,12 +217,34 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     try:
-        results = run_screening(
-            TARGET_STRATEGY_REGISTRY,
-            TARGET_STRATEGY_ADAPTERS,
-            clock,
-            strategy_ids=requested_strategy_ids,
-        )
+        if args.live:
+            config = _live_only_config(load_market_data_config_from_environment())
+            if not enabled_provider_configs(config):
+                print(
+                    "error: --live requires at least one enabled live provider "
+                    "(tradier, finnhub, or alpha_vantage) configured via environment "
+                    "variables -- none are enabled.",
+                    file=sys.stderr,
+                )
+                return _ORCHESTRATION_FAILURE_EXIT_CODE
+            fulfillment = build_fulfillment_service(config, build_live_transport, clock)
+            results = tuple(
+                result
+                for symbol in requested_universe
+                for result in run_screening(
+                    TARGET_STRATEGY_REGISTRY,
+                    build_live_adapters(symbol, fulfillment),
+                    clock,
+                    strategy_ids=requested_strategy_ids,
+                )
+            )
+        else:
+            results = run_screening(
+                TARGET_STRATEGY_REGISTRY,
+                TARGET_STRATEGY_ADAPTERS,
+                clock,
+                strategy_ids=requested_strategy_ids,
+            )
     except UnknownScreeningStrategyIdError as exc:
         print(f"error: orchestration failure: {exc}", file=sys.stderr)
         return _ORCHESTRATION_FAILURE_EXIT_CODE

--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -1,0 +1,340 @@
+"""Live target strategy adapters (LIVE-002).
+
+Live-data counterparts of screening/adapters.py's fixture-backed run_*
+functions: same manifests, same context_builders, same result
+construction -- only the source of canonical market data changes, from
+screening/fixtures.py to screening/live_acquisition.py. No strategy logic
+is reimplemented here, same as SCREEN-004/ANALYTICS-003.
+
+Each factory function closes over one symbol and one already-constructed
+CapabilityFulfillmentService, returning a StrategyAdapter-conforming
+callable. A missing or unfulfillable live capability, or no expiration
+pair satisfying a strategy's DTE policy, raises StrategyAdapterError with
+MISSING_DATA -- an expected, isolated, non-crashing outcome (SCREEN-003),
+never a raw exception escaping to the runner's more generic
+STRATEGY_EXCEPTION handling.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+
+from analytics.expiration_selection import (
+    ExpirationCandidate,
+    select_earnings_relative_expiration_pair,
+    select_expiration_pair,
+)
+from domain import DomainInvariantError, EarningsEvent, MarketCapability, OptionType, Quote
+from market_data import CapabilityFulfillmentService, FulfillmentStatus
+from screening.clock import Clock
+from screening.context_builders import (
+    FORWARD_FACTOR_DTE_POLICY,
+    build_earnings_calendar_context,
+    build_forward_factor_context,
+    build_skew_momentum_context,
+)
+from screening.live_acquisition import acquire_capability
+from screening.live_context import (
+    build_capability_subject,
+    expirations_from_chain,
+    select_atm_strike_at_expiration,
+)
+from screening.registry import ScreeningStrategyDefinition
+from screening.results import ScreeningOutcomeStatus, ScreeningResult
+from screening.runner import StrategyAdapter, StrategyAdapterError
+from strategies import (
+    CORE_COMPONENTS,
+    EARNINGS_CALENDAR_MANIFEST,
+    FORWARD_FACTOR_CALENDAR_MANIFEST,
+    SKEW_MOMENTUM_VERTICAL_MANIFEST,
+    STONK_STRATEGY_PLUGINS,
+    compile_strategy_graph,
+    execute_strategy_graph,
+)
+from strategies.plugins import build_plugin_registry
+
+_COMPONENT_REGISTRY = build_plugin_registry(CORE_COMPONENTS, STONK_STRATEGY_PLUGINS)
+_NON_FAIL_VERDICTS = frozenset({"PASS", "WATCH"})
+
+# Earnings Calendar's own frozen expiration_pair_selector node parameters
+# (strategies/stonk_manifests.py) -- duplicated here for the same reason
+# FORWARD_FACTOR_DTE_POLICY is: this ticket's data still needs an
+# externally-selected pair for the parts of each manifest not connected to
+# expiration_select via a graph edge.
+EARNINGS_CALENDAR_DTE_POLICY = {
+    "front_min_dte": 7,
+    "front_max_dte": 21,
+    "back_min_dte": 22,
+    "back_max_dte": 75,
+}
+
+
+def _outcome_status_for_verdict(verdict: str) -> ScreeningOutcomeStatus:
+    return (
+        ScreeningOutcomeStatus.PASS
+        if verdict in _NON_FAIL_VERDICTS
+        else ScreeningOutcomeStatus.NO_SIGNAL
+    )
+
+
+def _live_result(
+    definition: ScreeningStrategyDefinition,
+    clock: Clock,
+    run_id: str,
+    symbol: str,
+    verdict: object,
+    score: object,
+    evidence: tuple[object, ...],
+) -> ScreeningResult:
+    verdict_text = str(verdict)
+    return ScreeningResult(
+        run_id,
+        definition.strategy_id,
+        definition.strategy_version,
+        f"symbol:{symbol}",
+        clock.now(),
+        _outcome_status_for_verdict(verdict_text),
+        verdict_text,
+        score if isinstance(score, Decimal) else None,
+        evidence,  # type: ignore[arg-type]
+        evidence,  # type: ignore[arg-type]
+        None,
+        None,
+    )
+
+
+def _acquire_or_raise(
+    fulfillment: CapabilityFulfillmentService,
+    symbol: str,
+    capability: MarketCapability,
+    now: datetime,
+    required_fields: tuple[str, ...],
+) -> object:
+    subject = build_capability_subject(symbol, capability, now)
+    try:
+        result = acquire_capability(
+            fulfillment,
+            capability,
+            subject,
+            effective_start=now,
+            effective_end=now,
+            required_fields=required_fields,
+            maximum_age_seconds=3600,
+        )
+    except DomainInvariantError as exc:
+        # No enabled provider declares this capability at all (e.g. only
+        # Tradier is configured and Tradier doesn't serve earnings data) --
+        # CapabilityRegistry.lookup() raises rather than returning a
+        # not-fulfilled result. A live-configuration gap, not an adapter
+        # bug: same MISSING_DATA outcome as any other unfulfillable request.
+        raise StrategyAdapterError(
+            ScreeningOutcomeStatus.MISSING_DATA,
+            f"no enabled live provider offers {capability.value} for {symbol}: {exc}",
+        ) from exc
+    if result.status is not FulfillmentStatus.FULFILLED or not result.observations:
+        raise StrategyAdapterError(
+            ScreeningOutcomeStatus.MISSING_DATA,
+            f"could not acquire live {capability.value} for {symbol}",
+        )
+    return result.observations[0].value
+
+
+def _spot_price(quote: Quote) -> Decimal:
+    if quote.last is not None:
+        return quote.last
+    if quote.bid is not None and quote.ask is not None:
+        return (quote.bid + quote.ask) / 2
+    raise StrategyAdapterError(
+        ScreeningOutcomeStatus.MISSING_DATA, "live quote has no last price or bid/ask midpoint"
+    )
+
+
+def build_live_forward_factor_adapter(
+    symbol: str, fulfillment: CapabilityFulfillmentService
+) -> StrategyAdapter:
+    def _run(
+        definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
+    ) -> ScreeningResult:
+        now = clock.now()
+        as_of = now.date()
+        quote = _acquire_or_raise(
+            fulfillment, symbol, MarketCapability.REAL_TIME_QUOTE_V1, now, ("last",)
+        )
+        spot_price = _spot_price(quote)  # type: ignore[arg-type]
+        chain = _acquire_or_raise(
+            fulfillment, symbol, MarketCapability.OPTION_CHAIN_V1, now, ("contracts",)
+        )
+        available_expirations = expirations_from_chain(chain, as_of)  # type: ignore[arg-type]
+        candidates = tuple(
+            ExpirationCandidate(cycle.expiration_date, cycle.days_to_expiration)
+            for cycle in available_expirations
+        )
+        selected = select_expiration_pair(candidates, **FORWARD_FACTOR_DTE_POLICY)
+        if selected is None:
+            raise StrategyAdapterError(
+                ScreeningOutcomeStatus.MISSING_DATA,
+                f"no expiration pair for {symbol} satisfies Forward Factor's DTE policy",
+            )
+        front, _back = selected
+        strike = select_atm_strike_at_expiration(
+            chain, front.expiration_date, spot_price, OptionType.CALL  # type: ignore[arg-type]
+        )
+        context = build_forward_factor_context(
+            chain, available_expirations, as_of, strike=strike, option_type=OptionType.CALL  # type: ignore[arg-type]
+        )
+        graph = compile_strategy_graph(FORWARD_FACTOR_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
+        result = execute_strategy_graph(graph, context)
+        return _live_result(
+            definition,
+            clock,
+            run_id,
+            symbol,
+            result.outputs.get("verdict").value,
+            result.outputs.get("forward_factor").value,
+            chain.evidence,  # type: ignore[attr-defined]
+        )
+
+    return _run
+
+
+def build_live_earnings_calendar_adapter(
+    symbol: str, fulfillment: CapabilityFulfillmentService
+) -> StrategyAdapter:
+    def _run(
+        definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
+    ) -> ScreeningResult:
+        now = clock.now()
+        as_of = now.date()
+        event = _acquire_or_raise(
+            fulfillment, symbol, MarketCapability.EARNINGS_CALENDAR_V1, now, ("earnings_date",)
+        )
+        quote = _acquire_or_raise(
+            fulfillment, symbol, MarketCapability.REAL_TIME_QUOTE_V1, now, ("last",)
+        )
+        spot_price = _spot_price(quote)  # type: ignore[arg-type]
+        chain = _acquire_or_raise(
+            fulfillment, symbol, MarketCapability.OPTION_CHAIN_V1, now, ("contracts",)
+        )
+        available_expirations = expirations_from_chain(chain, as_of)  # type: ignore[arg-type]
+        candidates = tuple(
+            ExpirationCandidate(cycle.expiration_date, cycle.days_to_expiration)
+            for cycle in available_expirations
+        )
+        earnings_date = _earnings_date(event)  # type: ignore[arg-type]
+        selected = select_earnings_relative_expiration_pair(
+            candidates,
+            earnings_date,
+            front_min_dte=EARNINGS_CALENDAR_DTE_POLICY["front_min_dte"],
+            front_max_dte=EARNINGS_CALENDAR_DTE_POLICY["front_max_dte"],
+            back_min_dte=EARNINGS_CALENDAR_DTE_POLICY["back_min_dte"],
+            back_max_dte=EARNINGS_CALENDAR_DTE_POLICY["back_max_dte"],
+        )
+        if selected is None:
+            raise StrategyAdapterError(
+                ScreeningOutcomeStatus.MISSING_DATA,
+                f"no expiration pair for {symbol} spans its earnings date within policy",
+            )
+        front_candidate, back_candidate = selected
+        front_cycle = next(
+            cycle
+            for cycle in available_expirations
+            if cycle.expiration_date == front_candidate.expiration_date
+        )
+        back_cycle = next(
+            cycle
+            for cycle in available_expirations
+            if cycle.expiration_date == back_candidate.expiration_date
+        )
+        target_strike = select_atm_strike_at_expiration(
+            chain, front_cycle.expiration_date, spot_price, OptionType.CALL  # type: ignore[arg-type]
+        )
+        context = build_earnings_calendar_context(
+            chain, event, front_cycle, back_cycle, as_of, target_strike=target_strike  # type: ignore[arg-type]
+        )
+        graph = compile_strategy_graph(EARNINGS_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
+        result = execute_strategy_graph(graph, context)
+        return _live_result(
+            definition,
+            clock,
+            run_id,
+            symbol,
+            result.outputs.get("verdict").value,
+            result.outputs.get("score").value,
+            chain.evidence,  # type: ignore[attr-defined]
+        )
+
+    return _run
+
+
+def build_live_skew_momentum_adapter(
+    symbol: str, fulfillment: CapabilityFulfillmentService
+) -> StrategyAdapter:
+    def _run(
+        definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
+    ) -> ScreeningResult:
+        now = clock.now()
+        as_of = now.date()
+        quote = _acquire_or_raise(
+            fulfillment, symbol, MarketCapability.REAL_TIME_QUOTE_V1, now, ("last",)
+        )
+        spot_price = _spot_price(quote)  # type: ignore[arg-type]
+        chain = _acquire_or_raise(
+            fulfillment, symbol, MarketCapability.OPTION_CHAIN_V1, now, ("contracts",)
+        )
+        available_expirations = expirations_from_chain(chain, as_of)  # type: ignore[arg-type]
+        future_expirations = tuple(
+            cycle for cycle in available_expirations if cycle.expiration_date > as_of
+        )
+        if not future_expirations:
+            raise StrategyAdapterError(
+                ScreeningOutcomeStatus.MISSING_DATA, f"no future expiration available for {symbol}"
+            )
+        # No dte_pair_selector node exists for Skew Momentum (it takes one
+        # bare expiration, unlike the other two strategies) -- nearest
+        # upcoming expiration ("front month") is the simplest, standard,
+        # non-editorial default absent any other established policy.
+        nearest = min(future_expirations, key=lambda cycle: cycle.expiration_date)
+        strike = select_atm_strike_at_expiration(
+            chain, nearest.expiration_date, spot_price, OptionType.CALL  # type: ignore[arg-type]
+        )
+        context = build_skew_momentum_context(
+            chain, nearest.expiration_date, strike=strike, option_type=OptionType.CALL  # type: ignore[arg-type]
+        )
+        graph = compile_strategy_graph(SKEW_MOMENTUM_VERTICAL_MANIFEST, _COMPONENT_REGISTRY)
+        result = execute_strategy_graph(graph, context)
+        return _live_result(
+            definition,
+            clock,
+            run_id,
+            symbol,
+            result.outputs.get("verdict").value,
+            result.outputs.get("score").value,
+            chain.evidence,  # type: ignore[attr-defined]
+        )
+
+    return _run
+
+
+def _earnings_date(event: EarningsEvent) -> date:
+    return event.earnings_date
+
+
+LIVE_ADAPTER_FACTORIES = {
+    "forward_factor": build_live_forward_factor_adapter,
+    "earnings_calendar": build_live_earnings_calendar_adapter,
+    "skew_momentum": build_live_skew_momentum_adapter,
+}
+
+
+def build_live_adapters(
+    symbol: str, fulfillment: CapabilityFulfillmentService
+) -> dict[str, StrategyAdapter]:
+    """One live-driven adapter per target strategy, all bound to the same
+    symbol and fulfillment service -- the live counterpart of
+    screening.adapters.TARGET_STRATEGY_ADAPTERS.
+    """
+    return {
+        strategy_id: factory(symbol, fulfillment)
+        for strategy_id, factory in LIVE_ADAPTER_FACTORIES.items()
+    }

--- a/screening/live_context.py
+++ b/screening/live_context.py
@@ -1,0 +1,124 @@
+"""Live subject construction and chain-derived expirations (LIVE-002).
+
+Bridges screening/live_acquisition.py's canonical acquisition output back
+into the shapes screening/context_builders.py already expects -- no new
+strategy logic, no provider-specific code. Monthly/weekly classification
+uses the same standard third-Friday convention already used elsewhere in
+this codebase (strategies/stonk_components.py's private
+_is_monthly_expiration), reimplemented locally since screening/ cannot
+reach into strategies/'s private internals and this is a small, standard,
+non-controversial calendar rule, not strategy logic.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+
+from analytics.atm_selection import select_atm_strike
+from domain import (
+    CanonicalInstrumentIdentity,
+    EvidenceKind,
+    EvidenceReference,
+    ExpirationCycle,
+    Instrument,
+    InstrumentKind,
+    MarketCapability,
+    MarketDataRequestContext,
+    MarketDataSubject,
+    MarketDataSubjectType,
+    OptionChain,
+    OptionType,
+    ProviderAddressProjection,
+)
+
+
+class NoContractsAtExpirationError(ValueError):
+    """No contract of the requested type exists at the given expiration."""
+
+
+def select_atm_strike_at_expiration(
+    chain: OptionChain, expiration: date, spot_price: Decimal, option_type: OptionType
+) -> Decimal:
+    strikes = tuple(
+        contract.strike
+        for contract in chain.find(expiration=expiration, option_type=option_type)
+    )
+    if not strikes:
+        raise NoContractsAtExpirationError(
+            f"no {option_type.value} contracts at expiration {expiration.isoformat()}"
+        )
+    return select_atm_strike(strikes, spot_price)
+
+
+def _is_monthly_expiration(expiration: date) -> bool:
+    """Third Friday of the month -- the standard monthly options cycle."""
+    return expiration.weekday() == 4 and 15 <= expiration.day <= 21
+
+
+def expirations_from_chain(chain: OptionChain, as_of: date) -> tuple[ExpirationCycle, ...]:
+    """Derive the distinct expiration cycles actually present in an
+    acquired live OptionChain -- no separate acquisition needed.
+    """
+    unique_dates = sorted({contract.expiration for contract in chain.contracts})
+    return tuple(
+        ExpirationCycle(
+            expiration,
+            (expiration - as_of).days,
+            _is_monthly_expiration(expiration),
+            not _is_monthly_expiration(expiration),
+            as_of,
+            chain.evidence,
+        )
+        for expiration in unique_dates
+        if expiration >= as_of
+    )
+
+
+# CapabilityFulfillmentService selects the serving provider internally
+# (priority order, with fallback) -- the caller cannot know in advance
+# which one will actually be tried, and each provider looks up its own
+# symbol mapping via subject.projection_for(that provider's own
+# provider_id, ...). So the subject must carry one projection per provider
+# that could possibly be selected, not a single placeholder -- every
+# provider this codebase knows how to construct uses the ticker symbol
+# directly as its own address value, so the same symbol is valid for all.
+KNOWN_PROVIDER_IDS = ("tradier", "finnhub", "alpha_vantage", "deterministic_fixture")
+
+
+def build_capability_subject(
+    symbol: str,
+    capability: MarketCapability,
+    as_of: datetime,
+    *,
+    provider_symbol_window_days: int = 2,
+) -> MarketDataSubject:
+    """A bounded, symbol-scoped subject for acquire_capability(). The
+    symbol is always caller-supplied explicitly -- never inferred, never
+    unbounded (screening/cli.py validates it against an explicit,
+    finite universe before this is ever called).
+    """
+    subject_type = {
+        MarketCapability.OPTION_CHAIN_V1: MarketDataSubjectType.OPTION_UNDERLYING,
+        MarketCapability.EARNINGS_CALENDAR_V1: MarketDataSubjectType.EARNINGS_SECURITY,
+    }.get(capability, MarketDataSubjectType.INSTRUMENT)
+    evidence = (EvidenceReference(EvidenceKind.OBSERVATION, f"screening:live:{symbol}"),)
+    window_start = as_of - timedelta(days=provider_symbol_window_days)
+    projections = tuple(
+        ProviderAddressProjection(provider_id, "v1", "symbol", symbol, window_start, None, evidence)
+        for provider_id in KNOWN_PROVIDER_IDS
+    )
+    instrument = Instrument(
+        CanonicalInstrumentIdentity("symbol", symbol), InstrumentKind.EQUITY, symbol, "USD"
+    )
+    required_fields = {
+        MarketCapability.OPTION_CHAIN_V1: ("contracts",),
+        MarketCapability.EARNINGS_CALENDAR_V1: ("earnings_date",),
+        MarketCapability.REAL_TIME_QUOTE_V1: ("last",),
+    }.get(capability, ("last",))
+    return MarketDataSubject(
+        instrument,
+        subject_type,
+        capability,
+        MarketDataRequestContext(as_of, as_of, required_fields, projections, evidence),
+    )

--- a/tests/analytics/test_atm_selection.py
+++ b/tests/analytics/test_atm_selection.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from analytics.atm_selection import select_atm_strike
+
+
+class TestSelectAtmStrike:
+    def test_selects_the_closest_strike(self) -> None:
+        strikes = (Decimal("195"), Decimal("200"), Decimal("205"), Decimal("210"), Decimal("215"))
+        assert select_atm_strike(strikes, Decimal("207")) == Decimal("205")
+
+    def test_exact_match_wins(self) -> None:
+        strikes = (Decimal("200"), Decimal("210"), Decimal("220"))
+        assert select_atm_strike(strikes, Decimal("210")) == Decimal("210")
+
+    def test_ties_break_toward_the_lower_strike(self) -> None:
+        strikes = (Decimal("205"), Decimal("215"))
+        assert select_atm_strike(strikes, Decimal("210")) == Decimal("205")
+
+    def test_empty_strikes_rejected(self) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            select_atm_strike((), Decimal("210"))
+
+    def test_non_positive_spot_price_rejected(self) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            select_atm_strike((Decimal("210"),), Decimal("0"))

--- a/tests/analytics/test_expiration_selection.py
+++ b/tests/analytics/test_expiration_selection.py
@@ -4,7 +4,11 @@ from datetime import date
 
 import pytest
 
-from analytics.expiration_selection import ExpirationCandidate, select_expiration_pair
+from analytics.expiration_selection import (
+    ExpirationCandidate,
+    select_earnings_relative_expiration_pair,
+    select_expiration_pair,
+)
 
 _POLICY = {
     "front_min_dte": 35,
@@ -73,3 +77,65 @@ class TestSelectExpirationPair:
         policy.update(overrides)
         with pytest.raises(ValueError, match="policy is invalid"):
             select_expiration_pair((), **policy)
+
+
+_EARNINGS_POLICY = {
+    "front_min_dte": 7,
+    "front_max_dte": 21,
+    "back_min_dte": 22,
+    "back_max_dte": 75,
+}
+_EARNINGS_DATE = date(2026, 8, 5)
+
+
+class TestSelectEarningsRelativeExpirationPair:
+    def test_selects_a_pair_spanning_the_earnings_date(self) -> None:
+        candidates = (
+            _candidate(9, date(2026, 7, 31)),  # before earnings, front window
+            _candidate(58, date(2026, 9, 18)),  # after earnings, back window
+        )
+        selected = select_earnings_relative_expiration_pair(
+            candidates, _EARNINGS_DATE, **_EARNINGS_POLICY
+        )
+        assert selected is not None
+        front, back = selected
+        assert front.expiration_date < _EARNINGS_DATE < back.expiration_date
+
+    def test_front_after_earnings_date_is_rejected(self) -> None:
+        candidates = (
+            _candidate(16, date(2026, 8, 7)),  # after earnings -- invalid front
+            _candidate(58, date(2026, 9, 18)),
+        )
+        assert select_earnings_relative_expiration_pair(
+            candidates, _EARNINGS_DATE, **_EARNINGS_POLICY
+        ) is None
+
+    def test_back_before_earnings_date_is_rejected(self) -> None:
+        candidates = (
+            _candidate(9, date(2026, 7, 31)),
+            _candidate(2, date(2026, 8, 3)),  # before earnings -- invalid back regardless of DTE
+        )
+        assert select_earnings_relative_expiration_pair(
+            candidates, _EARNINGS_DATE, **_EARNINGS_POLICY
+        ) is None
+
+    def test_returns_none_for_empty_candidates(self) -> None:
+        assert (
+            select_earnings_relative_expiration_pair((), _EARNINGS_DATE, **_EARNINGS_POLICY)
+            is None
+        )
+
+    def test_is_deterministic(self) -> None:
+        candidates = (
+            _candidate(9, date(2026, 7, 31)),
+            _candidate(58, date(2026, 9, 18)),
+        )
+        first = select_earnings_relative_expiration_pair(candidates, _EARNINGS_DATE, **_EARNINGS_POLICY)
+        second = select_earnings_relative_expiration_pair(candidates, _EARNINGS_DATE, **_EARNINGS_POLICY)
+        assert first == second
+
+    def test_invalid_policy_rejected(self) -> None:
+        policy = dict(_EARNINGS_POLICY)
+        policy["front_min_dte"] = 100
+        with pytest.raises(ValueError, match="policy is invalid"):
+            select_earnings_relative_expiration_pair((), _EARNINGS_DATE, **policy)

--- a/tests/screening/test_cli.py
+++ b/tests/screening/test_cli.py
@@ -4,9 +4,49 @@ import json
 
 import pytest
 
-from screening.cli import main
+from market_data.transport import ReadOnlyTransportError
+from screening.cli import APPROVED_LIVE_UNIVERSE, main
 
 AS_OF = "2026-07-22T16:00:00+00:00"
+
+# No test here ever sets a real credential -- clearing these first makes
+# every --live test's "no provider available" behavior independent of
+# whatever the host environment happens to have configured.
+_PROVIDER_ENV_VARS = (
+    "ASA_TRADIER_ACCESS_TOKEN",
+    "TRADIER_ACCESS_TOKEN",
+    "ASA_TRADIER_ENABLED",
+    "ASA_FINNHUB_API_KEY",
+    "FINNHUB_API_KEY",
+    "ASA_FINNHUB_ENABLED",
+    "ASA_ALPHA_VANTAGE_API_KEY",
+    "ALPHA_VANTAGE_API_KEY",
+    "ASA_ALPHA_VANTAGE_ENABLED",
+    "ASA_DETERMINISTIC_FIXTURE_ENABLED",
+)
+
+
+def _clear_provider_env(monkeypatch) -> None:
+    for name in _PROVIDER_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+class _NetworkFreeTransport:
+    """Never performs real network I/O -- fails every request immediately,
+    the same shape a real transport failure would take. Enough to prove
+    --live's wiring (config -> provider -> per-symbol adapters -> results)
+    works end to end without a live CLI test ever touching a real host.
+    """
+
+    def get(self, _request):
+        raise ReadOnlyTransportError("test transport never performs real network I/O")
+
+
+def _enable_one_live_provider(monkeypatch) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "test-token-not-a-real-credential")
+    monkeypatch.setattr("screening.cli.build_live_transport", lambda _provider_id: _NetworkFreeTransport())
 
 
 class TestDryRun:
@@ -69,16 +109,71 @@ class TestRealRun:
         assert "Bearer" not in out and "Authorization" not in out
 
 
-class TestFailClosed:
-    def test_live_flag_fails_closed_and_never_reaches_the_runner(self, capsys, monkeypatch) -> None:
-        def _fail(*_args, **_kwargs):
-            raise AssertionError("--live must never reach run_screening")
-
-        monkeypatch.setattr("screening.cli.run_screening", _fail)
-        exit_code = main(["--live"])
+class TestLive:
+    def test_no_enabled_live_provider_fails_closed_not_a_crash(self, capsys, monkeypatch) -> None:
+        _clear_provider_env(monkeypatch)
+        exit_code = main(["--live", "--universe", "AAPL", "--as-of", AS_OF])
         assert exit_code == 2
-        assert "not yet available" in capsys.readouterr().err
+        assert "requires at least one enabled live provider" in capsys.readouterr().err
 
+    def test_fixture_alone_does_not_count_as_an_enabled_live_provider(self, capsys, monkeypatch) -> None:
+        # The fixture provider defaults to enabled (market_data/config.py's
+        # own safety default) and, being alphabetically first, would
+        # otherwise be tried before any real provider by CapabilityRegistry's
+        # deterministic priority order -- silently serving every --live
+        # request from offline fixture data. --live must force it out of the
+        # provider pool regardless, so with no *real* provider configured
+        # this must still fail closed, not quietly "succeed" via the fixture.
+        _clear_provider_env(monkeypatch)
+        monkeypatch.setenv("ASA_DETERMINISTIC_FIXTURE_ENABLED", "true")
+        exit_code = main(["--live", "--universe", "AAPL", "--as-of", AS_OF])
+        assert exit_code == 2
+        assert "requires at least one enabled live provider" in capsys.readouterr().err
+
+    def test_one_enabled_provider_runs_the_default_live_universe(self, capsys, monkeypatch) -> None:
+        _enable_one_live_provider(monkeypatch)
+        exit_code = main(["--live", "--as-of", AS_OF, "--json"])
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        # One StrategyAdapterError-raising failure per strategy per symbol --
+        # runner.py reports "unknown" subject_identity for adapter-raised
+        # failures (no subject was ever resolved), so per-symbol iteration is
+        # verified by result count, not by echoed identity.
+        assert len(payload["results"]) == len(APPROVED_LIVE_UNIVERSE) * 3
+        # The injected transport fails every request -- proves acquisition
+        # actually ran through the live path (never the offline fixture).
+        assert all(result["outcome_status"] == "missing_data" for result in payload["results"])
+
+    def test_can_be_scoped_to_a_subset_of_the_live_universe(self, capsys, monkeypatch) -> None:
+        _enable_one_live_provider(monkeypatch)
+        exit_code = main(["--live", "--universe", "AAPL", "--as-of", AS_OF, "--json"])
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert len(payload["results"]) == 3
+        assert all(result["outcome_status"] == "missing_data" for result in payload["results"])
+
+    def test_live_universe_symbol_rejected_without_live_flag(self, capsys) -> None:
+        exit_code = main(["--universe", "SPY", "--as-of", AS_OF])
+        assert exit_code == 2
+        assert "unsupported universe" in capsys.readouterr().err
+
+    def test_fixture_only_universe_symbol_rejected_with_live_flag(self, capsys, monkeypatch) -> None:
+        _clear_provider_env(monkeypatch)
+        exit_code = main(["--live", "--universe", "TSLA", "--as-of", AS_OF])
+        assert exit_code == 2
+        assert "unsupported universe" in capsys.readouterr().err
+
+    def test_output_contains_no_evidence_of_a_raw_provider_payload(self, capsys, monkeypatch) -> None:
+        _enable_one_live_provider(monkeypatch)
+        exit_code = main(["--live", "--universe", "AAPL", "--as-of", AS_OF, "--json"])
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        assert "http://" not in out and "https://" not in out
+        assert "Bearer" not in out and "Authorization" not in out
+        assert "test-token-not-a-real-credential" not in out
+
+
+class TestFailClosed:
     def test_unknown_strategy_id_fails_closed(self, capsys) -> None:
         exit_code = main(["--strategies", "does_not_exist", "--as-of", AS_OF])
         assert exit_code == 2

--- a/tests/screening/test_live_adapters.py
+++ b/tests/screening/test_live_adapters.py
@@ -1,0 +1,326 @@
+"""LIVE-002 live adapter tests.
+
+market_data's deterministic_fixture provider always returns exactly one
+option expiration with one strike per side (market_data/fixture.py::
+_value), which is not enough for any of the three target strategies' real
+selection logic: Forward Factor and Earnings Calendar each need two
+expirations spanning a DTE policy window, and Skew Momentum needs multiple
+strikes/deltas to select both legs of a vertical spread.
+MultiExpirationFixtureProvider overrides only option-chain value
+generation to supply four expirations and a seven-strike delta ladder at
+each -- everything else (provider_id, capabilities, budget, health,
+validate, shutdown) stays the real deterministic_fixture implementation,
+still zero network, still fully deterministic.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from domain import (
+    AnnouncementTime,
+    CanonicalInstrumentIdentity,
+    EarningsEvent,
+    MarketCapability,
+    OHLCVBar,
+    OptionChain,
+    OptionContract,
+    OptionType,
+    Quote,
+    Security,
+    SecurityAssetType,
+)
+from market_data import (
+    CapabilityFulfillmentService,
+    CapabilityRegistry,
+    ProviderDependencies,
+    ProviderPriority,
+    ProviderPriorityPolicy,
+    ProviderRegistry,
+    load_market_data_config,
+)
+from market_data.fixture import DeterministicFixtureProvider
+from screening.adapters import TARGET_STRATEGY_REGISTRY
+from screening.live_acquisition import build_capability_registry, build_request_budget_manager
+from screening.live_adapters import build_live_adapters
+from screening.results import ScreeningOutcomeStatus
+from screening.runner import run_screening
+
+NOW = datetime(2026, 7, 22, 16, 0, tzinfo=UTC)
+SYMBOL = "AAPL"
+
+
+class FixedClock:
+    """Advances by one microsecond on every call -- a real clock always
+    advances between successive requests too (an HTTP round-trip takes
+    measurable time); a frozen clock is the unrealistic case, and collides
+    with RequestBudgetPolicy's default burst_limit=1 (keyed by exact
+    timestamp) the moment one adapter run needs more than one acquisition
+    (every target strategy here does: at least a quote and a chain).
+    Deterministic across repeated test runs since it always starts from
+    the same NOW and advances by the same fixed increment.
+    """
+
+    def __init__(self, start: datetime = NOW) -> None:
+        self._next = start
+
+    def now(self) -> datetime:
+        current = self._next
+        self._next = current + timedelta(microseconds=1)
+        return current
+
+
+# (strike offset from spot, call delta) -- a simple, monotonic, realistic-
+# shaped ladder. Put delta is the standard put_delta = call_delta - 1
+# relationship. Not precise Black-Scholes, just enough spread for
+# _nearest_delta (VerticalStructure's long/short leg selection) to have
+# real candidates on both sides of its 0.50/0.25 targets.
+_STRIKE_DELTA_LADDER = (
+    (Decimal("-15"), Decimal("0.80")),
+    (Decimal("-10"), Decimal("0.70")),
+    (Decimal("-5"), Decimal("0.60")),
+    (Decimal("0"), Decimal("0.50")),
+    (Decimal("5"), Decimal("0.35")),
+    (Decimal("10"), Decimal("0.25")),
+    (Decimal("15"), Decimal("0.15")),
+)
+_SPOT = Decimal("210")
+
+# (days out, ATM implied_volatility) -- spans both Earnings Calendar's
+# front_min/max_dte=7/21, back_min/max_dte=22/75 policy and Forward
+# Factor's front_min/max_dte=35/90, back_min/max_dte=49/139, gap 14-49
+# policy, deliberately without the two ranges overlapping, so each
+# strategy's selector has exactly one unambiguous valid pair.
+_EXPIRATIONS_DAYS_OUT_AND_IV = (
+    (10, Decimal("0.55")),
+    (25, Decimal("0.50")),
+    (61, Decimal("0.48")),
+    (91, Decimal("0.4548992562461861547567860943472296")),
+)
+
+
+class MultiExpirationFixtureProvider(DeterministicFixtureProvider):
+    """deterministic_fixture with a four-expiration, multi-strike option
+    chain -- still zero network, still fully deterministic, only the
+    chain's *shape* changes, so every target strategy's real selection
+    logic (DTE-window pairing, earnings-relative pairing, delta-based leg
+    selection) has genuine candidates to choose from instead of exactly
+    one contract per side.
+    """
+
+    def _value(self, subject, address, observed_at, evidence):  # noqa: ANN001
+        instrument = subject.canonical_instrument
+        capability = subject.requested_capability
+        if capability is MarketCapability.REAL_TIME_QUOTE_V1:
+            return Quote(
+                instrument,
+                _SPOT - Decimal("0.10"),
+                _SPOT + Decimal("0.10"),
+                _SPOT,
+                Decimal("100"),
+                Decimal("120"),
+                Decimal("1000000"),
+                instrument.currency,
+            )
+        security = Security(instrument, address.upper(), SecurityAssetType.EQUITY, "XNAS")
+        if capability is MarketCapability.EARNINGS_CALENDAR_V1:
+            event_date = observed_at.date() + timedelta(days=14)
+            return EarningsEvent(
+                f"fixture:{address}:{event_date.isoformat()}",
+                security,
+                event_date,
+                AnnouncementTime.AFTER_CLOSE,
+                Decimal("0.05"),
+                True,
+                (),
+                observed_at,
+                evidence,
+            )
+        if capability is MarketCapability.HISTORICAL_BARS_V1:
+            return OHLCVBar(
+                instrument,
+                86400,
+                observed_at - timedelta(days=1),
+                observed_at,
+                Decimal("205"),
+                Decimal("212"),
+                Decimal("204"),
+                Decimal("210"),
+                Decimal("50000000"),
+            )
+        contracts = tuple(
+            OptionContract(
+                CanonicalInstrumentIdentity(
+                    "fixture-option",
+                    f"{address}-{days_out}-{_SPOT + offset}-{kind.value}",
+                ),
+                security,
+                observed_at.date() + timedelta(days=days_out),
+                _SPOT + offset,
+                kind,
+                Decimal("4.90"),
+                Decimal("5.10"),
+                Decimal("5.00"),
+                1000,
+                5000,
+                call_delta if kind is OptionType.CALL else call_delta - 1,
+                Decimal("0.03"),
+                Decimal("-0.10"),
+                Decimal("0.20"),
+                Decimal("0.01"),
+                iv,
+                observed_at,
+                evidence,
+            )
+            for days_out, iv in _EXPIRATIONS_DAYS_OUT_AND_IV
+            for offset, call_delta in _STRIKE_DELTA_LADDER
+            for kind in (OptionType.CALL, OptionType.PUT)
+        )
+        return OptionChain(
+            f"fixture:{address}:multi-expiration", security, observed_at, contracts, evidence
+        )
+
+
+def _no_transport(_provider_id: str) -> object:
+    return object()
+
+
+def _fulfillment(provider_cls=DeterministicFixtureProvider, clock: FixedClock | None = None):
+    # One shared clock instance for both the budget manager and the
+    # provider's dependencies: RequestBudgetManager.authorize()'s burst-key
+    # is keyed by *its own* clock reading, independent of whatever clock a
+    # caller later passes to run_screening() -- sharing one advancing
+    # instance here is what actually avoids burst collisions across the
+    # several acquisitions one adapter run makes (a quote and a chain, at
+    # minimum).
+    shared_clock = clock or FixedClock()
+    config = load_market_data_config({})
+    (fixture_config,) = tuple(item for item in config.providers if item.enabled)
+    budget_manager = build_request_budget_manager((fixture_config,), shared_clock)
+    provider = provider_cls(
+        fixture_config, ProviderDependencies(object(), shared_clock, budget_manager)
+    )
+    registry = ProviderRegistry((provider,))
+    capability_registry = build_capability_registry(registry)
+    return CapabilityFulfillmentService(registry, capability_registry, budget_manager), shared_clock
+
+
+class TestSkewMomentumLiveNeedsMultipleStrikes:
+    def test_reports_strategy_exception_against_the_single_strike_default_fixture(self) -> None:
+        """The plain deterministic_fixture provider has exactly one call
+        and one put per expiration -- VerticalStructure's short-leg,
+        delta-target selection has no second strike to choose from. This
+        is a genuine data-richness requirement, not an artifact of this
+        test's own setup -- the same failure would occur against any real
+        chain missing sufficient strikes.
+        """
+        fulfillment, clock = _fulfillment()
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        (result,) = run_screening(
+            TARGET_STRATEGY_REGISTRY,
+            adapters,
+            clock,
+            strategy_ids=("skew_momentum",),
+        )
+        assert result.outcome_status is ScreeningOutcomeStatus.STRATEGY_EXCEPTION
+
+    def test_produces_a_valid_pass_result_against_the_multi_strike_fixture(self) -> None:
+        fulfillment, clock = _fulfillment(MultiExpirationFixtureProvider)
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        (result,) = run_screening(
+            TARGET_STRATEGY_REGISTRY,
+            adapters,
+            clock,
+            strategy_ids=("skew_momentum",),
+        )
+        assert result.outcome_status in (ScreeningOutcomeStatus.PASS, ScreeningOutcomeStatus.NO_SIGNAL)
+        assert result.subject_identity == f"symbol:{SYMBOL}"
+
+
+class TestForwardFactorAndEarningsCalendarNeedTwoExpirations:
+    def test_forward_factor_reports_missing_data_against_the_single_expiration_default_fixture(
+        self,
+    ) -> None:
+        fulfillment, clock = _fulfillment()
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        (result,) = run_screening(
+            TARGET_STRATEGY_REGISTRY,
+            adapters,
+            clock,
+            strategy_ids=("forward_factor",),
+        )
+        assert result.outcome_status is ScreeningOutcomeStatus.MISSING_DATA
+        assert result.failure_detail is not None
+        assert "DTE policy" in result.failure_detail
+
+    def test_forward_factor_succeeds_against_the_two_expiration_fixture(self) -> None:
+        fulfillment, clock = _fulfillment(MultiExpirationFixtureProvider)
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        (result,) = run_screening(
+            TARGET_STRATEGY_REGISTRY,
+            adapters,
+            clock,
+            strategy_ids=("forward_factor",),
+        )
+        assert result.outcome_status in (ScreeningOutcomeStatus.PASS, ScreeningOutcomeStatus.NO_SIGNAL)
+        assert result.subject_identity == f"symbol:{SYMBOL}"
+
+    def test_earnings_calendar_succeeds_against_the_two_expiration_fixture(self) -> None:
+        fulfillment, clock = _fulfillment(MultiExpirationFixtureProvider)
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        (result,) = run_screening(
+            TARGET_STRATEGY_REGISTRY,
+            adapters,
+            clock,
+            strategy_ids=("earnings_calendar",),
+        )
+        assert result.outcome_status in (ScreeningOutcomeStatus.PASS, ScreeningOutcomeStatus.NO_SIGNAL)
+        assert result.subject_identity == f"symbol:{SYMBOL}"
+
+
+class TestCapabilityNotOfferedByAnyEnabledProvider:
+    def test_earnings_calendar_reports_missing_data_not_strategy_exception(self) -> None:
+        """A real deployment might enable only a provider that doesn't
+        serve earnings data at all (e.g. only Tradier). CapabilityRegistry
+        .lookup() raises DomainInvariantError in that case rather than
+        returning a not-fulfilled result -- _acquire_or_raise must still
+        convert that into a clean, isolated MISSING_DATA outcome per this
+        module's own documented contract, never let it escape as a raw
+        exception into the runner's generic STRATEGY_EXCEPTION handling.
+        """
+        shared_clock = FixedClock()
+        config = load_market_data_config({})
+        (fixture_config,) = tuple(item for item in config.providers if item.enabled)
+        budget_manager = build_request_budget_manager((fixture_config,), shared_clock)
+        provider = MultiExpirationFixtureProvider(
+            fixture_config, ProviderDependencies(object(), shared_clock, budget_manager)
+        )
+        registry = ProviderRegistry((provider,))
+        priorities = tuple(
+            ProviderPriority(capability, (provider.provider_id,))
+            for capability in provider.capabilities
+            if capability is not MarketCapability.EARNINGS_CALENDAR_V1
+        )
+        capability_registry = CapabilityRegistry(registry, ProviderPriorityPolicy("test-v1", priorities))
+        fulfillment = CapabilityFulfillmentService(registry, capability_registry, budget_manager)
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        (result,) = run_screening(
+            TARGET_STRATEGY_REGISTRY, adapters, shared_clock, strategy_ids=("earnings_calendar",)
+        )
+        assert result.outcome_status is ScreeningOutcomeStatus.MISSING_DATA
+        assert result.failure_detail is not None
+        assert "no enabled live provider offers" in result.failure_detail
+
+
+class TestFullLiveRunAcrossAllThreeStrategies:
+    def test_all_three_run_and_are_isolated_from_each_other(self) -> None:
+        fulfillment, clock = _fulfillment(MultiExpirationFixtureProvider)
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        results = run_screening(TARGET_STRATEGY_REGISTRY, adapters, clock)
+        assert {result.strategy_id for result in results} == {
+            "earnings_calendar",
+            "forward_factor",
+            "skew_momentum",
+        }
+        assert all(result.subject_identity == f"symbol:{SYMBOL}" for result in results)


### PR DESCRIPTION
## Ticket
LIVE-002 (SPRINT-007, delegated merge under GOV-007/Amendment 013, active since #150 merged)

## Summary
Replaces `screening/cli.py`'s fixture-only `--live` stub (previously hardcoded to fail closed with "not yet available") with real bounded live execution: all three target strategies (forward_factor, earnings_calendar, skew_momentum) now run against a `CapabilityFulfillmentService` backed by real, network-connected providers, one symbol at a time across an explicit, finite universe -- never an unbounded one.

## Repository evidence -- investigated before implementing
- `screening/live_acquisition.py` (LIVE-001, merged in #154) already exposes everything needed to acquire canonical capabilities against real providers; this ticket adds no new acquisition machinery, only the strategy-facing adapters and CLI wiring on top of it.
- `screening/adapters.py`'s fixture-backed `run_*` functions and `screening/context_builders.py` are reused unmodified -- `screening/live_adapters.py` supplies only live-sourced inputs (spot price, option chain, earnings event) to the same manifests and context builders, no strategy logic is reimplemented.
- `market_data`'s `deterministic_fixture` provider defaults to `enabled=True` (its own documented safety default) and, being alphabetically first, is tried before any real provider by `CapabilityRegistry`'s deterministic priority order. Left unchecked, `--live` would silently serve every request from offline fixture data. `screening/cli.py::_live_only_config()` force-disables it for `--live` regardless of environment configuration, and `--live` now fails closed with a clear error if that leaves zero enabled providers, instead of only discovering the empty-provider case as an unhandled `DomainInvariantError` (which is what actually happened during testing -- see below).
- Discovered and fixed during testing, not anticipated up front: when only a subset of providers is enabled (e.g. only Tradier, which doesn't serve earnings data), `CapabilityRegistry.lookup()` raises `DomainInvariantError` for a capability no enabled provider declares, rather than returning a not-fulfilled result. `screening/live_adapters.py::_acquire_or_raise` previously let this escape as a raw exception, surfacing as `STRATEGY_EXCEPTION` -- a violation of this module's own documented contract ("never a raw exception escaping to the runner's more generic STRATEGY_EXCEPTION handling"). Now caught and converted to a clean, isolated `MISSING_DATA` result, with a regression test.
- `analytics/atm_selection.py` and `analytics/expiration_selection.py::select_earnings_relative_expiration_pair` reimplement, independently (this package cannot import `strategies/`), the same standard ATM-strike and earnings-relative-pairing semantics `strategies/stonk_components.py` already uses privately -- same pattern as ANALYTICS-002/003.
- `market_data/live_transport.py` (a stdlib `urllib` implementation of `market_data/transport.py`'s `ReadOnlyHttpTransport` protocol) deliberately lives in `market_data/`, not `screening/`: `tests/architecture/test_screening_boundaries.py` forbids `screening/` from importing `urllib` or performing network I/O directly (confirmed by first writing it in `screening/` and watching the boundary tests fail, then relocating it). `market_data/` carries no such restriction. This is the same kind of duplication `screening/live_acquisition.py`'s own docstring already documents for `backend/`'s independent copy of the same port, just resolved to a different location once the actual boundary rule was checked.

## Relevant issues and PRs
#150 (GOV-007 activation), #154 (LIVE-001). No other directly relevant issues.

## Architecture compliance
- `tests/architecture/test_screening_boundaries.py` -- unchanged, all pass; no new import roots needed in `screening/`.
- No provider-specific code entered `screening/`; the live transport implementation lives in `market_data/` for exactly that reason.
- `--universe` stays bounded: `APPROVED_FIXTURE_UNIVERSE` (unchanged, fixture-only) without `--live`; `APPROVED_LIVE_UNIVERSE` (SPRINT-007's six-symbol `validation_universe`: AAPL, MSFT, NVDA, AMD, SPY, QQQ) with it. No arbitrary or unbounded universe is ever accepted.

## Security and secret handling
Secret scan (`grep -riE "token|secret|password|api[_-]?key|bearer"`) against all new/changed files: only environment-variable *names* (`ASA_TRADIER_ACCESS_TOKEN`, etc.) and one clearly-labeled test placeholder string (`"test-token-not-a-real-credential"`), asserted to never appear in CLI output. No real credential material anywhere.

## Network behavior
No real network access anywhere in this PR. `tests/screening/test_live_adapters.py` uses `market_data.fixture.DeterministicFixtureProvider` (zero network by design) plus a custom subclass supplying multi-expiration, multi-strike data. `tests/screening/test_cli.py`'s live tests enable one real provider (Tradier) via env vars but inject a network-free fake transport (`screening.cli.build_live_transport` monkeypatched) that fails every request immediately -- proves the live wiring end-to-end (config -> provider construction -> per-symbol adapters -> results) without ever touching a real host.

## Request budget behavior
Unchanged from LIVE-001: one `RequestBudgetManager` shared across every enabled provider's dependencies, derived from each provider's own `ProviderConfig.request_budget`, never widened or overridden by this ticket's CLI wiring.

## Tests
- `pytest tests/screening/test_live_adapters.py tests/screening/test_cli.py tests/analytics/` -> 84 passed.
- `pytest tests/screening/ tests/analytics/ tests/architecture/ tests/market_data/` -> 371 passed, 1 skipped (pre-existing, unrelated).
- `pytest tests/` (full repo) -> 2180 passed, 2 skipped (pre-existing, unrelated).
- `ruff check screening/ market_data/ analytics/ tests/screening/ tests/analytics/` -> clean.
- `mypy` on every new/touched file -> zero errors attributed to this PR's own files; the same pre-existing `strategies`/`indicators` findings (tracked in #147) surface transitively, unchanged from prior PRs.
- `tools/pos/lean/check_integrity.py` / `check_entrypoints.py` / `pre_push_check.py` -> all green.
- `tools/pos/lean/generate.py current-state` against `CURRENT_STATE.md` -> only the `Generated:` timestamp line differs (expected, matches the pinned placeholder pattern); no real content drift.
- `git status --short` -> exactly this ticket's files (`analytics/atm_selection.py`, `analytics/expiration_selection.py`, `analytics/__init__.py`, `market_data/live_transport.py`, `screening/live_adapters.py`, `screening/live_context.py`, `screening/cli.py`, `screening/__init__.py`, and their tests) -- matches approved ticket scope.

## Live validation status
N/A for real provider credentials -- per this ticket's own scope and SPRINT-007's `live_execution_policy`, the first real run against live provider credentials is LIVE-003's explicitly Founder-gated concern, not this one's. This PR makes `--live` functionally real (wired end-to-end against injectable transports) without ever exercising it against an actual live host.

## Explicit exclusions
No real provider credentials used or required anywhere in this PR. No changes to `market_data/`'s existing acquisition machinery, `strategies/`, or governance/workflow files. LIVE-003 (Founder-gated operational live validation) is explicitly out of scope for this PR.

## Merge authority
`delegated_after_required_checks` per SPRINT-007/GOV-007 -- active since #150 merged. All required gates above are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)