### PR TITLE
OPS-RAILWAY-ROOT-001: diagnostic bisection of silent PRE_DEPLOY_COMMAND failure

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -4,7 +4,7 @@
     "builder": "RAILPACK"
   },
   "deploy": {
-    "preDeployCommand": "cd backend && python -m alembic upgrade head",
+    "preDeployCommand": "cd backend && python -c \"print('OPS-RAILWAY-ROOT-001 predeploy bisection: container init ok')\"",
     "startCommand": "cd backend && export PYTHONPATH=src:.. && python -m alembic upgrade head && exec python -m uvicorn asa.asgi:create_application --factory --host 0.0.0.0 --port \"${PORT}\"",
     "healthcheckPath": "/api/v1/health",
     "healthcheckTimeout": 300,

--- a/backend/tests/test_railway_runtime.py
+++ b/backend/tests/test_railway_runtime.py
@@ -30,7 +30,10 @@ class BrokerMustNotBeCalled:
         raise AssertionError("health endpoint called broker provider")
 
 
-EXPECTED_PRE_DEPLOY_COMMAND = "cd backend && python -m alembic upgrade head"
+EXPECTED_PRE_DEPLOY_COMMAND = (
+    'cd backend && python -c "print(\'OPS-RAILWAY-ROOT-001 predeploy bisection: '
+    "container init ok')\""
+)
 EXPECTED_START_COMMAND = (
     "cd backend && export PYTHONPATH=src:.. && python -m alembic upgrade head && "
     "exec python -m uvicorn asa.asgi:create_application --factory "


### PR DESCRIPTION
## Summary
- #171 got Railpack to correctly install backend's real dependencies (`pythonPackageManager: "pip"`), and `BUILD_IMAGE`/`PUBLISH_IMAGE` both completed for the first time. The next stage, `PRE_DEPLOY_COMMAND`, now fails completely silently: deploy logs show only "Starting Container" -> "Stopping Container" ~1 second apart, no exit code, no exception text, nothing from any diagnostic tool available.
- Founder-approved bisection (recommended by Railway's own support agent): temporarily replace `preDeployCommand` with a trivial Python print, keeping `cd backend` (already proven to succeed). Tells us whether the failure is specific to the alembic invocation or a more fundamental container-init problem for this stage.
- `startCommand` is intentionally unchanged -- if this deploy gets past `PRE_DEPLOY_COMMAND`, the startup phase still runs the real migration and may surface more log detail than the ephemeral pre-deploy container did.
- **This commit is explicitly temporary.** A follow-up will restore the real command once the bisection result is known.

## Test plan
- [x] `backend/tests/test_railway_runtime.py`: 7 passed
- [ ] Live Railway deployment: does `PRE_DEPLOY_COMMAND` now succeed?

Under GOV-008B (OPS-RAILWAY-ROOT-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)