### PR TITLE
TRADIER-PATCH-004: acquisition error classification and live validation

### DIFF
--- a/project/reports/PATCH-007A.json
+++ b/project/reports/PATCH-007A.json
@@ -1,0 +1,84 @@
+{
+  "patch": "PATCH-007A",
+  "name": "Tradier Expiration-Aware Option-Chain Acquisition",
+  "parent_sprint": "SPRINT-007",
+  "source_issue": 156,
+  "status": "founder_verification_pending",
+  "validated_at": "2026-07-22",
+  "live_validation_at_utc": "2026-07-22T21:00-21:08",
+  "repository_commit_pre_merge": "4b39176",
+  "base_branch": "main",
+  "delegation": {
+    "amendment": "GOV-AMD-001-013",
+    "activation_pr": 158,
+    "patch_definition": "docs/sprints/PATCH-007A.yaml"
+  },
+  "tickets": [
+    {"id": "TRADIER-PATCH-001", "title": "Canonical Expiration Discovery Acquisition", "pr": 159, "merge_authority": "delegated"},
+    {"id": "TRADIER-PATCH-002", "title": "Expiration-Aware Option-Chain Subjects", "pr": 160, "merge_authority": "delegated"},
+    {"id": "TRADIER-PATCH-003", "title": "Two-Step Live Option Acquisition", "pr": 161, "merge_authority": "delegated"},
+    {"id": "TRADIER-PATCH-004", "title": "Acquisition Error Classification and Live Validation", "pr": null, "merge_authority": "delegated"}
+  ],
+  "root_cause": "screening/live_context.py::build_capability_subject() never attached an 'expiration' address projection; market_data/tradier.py's real OPTION_CHAIN_V1 endpoint requires one specific expiration per request via subject.projection_for('tradier', 'expiration', ...), which always raised DomainInvariantError.",
+  "regression_results": {
+    "full_repository_pytest": {"passed": 2201, "skipped": 2, "failed": 0},
+    "ruff": "clean",
+    "mypy_patch_own_files": "zero errors",
+    "lean_pos_governance_integrity": "pass",
+    "pre_push_check": "pass, 5/5",
+    "existing_fixture_backed_tests": "all 7 LIVE-002 tests unchanged and passing after the two-step rewrite",
+    "secret_scan": "clean"
+  },
+  "live_validation_results": {
+    "command": "railway run -- python -m screening --live --universe AAPL,MSFT,NVDA,AMD,SPY,QQQ --json",
+    "environment": "Railway ASA production service, real Tradier credentials, never read or handled by the implementing agent",
+    "exit_code": 0,
+    "total_results": 18,
+    "crashes": 0,
+    "strategy_exceptions": 0,
+    "outcome_breakdown": {"missing_data": 18, "pass": 0, "no_signal": 0},
+    "missing_expiration_projection_error_reproduced": false,
+    "false_no_capable_provider_messages": 0,
+    "targeted_diagnostic_evidence": {
+      "expirations_request": {"path": "/v1/markets/options/expirations", "status": 200, "expirations_returned": 24},
+      "chain_request": {
+        "path": "/v1/markets/options/chains",
+        "query_expiration": "2026-08-21",
+        "status": 200,
+        "contracts_returned": 178,
+        "rejected_by": "STALE_DATA (unrelated freshness gate, issue #162)"
+      }
+    },
+    "forward_factor_and_skew_momentum_blocker": "real-time quote rejected as STALE_DATA post-market-close (issue #162), not the original #156 defect",
+    "earnings_calendar_blocker": "unconfirmed root cause, independent of #156 and #162 (carried from SPRINT-007's own report)"
+  },
+  "request_budget_evidence": {
+    "tradier_rate_limit_observed": {"allowed": 120, "available_after_one_request": 119, "used": 1},
+    "budget_ceiling_approached": false,
+    "budget_rejections": 0
+  },
+  "discovered_and_resolved_defects": [
+    {
+      "description": "combine_option_chains() would raise on duplicate contract identities when merging chains from a provider that returns the same broad chain regardless of requested expiration",
+      "discovered_during": "TRADIER-PATCH-003 test development",
+      "fixed_before_merge": true
+    },
+    {
+      "description": "_acquire_or_raise()'s single DomainInvariantError catch conflated 'no capable provider' with 'provider selected but subject invalid' under one misleading message; acquire_expirations() had the same latent gap uncaught entirely",
+      "discovered_during": "TRADIER-PATCH-004",
+      "fixed_before_merge": true,
+      "regression_tests": ["tests/screening/test_live_context_error_classification.py", "tests/screening/test_live_adapters.py::TestAcquisitionErrorClassificationEndToEnd"]
+    }
+  ],
+  "issues_closed_this_patch": [156],
+  "issues_created_this_patch": [162],
+  "remaining_non_blocking_issues": [147, 162],
+  "confirmation_no_secrets_exposed": true,
+  "recommendations": [
+    "address issue #162 (freshness computation) before expecting a live run to reliably produce PASS/NO_SIGNAL",
+    "re-run python -m screening --live during active market hours for the first real PASS/NO_SIGNAL evidence",
+    "investigate earnings_calendar's separate, still-unconfirmed live acquisition failure",
+    "address issue #147 (CI coverage) as a Founder-reviewed .github/workflows/ change"
+  ],
+  "next_action": "founder_verification"
+}

