### PR TITLE
TRADIER-PATCH-001: canonical expiration discovery acquisition

### DIFF
--- a/screening/live_context.py
+++ b/screening/live_context.py
@@ -1,4 +1,5 @@
-"""Live subject construction and chain-derived expirations (LIVE-002).
+"""Live subject construction and chain-derived expirations (LIVE-002,
+PATCH-007A/TRADIER-PATCH-001).
 
 Bridges screening/live_acquisition.py's canonical acquisition output back
 into the shapes screening/context_builders.py already expects -- no new
@@ -31,6 +32,10 @@ from domain import (
     OptionType,
     ProviderAddressProjection,
 )
+from market_data import CapabilityFulfillmentService, FulfillmentStatus
+from screening.live_acquisition import acquire_capability
+from screening.results import ScreeningOutcomeStatus
+from screening.runner import StrategyAdapterError
 
 
 class NoContractsAtExpirationError(ValueError):
@@ -92,11 +97,18 @@ def build_capability_subject(
     as_of: datetime,
     *,
     provider_symbol_window_days: int = 2,
+    required_fields: tuple[str, ...] | None = None,
 ) -> MarketDataSubject:
     """A bounded, symbol-scoped subject for acquire_capability(). The
     symbol is always caller-supplied explicitly -- never inferred, never
     unbounded (screening/cli.py validates it against an explicit,
     finite universe before this is ever called).
+
+    required_fields defaults to each capability's usual shape but can be
+    overridden (e.g. ("expirations",) for an expirations-only OPTION_CHAIN_V1
+    request) -- CapabilityRequest.__post_init__ requires the subject's own
+    required_fields to match exactly what acquire_capability() is called
+    with, so the two must always be constructed together, not independently.
     """
     subject_type = {
         MarketCapability.OPTION_CHAIN_V1: MarketDataSubjectType.OPTION_UNDERLYING,
@@ -111,14 +123,80 @@ def build_capability_subject(
     instrument = Instrument(
         CanonicalInstrumentIdentity("symbol", symbol), InstrumentKind.EQUITY, symbol, "USD"
     )
-    required_fields = {
-        MarketCapability.OPTION_CHAIN_V1: ("contracts",),
-        MarketCapability.EARNINGS_CALENDAR_V1: ("earnings_date",),
-        MarketCapability.REAL_TIME_QUOTE_V1: ("last",),
-    }.get(capability, ("last",))
+    if required_fields is None:
+        required_fields = {
+            MarketCapability.OPTION_CHAIN_V1: ("contracts",),
+            MarketCapability.EARNINGS_CALENDAR_V1: ("earnings_date",),
+            MarketCapability.REAL_TIME_QUOTE_V1: ("last",),
+        }.get(capability, ("last",))
     return MarketDataSubject(
         instrument,
         subject_type,
         capability,
         MarketDataRequestContext(as_of, as_of, required_fields, projections, evidence),
     )
+
+
+def acquire_expirations(
+    fulfillment: CapabilityFulfillmentService,
+    symbol: str,
+    now: datetime,
+) -> tuple[ExpirationCycle, ...]:
+    """Acquire the option expirations available for `symbol`, independent
+    of any single expiration's contracts (TRADIER-PATCH-001).
+
+    Normalizes two distinct, both-legitimate provider response shapes into
+    one canonical, deterministically-ordered result:
+
+    - A provider (Tradier) that treats an expirations-only request
+      (required_fields=("expirations",), no "contracts") as its own
+      narrower query and returns one MarketObservation per expiration,
+      each wrapping a bare ExpirationCycle.
+    - A provider or fixture that doesn't distinguish an expirations-only
+      request from a full chain request and returns one MarketObservation
+      wrapping a complete OptionChain -- expirations are derived from its
+      contracts locally via expirations_from_chain(), exactly as this
+      module already does for a chain acquired for other reasons.
+
+    Raises StrategyAdapterError(MISSING_DATA) on acquisition failure, an
+    unrecognized response shape, or a result that normalizes to zero
+    expirations -- callers never need a separate empty-result branch, since
+    there is no legitimate case that looks empty but isn't a failure.
+    """
+    subject = build_capability_subject(
+        symbol, MarketCapability.OPTION_CHAIN_V1, now, required_fields=("expirations",)
+    )
+    result = acquire_capability(
+        fulfillment,
+        MarketCapability.OPTION_CHAIN_V1,
+        subject,
+        effective_start=now,
+        effective_end=now,
+        required_fields=("expirations",),
+        maximum_age_seconds=3600,
+    )
+    if result.status is not FulfillmentStatus.FULFILLED or not result.observations:
+        raise StrategyAdapterError(
+            ScreeningOutcomeStatus.MISSING_DATA,
+            f"could not acquire live option expirations for {symbol}",
+        )
+    as_of = now.date()
+    values = tuple(observation.value for observation in result.observations)
+    if all(isinstance(value, ExpirationCycle) for value in values):
+        cycles: tuple[ExpirationCycle, ...] = values  # type: ignore[assignment]
+    elif len(values) == 1 and isinstance(values[0], OptionChain):
+        cycles = expirations_from_chain(values[0], as_of)
+    else:
+        raise StrategyAdapterError(
+            ScreeningOutcomeStatus.MISSING_DATA,
+            f"live option expiration response for {symbol} was neither a clean "
+            "expiration list nor a single option chain",
+        )
+    unique_by_date = {cycle.expiration_date: cycle for cycle in cycles}
+    ordered = tuple(unique_by_date[expiration] for expiration in sorted(unique_by_date))
+    if not ordered:
+        raise StrategyAdapterError(
+            ScreeningOutcomeStatus.MISSING_DATA,
+            f"live provider returned zero option expirations for {symbol}",
+        )
+    return ordered

--- a/tests/screening/test_live_context_expirations.py
+++ b/tests/screening/test_live_context_expirations.py
@@ -1,0 +1,221 @@
+"""TRADIER-PATCH-001: canonical expiration discovery acquisition tests.
+
+acquire_expirations() must normalize two distinct, both-legitimate live
+provider response shapes into one canonical, deterministic result:
+Tradier's real shape (one MarketObservation per expiration, each wrapping a
+bare ExpirationCycle, returned only for an expirations-only request) and a
+provider/fixture that doesn't distinguish an expirations-only request from
+a full chain request (one MarketObservation wrapping a complete
+OptionChain). TradierShapedExpirationsProvider below reproduces Tradier's
+actual required_fields branching (market_data/tradier.py's own
+_endpoint()/_normalize()) without needing real Tradier code or network
+access -- it's a deterministic_fixture-identified provider whose only
+difference from DeterministicFixtureProvider is that one response shape.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from domain import (
+    CompletenessMetadata,
+    EvidenceKind,
+    EvidenceReference,
+    ExpirationCycle,
+    FreshnessMetadata,
+    FreshnessStatus,
+    MarketCapability,
+    MarketObservation,
+    ProviderProvenance,
+    market_observation_identity,
+)
+from market_data import (
+    CapabilityFulfillmentService,
+    ProviderDependencies,
+    ProviderRegistry,
+    load_market_data_config,
+)
+from market_data.fixture import DeterministicFixtureProvider
+from market_data.providers import (
+    ProviderAttemptMetadata,
+    ProviderErrorCode,
+    ProviderFetchResult,
+    ProviderResponseMetadata,
+    normalized_provider_error,
+)
+from screening.live_acquisition import build_capability_registry, build_request_budget_manager
+from screening.live_context import acquire_expirations
+from screening.results import ScreeningOutcomeStatus
+from screening.runner import StrategyAdapterError
+
+NOW = datetime(2026, 7, 22, 16, 0, tzinfo=UTC)
+SYMBOL = "AAPL"
+
+
+class FixedClock:
+    def __init__(self, start: datetime = NOW) -> None:
+        self._next = start
+
+    def now(self) -> datetime:
+        current = self._next
+        self._next = current + timedelta(microseconds=1)
+        return current
+
+
+class TradierShapedExpirationsProvider(DeterministicFixtureProvider):
+    """Returns Tradier's real expirations-only response shape (multiple
+    bare-ExpirationCycle observations) for required_fields=("expirations",)
+    with no "contracts"; everything else defers to the normal fixture
+    behavior, unmodified.
+    """
+
+    def fetch(self, request, budget):  # noqa: ANN001
+        if (
+            request.capability is MarketCapability.OPTION_CHAIN_V1
+            and "expirations" in request.required_fields
+            and "contracts" not in request.required_fields
+        ):
+            received_at = self._dependencies.clock.now().astimezone(UTC)
+            reference = self._request_reference(request)
+            response = ProviderResponseMetadata(
+                self.provider_id, reference, received_at, "fixture", 0, 0, (("network_requests", "0"),)
+            )
+            attempt = ProviderAttemptMetadata(self.provider_id, request.capability, 1, 1, response)
+            (subject,) = request.subjects
+            as_of = received_at.date()
+            evidence = (EvidenceReference(EvidenceKind.OBSERVATION, "test:tradier-shaped-expirations"),)
+            # Deliberately unsorted and with a duplicate date -- proves
+            # acquire_expirations() sorts and dedupes rather than trusting
+            # provider response order.
+            raw_cycles = (
+                ExpirationCycle(as_of + timedelta(days=25), 25, False, True, as_of, evidence),
+                ExpirationCycle(as_of + timedelta(days=10), 10, False, True, as_of, evidence),
+                ExpirationCycle(as_of + timedelta(days=10), 10, False, True, as_of, evidence),
+            )
+            observations = tuple(
+                MarketObservation(
+                    market_observation_identity(
+                        self.provider_id, request.capability, subject, received_at, cycle, "v1"
+                    ),
+                    request.capability,
+                    subject,
+                    received_at,
+                    received_at,
+                    cycle,
+                    "v1",
+                    ProviderProvenance(self.provider_id, reference, evidence),
+                    FreshnessMetadata(received_at, received_at, request.maximum_age_seconds, 0, FreshnessStatus.FRESH),
+                    CompletenessMetadata(request.required_fields, request.required_fields, ()),
+                )
+                for cycle in raw_cycles
+            )
+            return ProviderFetchResult(observations, None, (attempt,))
+        return super().fetch(request, budget)
+
+
+class EmptyExpirationsProvider(DeterministicFixtureProvider):
+    """Returns an EMPTY_PAYLOAD error for an expirations-only request -- a
+    legitimate, if unhelpful, real response shape (e.g. a symbol with no
+    listed options), matching real Tradier's own "no observations -> empty
+    payload error" convention (market_data/tradier.py's fetch()).
+    """
+
+    def fetch(self, request, budget):  # noqa: ANN001
+        if (
+            request.capability is MarketCapability.OPTION_CHAIN_V1
+            and "expirations" in request.required_fields
+            and "contracts" not in request.required_fields
+        ):
+            received_at = self._dependencies.clock.now().astimezone(UTC)
+            reference = self._request_reference(request)
+            response = ProviderResponseMetadata(
+                self.provider_id, reference, received_at, "fixture", 0, 0, (("network_requests", "0"),)
+            )
+            attempt = ProviderAttemptMetadata(self.provider_id, request.capability, 1, 1, response)
+            error = normalized_provider_error(
+                ProviderErrorCode.EMPTY_PAYLOAD,
+                "no expirations listed",
+                self.provider_id,
+                request.capability,
+                reference,
+            )
+            return ProviderFetchResult((), error, (attempt,))
+        return super().fetch(request, budget)
+
+
+class MalformedExpirationsProvider(DeterministicFixtureProvider):
+    """Returns two OptionChain-valued observations for an expirations-only
+    request -- neither a clean Tradier-shaped expiration list (every value
+    an ExpirationCycle) nor a single chain-shaped response. Not a real
+    provider behavior, but acquire_expirations() must still fail cleanly,
+    not crash, if a provider ever produced something this malformed.
+    """
+
+    def fetch(self, request, budget):  # noqa: ANN001
+        if (
+            request.capability is MarketCapability.OPTION_CHAIN_V1
+            and "expirations" in request.required_fields
+            and "contracts" not in request.required_fields
+        ):
+            received_at = self._dependencies.clock.now().astimezone(UTC)
+            reference = self._request_reference(request)
+            (subject,) = request.subjects
+            observation = self._observation(subject, received_at, reference, request.maximum_age_seconds)
+            response = ProviderResponseMetadata(
+                self.provider_id, reference, received_at, "fixture", 0, 0, (("network_requests", "0"),)
+            )
+            attempt = ProviderAttemptMetadata(self.provider_id, request.capability, 1, 1, response)
+            return ProviderFetchResult((observation, observation), None, (attempt,))
+        return super().fetch(request, budget)
+
+
+def _fulfillment(provider_cls=DeterministicFixtureProvider):
+    clock = FixedClock()
+    config = load_market_data_config({})
+    (fixture_config,) = tuple(item for item in config.providers if item.enabled)
+    budget_manager = build_request_budget_manager((fixture_config,), clock)
+    provider = provider_cls(fixture_config, ProviderDependencies(object(), clock, budget_manager))
+    registry = ProviderRegistry((provider,))
+    capability_registry = build_capability_registry(registry)
+    return CapabilityFulfillmentService(registry, capability_registry, budget_manager), clock
+
+
+class TestTradierShapedExpirationListResponse:
+    def test_normalizes_multiple_expiration_cycle_observations(self) -> None:
+        fulfillment, clock = _fulfillment(TradierShapedExpirationsProvider)
+        result = acquire_expirations(fulfillment, SYMBOL, clock.now())
+        assert [cycle.days_to_expiration for cycle in result] == [10, 25]
+
+    def test_deduplicates_and_sorts_deterministically(self) -> None:
+        fulfillment, clock = _fulfillment(TradierShapedExpirationsProvider)
+        result = acquire_expirations(fulfillment, SYMBOL, clock.now())
+        dates = [cycle.expiration_date for cycle in result]
+        assert dates == sorted(set(dates))
+        assert len(dates) == len(set(dates))
+
+
+class TestChainShapedExpirationResponse:
+    def test_derives_expirations_from_a_single_option_chain_observation(self) -> None:
+        fulfillment, clock = _fulfillment(DeterministicFixtureProvider)
+        result = acquire_expirations(fulfillment, SYMBOL, clock.now())
+        assert len(result) == 1
+        assert result[0].expiration_date > clock.now().date()
+
+
+class TestEmptyAndMalformedResponses:
+    def test_zero_observations_raises_missing_data(self) -> None:
+        fulfillment, clock = _fulfillment(EmptyExpirationsProvider)
+        try:
+            acquire_expirations(fulfillment, SYMBOL, clock.now())
+            raise AssertionError("expected StrategyAdapterError")
+        except StrategyAdapterError as error:
+            assert error.outcome_status is ScreeningOutcomeStatus.MISSING_DATA
+
+    def test_neither_expiration_list_nor_single_chain_raises_missing_data_not_a_crash(self) -> None:
+        fulfillment, clock = _fulfillment(MalformedExpirationsProvider)
+        try:
+            acquire_expirations(fulfillment, SYMBOL, clock.now())
+            raise AssertionError("expected StrategyAdapterError")
+        except StrategyAdapterError as error:
+            assert error.outcome_status is ScreeningOutcomeStatus.MISSING_DATA
+            assert "neither a clean expiration list nor a single option chain" in str(error)


### PR DESCRIPTION
## Ticket
TRADIER-PATCH-001 (PATCH-007A, delegated merge under GOV-007A/Amendment 013, active since #158 merged)

## Summary
Extends the live acquisition vocabulary so screening adapters can request and receive an option expiration list independently from option contracts -- the first of PATCH-007A's four tickets fixing issue #156 (Tradier's option-chain endpoint requires a specific expiration per request, which nothing in `screening/` previously supplied).

## Repository evidence -- investigated before implementing
- Confirmed by reading `market_data/tradier.py:247-258` directly (not assumed): Tradier already implements a real branch for `required_fields=("expirations",)` with `"contracts"` absent, hitting `/v1/markets/options/expirations` and normalizing to one `MarketObservation` per expiration, each wrapping a bare `ExpirationCycle` (`tradier.py:275-295`). This ticket's job is exposing that existing capability through `screening/`'s canonical acquisition layer, not building new Tradier-side machinery.
- `market_data.fixture.DeterministicFixtureProvider` does **not** distinguish an expirations-only request from a full chain request -- it always returns one `MarketObservation` wrapping a complete `OptionChain`, regardless of `required_fields`. `acquire_expirations()` handles this as an equally legitimate response shape, deriving expirations from the chain's contracts via the existing `expirations_from_chain()` (LIVE-002), not a new implementation -- satisfies the ticket's own "preserve support for providers or fixtures capable of returning broader chain data" requirement.
- Discovered during test-writing, not assumed up front: `CapabilityRequest.__post_init__` (`market_data/providers.py:159`) enforces that a subject's own `request_context.required_fields` exactly matches what `acquire_capability()` is called with -- passing `required_fields=("expirations",)` to `acquire_capability()` alone, against a subject still built with the old hardcoded `("contracts",)` default, raised `DomainInvariantError` on the very first test run. Fixed by adding an optional `required_fields` override to `build_capability_subject()` (backward-compatible -- every existing caller keeps its current default behavior unchanged).
- `ProviderFetchResult`'s own invariant (`observations` and `error` are mutually exclusive, `attempts` must be non-empty) meant the test double for "provider returns nothing" needed a real `EMPTY_PAYLOAD`-style error, not just an empty tuple -- matched real Tradier's own `fetch()` convention (`if not observations: return self._failure(..., EMPTY_PAYLOAD, ...)`) rather than inventing a different shape.

## Relevant issues and PRs
#156 (the defect this patch fixes), #139 (the related, already-fixed instance of the same bug class in `backend/`'s independent code path), #158 (this patch's GOV-007A activation).

## Architecture compliance
- `tests/architecture/test_screening_boundaries.py` -- all 77 tests pass unchanged; no new import roots needed (`market_data`, `screening.live_acquisition`, `screening.results`, `screening.runner` were all already permitted).
- No provider-specific object crosses the market-data boundary -- `acquire_expirations()` returns only canonical `tuple[ExpirationCycle, ...]`, never a raw Tradier response or provider-specific type.
- No strategy logic touched; this ticket only extends acquisition/normalization plumbing.

## Security and secret handling
Secret scan (`grep -riE "token|secret|password|api[_-]?key|bearer"`) against both changed files: zero matches.

## Network behavior
None. All 5 new tests run against `DeterministicFixtureProvider` and two small subclasses reproducing Tradier's and a malformed provider's exact response shapes -- zero network, fully deterministic.

## Request budget behavior
Unchanged -- `acquire_expirations()` makes exactly one `acquire_capability()` call per invocation, subject to the same shared `RequestBudgetManager` every other live acquisition already uses.

## Tests
- `pytest tests/screening/test_live_context_expirations.py` -> 5 passed (Tradier-shaped multi-observation normalization + dedup/sort, chain-shaped single-observation derivation, empty-response MISSING_DATA, malformed-response MISSING_DATA).
- `pytest tests/` (full repo) -> 2185 passed, 2 skipped (pre-existing, unrelated).
- `pytest tests/architecture/test_screening_boundaries.py` -> 77 passed.
- `ruff check screening/ tests/screening/` -> clean.
- `mypy screening/live_context.py screening/live_adapters.py screening/live_acquisition.py screening/cli.py` -> zero errors. (Test-file "no-untyped-def" findings on the small provider-double subclasses match the same pre-existing, accepted pattern already present in the merged `tests/screening/test_live_adapters.py`.)
- `tools/pos/lean/check_integrity.py` / `check_entrypoints.py` / `pre_push_check.py` -> all green.
- `git status --short` -> exactly `screening/live_context.py` and the one new test file.

## Live validation status
N/A for this ticket -- fixture-backed and synthetic-double-backed only, per TRADIER-PATCH-001's own scope. Live Tradier validation is TRADIER-PATCH-004's concern.

## Explicit exclusions
No live adapter wiring (`screening/live_adapters.py` untouched -- that's TRADIER-PATCH-003). No error-classification changes (TRADIER-PATCH-004). No strategy, `analytics/`, governance, or workflow changes.

## Merge authority
`delegated_after_required_checks` per PATCH-007A/GOV-007A -- active since #158 merged. All required gates above are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)