### PR TITLE
OPS-RAILWAY-ROOT-001: guard backend cd against ambiguous build cwd

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -4,8 +4,8 @@
     "builder": "RAILPACK"
   },
   "deploy": {
-    "preDeployCommand": "cd backend && python -m alembic upgrade head",
-    "startCommand": "cd backend && export PYTHONPATH=src:.. && python -m alembic upgrade head && exec python -m uvicorn asa.asgi:create_application --factory --host 0.0.0.0 --port \"${PORT}\"",
+    "preDeployCommand": "(if [ -d backend ]; then cd backend; fi) && python -m alembic upgrade head",
+    "startCommand": "(if [ -d backend ]; then cd backend; fi) && export PYTHONPATH=src:.. && python -m alembic upgrade head && exec python -m uvicorn asa.asgi:create_application --factory --host 0.0.0.0 --port \"${PORT}\"",
     "healthcheckPath": "/api/v1/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",

--- a/backend/tests/test_railway_runtime.py
+++ b/backend/tests/test_railway_runtime.py
@@ -30,9 +30,12 @@ class BrokerMustNotBeCalled:
         raise AssertionError("health endpoint called broker provider")
 
 
-EXPECTED_PRE_DEPLOY_COMMAND = "cd backend && python -m alembic upgrade head"
+EXPECTED_PRE_DEPLOY_COMMAND = (
+    "(if [ -d backend ]; then cd backend; fi) && python -m alembic upgrade head"
+)
 EXPECTED_START_COMMAND = (
-    "cd backend && export PYTHONPATH=src:.. && python -m alembic upgrade head && "
+    '(if [ -d backend ]; then cd backend; fi) && export PYTHONPATH=src:.. && '
+    "python -m alembic upgrade head && "
     "exec python -m uvicorn asa.asgi:create_application --factory "
     '--host 0.0.0.0 --port "${PORT}"'
 )
@@ -45,6 +48,15 @@ def test_railway_backend_runtime_contract() -> None:
     # additionally includes ".." (the repo root) so screening/, analytics/,
     # strategies/, market_data/, and domain/ (the shared execution-graph
     # modules asa now imports) are importable, not just backend/src.
+    #
+    # OPS-RAILWAY-ROOT-001: the "cd backend" is guarded by "if [ -d backend
+    # ]" rather than assumed unconditionally -- Railpack's actual build-step
+    # working directory when rootDirectory is the repo root is undocumented
+    # and could plausibly already be backend/ (where it found the FastAPI/
+    # pip signals it detected), in which case an unconditional "cd backend"
+    # fails immediately ("No such file or directory"). The guarded form
+    # reaches backend/ correctly whether it starts at the repo root or is
+    # already there.
     backend_root = Path(__file__).parents[1]
     config = json.loads((backend_root / "railway.json").read_text())
 
@@ -105,6 +117,53 @@ def test_exact_production_command_runs_migration_then_serves_health(tmp_path: Pa
     process = subprocess.Popen(
         EXPECTED_START_COMMAND,
         cwd=backend_root.parent,
+        env=environment,
+        executable="/bin/sh",
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    response_body = None
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                output = "" if process.stdout is None else process.stdout.read()
+                raise AssertionError(f"production server exited before healthcheck: {output}")
+            try:
+                with urlopen(f"http://127.0.0.1:{port}/api/v1/health", timeout=1) as response:
+                    assert response.status == 200
+                    response_body = json.loads(response.read())
+                    break
+            except URLError:
+                time.sleep(0.05)
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+    assert response_body == {"status": "ok"}
+    assert time.monotonic() - started_at < 5
+
+
+def test_exact_production_command_also_works_when_cwd_is_already_backend(
+    tmp_path: Path,
+) -> None:
+    # OPS-RAILWAY-ROOT-001: the sibling test above proves the command works
+    # when Railway's build/runtime starts at the repo root. This proves it
+    # also works if Railway instead starts already inside backend/ -- the
+    # scenario the "if [ -d backend ]" guard exists for. Both must pass
+    # since which cwd Railpack actually uses is undocumented.
+    backend_root = Path(__file__).parents[1]
+    environment, port = _production_environment(tmp_path, migration_exit_code=0)
+    started_at = time.monotonic()
+    process = subprocess.Popen(
+        EXPECTED_START_COMMAND,
+        cwd=backend_root,
         env=environment,
         executable="/bin/sh",
         shell=True,

--- a/railpack.json
+++ b/railpack.json
@@ -7,7 +7,7 @@
   "steps": {
     "install": {
       "commands": [
-        "cd backend && pip install -r requirements.txt"
+        "pwd && ls -la && (if [ -d backend ]; then cd backend; fi) && pwd && pip install -r requirements.txt"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Two consecutive repository-root deployments (following API-001/GOV-008A's `rootDirectory` change) failed at `BUILD_IMAGE` in ~5 seconds with no retrievable error beyond the generic "Failed to build an image" -- too fast to be a real `pip install` failure, and Railpack's own metadata confirms provider/package detection succeeded before the failure.
- Railpack's build-step working directory when `rootDirectory` is the repo root is undocumented (confirmed against railpack.com's docs and Railway's own support agent). Since Railpack detected FastAPI/pip signals living under `backend/`, its default build-step cwd may already be `backend/`, making the previous unconditional `cd backend && ...` fail immediately.
- Guards every `cd backend` in `railpack.json` and `backend/railway.json` with `if [ -d backend ]; then cd backend; fi`, so the command reaches `backend/` correctly regardless of which directory the process actually starts in. Also adds `pwd`/`ls` diagnostics to the install step so a future failure carries real log output.
- Ruled out first: build-context bloat (git-tracked repo is 5.1MB), and Railpack picking `uv` over `pip` because of an unrelated root `pyproject.toml`/`uv.lock` pair (Railpack's own metadata already showed `pythonPackageManager: "pip"`, and that pair is inert for any CI/build install path -- left untouched).

## Test plan
- [x] `backend/tests/test_railway_runtime.py::test_exact_production_command_runs_migration_then_serves_health` (cwd=repo root) still passes
- [x] New `test_exact_production_command_also_works_when_cwd_is_already_backend` (cwd=backend/) passes -- proves the guard works from the untested starting directory
- [x] Full backend suite: 86 passed, 13 skipped (Postgres, no local Docker)
- [x] `ruff check .` and `mypy src` clean
- [ ] CI green
- [ ] Live Railway deployment reaches SUCCESS and `/api/v1/health` returns 200

Under GOV-008B (OPS-RAILWAY-ROOT-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)