### PR TITLE
OPS-RAILWAY-ROOT-001: make preDeployCommand a guaranteed no-op

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -4,7 +4,7 @@
     "builder": "RAILPACK"
   },
   "deploy": {
-    "preDeployCommand": "cd backend && export PATH=\"/app/.venv/bin:$PATH\" && python -m alembic upgrade head",
+    "preDeployCommand": "true",
     "startCommand": "cd backend && export PATH=\"/app/.venv/bin:$PATH\" && export PYTHONPATH=src:.. && echo DIAG_PATH=$PATH && echo DIAG_WHICH=$(which python) && python -m site && find /app /root /mise/installs/python/3.12.13 -maxdepth 6 -iname 'alembic*' 2>/dev/null; python -m alembic upgrade head && exec python -m uvicorn asa.asgi:create_application --factory --host 0.0.0.0 --port \"${PORT}\"",
     "healthcheckPath": "/api/v1/health",
     "healthcheckTimeout": 300,

--- a/backend/tests/test_railway_runtime.py
+++ b/backend/tests/test_railway_runtime.py
@@ -30,9 +30,7 @@ class BrokerMustNotBeCalled:
         raise AssertionError("health endpoint called broker provider")
 
 
-EXPECTED_PRE_DEPLOY_COMMAND = (
-    'cd backend && export PATH="/app/.venv/bin:$PATH" && python -m alembic upgrade head'
-)
+EXPECTED_PRE_DEPLOY_COMMAND = "true"
 EXPECTED_START_COMMAND = (
     'cd backend && export PATH="/app/.venv/bin:$PATH" && export PYTHONPATH=src:.. && '
     "echo DIAG_PATH=$PATH && echo DIAG_WHICH=$(which python) && python -m site && "


### PR DESCRIPTION
## Summary
- The previous deploy never reached the diagnostic in startCommand -- PRE_DEPLOY_COMMAND failed first, with zero output at all. Consistent with the already-established finding that preDeployCommand's stdout/stderr capture is unreliable via Railway's deploy-log stream.
- `startCommand` already runs the migration itself before exec-ing uvicorn (redundant with preDeployCommand, harmless -- alembic upgrades are idempotent), and its output capture has been reliable twice now.
- Replaces `preDeployCommand` with `"true"` -- an unconditional no-op -- so the deployment reliably reaches `startCommand`, where the diagnostic (#175) can actually run and its output can finally be observed.

## Test plan
- [x] `backend/tests/test_railway_runtime.py`: 7 passed
- [ ] Live Railway deployment: does it now reach startCommand and show the diagnostic output?

Under GOV-008B (OPS-RAILWAY-ROOT-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)