### PR TITLE
OPS-RAILWAY-ROOT-001: drop custom install step, trust Railpack detection

### DIFF
--- a/railpack.json
+++ b/railpack.json
@@ -3,12 +3,5 @@
   "provider": "python",
   "packages": {
     "python": "3.12.13"
-  },
-  "steps": {
-    "install": {
-      "commands": [
-        "pwd && ls -la && (if [ -d backend ]; then cd backend; fi) && pwd && pip install -r requirements.txt"
-      ]
-    }
   }
 }


### PR DESCRIPTION
## Summary
- The cwd-guard fix (#168) surfaced real diagnostic evidence for the first time (previously blocked by a stray dashboard change of `rootDirectory` to `/`, silently suppressing all build log delivery): the working directory was completely **empty** when the custom install step ran. `pip` itself executed fine -- the error was "Could not open requirements file: No such file or directory", not "command not found" -- the repo source simply wasn't present.
- Root cause: `railpack.json`'s `steps.install.commands` override (added in #166 to defend against Railpack detecting an unrelated root-level `pyproject.toml`) fully replaces Railpack's auto-generated install step, including whatever implicit wiring gives that step access to the copied repo files. That defensive concern never actually materialized -- Railpack's own detection has consistently and correctly resolved `pythonRuntime: fastapi` / `pythonPackageManager: pip` across every attempt, meaning it already scans into `backend/` specifically. The override was solving a problem that wasn't happening, while introducing one that was.
- Fix: `railpack.json` now only pins provider/python version (its original, narrower purpose); the install step is Railpack's own default again.

## Test plan
- [x] No test asserts on `railpack.json`'s internal step structure (confirmed via grep)
- [x] Full backend suite: 86 passed, 13 skipped (Postgres, no local Docker)
- [ ] CI green
- [ ] Live Railway deployment reaches SUCCESS and `/api/v1/health` returns 200

Under GOV-008B (OPS-RAILWAY-ROOT-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)