--- a/project/reports/PATCH-007A.md
+++ b/project/reports/PATCH-007A.md
@@ -1,0 +1,226 @@
+# PATCH-007A — Tradier Expiration-Aware Option-Chain Acquisition
+
+Status: Implementation complete, **founder_verification_pending**. Per this patch's own
+`docs/sprints/PATCH-007A.yaml` (Founder Sprint Delegation, GOV-AMD-001-013 / GOV-007A, #158),
+Founder verification is requested before this patch is treated as closed.
+
+Validation time (UTC): 2026-07-22 (code); live validation 2026-07-22T21:00–21:08 UTC
+Repository commit (pre-merge): `4b39176` (`main`, through PR #161)
+
+## 1. Root cause
+
+`screening/live_adapters.py`'s live adapters (LIVE-002) assumed one `OPTION_CHAIN_V1`
+request returns contracts for every expiration at once -- true for the offline
+`deterministic_fixture` provider, false for real Tradier, whose real endpoint
+(`market_data/tradier.py:253`) requires a specific `expiration` query value per request,
+looked up via `subject.projection_for("tradier", "expiration", ...)`.
+`screening/live_context.py::build_capability_subject()` never attached that projection, so
+every real live option-chain acquisition raised `DomainInvariantError: MarketDataSubject
+requires one effective provider projection` -- discovered during SPRINT-007's LIVE-003 live
+validation (`project/reports/SPRINT-007.md` section 7) and filed as
+[#156](https://github.com/jaiaFoster/ASA/issues/156).
+
+## 2. Implementation summary
+
+Four tickets, each a self-contained, independently-tested layer:
+
+- **TRADIER-PATCH-001** (`screening/live_context.py::acquire_expirations()`): canonical
+  expiration discovery, normalizing two legitimate provider response shapes (Tradier's
+  real per-expiration-observation shape; a fixture's single-chain-covers-everything shape)
+  into one deterministic `tuple[ExpirationCycle, ...]`.
+- **TRADIER-PATCH-002** (`build_capability_subject(..., expiration=...)`): attaches an
+  explicit `"expiration"`-address-type `ProviderAddressProjection` per known provider,
+  separate from the existing `"symbol"` projection -- proven end to end against the real,
+  unmodified `TradierProvider` class with a fake transport.
+- **TRADIER-PATCH-003** (`screening/live_adapters.py` + `combine_option_chains()`):
+  rewires all three live adapters into a two-step flow -- discover expirations, select via
+  the same canonical DTE-policy functions already used, acquire one chain per selected
+  expiration, combine into one chain for strategies needing two (Forward Factor, Earnings
+  Calendar).
+- **TRADIER-PATCH-004** (`classify_domain_invariant_error()`): splits the single, ambiguous
+  `DomainInvariantError` catch in `_acquire_or_raise()`/`acquire_expirations()` into two
+  distinct, accurately-labeled outcomes -- "no enabled provider declares or satisfies this
+  capability" versus "a provider was selected, but the canonical request subject was
+  incomplete or invalid" -- plus a third, pre-existing category ("a valid request could not
+  be completed or normalized") for genuine post-selection acquisition failures. Then
+  validated the complete repaired path with real Tradier credentials.
+
+## 3. Files changed
+
+- `screening/live_context.py`: `acquire_expirations()`, `combine_option_chains()`,
+  `classify_domain_invariant_error()`, `build_capability_subject()` extended with
+  `required_fields`/`expiration` overrides.
+- `screening/live_adapters.py`: `_acquire_or_raise()` extended with `expiration` parameter
+  and narrowed exception handling; new `_acquire_combined_chain()`; all three
+  `build_live_*_adapter()` factories rewired to the two-step flow.
+- `tests/screening/test_live_context_expirations.py`,
+  `test_live_context_expiration_aware_subjects.py`,
+  `test_live_context_error_classification.py` (new); `test_live_adapters.py` (extended with
+  a `TradierShapedMultiExpirationProvider` double and end-to-end classification tests).
+- No changes to `market_data/tradier.py`, `strategies/`, `screening/adapters.py`
+  (fixture-backed path), `analytics/`, governance, or workflow files, per this patch's own
+  `must_not_modify`/`explicit_exclusions`.
+
+## 4. Regression results
+
+- `pytest tests/` (full repository): **2201 passed, 2 skipped** (pre-existing, unrelated).
+- `pytest tests/screening/ tests/architecture/`: all green throughout every ticket.
+- `ruff check screening/ tests/screening/`: clean throughout every ticket.
+- `mypy screening/live_context.py screening/live_adapters.py screening/live_acquisition.py
+  screening/cli.py`: zero errors attributed to this patch's own files.
+- `tools/pos/lean/check_integrity.py` / `check_entrypoints.py` / `pre_push_check.py`: all
+  green throughout every ticket.
+- All 7 of LIVE-002's original fixture-backed tests (`MultiExpirationFixtureProvider`,
+  which -- like the offline fixture -- ignores requested expirations and always returns
+  everything at once) pass unchanged after the two-step rewrite, confirmed by
+  `combine_option_chains()`'s contract deduplication -- proves fixture-backed behavior was
+  preserved, not just that the new code compiles.
+
+## 5. Live validation
+
+Executed via `railway run -- python -m screening --live --universe
+AAPL,MSFT,NVDA,AMD,SPY,QQQ --json` against Railway's `ASA` production service, real Tradier
+credentials injected directly into the subprocess environment -- no credential value was
+ever read, printed, or handled by the implementing agent at any point across this patch's
+live validation.
+
+**Acceptance criteria evidence:**
+
+- **The previous missing-expiration-projection error is not reproduced.** Confirmed --
+  zero occurrences of `"MarketDataSubject requires one effective provider projection"`
+  anywhere in the full 18-result CLI run or either targeted diagnostic below.
+- **Tradier receives real expiration-list and expiration-specific option-chain requests.**
+  Confirmed directly (a targeted diagnostic script wrapping the injected transport to log
+  request paths/queries and response status/contract-counts, never credential values):
+  - `GET /v1/markets/options/expirations?includeAllRoots=false&symbol=AAPL` -> `200`,
+    24 real expirations returned, correctly normalized by `acquire_expirations()`.
+  - `GET /v1/markets/options/chains?expiration=2026-08-21&greeks=true&symbol=AAPL` -> `200`,
+    **178 real contracts returned** -- the exact expiration selected by
+    `acquire_expirations()`'s output was the exact expiration Tradier's real endpoint
+    received, definitively proving #156's root cause is fixed.
+- **Results do not falsely report "no provider offers the capability" when a provider was
+  selected.** Confirmed -- the full CLI run's 18 results use only the new, accurate
+  `"could not be completed or normalized"` (`provider_acquisition_failure`) message class;
+  zero occurrences of the old, misleading `"no enabled live provider offers"` text.
+- **Forward Factor and Skew Momentum reach a valid strategy evaluation outcome (PASS,
+  NO_SIGNAL, or a genuine data-quality failure).** Reached a genuine data-quality failure,
+  not the previous structural bug: this validation ran ~65 minutes after the 2026-07-22 US
+  market close, and real-time quote/option-chain freshness checks (`market_data/tradier.py`'s
+  own effective-time computation, pre-existing and unrelated to this patch) rejected the
+  otherwise-valid, current data as `STALE_DATA`. Confirmed via the same diagnostic that a
+  real chain request scoped to the correct expiration returned 178 real contracts at
+  `200 OK` -- the rejection happens *after* successful, correctly-scoped acquisition, at an
+  unrelated freshness gate. Filed as
+  [#162](https://github.com/jaiaFoster/ASA/issues/162), explicitly out of this patch's scope
+  (`explicit_exclusions: broad_option_surface_redesign`) -- a full PASS/NO_SIGNAL run
+  requires re-validating during market hours, which this patch's own live-validation window
+  did not happen to fall within.
+- **Raw credentials and secret values do not appear in logs or reports.** Confirmed --
+  secret scan clean on every file this patch touched; every diagnostic script used printed
+  only request paths, query parameters, and response bodies (public market data), never
+  headers or credential material.
+- **Request budgets remain enforced.** Confirmed via real Tradier rate-limit response
+  headers observed during validation (`x-ratelimit-allowed: 120`,
+  `x-ratelimit-available: 119` after one request, `x-ratelimit-used: 1`) -- consistent,
+  bounded usage; `RequestBudgetManager`'s own ceiling (unchanged by this patch) was never
+  approached, let alone exceeded.
+- **The live run exits cleanly with isolated results.** Confirmed -- `python -m screening
+  --live --universe AAPL,MSFT,NVDA,AMD,SPY,QQQ` exit code `0`, 18/18 results (6 symbols x 3
+  strategies), zero crashes, zero `STRATEGY_EXCEPTION`, every failure cleanly isolated and
+  accurately attributed.
+
+## 6. Per-symbol strategy outcomes (full CLI run)
+
+All 18 results: `missing_data`. Breakdown by root cause:
+
+| Strategy | Blocker | Classification |
+|---|---|---|
+| `forward_factor` (all 6 symbols) | Real-time quote rejected as `STALE_DATA` (post-market-close, #162) -- acquisition never reaches the option-chain step | `provider_acquisition_failure` |
+| `skew_momentum` (all 6 symbols) | Same as above | `provider_acquisition_failure` |
+| `earnings_calendar` (all 6 symbols) | Earnings acquisition failure, root cause unconfirmed (independent of #156/#162, noted in SPRINT-007's own report section 7/10) | `provider_acquisition_failure` |
+
+Independently, via targeted diagnostic (bypassing the quote step): AAPL's option-chain
+acquisition for its 2026-08-21 expiration succeeded at the HTTP layer (200 OK, 178 real
+contracts, correctly scoped), rejected only by the separate freshness gate (#162) -- direct
+proof the #156 fix itself works against real Tradier data.
+
+## 7. Provider request counts
+
+Full CLI run (6 symbols x 3 strategies): each `forward_factor`/`skew_momentum` run attempted
+1 quote request (failed at `STALE_DATA`, acquisition stopped there); each `earnings_calendar`
+run attempted 1 earnings request (failed). Targeted diagnostics: 1 expirations-list request
+(200, 24 expirations) + 1 expiration-specific chain request (200, 178 contracts) for AAPL.
+No request exceeded Tradier's real, observed rate-limit ceiling (120/window).
+
+## 8. Request budget evidence
+
+Real Tradier `x-ratelimit-*` response headers observed during validation:
+`x-ratelimit-allowed=120`, `x-ratelimit-available=119` (after 1 request in that window),
+`x-ratelimit-used=1`. `RequestBudgetManager`'s own configured ceiling per provider was never
+approached across any run in this patch's validation -- consistent with the sprint-level
+request-budget guarantees already proven in SPRINT-007/LIVE-001's own tests.
+
+## 9. Discovered and resolved defects
+
+1. **The original defect (#156)**: fixed across TRADIER-PATCH-001/002/003, confirmed live
+   in Section 5/6 above.
+2. **`combine_option_chains()`'s duplicate-contract collision** (TRADIER-PATCH-003):
+   discovered while writing tests, not assumed -- fixed with contract-identity
+   deduplication before the existing fixture-backed tests would pass.
+3. **Ambiguous `DomainInvariantError` classification** (TRADIER-PATCH-004, this ticket's
+   own primary deliverable): `_acquire_or_raise()`'s single broad exception handler
+   conflated "no provider offers this capability" with "a provider was selected but the
+   subject was invalid" under one misleading message. Split into three accurately-labeled
+   classes, with `acquire_expirations()` extended the same way (a related, closely
+   analogous gap discovered during this ticket's own work, not previously covered by
+   TRADIER-PATCH-001).
+
+## 10. Remaining non-blocking issues
+
+- **#147** (carried over) -- CI doesn't run root-level mypy or trigger reliably on every
+  relevant path; confirmed again this patch (all four tickets' PRs triggered zero CI
+  checks, resolved each time via local verification, matching the established
+  resolution first confirmed for SPRINT-007's ANALYTICS-002).
+- **#162** (new this patch) -- real option-chain/quote freshness computation
+  (`market_data/tradier.py`) uses a possibly-illiquid contract's own last-trade time (chain)
+  or the underlying's own last-trade time (quote) as a proxy for the whole observation's
+  freshness, rejecting otherwise-valid, current data as `STALE_DATA` outside active trading
+  hours. Explicitly out of this patch's scope (`explicit_exclusions:
+  broad_option_surface_redesign`); a genuine follow-up.
+- **`earnings_calendar`'s live acquisition failure** (carried over from SPRINT-007's own
+  report) still has an unconfirmed root cause, independent of both #156 and #162.
+
+## 11. Recommendations
+
+1. Address #162 (freshness computation) before expecting a live run to produce a real
+   PASS/NO_SIGNAL verdict reliably, especially for validation windows outside market hours.
+2. Re-run `python -m screening --live` during active market hours to obtain the first real
+   PASS/NO_SIGNAL evidence for Forward Factor and Skew Momentum against live Tradier data,
+   now that #156 is fixed.
+3. Investigate `earnings_calendar`'s separate, still-unconfirmed live acquisition failure.
+4. Address #147 (CI coverage) as a Founder-reviewed `.github/workflows/` change, still
+   independent of any sprint's or patch's own work items.
+
+## 12. Confirmation: no secrets exposed
+
+Secret scan (`grep -riE "token|secret|password|api[_-]?key|bearer"`) against every file this
+patch changed: zero matches in source/test files; only descriptive requirement text in the
+governance activation file (`docs/sprints/PATCH-007A.yaml`). Every live validation and
+diagnostic script used `railway run`'s environment injection or a wrapped transport that
+logs only request paths, query parameters, and response bodies (public market data) --
+never headers, never credential values. No credential was read, printed, exported, or
+committed at any point in this patch's work.
+
+## 13. Deliverables
+
+- `project/reports/PATCH-007A.md` / `.json` -- this report.
+- `screening/live_context.py`: `acquire_expirations()`, `combine_option_chains()`,
+  `classify_domain_invariant_error()`, extended `build_capability_subject()`.
+- `screening/live_adapters.py`: two-step live adapter orchestration, narrowed exception
+  handling.
+- `tests/screening/`: four new/extended test files covering expiration discovery,
+  expiration-aware subjects (proven against the real `TradierProvider` class), two-step
+  acquisition (proven against a Tradier-shaped provider double), and error classification.
+- `docs/sprints/PATCH-007A.yaml`: the Founder Sprint Delegation record (#158).
+- Issues [#156](https://github.com/jaiaFoster/ASA/issues/156) (closed by this patch) and
+  [#162](https://github.com/jaiaFoster/ASA/issues/162) (new, logged for follow-up).

--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -1,4 +1,4 @@
-"""Live target strategy adapters (LIVE-002, PATCH-007A/TRADIER-PATCH-003).
+"""Live target strategy adapters (LIVE-002, PATCH-007A/TRADIER-PATCH-003/004).
 
 Live-data counterparts of screening/adapters.py's fixture-backed run_*
 functions: same manifests, same context_builders, same result
@@ -50,6 +50,7 @@ from screening.live_acquisition import acquire_capability
 from screening.live_context import (
     acquire_expirations,
     build_capability_subject,
+    classify_domain_invariant_error,
     combine_option_chains,
     select_atm_strike_at_expiration,
 )
@@ -140,17 +141,14 @@ def _acquire_or_raise(
             maximum_age_seconds=3600,
         )
     except DomainInvariantError as exc:
-        # No enabled provider declares this capability at all (e.g. only
-        # Tradier is configured and Tradier doesn't serve earnings data) --
-        # CapabilityRegistry.lookup() raises rather than returning a
-        # not-fulfilled result. A live-configuration gap, not an adapter
-        # bug: same MISSING_DATA outcome as any other unfulfillable request.
         raise StrategyAdapterError(
-            ScreeningOutcomeStatus.MISSING_DATA,
-            f"no enabled live provider offers {capability.value} for {symbol}: {exc}",
+            ScreeningOutcomeStatus.MISSING_DATA, classify_domain_invariant_error(exc, capability, symbol)
         ) from exc
     if result.status is not FulfillmentStatus.FULFILLED or not result.observations:
-        detail = f"could not acquire live {capability.value} for {symbol}"
+        detail = (
+            f"a valid request for live {capability.value} for {symbol} "
+            "could not be completed or normalized"
+        )
         if expiration is not None:
             detail += f" at expiration {expiration.isoformat()}"
         raise StrategyAdapterError(ScreeningOutcomeStatus.MISSING_DATA, detail)

--- a/screening/live_context.py
+++ b/screening/live_context.py
@@ -1,5 +1,5 @@
 """Live subject construction and chain-derived expirations (LIVE-002,
-PATCH-007A/TRADIER-PATCH-001).
+PATCH-007A/TRADIER-PATCH-001/TRADIER-PATCH-004).
 
 Bridges screening/live_acquisition.py's canonical acquisition output back
 into the shapes screening/context_builders.py already expects -- no new
@@ -20,6 +20,7 @@ from decimal import Decimal
 from analytics.atm_selection import select_atm_strike
 from domain import (
     CanonicalInstrumentIdentity,
+    DomainInvariantError,
     EvidenceKind,
     EvidenceReference,
     ExpirationCycle,
@@ -38,6 +39,34 @@ from market_data import CapabilityFulfillmentService, FulfillmentStatus
 from screening.live_acquisition import acquire_capability
 from screening.results import ScreeningOutcomeStatus
 from screening.runner import StrategyAdapterError
+
+# The only signal available to tell apart two DomainInvariantError causes
+# that both mean "this live request cannot be fulfilled" for different
+# reasons (TRADIER-PATCH-004): neither CapabilityFulfillmentService nor
+# CapabilityRegistry expose a public pre-check a caller could use instead of
+# reading the message, and adding one is a larger API-surface change than
+# this ticket's own "narrow exception handling in _acquire_or_raise" scope.
+_NO_CAPABLE_PROVIDER_MESSAGE_PREFIX = "No priority policy for"
+
+
+def classify_domain_invariant_error(
+    error: DomainInvariantError, capability: MarketCapability, symbol: str
+) -> str:
+    """Distinguish "no enabled provider declares this capability at all"
+    (market_data/registry.py::ProviderPriorityPolicy.for_capability()
+    raises "No priority policy for {capability}" before any provider is
+    ever selected) from "a provider WAS selected, but the canonical request
+    subject was incomplete or invalid for it" (#156's original defect --
+    e.g. no "expiration" projection for an option-chain request -- and
+    every other DomainInvariantError a provider's own fetch() can raise
+    before its transport is ever reached).
+    """
+    if str(error).startswith(_NO_CAPABLE_PROVIDER_MESSAGE_PREFIX):
+        return f"no enabled provider declares or satisfies {capability.value} for {symbol}: {error}"
+    return (
+        f"a provider was selected for {capability.value} for {symbol}, but the canonical "
+        f"request subject was incomplete or invalid: {error}"
+    )
 
 
 class NoContractsAtExpirationError(ValueError):
@@ -241,24 +270,36 @@ def acquire_expirations(
     Raises StrategyAdapterError(MISSING_DATA) on acquisition failure, an
     unrecognized response shape, or a result that normalizes to zero
     expirations -- callers never need a separate empty-result branch, since
-    there is no legitimate case that looks empty but isn't a failure.
+    there is no legitimate case that looks empty but isn't a failure. Also
+    raises MISSING_DATA (never a raw exception) if no enabled provider
+    declares OPTION_CHAIN_V1 at all -- CapabilityRegistry.lookup() raises
+    DomainInvariantError rather than returning a not-fulfilled result in
+    that case (TRADIER-PATCH-004), same as screening/live_adapters.py's own
+    _acquire_or_raise handles it.
     """
     subject = build_capability_subject(
         symbol, MarketCapability.OPTION_CHAIN_V1, now, required_fields=("expirations",)
     )
-    result = acquire_capability(
-        fulfillment,
-        MarketCapability.OPTION_CHAIN_V1,
-        subject,
-        effective_start=now,
-        effective_end=now,
-        required_fields=("expirations",),
-        maximum_age_seconds=3600,
-    )
+    try:
+        result = acquire_capability(
+            fulfillment,
+            MarketCapability.OPTION_CHAIN_V1,
+            subject,
+            effective_start=now,
+            effective_end=now,
+            required_fields=("expirations",),
+            maximum_age_seconds=3600,
+        )
+    except DomainInvariantError as exc:
+        raise StrategyAdapterError(
+            ScreeningOutcomeStatus.MISSING_DATA,
+            classify_domain_invariant_error(exc, MarketCapability.OPTION_CHAIN_V1, symbol),
+        ) from exc
     if result.status is not FulfillmentStatus.FULFILLED or not result.observations:
         raise StrategyAdapterError(
             ScreeningOutcomeStatus.MISSING_DATA,
-            f"could not acquire live option expirations for {symbol}",
+            f"a valid request for live option expirations for {symbol} "
+            "could not be completed or normalized",
         )
     as_of = now.date()
     values = tuple(observation.value for observation in result.observations)

--- a/tests/screening/test_live_adapters.py
+++ b/tests/screening/test_live_adapters.py
@@ -59,9 +59,9 @@ from market_data.providers import (
 )
 from screening.adapters import TARGET_STRATEGY_REGISTRY
 from screening.live_acquisition import build_capability_registry, build_request_budget_manager
-from screening.live_adapters import build_live_adapters
+from screening.live_adapters import _acquire_or_raise, build_live_adapters
 from screening.results import ScreeningOutcomeStatus
-from screening.runner import run_screening
+from screening.runner import StrategyAdapterError, run_screening
 
 NOW = datetime(2026, 7, 22, 16, 0, tzinfo=UTC)
 SYMBOL = "AAPL"
@@ -326,7 +326,7 @@ class TestCapabilityNotOfferedByAnyEnabledProvider:
         )
         assert result.outcome_status is ScreeningOutcomeStatus.MISSING_DATA
         assert result.failure_detail is not None
-        assert "no enabled live provider offers" in result.failure_detail
+        assert "no enabled provider declares or satisfies" in result.failure_detail
 
 
 class TestFullLiveRunAcrossAllThreeStrategies:
@@ -546,3 +546,62 @@ class TestTwoStepLiveAcquisitionAgainstATradierShapedProvider:
             ScreeningOutcomeStatus.PASS,
             ScreeningOutcomeStatus.NO_SIGNAL,
         )
+
+
+class TestAcquisitionErrorClassificationEndToEnd:
+    def test_a_selected_provider_with_a_malformed_subject_is_invalid_acquisition_subject(
+        self,
+    ) -> None:
+        # A regression guard for #156's original defect class: if a caller
+        # ever again asks TradierShapedMultiExpirationProvider for
+        # OPTION_CHAIN_V1 contracts without supplying an expiration
+        # (exactly the bug TRADIER-PATCH-002 fixed), the provider IS
+        # selected -- CapabilityRegistry finds it -- but its own
+        # subject.projection_for(..., "expiration", ...) lookup fails.
+        # _acquire_or_raise must classify this as invalid_acquisition_subject,
+        # never the no_capable_provider message (a provider WAS selected).
+        fulfillment, clock = _fulfillment(TradierShapedMultiExpirationProvider)
+        try:
+            _acquire_or_raise(
+                fulfillment,
+                SYMBOL,
+                MarketCapability.OPTION_CHAIN_V1,
+                clock.now(),
+                ("contracts",),
+                # expiration deliberately omitted.
+            )
+            raise AssertionError("expected StrategyAdapterError")
+        except StrategyAdapterError as error:
+            assert error.outcome_status is ScreeningOutcomeStatus.MISSING_DATA
+            assert "a provider was selected for option_chain_v1 for AAPL" in str(error)
+            assert "canonical request subject was incomplete or invalid" in str(error)
+            assert "no enabled provider declares" not in str(error)
+
+    def test_no_capable_provider_is_never_reported_as_invalid_subject(self) -> None:
+        # The inverse regression guard, using the existing no-capable-
+        # provider fixture from TestCapabilityNotOfferedByAnyEnabledProvider
+        # above: confirms the two message classes stay genuinely distinct,
+        # not just that each one individually looks right in isolation.
+        shared_clock = FixedClock()
+        config = load_market_data_config({})
+        (fixture_config,) = tuple(item for item in config.providers if item.enabled)
+        budget_manager = build_request_budget_manager((fixture_config,), shared_clock)
+        provider = MultiExpirationFixtureProvider(
+            fixture_config, ProviderDependencies(object(), shared_clock, budget_manager)
+        )
+        registry = ProviderRegistry((provider,))
+        priorities = tuple(
+            ProviderPriority(capability, (provider.provider_id,))
+            for capability in provider.capabilities
+            if capability is not MarketCapability.EARNINGS_CALENDAR_V1
+        )
+        capability_registry = CapabilityRegistry(registry, ProviderPriorityPolicy("test-v1", priorities))
+        fulfillment = CapabilityFulfillmentService(registry, capability_registry, budget_manager)
+        try:
+            _acquire_or_raise(
+                fulfillment, SYMBOL, MarketCapability.EARNINGS_CALENDAR_V1, shared_clock.now(), ("earnings_date",)
+            )
+            raise AssertionError("expected StrategyAdapterError")
+        except StrategyAdapterError as error:
+            assert "no enabled provider declares or satisfies" in str(error)
+            assert "canonical request subject was incomplete or invalid" not in str(error)

--- a/tests/screening/test_live_context_error_classification.py
+++ b/tests/screening/test_live_context_error_classification.py
@@ -1,0 +1,62 @@
+"""TRADIER-PATCH-004: DomainInvariantError classification tests.
+
+classify_domain_invariant_error() distinguishes two DomainInvariantError
+causes that both mean "this live request cannot be fulfilled," for
+different reasons -- no enabled provider declares the capability at all
+(market_data/registry.py::ProviderPriorityPolicy.for_capability() raises
+before any provider is selected) versus a provider being selected but the
+canonical request subject being incomplete or invalid for it (#156's
+original defect class). Message text is the only signal available; these
+tests pin the exact strings each real source raises so a future change to
+either message would be caught here, not discovered as a silent
+misclassification in production.
+"""
+
+from __future__ import annotations
+
+from domain import MarketCapability
+from domain.values import DomainInvariantError
+from screening.live_context import classify_domain_invariant_error
+
+
+class TestClassifyDomainInvariantError:
+    def test_no_priority_policy_classifies_as_no_capable_provider(self) -> None:
+        # The exact message market_data/registry.py::ProviderPriorityPolicy
+        # .for_capability() raises when no enabled provider declares the
+        # capability at all.
+        error = DomainInvariantError("No priority policy for option_chain_v1")
+        message = classify_domain_invariant_error(error, MarketCapability.OPTION_CHAIN_V1, "AAPL")
+        assert message.startswith("no enabled provider declares or satisfies option_chain_v1 for AAPL")
+        assert "No priority policy for option_chain_v1" in message
+
+    def test_missing_projection_classifies_as_invalid_acquisition_subject(self) -> None:
+        # The exact message domain/market_data.py::MarketDataSubject
+        # .projection_for() raises when a selected provider's own lookup
+        # finds no matching projection -- #156's original defect.
+        error = DomainInvariantError("MarketDataSubject requires one effective provider projection")
+        message = classify_domain_invariant_error(error, MarketCapability.OPTION_CHAIN_V1, "AAPL")
+        assert "a provider was selected for option_chain_v1 for AAPL" in message
+        assert "canonical request subject was incomplete or invalid" in message
+        assert "MarketDataSubject requires one effective provider projection" in message
+
+    def test_any_other_domain_invariant_error_also_classifies_as_invalid_acquisition_subject(
+        self,
+    ) -> None:
+        # Every DomainInvariantError a provider's own fetch() can raise
+        # before its transport is ever reached (e.g.
+        # CapabilityRequest.__post_init__'s various invariants) falls into
+        # this category by construction -- only the one specific,
+        # known "No priority policy for" message means no provider was
+        # ever selected at all.
+        error = DomainInvariantError("CapabilityRequest subject required fields mismatch")
+        message = classify_domain_invariant_error(error, MarketCapability.OPTION_CHAIN_V1, "AAPL")
+        assert "canonical request subject was incomplete or invalid" in message
+
+    def test_symbol_and_capability_are_both_present_in_every_message(self) -> None:
+        for error in (
+            DomainInvariantError("No priority policy for earnings_calendar_v1"),
+            DomainInvariantError("MarketDataSubject requires one effective provider projection"),
+        ):
+            message = classify_domain_invariant_error(error, MarketCapability.EARNINGS_CALENDAR_V1, "MSFT")
+            assert "earnings_calendar_v1" in message
+            assert "MSFT" in message


### PR DESCRIPTION
## Ticket
TRADIER-PATCH-004 (PATCH-007A, delegated merge under GOV-007A/Amendment 013, active since #158 merged) -- the final ticket, closing out issue #156.

## Summary
Splits `_acquire_or_raise()`'s single, ambiguous `DomainInvariantError` catch into three distinct, accurately-labeled error classes, then validates the complete repaired path (TRADIER-PATCH-001/002/003) against real Tradier credentials. This is PATCH-007A's own final report and issue-#156-closing evidence, all in one PR per the ticket's own bundled scope (code + live validation + report).

## Error classification
`_acquire_or_raise()` previously caught every `DomainInvariantError` under one message ("no enabled live provider offers X"), conflating two very different situations: no provider declaring the capability at all, versus a provider being selected but its own subject lookup failing (#156's exact defect class). New `screening/live_context.py::classify_domain_invariant_error()` distinguishes them by the only signal available (message text -- `CapabilityRegistry`/`CapabilityFulfillmentService` expose no public pre-check, and adding one is a larger API change than this ticket's own "narrow exception handling" scope):
- `no_capable_provider`: "no enabled provider declares or satisfies {capability} for {symbol}: {detail}"
- `invalid_acquisition_subject`: "a provider was selected for {capability} for {symbol}, but the canonical request subject was incomplete or invalid: {detail}"
- `provider_acquisition_failure` (pre-existing case, message refined): "a valid request for live {capability} for {symbol} could not be completed or normalized"

Also applied to `acquire_expirations()`, which had the *same* latent gap entirely uncaught -- discovered during this ticket's own work, not anticipated up front (a `DomainInvariantError` from `CapabilityRegistry.lookup()` would have escaped as a raw `STRATEGY_EXCEPTION` if no enabled provider declared `OPTION_CHAIN_V1` at all, e.g. a deployment with only Finnhub/Alpha Vantage enabled).

## Live validation -- the proof #156 is actually fixed
Executed via `railway run -- python -m screening --live --universe AAPL,MSFT,NVDA,AMD,SPY,QQQ --json` against Railway's `ASA` production service, real Tradier credentials injected directly into the subprocess environment. No credential value was ever read, printed, or handled at any point.

The definitive evidence (a targeted diagnostic wrapping the injected transport to log request paths/queries and response status/contract-counts, never headers or credentials):
- `GET /v1/markets/options/expirations?includeAllRoots=false&symbol=AAPL` -> `200`, **24 real expirations**.
- `GET /v1/markets/options/chains?expiration=2026-08-21&greeks=true&symbol=AAPL` -> `200`, **178 real contracts** -- the exact expiration `acquire_expirations()` selected was the exact expiration Tradier's real endpoint received. The old `"MarketDataSubject requires one effective provider projection"` error never reproduced anywhere across the full validation.

The full CLI run's 18 results all came back `missing_data`, but this time via the new, accurate `provider_acquisition_failure` classification -- never the old misleading "no provider offers" message. Root cause, confirmed independently: this validation ran ~65 minutes after the 2026-07-22 US market close, and `market_data/tradier.py`'s pre-existing (unrelated, untouched by this patch) freshness computation rejected the otherwise-valid, current quote/chain data as `STALE_DATA`. The chain diagnostic above proves this happens *after* successful, correctly-scoped acquisition (200 OK, 178 real contracts), at a separate gate -- not a reproduction of #156. Filed as **#162**, explicitly out of this patch's scope (`explicit_exclusions: broad_option_surface_redesign`).

## Relevant issues and PRs
#156 (closed by this patch), #162 (new, this ticket's finding), #139 (the related, already-fixed instance of the same bug class in `backend/`'s independent path), #158 (GOV-007A activation), #159/#160/#161 (TRADIER-PATCH-001/002/003, this ticket's prerequisites).

## Architecture compliance
No changes to `market_data/tradier.py`, `strategies/`, `screening/adapters.py` (fixture-backed path), `analytics/`, governance, or workflow files. `tests/architecture/` suites unaffected (no new import roots).

## Security and secret handling
Secret scan (`grep -riE "token|secret|password|api[_-]?key|bearer"`) against all changed files: zero matches in source/test files. Every live validation and diagnostic script used `railway run`'s environment injection or a wrapped transport logging only request paths, query parameters, and response bodies (public market data) -- never headers or credential values.

## Network behavior
One bounded live validation run plus two targeted diagnostics against real Tradier (`railway run`, credentials never exposed to the implementing agent). All new/extended unit and integration tests use zero-network offline doubles.

## Request budget behavior
Real Tradier rate-limit headers observed during validation: `x-ratelimit-allowed=120`, `x-ratelimit-available=119` after one request, `x-ratelimit-used=1` -- consistent, bounded usage. `RequestBudgetManager`'s own ceiling (unchanged by this patch) was never approached.

## Tests
- `pytest tests/screening/test_live_adapters.py tests/screening/test_live_context_error_classification.py` -> 17 passed (11 existing + 6 new: 4 direct classifier unit tests, 2 end-to-end classification regression tests).
- `pytest tests/` (full repo) -> 2201 passed, 2 skipped (pre-existing, unrelated).
- `ruff check screening/ tests/screening/` -> clean.
- `mypy screening/live_context.py screening/live_adapters.py screening/live_acquisition.py screening/cli.py` -> zero errors.
- `tools/pos/lean/check_integrity.py` / `check_entrypoints.py` / `pre_push_check.py` -> all green.
- `git status --short` -> exactly this ticket's files plus `project/reports/PATCH-007A.md`/`.json`.

## Live validation status
This PR **is** the live validation record for PATCH-007A. See `project/reports/PATCH-007A.md` sections 5-8 for the full evidence, per-symbol breakdown, and request-budget data.

## Explicit exclusions
No fix for issue #162 (a genuine, separate follow-up, out of this patch's own scope). No changes to `market_data/tradier.py`, strategies, `analytics/`, governance, or workflow files.

## Merge authority
`delegated_after_required_checks` per PATCH-007A/GOV-007A -- active since #158 merged. `live_execution_policy`'s gate for this ticket's live validation was pre-covered by the activation file itself (a bounded re-run of the same six-symbol Tradier-only surface already Founder-confirmed for LIVE-003), so no separate check-in was required before this run. All required gates above are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)