### PR TITLE
TRADIER-PATCH-002: expiration-aware option-chain subjects

### DIFF
--- a/screening/live_context.py
+++ b/screening/live_context.py
@@ -98,6 +98,7 @@ def build_capability_subject(
     *,
     provider_symbol_window_days: int = 2,
     required_fields: tuple[str, ...] | None = None,
+    expiration: date | None = None,
 ) -> MarketDataSubject:
     """A bounded, symbol-scoped subject for acquire_capability(). The
     symbol is always caller-supplied explicitly -- never inferred, never
@@ -109,7 +110,24 @@ def build_capability_subject(
     request) -- CapabilityRequest.__post_init__ requires the subject's own
     required_fields to match exactly what acquire_capability() is called
     with, so the two must always be constructed together, not independently.
+
+    expiration, when given, additionally attaches one "expiration"-address-
+    type ProviderAddressProjection per KNOWN_PROVIDER_IDS entry, explicit
+    and separate from the "symbol" projection -- required by providers
+    (Tradier) whose OPTION_CHAIN_V1 endpoint is scoped to one specific
+    expiration per request (market_data/tradier.py's own
+    subject.projection_for("tradier", "expiration", ...) lookup,
+    TRADIER-PATCH-001/#156). Selecting *which* expiration to request is
+    entirely the caller's own responsibility (via
+    analytics/expiration_selection.py's canonical DTE-policy functions,
+    over acquire_expirations()'s output) -- this only attaches whatever
+    expiration the caller already chose, as an explicit projection value;
+    it never invents, defaults, or hard-codes a selection policy itself.
     """
