### PR TITLE
OPS-RAILWAY-ROOT-001: diagnostic to locate alembic in the built image

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -4,7 +4,7 @@
     "builder": "RAILPACK"
   },
   "deploy": {
-    "preDeployCommand": "cd backend && export PATH=\"/app/.venv/bin:$PATH\" && python -m alembic upgrade head",
+    "preDeployCommand": "echo PATH=$PATH; echo WHICH_PYTHON=$(which python); python -m site; find / -maxdepth 6 -iname 'alembic*' -not -path '/proc/*' 2>/dev/null",
     "startCommand": "cd backend && export PATH=\"/app/.venv/bin:$PATH\" && export PYTHONPATH=src:.. && python -m alembic upgrade head && exec python -m uvicorn asa.asgi:create_application --factory --host 0.0.0.0 --port \"${PORT}\"",
     "healthcheckPath": "/api/v1/health",
     "healthcheckTimeout": 300,

--- a/backend/tests/test_railway_runtime.py
+++ b/backend/tests/test_railway_runtime.py
@@ -31,7 +31,8 @@ class BrokerMustNotBeCalled:
 
 
 EXPECTED_PRE_DEPLOY_COMMAND = (
-    'cd backend && export PATH="/app/.venv/bin:$PATH" && python -m alembic upgrade head'
+    "echo PATH=$PATH; echo WHICH_PYTHON=$(which python); python -m site; "
+    "find / -maxdepth 6 -iname 'alembic*' -not -path '/proc/*' 2>/dev/null"
 )
 EXPECTED_START_COMMAND = (
     'cd backend && export PATH="/app/.venv/bin:$PATH" && export PYTHONPATH=src:.. && '


### PR DESCRIPTION
## Summary
- The venv-activation guess (#173, prepending `/app/.venv/bin` to PATH) did not fix the deploy -- identical error, identical interpreter path. Either `/app/.venv` doesn't exist for this pip-mode build, or alembic isn't there either.
- Temporarily replaces `preDeployCommand` with a real diagnostic: prints `PATH`/`which python`, dumps `python -m site`, and searches the filesystem for anything named `alembic*`. This will show definitively where (if anywhere) pip installed backend's dependencies, rather than continuing to guess paths blindly.
- `startCommand` is left with the harmless #173 PATH prepend for now; this round only needs `preDeployCommand` to succeed and produce output.

## Test plan
- [x] `backend/tests/test_railway_runtime.py`: 7 passed
- [ ] Live Railway deployment: pull the diagnostic output from preDeployCommand's logs

Under GOV-008B (OPS-RAILWAY-ROOT-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)