### PR TITLE
TRADIER-PATCH-003: two-step live option acquisition

### DIFF
--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -1,4 +1,4 @@
-"""Live target strategy adapters (LIVE-002).
+"""Live target strategy adapters (LIVE-002, PATCH-007A/TRADIER-PATCH-003).
 
 Live-data counterparts of screening/adapters.py's fixture-backed run_*
 functions: same manifests, same context_builders, same result
@@ -13,6 +13,18 @@ pair satisfying a strategy's DTE policy, raises StrategyAdapterError with
 MISSING_DATA -- an expected, isolated, non-crashing outcome (SCREEN-003),
 never a raw exception escaping to the runner's more generic
 STRATEGY_EXCEPTION handling.
+
+Option-chain acquisition is a two-step flow (TRADIER-PATCH-003, #156):
+Tradier's real endpoint is scoped to one expiration per request, so a
+strategy needing two expirations (Forward Factor, Earnings Calendar)
+discovers available expirations first (acquire_expirations,
+TRADIER-PATCH-001), selects the required pair via the same canonical
+selection functions screening/context_builders.py already uses, acquires
+one chain per selected expiration with an expiration-aware subject
+(TRADIER-PATCH-002), and combines them into one chain
+(combine_option_chains) before handing it to the unmodified context
+builders and strategy graphs -- never assuming one chain response covers
+every expiration.
 """
 
 from __future__ import annotations
@@ -25,7 +37,7 @@ from analytics.expiration_selection import (
     select_earnings_relative_expiration_pair,
     select_expiration_pair,
 )
-from domain import DomainInvariantError, EarningsEvent, MarketCapability, OptionType, Quote
+from domain import DomainInvariantError, EarningsEvent, MarketCapability, OptionChain, OptionType, Quote
 from market_data import CapabilityFulfillmentService, FulfillmentStatus
 from screening.clock import Clock
 from screening.context_builders import (
@@ -36,8 +48,9 @@ from screening.context_builders import (
 )
 from screening.live_acquisition import acquire_capability
 from screening.live_context import (
+    acquire_expirations,
     build_capability_subject,
-    expirations_from_chain,
+    combine_option_chains,
     select_atm_strike_at_expiration,
 )
 from screening.registry import ScreeningStrategyDefinition
@@ -110,8 +123,12 @@ def _acquire_or_raise(
     capability: MarketCapability,
     now: datetime,
     required_fields: tuple[str, ...],
+    *,
+    expiration: date | None = None,
 ) -> object:
-    subject = build_capability_subject(symbol, capability, now)
+    subject = build_capability_subject(
+        symbol, capability, now, required_fields=required_fields, expiration=expiration
+    )
     try:
         result = acquire_capability(
             fulfillment,
@@ -133,11 +150,33 @@ def _acquire_or_raise(
             f"no enabled live provider offers {capability.value} for {symbol}: {exc}",
         ) from exc
     if result.status is not FulfillmentStatus.FULFILLED or not result.observations:
-        raise StrategyAdapterError(
-            ScreeningOutcomeStatus.MISSING_DATA,
-            f"could not acquire live {capability.value} for {symbol}",
-        )
+        detail = f"could not acquire live {capability.value} for {symbol}"
+        if expiration is not None:
+            detail += f" at expiration {expiration.isoformat()}"
+        raise StrategyAdapterError(ScreeningOutcomeStatus.MISSING_DATA, detail)
     return result.observations[0].value
+
+
+def _acquire_combined_chain(
+    fulfillment: CapabilityFulfillmentService,
+    symbol: str,
+    now: datetime,
+    expirations: tuple[date, ...],
+) -> OptionChain:
+    """Acquire one option chain per distinct expiration in `expirations`
+    (deduplicated, order preserved) and combine them into a single chain --
+    the two-step live counterpart of a single, all-expirations fixture
+    chain fetch (TRADIER-PATCH-003).
+    """
+    unique_expirations = tuple(dict.fromkeys(expirations))
+    chains = tuple(
+        _acquire_or_raise(
+            fulfillment, symbol, MarketCapability.OPTION_CHAIN_V1, now, ("contracts",),
+            expiration=expiration,
+        )
+        for expiration in unique_expirations
+    )
+    return combine_option_chains(chains, observed_at=now)  # type: ignore[arg-type]
 
 
 def _spot_price(quote: Quote) -> Decimal:
@@ -162,10 +201,7 @@ def build_live_forward_factor_adapter(
             fulfillment, symbol, MarketCapability.REAL_TIME_QUOTE_V1, now, ("last",)
         )
         spot_price = _spot_price(quote)  # type: ignore[arg-type]
-        chain = _acquire_or_raise(
-            fulfillment, symbol, MarketCapability.OPTION_CHAIN_V1, now, ("contracts",)
-        )
-        available_expirations = expirations_from_chain(chain, as_of)  # type: ignore[arg-type]
+        available_expirations = acquire_expirations(fulfillment, symbol, now)
         candidates = tuple(
             ExpirationCandidate(cycle.expiration_date, cycle.days_to_expiration)
             for cycle in available_expirations
@@ -176,12 +212,13 @@ def build_live_forward_factor_adapter(
                 ScreeningOutcomeStatus.MISSING_DATA,
                 f"no expiration pair for {symbol} satisfies Forward Factor's DTE policy",
             )
-        front, _back = selected
-        strike = select_atm_strike_at_expiration(
-            chain, front.expiration_date, spot_price, OptionType.CALL  # type: ignore[arg-type]
+        front, back = selected
+        chain = _acquire_combined_chain(
+            fulfillment, symbol, now, (front.expiration_date, back.expiration_date)
         )
+        strike = select_atm_strike_at_expiration(chain, front.expiration_date, spot_price, OptionType.CALL)
         context = build_forward_factor_context(
-            chain, available_expirations, as_of, strike=strike, option_type=OptionType.CALL  # type: ignore[arg-type]
+            chain, available_expirations, as_of, strike=strike, option_type=OptionType.CALL
         )
         graph = compile_strategy_graph(FORWARD_FACTOR_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
         result = execute_strategy_graph(graph, context)
@@ -192,7 +229,7 @@ def build_live_forward_factor_adapter(
             symbol,
             result.outputs.get("verdict").value,
             result.outputs.get("forward_factor").value,
-            chain.evidence,  # type: ignore[attr-defined]
+            chain.evidence,
         )
 
     return _run
@@ -213,10 +250,7 @@ def build_live_earnings_calendar_adapter(
             fulfillment, symbol, MarketCapability.REAL_TIME_QUOTE_V1, now, ("last",)
         )
         spot_price = _spot_price(quote)  # type: ignore[arg-type]
-        chain = _acquire_or_raise(
-            fulfillment, symbol, MarketCapability.OPTION_CHAIN_V1, now, ("contracts",)
-        )
-        available_expirations = expirations_from_chain(chain, as_of)  # type: ignore[arg-type]
+        available_expirations = acquire_expirations(fulfillment, symbol, now)
         candidates = tuple(
             ExpirationCandidate(cycle.expiration_date, cycle.days_to_expiration)
             for cycle in available_expirations
@@ -246,8 +280,14 @@ def build_live_earnings_calendar_adapter(
             for cycle in available_expirations
             if cycle.expiration_date == back_candidate.expiration_date
         )
+        chain = _acquire_combined_chain(
+            fulfillment,
+            symbol,
+            now,
+            (front_candidate.expiration_date, back_candidate.expiration_date),
+        )
         target_strike = select_atm_strike_at_expiration(
-            chain, front_cycle.expiration_date, spot_price, OptionType.CALL  # type: ignore[arg-type]
+            chain, front_cycle.expiration_date, spot_price, OptionType.CALL
         )
         context = build_earnings_calendar_context(
             chain, event, front_cycle, back_cycle, as_of, target_strike=target_strike  # type: ignore[arg-type]
@@ -261,7 +301,7 @@ def build_live_earnings_calendar_adapter(
             symbol,
             result.outputs.get("verdict").value,
             result.outputs.get("score").value,
-            chain.evidence,  # type: ignore[attr-defined]
+            chain.evidence,
         )
 
     return _run
@@ -279,10 +319,7 @@ def build_live_skew_momentum_adapter(
             fulfillment, symbol, MarketCapability.REAL_TIME_QUOTE_V1, now, ("last",)
         )
         spot_price = _spot_price(quote)  # type: ignore[arg-type]
-        chain = _acquire_or_raise(
-            fulfillment, symbol, MarketCapability.OPTION_CHAIN_V1, now, ("contracts",)
-        )
-        available_expirations = expirations_from_chain(chain, as_of)  # type: ignore[arg-type]
+        available_expirations = acquire_expirations(fulfillment, symbol, now)
         future_expirations = tuple(
             cycle for cycle in available_expirations if cycle.expiration_date > as_of
         )
@@ -295,6 +332,14 @@ def build_live_skew_momentum_adapter(
         # upcoming expiration ("front month") is the simplest, standard,
         # non-editorial default absent any other established policy.
         nearest = min(future_expirations, key=lambda cycle: cycle.expiration_date)
+        chain = _acquire_or_raise(
+            fulfillment,
+            symbol,
+            MarketCapability.OPTION_CHAIN_V1,
+            now,
+            ("contracts",),
+            expiration=nearest.expiration_date,
+        )
         strike = select_atm_strike_at_expiration(
             chain, nearest.expiration_date, spot_price, OptionType.CALL  # type: ignore[arg-type]
         )

--- a/screening/live_context.py
+++ b/screening/live_context.py
@@ -13,6 +13,7 @@ non-controversial calendar rule, not strategy logic.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 
@@ -29,6 +30,7 @@ from domain import (
     MarketDataSubject,
     MarketDataSubjectType,
     OptionChain,
+    OptionContract,
     OptionType,
     ProviderAddressProjection,
 )
@@ -59,6 +61,53 @@ def select_atm_strike_at_expiration(
 def _is_monthly_expiration(expiration: date) -> bool:
     """Third Friday of the month -- the standard monthly options cycle."""
     return expiration.weekday() == 4 and 15 <= expiration.day <= 21
+
+
+def combine_option_chains(
+    chains: tuple[OptionChain, ...], observed_at: datetime
+) -> OptionChain:
+    """Combine one or more per-expiration OptionChain acquisitions into a
+    single OptionChain a strategy manifest can query across all of them
+    (TRADIER-PATCH-003).
+
+    Tradier's real option-chain endpoint scopes each request to one
+    expiration (TRADIER-PATCH-002/#156), so live acquisition of a strategy
+    that needs two expirations (Forward Factor, Earnings Calendar) makes
+    two separate chain requests -- but strategy components like
+    strategies/stonk_components.py's CalendarStructure expect one chain
+    object spanning every expiration they need, exactly like the offline
+    fixture's single, all-expirations-at-once response already provides.
+
+    OptionChain's own invariant requires every contract to share the
+    chain's own observed_at exactly. Contracts from separately-timed
+    acquisitions are rebuilt with one canonical observed_at (this
+    combination's own caller-supplied timestamp) -- never their raw
+    prices, strikes, or greeks -- the same modeling choice as treating
+    near-simultaneous per-expiration reads as one logical market-data
+    snapshot, not fabricating data.
+
+    Deduplicates by contract identity after normalizing observed_at: a
+    provider that (like the offline fixture) doesn't actually scope its
+    response to the requested expiration and returns the same contracts
+    for both requests would otherwise violate OptionCollection's own
+    duplicate-contract invariant on merge.
+    """
+    if not chains:
+        raise ValueError("combine_option_chains requires at least one chain")
+    underlying = chains[0].underlying
+    for chain in chains[1:]:
+        if chain.underlying.identity != underlying.identity:
+            raise ValueError("combine_option_chains requires every chain to share one underlying")
+    deduplicated: dict[str, OptionContract] = {}
+    for chain in chains:
+        for contract in chain.contracts:
+            normalized = replace(contract, observed_at=observed_at)
+            deduplicated[normalized.identity] = normalized
+    evidence = tuple(dict.fromkeys(item for chain in chains for item in chain.evidence))
+    chain_id = "combined:" + ":".join(chain.option_chain_id for chain in chains)
+    return OptionChain(
+        chain_id, underlying, observed_at, tuple(deduplicated.values()), evidence
+    )
 
 
 def expirations_from_chain(chain: OptionChain, as_of: date) -> tuple[ExpirationCycle, ...]:

--- a/tests/screening/test_live_adapters.py
+++ b/tests/screening/test_live_adapters.py
@@ -15,21 +15,30 @@ still zero network, still fully deterministic.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 
 from domain import (
     AnnouncementTime,
     CanonicalInstrumentIdentity,
+    CompletenessMetadata,
     EarningsEvent,
+    EvidenceKind,
+    EvidenceReference,
+    ExpirationCycle,
+    FreshnessMetadata,
+    FreshnessStatus,
     MarketCapability,
+    MarketObservation,
     OHLCVBar,
     OptionChain,
     OptionContract,
     OptionType,
+    ProviderProvenance,
     Quote,
     Security,
     SecurityAssetType,
+    market_observation_identity,
 )
 from market_data import (
     CapabilityFulfillmentService,
@@ -41,6 +50,13 @@ from market_data import (
     load_market_data_config,
 )
 from market_data.fixture import DeterministicFixtureProvider
+from market_data.providers import (
+    ProviderAttemptMetadata,
+    ProviderErrorCode,
+    ProviderFetchResult,
+    ProviderResponseMetadata,
+    normalized_provider_error,
+)
 from screening.adapters import TARGET_STRATEGY_REGISTRY
 from screening.live_acquisition import build_capability_registry, build_request_budget_manager
 from screening.live_adapters import build_live_adapters
@@ -324,3 +340,209 @@ class TestFullLiveRunAcrossAllThreeStrategies:
             "skew_momentum",
         }
         assert all(result.subject_identity == f"symbol:{SYMBOL}" for result in results)
+
+
+class TradierShapedMultiExpirationProvider(DeterministicFixtureProvider):
+    """Reproduces real Tradier's actual two-step option-chain acquisition
+    shape (market_data/tradier.py's own required_fields branching), unlike
+    MultiExpirationFixtureProvider above (which -- like the real offline
+    fixture -- always returns every expiration's contracts in one unscoped
+    response, regardless of what was asked for). Each OPTION_CHAIN_V1
+    contracts request here is scoped to exactly the expiration named in the
+    subject's own "expiration" projection -- looked up the same way real
+    Tradier looks it up (subject.projection_for(self.provider_id,
+    "expiration", ...)), so this proves TRADIER-PATCH-003's adapters
+    actually drive the real two-step flow (discover expirations, select,
+    acquire per expiration), not just that they still work against a
+    provider generous enough not to need it.
+
+    option_chain_requests records every OPTION_CHAIN_V1 request's
+    required_fields, in order, for request-count and deduplication
+    assertions.
+    """
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        self.option_chain_requests: list[tuple[str, ...]] = []
+
+    def fetch(self, request, budget):  # noqa: ANN001
+        if request.capability is MarketCapability.OPTION_CHAIN_V1:
+            self.option_chain_requests.append(request.required_fields)
+            if "expirations" in request.required_fields and "contracts" not in request.required_fields:
+                return self._expirations_response(request)
+            if "contracts" in request.required_fields:
+                return self._chain_response_for_one_expiration(request)
+        return super().fetch(request, budget)
+
+    def _attempt(self, request, reference, received_at):  # noqa: ANN001
+        response = ProviderResponseMetadata(
+            self.provider_id, reference, received_at, "fixture", 0, 0, (("network_requests", "0"),)
+        )
+        return ProviderAttemptMetadata(self.provider_id, request.capability, 1, 1, response)
+
+    def _expirations_response(self, request):  # noqa: ANN001
+        received_at = self._dependencies.clock.now().astimezone(UTC)
+        reference = self._request_reference(request)
+        (subject,) = request.subjects
+        as_of = received_at.date()
+        evidence = (EvidenceReference(EvidenceKind.OBSERVATION, "test:tradier-shaped-multi"),)
+        observations = tuple(
+            MarketObservation(
+                market_observation_identity(
+                    self.provider_id, request.capability, subject, received_at, cycle, "v1"
+                ),
+                request.capability,
+                subject,
+                received_at,
+                received_at,
+                cycle,
+                "v1",
+                ProviderProvenance(self.provider_id, reference, evidence),
+                FreshnessMetadata(received_at, received_at, request.maximum_age_seconds, 0, FreshnessStatus.FRESH),
+                CompletenessMetadata(request.required_fields, request.required_fields, ()),
+            )
+            for cycle in (
+                ExpirationCycle(as_of + timedelta(days=days_out), days_out, False, True, as_of, evidence)
+                for days_out, _iv in _EXPIRATIONS_DAYS_OUT_AND_IV
+            )
+        )
+        return ProviderFetchResult(observations, None, (self._attempt(request, reference, received_at),))
+
+    def _chain_response_for_one_expiration(self, request):  # noqa: ANN001
+        (subject,) = request.subjects
+        projection = subject.projection_for(self.provider_id, "expiration", request.effective_end)
+        expiration = date.fromisoformat(projection.address_value)
+        received_at = self._dependencies.clock.now().astimezone(UTC)
+        reference = self._request_reference(request)
+        as_of = received_at.date()
+        days_out = (expiration - as_of).days
+        iv = next(iv for offset_days, iv in _EXPIRATIONS_DAYS_OUT_AND_IV if offset_days == days_out)
+        symbol = subject.canonical_instrument.display_symbol
+        security = Security(subject.canonical_instrument, symbol.upper(), SecurityAssetType.EQUITY, "XNAS")
+        evidence = (
+            EvidenceReference(EvidenceKind.OBSERVATION, f"test:tradier-shaped-chain:{expiration.isoformat()}"),
+        )
+        contracts = tuple(
+            OptionContract(
+                CanonicalInstrumentIdentity(
+                    "fixture-option", f"{symbol}-{expiration.isoformat()}-{_SPOT + offset}-{kind.value}"
+                ),
+                security,
+                expiration,
+                _SPOT + offset,
+                kind,
+                Decimal("4.90"),
+                Decimal("5.10"),
+                Decimal("5.00"),
+                1000,
+                5000,
+                call_delta if kind is OptionType.CALL else call_delta - 1,
+                Decimal("0.03"),
+                Decimal("-0.10"),
+                Decimal("0.20"),
+                Decimal("0.01"),
+                iv,
+                received_at,
+                evidence,
+            )
+            for offset, call_delta in _STRIKE_DELTA_LADDER
+            for kind in (OptionType.CALL, OptionType.PUT)
+        )
+        chain = OptionChain(
+            f"test:tradier-shaped:{expiration.isoformat()}", security, received_at, contracts, evidence
+        )
+        observation = MarketObservation(
+            market_observation_identity(
+                self.provider_id, request.capability, subject, received_at, chain, "v1"
+            ),
+            request.capability,
+            subject,
+            received_at,
+            received_at,
+            chain,
+            "v1",
+            ProviderProvenance(self.provider_id, reference, evidence),
+            FreshnessMetadata(received_at, received_at, request.maximum_age_seconds, 0, FreshnessStatus.FRESH),
+            CompletenessMetadata(request.required_fields, request.required_fields, ()),
+        )
+        return ProviderFetchResult(
+            (observation,), None, (self._attempt(request, reference, received_at),)
+        )
+
+
+class TestTwoStepLiveAcquisitionAgainstATradierShapedProvider:
+    def test_forward_factor_receives_front_and_back_expiration_chains(self) -> None:
+        fulfillment, clock = _fulfillment(TradierShapedMultiExpirationProvider)
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        (result,) = run_screening(
+            TARGET_STRATEGY_REGISTRY, adapters, clock, strategy_ids=("forward_factor",)
+        )
+        assert result.outcome_status in (ScreeningOutcomeStatus.PASS, ScreeningOutcomeStatus.NO_SIGNAL)
+
+    def test_skew_momentum_receives_its_one_required_expiration_chain(self) -> None:
+        fulfillment, clock = _fulfillment(TradierShapedMultiExpirationProvider)
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        (result,) = run_screening(
+            TARGET_STRATEGY_REGISTRY, adapters, clock, strategy_ids=("skew_momentum",)
+        )
+        assert result.outcome_status in (ScreeningOutcomeStatus.PASS, ScreeningOutcomeStatus.NO_SIGNAL)
+
+    def test_forward_factor_makes_exactly_three_option_chain_requests(self) -> None:
+        # One expirations-only request, one contracts request per selected
+        # expiration (front, back) -- proves the two-step flow, not a
+        # single all-expirations fetch. Constructed directly (not via
+        # _fulfillment()) to keep a direct reference to the provider
+        # instance for its own request-log, without reaching into
+        # CapabilityFulfillmentService's private internals.
+        shared_clock = FixedClock()
+        config = load_market_data_config({})
+        (fixture_config,) = tuple(item for item in config.providers if item.enabled)
+        budget_manager = build_request_budget_manager((fixture_config,), shared_clock)
+        provider = TradierShapedMultiExpirationProvider(
+            fixture_config, ProviderDependencies(object(), shared_clock, budget_manager)
+        )
+        registry = ProviderRegistry((provider,))
+        capability_registry = build_capability_registry(registry)
+        fulfillment = CapabilityFulfillmentService(registry, capability_registry, budget_manager)
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        run_screening(TARGET_STRATEGY_REGISTRY, adapters, shared_clock, strategy_ids=("forward_factor",))
+        assert len(provider.option_chain_requests) == 3
+        assert provider.option_chain_requests[0] == ("expirations",)
+        assert all(request == ("contracts",) for request in provider.option_chain_requests[1:])
+
+    def test_a_failed_expiration_specific_chain_request_does_not_crash_the_run(self) -> None:
+        # The back-expiration chain request fails (a genuine per-request
+        # provider failure -- rate limit, timeout, bad data -- unrelated to
+        # whether the front request already succeeded); the whole
+        # screening run must still isolate this as one MISSING_DATA result
+        # for forward_factor, not crash or corrupt the other strategies.
+        class _BackExpirationFailsProvider(TradierShapedMultiExpirationProvider):
+            def _chain_response_for_one_expiration(self, request):  # noqa: ANN001
+                (subject,) = request.subjects
+                projection = subject.projection_for(self.provider_id, "expiration", request.effective_end)
+                expiration = date.fromisoformat(projection.address_value)
+                if (expiration - self._dependencies.clock.now().date()).days >= 49:
+                    reference = self._request_reference(request)
+                    received_at = self._dependencies.clock.now().astimezone(UTC)
+                    error = normalized_provider_error(
+                        ProviderErrorCode.PROVIDER_UNAVAILABLE,
+                        "simulated back-expiration failure",
+                        self.provider_id,
+                        request.capability,
+                        reference,
+                    )
+                    return ProviderFetchResult((), error, (self._attempt(request, reference, received_at),))
+                return super()._chain_response_for_one_expiration(request)
+
+        fulfillment, clock = _fulfillment(_BackExpirationFailsProvider)
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        results = run_screening(TARGET_STRATEGY_REGISTRY, adapters, clock)
+        by_strategy = {result.strategy_id: result for result in results}
+        assert by_strategy["forward_factor"].outcome_status is ScreeningOutcomeStatus.MISSING_DATA
+        # skew_momentum only needs one (front-month) expiration, unaffected
+        # by the back-expiration failure -- proves isolation is per
+        # acquisition, not a whole-provider outage.
+        assert by_strategy["skew_momentum"].outcome_status in (
+            ScreeningOutcomeStatus.PASS,
+            ScreeningOutcomeStatus.NO_SIGNAL,
+        )


### PR DESCRIPTION
## Ticket
TRADIER-PATCH-003 (PATCH-007A, delegated merge under GOV-007A/Amendment 013, active since #158 merged)

## Summary
Updates all three live strategy adapters to discover expirations, select the required expiration(s), and acquire one chain per expiration before constructing strategy inputs -- the third of PATCH-007A's four tickets fixing issue #156. This is where TRADIER-PATCH-001 and TRADIER-PATCH-002's pieces actually get wired together into live adapter orchestration.

## Repository evidence -- investigated before implementing
- `strategies/stonk_components.py`'s `CalendarStructure`/`_calendar()` (used by Forward Factor's `double_calendar` manifest node) needs **one** `OptionChain` object containing both the front and back expiration's contracts -- confirmed by reading it directly, not assumed. This ruled out simply passing two separate chains to `build_forward_factor_context()`; a genuine combine step is required.
- `OptionChain.__post_init__` (`domain/financial.py`) requires every contract to share the chain's own `observed_at` exactly, and `OptionCollection.__post_init__` raises on duplicate contract identities. Both discovered while writing `combine_option_chains()`, not assumed up front -- the first version without contract deduplication broke the *existing* fixture-backed tests, whose `MultiExpirationFixtureProvider` double returns the same full chain regardless of which expiration was requested (front-acquisition and back-acquisition would return identical contracts, colliding on merge).
- `_acquire_or_raise()` previously called `build_capability_subject(symbol, capability, now)` without passing `required_fields` explicitly, relying on its internal default happening to match every existing call site's own `required_fields` argument. This is the same class of latent mismatch TRADIER-PATCH-001 found and fixed for `acquire_expirations()` -- closed here too, now that `_acquire_or_raise` needs to pass a *different* `required_fields`/`expiration` combination per call site.

## The proof this actually drives a real two-step flow
`MultiExpirationFixtureProvider` (LIVE-002's existing test double) can't prove per-expiration scoping works, because it ignores `required_fields`/`expiration` entirely and always returns everything at once -- a bug in the adapter orchestration (e.g. forgetting to pass `expiration=`) would still pass every existing test. `TradierShapedMultiExpirationProvider` (new, this PR) reproduces Tradier's actual behavior: expirations-only requests return separate `ExpirationCycle` observations, and contracts requests are scoped to exactly the expiration named in the subject's own `"expiration"` projection (looked up the same way real Tradier looks it up). Against it: `test_forward_factor_makes_exactly_three_option_chain_requests` confirms exactly one expirations-list request plus one contracts request per selected expiration (not a single broad fetch), and `test_a_failed_expiration_specific_chain_request_does_not_crash_the_run` confirms a back-expiration-only provider failure isolates cleanly (forward_factor -> MISSING_DATA) without affecting skew_momentum (which only needs the front-month expiration, unaffected).

## Relevant issues and PRs
#156 (the defect this patch fixes), #139 (the related, already-fixed instance of the same bug class in `backend/`'s independent code path), #158 (GOV-007A activation), #159/#160 (TRADIER-PATCH-001/002, this ticket's prerequisites).

## Architecture compliance
- `tests/architecture/test_screening_boundaries.py` + `test_analytics_boundaries.py` -> 124 passed unchanged; no new import roots.
- No strategy decision logic touched -- `strategies/` package is untouched by this PR. No provider workflow moved into strategy packages -- all orchestration stays in `screening/live_adapters.py`.
- `screening/adapters.py` (the fixture-backed, non-live path) is untouched -- this PR only changes the live acquisition path.

## Security and secret handling
Secret scan (`grep -riE "token|secret|password|api[_-]?key|bearer"`) against all three changed files: zero matches.

## Network behavior
None. All new tests use `TradierShapedMultiExpirationProvider`, a zero-network, fully deterministic offline double.

## Request budget behavior
Request count per strategy run increased -- forward_factor and earnings_calendar now make 2 extra chain requests each (expirations-list + a second per-expiration chain, replacing one broad fetch); skew_momentum makes 1 extra (expirations-list, replacing the implicit derivation from a single broad fetch). None of this raises or bypasses any configured `RequestBudgetPolicy` ceiling -- `RequestBudgetManager` enforces whatever ceiling is already configured per provider, unchanged by this PR, and a rejection converts to a clean isolated `MISSING_DATA` result the same way any other unfulfillable request already does. `_acquire_combined_chain()` deduplicates requested expirations before acquiring, so a strategy needing the same expiration twice (not currently possible given the DTE policies' minimum gaps, but defensively handled) makes exactly one request for it.

## Tests
- `pytest tests/screening/test_live_adapters.py` -> 11 passed (7 existing fixture-backed tests unchanged and still green, 4 new Tradier-shaped two-step tests).
- `pytest tests/` (full repo) -> 2195 passed, 2 skipped (pre-existing, unrelated).
- `pytest tests/architecture/test_screening_boundaries.py tests/architecture/test_analytics_boundaries.py` -> 124 passed.
- `ruff check screening/ tests/screening/` -> clean.
- `mypy screening/live_context.py screening/live_adapters.py screening/live_acquisition.py screening/cli.py` -> zero errors (several previously-necessary `# type: ignore` comments on `chain`-typed values were removable now that `_acquire_combined_chain()` returns a properly-typed `OptionChain` instead of `object`).
- `tools/pos/lean/check_integrity.py` / `check_entrypoints.py` / `pre_push_check.py` -> all green.
- `git status --short` -> exactly `screening/live_context.py`, `screening/live_adapters.py`, and their test file.

## Live validation status
N/A for this ticket -- fixture-backed and Tradier-shaped-double-backed only, per TRADIER-PATCH-003's own scope. Live Tradier validation is TRADIER-PATCH-004's concern.

## Explicit exclusions
No error-classification changes (TRADIER-PATCH-004 -- `_acquire_or_raise`'s existing `DomainInvariantError` handling is unchanged here, only extended with the new `expiration` parameter). No changes to `market_data/tradier.py`, `strategies/`, `screening/adapters.py` (fixture-backed path), `analytics/`, governance, or workflow files.

## Merge authority
`delegated_after_required_checks` per PATCH-007A/GOV-007A -- active since #158 merged. All required gates above are green. Per the established resolution for this patch's known CI path-filter gap (#147, confirmed for #159 and #160), if CI doesn't trigger on `screening/**`/`tests/screening/**` changes here either, local verification above is the basis for merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)