+    if expiration is not None and expiration < as_of.date():
+        raise ValueError(
+            f"expiration {expiration.isoformat()} is before as_of {as_of.date().isoformat()}"
+        )
     subject_type = {
         MarketCapability.OPTION_CHAIN_V1: MarketDataSubjectType.OPTION_UNDERLYING,
         MarketCapability.EARNINGS_CALENDAR_V1: MarketDataSubjectType.EARNINGS_SECURITY,
@@ -120,6 +138,19 @@ def build_capability_subject(
         ProviderAddressProjection(provider_id, "v1", "symbol", symbol, window_start, None, evidence)
         for provider_id in KNOWN_PROVIDER_IDS
     )
+    if expiration is not None:
+        projections += tuple(
+            ProviderAddressProjection(
+                provider_id,
+                "v1",
+                "expiration",
+                expiration.isoformat(),
+                window_start,
+                None,
+                evidence,
+            )
+            for provider_id in KNOWN_PROVIDER_IDS
+        )
     instrument = Instrument(
         CanonicalInstrumentIdentity("symbol", symbol), InstrumentKind.EQUITY, symbol, "USD"
     )

--- a/tests/screening/test_live_context_expiration_aware_subjects.py
+++ b/tests/screening/test_live_context_expiration_aware_subjects.py
@@ -1,0 +1,175 @@
+"""TRADIER-PATCH-002: expiration-aware option-chain subject tests.
+
+Two layers: unit tests directly against build_capability_subject()'s new
+`expiration` parameter, and one integration-level test against the real
+TradierProvider class (market_data/tradier.py, unmodified) with a fake,
+zero-network transport -- proving the constructed subject actually resolves
+issue #156's root cause (subject.projection_for("tradier", "expiration",
+...) previously always raised DomainInvariantError for every live option-
+chain request), not just that the projection object looks right in
+isolation.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+from domain import MarketCapability, OptionChain
+from domain.values import DomainInvariantError
+from market_data import (
+    CapabilityFulfillmentService,
+    FulfillmentStatus,
+    ProviderDependencies,
+    ProviderRegistry,
+)
+from market_data.config import load_market_data_config
+from market_data.tradier import TradierProvider
+from market_data.transport import ReadOnlyHttpResponse
+from screening.live_acquisition import (
+    acquire_capability,
+    build_capability_registry,
+    build_request_budget_manager,
+)
+from screening.live_context import KNOWN_PROVIDER_IDS, build_capability_subject
+
+NOW = datetime(2026, 7, 22, 16, 0, tzinfo=UTC)
+SYMBOL = "AAPL"
+EXPIRATION = date(2026, 8, 21)
+
+
+class TestExpirationAwareSubjectConstruction:
+    def test_carries_one_expiration_projection_per_known_provider(self) -> None:
+        subject = build_capability_subject(
+            SYMBOL, MarketCapability.OPTION_CHAIN_V1, NOW, expiration=EXPIRATION
+        )
+        for provider_id in KNOWN_PROVIDER_IDS:
+            projection = subject.projection_for(provider_id, "expiration", NOW)
+            assert projection.address_value == EXPIRATION.isoformat()
+
+    def test_symbol_projection_stays_explicit_and_unaffected(self) -> None:
+        subject = build_capability_subject(
+            SYMBOL, MarketCapability.OPTION_CHAIN_V1, NOW, expiration=EXPIRATION
+        )
+        projection = subject.projection_for("tradier", "symbol", NOW)
+        assert projection.address_value == SYMBOL
+
+    def test_without_expiration_no_expiration_projection_exists(self) -> None:
+        # Existing symbol-only acquisitions remain unchanged -- the
+        # pre-TRADIER-PATCH-002 default behavior is preserved exactly.
+        subject = build_capability_subject(SYMBOL, MarketCapability.OPTION_CHAIN_V1, NOW)
+        with pytest.raises(DomainInvariantError, match="one effective provider projection"):
+            subject.projection_for("tradier", "expiration", NOW)
+
+    def test_expiration_before_as_of_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="is before as_of"):
+            build_capability_subject(
+                SYMBOL,
+                MarketCapability.OPTION_CHAIN_V1,
+                NOW,
+                expiration=NOW.date() - timedelta(days=1),
+            )
+
+    def test_expiration_has_no_effect_on_other_capabilities(self) -> None:
+        # expiration is meaningless for a quote request -- accepted without
+        # error, simply produces an otherwise-unused projection, since only
+        # OPTION_CHAIN_V1 acquisition ever looks one up.
+        subject = build_capability_subject(
+            SYMBOL, MarketCapability.REAL_TIME_QUOTE_V1, NOW, expiration=EXPIRATION
+        )
+        assert subject.projection_for("tradier", "symbol", NOW).address_value == SYMBOL
+
+
+class _RecordingTransport:
+    """Zero-network fake ReadOnlyHttpTransport -- records every request and
+    returns one canned, realistic Tradier options-chain JSON response.
+    """
+
+    def __init__(self) -> None:
+        self.requests = []
+
+    def get(self, request):  # noqa: ANN001
+        self.requests.append(request)
+        body = {
+            "options": {
+                "option": [
+                    {
+                        "symbol": "AAPL260821C00210000",
+                        "option_type": "call",
+                        "expiration_date": EXPIRATION.isoformat(),
+                        "strike": 210.0,
+                        "bid": 4.9,
+                        "ask": 5.1,
+                        "last": 5.0,
+                        "volume": 1000,
+                        "open_interest": 5000,
+                        "underlying": SYMBOL,
+                        "trade_date": "2026-07-22T16:00:00Z",
+                        "greeks": {
+                            "delta": 0.5,
+                            "gamma": 0.03,
+                            "theta": -0.1,
+                            "vega": 0.2,
+                            "rho": 0.01,
+                            "mid_iv": 0.25,
+                        },
+                    }
+                ]
+            }
+        }
+        return ReadOnlyHttpResponse(200, body, (), 5, "fake-tradier-ref")
+
+
+def _tradier_config():
+    config = load_market_data_config(
+        {"ASA_TRADIER_ENABLED": "true", "ASA_TRADIER_ACCESS_TOKEN": "test-token-not-a-real-credential"}
+    )
+    return next(item for item in config.providers if item.provider_id == "tradier")
+
+
+class _FixedClock:
+    def now(self) -> datetime:
+        return NOW
+
+
+class TestRealTradierProviderAgainstAnExpirationAwareSubject:
+    def test_tradier_receives_the_selected_expiration_as_its_query_value(self) -> None:
+        """The end-to-end regression proof for issue #156: before
+        TRADIER-PATCH-001/002, any real OPTION_CHAIN_V1 acquisition against
+        Tradier raised DomainInvariantError before ever reaching the
+        transport, because no subject carried an "expiration" projection.
+        This exercises the real, unmodified TradierProvider against a fake
+        transport and confirms the request actually goes out with the
+        selected expiration in its query string.
+        """
+        clock = _FixedClock()
+        transport = _RecordingTransport()
+        config = _tradier_config()
+        budget_manager = build_request_budget_manager((config,), clock)
+        provider = TradierProvider(config, ProviderDependencies(transport, clock, budget_manager))
+        registry = ProviderRegistry((provider,))
+        capability_registry = build_capability_registry(registry)
+        fulfillment = CapabilityFulfillmentService(registry, capability_registry, budget_manager)
+
+        subject = build_capability_subject(
+            SYMBOL, MarketCapability.OPTION_CHAIN_V1, NOW, expiration=EXPIRATION
+        )
+        result = acquire_capability(
+            fulfillment,
+            MarketCapability.OPTION_CHAIN_V1,
+            subject,
+            effective_start=NOW,
+            effective_end=NOW,
+            required_fields=("contracts",),
+            maximum_age_seconds=3600,
+        )
+
+        assert result.status is FulfillmentStatus.FULFILLED
+        (observation,) = result.observations
+        assert isinstance(observation.value, OptionChain)
+        assert observation.value.contracts[0].expiration == EXPIRATION
+
+        (sent_request,) = transport.requests
+        assert ("expiration", EXPIRATION.isoformat()) in sent_request.query
+        assert ("symbol", SYMBOL) in sent_request.query


### PR DESCRIPTION
## Ticket
TRADIER-PATCH-002 (PATCH-007A, delegated merge under GOV-007A/Amendment 013, active since #158 merged)

## Summary
Adds canonical construction of option-chain subjects carrying the selected expiration projection Tradier's real API requires -- the second of PATCH-007A's four tickets fixing issue #156.

## Repository evidence -- investigated before implementing
- `market_data/tradier.py:253` (`subject.projection_for("tradier", "expiration", request.effective_end)`) is the exact call that previously always raised `DomainInvariantError` for a live option-chain request. `domain/market_data.py`'s `MarketDataSubject.projection_for()` requires an exact `(provider_id, address_type, time)` match -- confirmed by reading it directly, not assumed.
- Extended the existing `build_capability_subject()` (rather than adding a separate function) with an optional `expiration: date | None` parameter, following the same pattern TRADIER-PATCH-001 already established for `required_fields` -- backward-compatible, every existing caller's behavior is unchanged when `expiration` is omitted (proven by a dedicated regression test).
- Per the ticket's own requirement ("do not hard-code expiration selection policy in the Tradier provider"): `build_capability_subject()` never picks or defaults an expiration itself -- it only attaches whatever expiration a caller already selected. `market_data/tradier.py` itself is untouched by this PR.
- One projection per `KNOWN_PROVIDER_IDS` entry (mirroring the existing "symbol" projection's own uniform-across-providers shape), keeping "symbol" and "expiration" as separate, explicit projections per the ticket's own requirement -- no Tradier-specific addressing leaks anywhere outside `market_data/tradier.py`'s own lookup.
- Added a simple invariant: an `expiration` before `as_of` is rejected with a plain `ValueError` at construction time, rather than silently accepted and failing confusingly downstream.

## The proof this actually fixes #156, not just in isolation
The strongest test here (`TestRealTradierProviderAgainstAnExpirationAwareSubject`) doesn't stop at asserting the projection object looks right -- it constructs a subject via `build_capability_subject(..., expiration=date(2026, 8, 21))`, runs it through the **real, unmodified `TradierProvider` class** (`market_data/tradier.py`) against a fake, zero-network transport with a realistic Tradier JSON response, and confirms: (a) the outgoing request's query string actually carries `("expiration", "2026-08-21")`, and (b) `acquire_capability()` returns `FulfillmentStatus.FULFILLED` with a correctly-parsed `OptionChain` -- instead of the `DomainInvariantError` every real live option-chain acquisition raised before this patch.

## Relevant issues and PRs
#156 (the defect this patch fixes), #139 (the related, already-fixed instance of the same bug class in `backend/`'s independent code path), #158 (GOV-007A activation), #159 (TRADIER-PATCH-001, this ticket's prerequisite).

## Architecture compliance
- `tests/architecture/test_screening_boundaries.py` -- all 77 tests pass unchanged; no new import roots.
- No provider-specific addressing exposed to strategies -- `expiration` is a plain `date`, formatted as an ISO string only inside the projection itself.

## Security and secret handling
Secret scan (`grep -riE "token|secret|password|api[_-]?key|bearer"`) against both changed files: one match, the same clearly-labeled test placeholder credential (`"test-token-not-a-real-credential"`) already used elsewhere in this codebase's test suite (`tests/screening/test_cli.py`). No real credential material.

## Network behavior
None. The `TradierProvider` integration test uses a fake `ReadOnlyHttpTransport` double that never opens a socket -- it records the constructed request and returns a canned response in-process.

## Request budget behavior
Unchanged -- one `acquire_capability()` call per test, subject to the same `RequestBudgetManager` machinery as every other live acquisition.

## Tests
- `pytest tests/screening/test_live_context_expiration_aware_subjects.py` -> 6 passed.
- `pytest tests/` (full repo) -> 2191 passed, 2 skipped (pre-existing, unrelated).
- `pytest tests/architecture/test_screening_boundaries.py` -> 77 passed.
- `ruff check screening/ tests/screening/` -> clean.
- `mypy screening/live_context.py screening/live_adapters.py screening/live_acquisition.py screening/cli.py` -> zero errors.
- `tools/pos/lean/check_integrity.py` / `check_entrypoints.py` / `pre_push_check.py` -> all green.
- `git status --short` -> exactly `screening/live_context.py` and the one new test file.

## Live validation status
N/A for this ticket -- one integration test against the real `TradierProvider` class with a fake transport, zero real network or credentials. Live Tradier validation is TRADIER-PATCH-004's concern.

## Explicit exclusions
No live adapter wiring (TRADIER-PATCH-003). No error-classification changes (TRADIER-PATCH-004). No changes to `market_data/tradier.py` itself, strategies, `analytics/`, governance, or workflow files.

## Merge authority
`delegated_after_required_checks` per PATCH-007A/GOV-007A -- active since #158 merged. All required gates above are green. Per the established resolution for this sprint's/patch's known CI path-filter gap (#147, most recently confirmed for #159), if CI doesn't trigger on `screening/**`/`tests/screening/**` changes here either, local verification above is the basis for merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)