### PR TITLE
OPS-RAILWAY-ROOT-001: move diagnostic into startCommand, preDeployCommand's stdout isn't captured

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -4,8 +4,8 @@
     "builder": "RAILPACK"
   },
   "deploy": {
-    "preDeployCommand": "echo PATH=$PATH; echo WHICH_PYTHON=$(which python); python -m site; find / -maxdepth 6 -iname 'alembic*' -not -path '/proc/*' 2>/dev/null",
-    "startCommand": "cd backend && export PATH=\"/app/.venv/bin:$PATH\" && export PYTHONPATH=src:.. && python -m alembic upgrade head && exec python -m uvicorn asa.asgi:create_application --factory --host 0.0.0.0 --port \"${PORT}\"",
+    "preDeployCommand": "cd backend && export PATH=\"/app/.venv/bin:$PATH\" && python -m alembic upgrade head",
+    "startCommand": "cd backend && export PATH=\"/app/.venv/bin:$PATH\" && export PYTHONPATH=src:.. && echo DIAG_PATH=$PATH && echo DIAG_WHICH=$(which python) && python -m site && find /app /root /mise/installs/python/3.12.13 -maxdepth 6 -iname 'alembic*' 2>/dev/null; python -m alembic upgrade head && exec python -m uvicorn asa.asgi:create_application --factory --host 0.0.0.0 --port \"${PORT}\"",
     "healthcheckPath": "/api/v1/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",

--- a/backend/tests/test_railway_runtime.py
+++ b/backend/tests/test_railway_runtime.py
@@ -31,11 +31,13 @@ class BrokerMustNotBeCalled:
 
 
 EXPECTED_PRE_DEPLOY_COMMAND = (
-    "echo PATH=$PATH; echo WHICH_PYTHON=$(which python); python -m site; "
-    "find / -maxdepth 6 -iname 'alembic*' -not -path '/proc/*' 2>/dev/null"
+    'cd backend && export PATH="/app/.venv/bin:$PATH" && python -m alembic upgrade head'
 )
 EXPECTED_START_COMMAND = (
     'cd backend && export PATH="/app/.venv/bin:$PATH" && export PYTHONPATH=src:.. && '
+    "echo DIAG_PATH=$PATH && echo DIAG_WHICH=$(which python) && python -m site && "
+    "find /app /root /mise/installs/python/3.12.13 -maxdepth 6 -iname 'alembic*' "
+    "2>/dev/null; "
     "python -m alembic upgrade head && "
     "exec python -m uvicorn asa.asgi:create_application --factory "
     '--host 0.0.0.0 --port "${PORT}"'


### PR DESCRIPTION
## Summary
- The preDeployCommand diagnostic (#174) ran successfully but produced zero visible output -- confirmed via Railway's own agent, which searched every available log filter. This is a platform-level gap: preDeployCommand's stdout is not captured by Railway's deploy-log stream at all. startCommand's stdout, by contrast, has reliably shown output twice (the "No module named alembic" errors).
- Moves the diagnostic (PATH, `which python`, `python -m site`, and a search for alembic's install location) into `startCommand`, ahead of the real alembic invocation, separated by `;` so it can't block the real migration attempt. Restores `preDeployCommand` to the real migration command.
- Bounds the filesystem search to specific plausible locations (`/app`, `/root`, `/mise/installs/python/3.12.13`) instead of `/` -- a real `find /` is far too slow (confirmed locally: made two subprocess tests exceed their 5-second budget).

## Test plan
- [x] `backend/tests/test_railway_runtime.py`: 7 passed, 2.66s (confirms the bounded find doesn't reintroduce the timeout)
- [ ] Live Railway deployment: pull the diagnostic output from startCommand's deploy logs

Under GOV-008B (OPS-RAILWAY-ROOT-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)