### PR TITLE
OPS-RAILWAY-ROOT-001: prepend venv bin to PATH, restore real alembic command

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -4,8 +4,8 @@
     "builder": "RAILPACK"
   },
   "deploy": {
-    "preDeployCommand": "cd backend && python -c \"print('OPS-RAILWAY-ROOT-001 predeploy bisection: container init ok')\"",
-    "startCommand": "cd backend && export PYTHONPATH=src:.. && python -m alembic upgrade head && exec python -m uvicorn asa.asgi:create_application --factory --host 0.0.0.0 --port \"${PORT}\"",
+    "preDeployCommand": "cd backend && export PATH=\"/app/.venv/bin:$PATH\" && python -m alembic upgrade head",
+    "startCommand": "cd backend && export PATH=\"/app/.venv/bin:$PATH\" && export PYTHONPATH=src:.. && python -m alembic upgrade head && exec python -m uvicorn asa.asgi:create_application --factory --host 0.0.0.0 --port \"${PORT}\"",
     "healthcheckPath": "/api/v1/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",

--- a/backend/tests/test_railway_runtime.py
+++ b/backend/tests/test_railway_runtime.py
@@ -31,11 +31,11 @@ class BrokerMustNotBeCalled:
 
 
 EXPECTED_PRE_DEPLOY_COMMAND = (
-    'cd backend && python -c "print(\'OPS-RAILWAY-ROOT-001 predeploy bisection: '
-    "container init ok')\""
+    'cd backend && export PATH="/app/.venv/bin:$PATH" && python -m alembic upgrade head'
 )
 EXPECTED_START_COMMAND = (
-    "cd backend && export PYTHONPATH=src:.. && python -m alembic upgrade head && "
+    'cd backend && export PATH="/app/.venv/bin:$PATH" && export PYTHONPATH=src:.. && '
+    "python -m alembic upgrade head && "
     "exec python -m uvicorn asa.asgi:create_application --factory "
     '--host 0.0.0.0 --port "${PORT}"'
 )
@@ -57,6 +57,16 @@ def test_railway_backend_runtime_contract() -> None:
     # is confirmed correct anyway -- Railpack's own default install step
     # (see railpack.json) builds successfully against the repo root without
     # any cwd tricks, so the deploy container starts there too.
+    #
+    # A diagnostic bisection (temporary, since reverted) proved container
+    # init itself was fine; the real failure was the running container's
+    # bare "python" resolving to Railpack's raw mise-managed interpreter
+    # (/mise/installs/python/.../bin/python, no site-packages) rather than
+    # the venv pip actually installed backend's dependencies into --
+    # confirmed by comparing against an earlier, differently-broken
+    # deployment whose error correctly showed /app/.venv/bin/python.
+    # Prepending "/app/.venv/bin" to PATH makes the venv's own python (and
+    # therefore alembic) resolve first.
     backend_root = Path(__file__).parents[1]
     config = json.loads((backend_root / "railway.json").read_text())
 


### PR DESCRIPTION
## Summary
- The bisection diagnostic (#172) proved container init itself was fine. The real `startCommand` then failed with `/mise/installs/python/3.12.13/bin/python: No module named alembic`, despite `backend/pyproject.toml` correctly declaring `alembic>=1.13,<2` and `pythonPackageManager: "pip"` being correct.
- Key evidence: an earlier, differently-broken deployment (uv-based, before #171) showed a *different* interpreter in the identical error -- `/app/.venv/bin/python`, not the raw mise-managed one. That deployment correctly invoked the venv (wrong packages inside it, already fixed). This one invokes the raw mise Python directly, bypassing whatever venv pip actually installed dependencies into. Railway's own build logs don't expose the actual `pip install` output via any available API -- this is Railpack's own undocumented internal behavior.
- Founder-approved: explicitly prepend `/app/.venv/bin` to PATH in both `startCommand` and `preDeployCommand` (restoring the real alembic command, replacing the temporary bisection print). Harmless if the inferred path is wrong (PATH lookup silently skips a nonexistent directory).

## Test plan
- [x] `backend/tests/test_railway_runtime.py`: 7 passed
- [ ] Live Railway deployment: does the real alembic migration now succeed?

Under GOV-008B (OPS-RAILWAY-ROOT-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)