### PR TITLE
API-004: explicit narrow refresh endpoint

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -1,5 +1,5 @@
 """Response models for the public /api/v1/screening* and /api/v1/capabilities
-endpoints (API-003, SPRINT-008).
+endpoints (API-003, API-004, SPRINT-008).
 
 Built on asa.api.agent_models.TimestampedResource so every screening result
 exposes updated_at/age_seconds through the one place that computes it, per
@@ -63,3 +63,23 @@ class ScreeningResultsEnvelope(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+class RefreshResultResponse(ScreeningResultResponse):
+    """Extends, not duplicates, ScreeningResultResponse -- a refresh result
+    is a screening result plus how many live provider requests it took
+    (API-004's own "request_accounting" requirement). Never the raw
+    RequestAccountingEntry records themselves: provider identity, quota
+    detail, and retry mechanics stay internal
+    (architecture_principles: "provider_implementations_remain_completely_
+    internal"), not exposed in a public response.
+    """
+
+    request_count: int
+
+    @classmethod
+    def from_record(  # type: ignore[override]
+        cls, record: ScreeningStateRecord, *, request_count: int
+    ) -> RefreshResultResponse:
+        base = ScreeningResultResponse.from_record(record)
+        return cls(request_count=request_count, **base.model_dump())

--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -1,33 +1,52 @@
-"""GET /api/v1/capabilities, GET /api/v1/screening[/{signal}[/{symbol}]]
-(API-003, SPRINT-008).
+"""GET /api/v1/capabilities, GET /api/v1/screening[/{signal}[/{symbol}]],
+POST /api/v1/screening/{signal}/{symbol}/refresh (API-003, API-004,
+SPRINT-008).
 
-Read-only: every handler here calls only screening.service.get_state(),
-which itself only ever reads through the injected repository and never
-triggers a provider request (screening/service.py's own documented
-guarantee) -- proven at this layer too by
-tests/asa/test_screening_routes.py, not merely inferred from get_state()'s
-own docstring.
+Read endpoints call only screening.service.get_state(), which itself only
+ever reads through the injected repository and never triggers a provider
+request (screening/service.py's own documented guarantee) -- proven at
+this layer too by tests/asa/test_screening_routes.py, not merely inferred
+from get_state()'s own docstring. The refresh endpoint is the one deliberate
+exception: it calls screening.service.refresh() for exactly the one
+requested signal/symbol pair, never a whole universe or a whole signal.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, Query, Request
 
 from asa.api.agent_models import agent_api_error
 from asa.api.screening_models import (
     CapabilitiesResponse,
+    RefreshResultResponse,
     ScreeningResultResponse,
     ScreeningResultsEnvelope,
     SignalCapabilityResponse,
 )
+from market_data import load_market_data_config_from_environment
+from market_data.live_transport import build_live_transport
+from screening.live_acquisition import (
+    APPROVED_LIVE_UNIVERSE,
+    build_fulfillment_service_with_accounting,
+    enabled_provider_configs,
+    live_only_config,
+)
 from screening.registry import ScreeningRegistry, signal_catalog
-from screening.service import get_state
+from screening.service import get_state, refresh
 from screening.state import ScreeningStateRecord, ScreeningStateRepository
 
 DEFAULT_LIMIT = 100
 MAX_LIMIT = 500
+
+
+@dataclass(frozen=True, slots=True)
+class _SystemClock:
+    def now(self) -> datetime:
+        return datetime.now(UTC)
 
 
 def _paginate(
@@ -41,6 +60,7 @@ def build_screening_router(
     repository: ScreeningStateRepository,
     registry: ScreeningRegistry,
     authorize: Callable[[Request], None],
+    transport_factory: Callable[[str], object] = build_live_transport,
 ) -> APIRouter:
     router = APIRouter(prefix="/api/v1", dependencies=[Depends(authorize)])
 
@@ -96,5 +116,36 @@ def build_screening_router(
                 404, "NO_SCREENING_RESULT", f"No screening result for {signal!r}/{symbol!r}"
             )
         return ScreeningResultResponse.from_record(records[0])
+
+    @router.post(
+        "/screening/{signal}/{symbol}/refresh",
+        response_model=RefreshResultResponse,
+    )
+    def refresh_screening_result(signal: str, symbol: str) -> RefreshResultResponse:
+        _require_registered_signal(signal)
+        if symbol not in APPROVED_LIVE_UNIVERSE:
+            raise agent_api_error(
+                422,
+                "UNSUPPORTED_SYMBOL",
+                f"Refresh is bounded to the approved live universe {APPROVED_LIVE_UNIVERSE}, "
+                f"not {symbol!r}",
+            )
+        config = live_only_config(load_market_data_config_from_environment())
+        if not enabled_provider_configs(config):
+            raise agent_api_error(
+                503,
+                "NO_LIVE_PROVIDER_CONFIGURED",
+                "No live market data provider is enabled for this deployment",
+            )
+        clock = _SystemClock()
+        fulfillment, budget_manager = build_fulfillment_service_with_accounting(
+            config, transport_factory, clock
+        )
+        record = refresh(
+            repository, registry, fulfillment, clock, signal_id=signal, symbol=symbol
+        )
+        return RefreshResultResponse.from_record(
+            record, request_count=len(budget_manager.accounting)
+        )
 
     return router

--- a/asa/bootstrap.py
+++ b/asa/bootstrap.py
@@ -105,7 +105,12 @@ def build_application(
         )
     )
     app.include_router(
-        build_screening_router(screening_state_repository, SIGNAL_REGISTRY, agent_authorize)
+        build_screening_router(
+            screening_state_repository,
+            SIGNAL_REGISTRY,
+            agent_authorize,
+            selected.market_data_transport_factory or build_transport_for_provider,
+        )
     )
 
     @app.middleware("http")

--- a/screening/__init__.py
+++ b/screening/__init__.py
@@ -14,11 +14,14 @@ from screening.errors import (
     UnknownScreeningStrategyIdError,
 )
 from screening.live_acquisition import (
+    APPROVED_LIVE_UNIVERSE,
     acquire_capability,
     build_capability_registry,
     build_fulfillment_service,
+    build_fulfillment_service_with_accounting,
     build_request_budget_manager,
     enabled_provider_configs,
+    live_only_config,
 )
 from screening.live_adapters import build_live_adapters
 from screening.registry import (
@@ -41,6 +44,7 @@ from screening.state import ScreeningStateRecord, ScreeningStateRepository
 SIGNAL_REGISTRY = TARGET_STRATEGY_REGISTRY
 
 __all__ = [
+    "APPROVED_LIVE_UNIVERSE",
     "SIGNAL_REGISTRY",
     "TARGET_STRATEGY_ADAPTERS",
     "TARGET_STRATEGY_REGISTRY",
@@ -61,10 +65,12 @@ __all__ = [
     "bounded_failure_detail",
     "build_capability_registry",
     "build_fulfillment_service",
+    "build_fulfillment_service_with_accounting",
     "build_live_adapters",
     "build_request_budget_manager",
     "enabled_provider_configs",
     "get_state",
+    "live_only_config",
     "refresh",
     "run_screening",
     "signal_catalog",

--- a/screening/cli.py
+++ b/screening/cli.py
@@ -26,15 +26,20 @@ import argparse
 import json
 import sys
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from dataclasses import dataclass, replace
 
-from market_data import MarketDataConfig, load_market_data_config_from_environment
+from market_data import load_market_data_config_from_environment
 from market_data.live_transport import build_live_transport
 from screening.adapters import TARGET_STRATEGY_ADAPTERS, TARGET_STRATEGY_REGISTRY
 from screening.errors import UnknownScreeningStrategyIdError
 from screening.fixtures import SAFE_SYMBOL
-from screening.live_acquisition import build_fulfillment_service, enabled_provider_configs
+from screening.live_acquisition import (
+    APPROVED_LIVE_UNIVERSE,
+    build_fulfillment_service,
+    enabled_provider_configs,
+    live_only_config,
+)
 from screening.live_adapters import build_live_adapters
 from screening.registry import ScreeningStrategyDefinition
 from screening.results import ScreeningResult
@@ -42,26 +47,8 @@ from screening.runner import run_screening
 from screening.serialization import results_to_json_payload
 
 APPROVED_FIXTURE_UNIVERSE = (SAFE_SYMBOL,)
-APPROVED_LIVE_UNIVERSE = ("AAPL", "MSFT", "NVDA", "AMD", "SPY", "QQQ")
 
 _ORCHESTRATION_FAILURE_EXIT_CODE = 2
-_FIXTURE_PROVIDER_ID = "deterministic_fixture"
-
-
-def _live_only_config(config: MarketDataConfig) -> MarketDataConfig:
-    """deterministic_fixture defaults to enabled (market_data/config.py's own
-    safety default) and, being alphabetically first among enabled providers,
-    would otherwise be tried before any real provider by
-    CapabilityRegistry's deterministic priority order -- silently serving
-    every --live request from offline fixture data instead of a real
-    provider. --live must mean live, so the fixture provider is always
-    force-disabled here, regardless of environment configuration.
-    """
-    providers = tuple(
-        replace(item, enabled=False) if item.provider_id == _FIXTURE_PROVIDER_ID else item
-        for item in config.providers
-    )
-    return replace(config, providers=providers)
 
 
 @dataclass(frozen=True)
@@ -218,7 +205,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     try:
         if args.live:
-            config = _live_only_config(load_market_data_config_from_environment())
+            config = live_only_config(load_market_data_config_from_environment())
             if not enabled_provider_configs(config):
                 print(
                     "error: --live requires at least one enabled live provider "

--- a/screening/live_acquisition.py
+++ b/screening/live_acquisition.py
@@ -24,6 +24,7 @@ only orchestrates.
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import replace
 from datetime import datetime
 
 from domain import MarketCapability, MarketDataSubject
@@ -68,6 +69,33 @@ def enabled_provider_configs(config: MarketDataConfig) -> tuple[ProviderConfig, 
     return tuple(item for item in config.providers if item.enabled)
 
 
+APPROVED_LIVE_UNIVERSE = ("AAPL", "MSFT", "NVDA", "AMD", "SPY", "QQQ")
+"""The SPRINT-007 Founder-approved live validation_universe. Both
+screening/cli.py's --live flag and asa/'s POST .../refresh endpoint bound
+live acquisition to this same set -- neither widens it independently."""
+
+_FIXTURE_PROVIDER_ID = "deterministic_fixture"
+
+
+def live_only_config(config: MarketDataConfig) -> MarketDataConfig:
+    """deterministic_fixture defaults to enabled (market_data/config.py's own
+    safety default) and, being alphabetically first among enabled providers,
+    would otherwise be tried before any real provider by
+    CapabilityRegistry's deterministic priority order -- silently serving
+    every live request from offline fixture data instead of a real
+    provider. Live must mean live, so the fixture provider is always
+    force-disabled here, regardless of environment configuration. Shared by
+    screening/cli.py's --live flag and asa/'s live refresh endpoint -- ported
+    from screening/cli.py's own original private _live_only_config, not
+    reimplemented, so both callers apply exactly the same safety rule.
+    """
+    providers = tuple(
+        replace(item, enabled=False) if item.provider_id == _FIXTURE_PROVIDER_ID else item
+        for item in config.providers
+    )
+    return replace(config, providers=providers)
+
+
 def build_capability_registry(provider_registry: ProviderRegistry) -> CapabilityRegistry:
     """Every enabled provider serves every capability it declares, in
     deterministic provider_id order.
@@ -104,15 +132,21 @@ def build_request_budget_manager(
     return RequestBudgetManager(policies, clock)
 
 
-def build_fulfillment_service(
+def build_fulfillment_service_with_accounting(
     config: MarketDataConfig,
     transport_factory: Callable[[str], object],
     clock: Clock,
-) -> CapabilityFulfillmentService:
+) -> tuple[CapabilityFulfillmentService, RequestBudgetManager]:
     """Construct a fully-wired CapabilityFulfillmentService for every
-    enabled provider in ``config``. The same RequestBudgetManager instance
-    is shared by every provider's dependencies, so budget consumption is
-    tracked correctly across all of them, not per-provider in isolation.
+    enabled provider in ``config``, and return its RequestBudgetManager
+    alongside it -- CapabilityFulfillmentService itself never exposes the
+    budget manager it was built with (a private, unreachable attribute), so
+    a caller that needs post-hoc request accounting (asa/'s own refresh
+    endpoint, API-004's "request_accounting" requirement) has no way to
+    read it back from build_fulfillment_service()'s own return value alone.
+    The same RequestBudgetManager instance is shared by every provider's
+    dependencies, so budget consumption is tracked correctly across all of
+    them, not per-provider in isolation.
     """
     enabled_configs = enabled_provider_configs(config)
     budget_manager = build_request_budget_manager(enabled_configs, clock)
@@ -126,7 +160,22 @@ def build_fulfillment_service(
     )
     provider_registry = ProviderRegistry(providers)
     capability_registry = build_capability_registry(provider_registry)
-    return CapabilityFulfillmentService(provider_registry, capability_registry, budget_manager)
+    service = CapabilityFulfillmentService(provider_registry, capability_registry, budget_manager)
+    return service, budget_manager
+
+
+def build_fulfillment_service(
+    config: MarketDataConfig,
+    transport_factory: Callable[[str], object],
+    clock: Clock,
+) -> CapabilityFulfillmentService:
+    """Construct a fully-wired CapabilityFulfillmentService for every
+    enabled provider in ``config``. The same RequestBudgetManager instance
+    is shared by every provider's dependencies, so budget consumption is
+    tracked correctly across all of them, not per-provider in isolation.
+    """
+    service, _ = build_fulfillment_service_with_accounting(config, transport_factory, clock)
+    return service
 
 
 def acquire_capability(

--- a/tests/asa/test_screening_refresh_route.py
+++ b/tests/asa/test_screening_refresh_route.py
@@ -1,0 +1,145 @@
+"""API-004: POST /api/v1/screening/{signal}/{symbol}/refresh."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from asa.bootstrap import DependencyOverrides, build_application
+from asa.config import Settings
+from market_data.transport import ReadOnlyHttpResponse
+from tests.asa.fakes import InMemoryScreeningStateRepository
+from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
+
+
+def _client(transport_factory: Callable[[str], object] | None = None) -> TestClient:
+    return TestClient(
+        build_application(
+            Settings(agent_api_token=SecretStr("correct-token"), _env_file=None),
+            DependencyOverrides(
+                screening_state_repository=InMemoryScreeningStateRepository(),
+                market_data_transport_factory=transport_factory,
+            ),
+        )
+    )
+
+
+def _auth() -> dict[str, str]:
+    return {"Authorization": "Bearer correct-token"}
+
+
+def _tradier_refresh_responses(expiration: str) -> list[ReadOnlyHttpResponse]:
+    return [
+        tradier_quote_response(),
+        ReadOnlyHttpResponse(
+            200, {"expirations": {"date": [expiration]}}, (), 12, "tradier-request-2"
+        ),
+        ReadOnlyHttpResponse(
+            200,
+            {
+                "options": {
+                    "option": [
+                        {
+                            "symbol": "AAPL_TEST_CALL",
+                            "underlying": "AAPL",
+                            "expiration_date": expiration,
+                            "strike": "190",
+                            "option_type": "call",
+                            "bid": "4.9",
+                            "ask": "5.1",
+                            "last": "5",
+                            "volume": 1000,
+                            "open_interest": 5000,
+                            "greeks": {
+                                "delta": "0.5",
+                                "gamma": "0.03",
+                                "theta": "-0.1",
+                                "vega": "0.2",
+                                "rho": "0.01",
+                            },
+                        }
+                    ]
+                }
+            },
+            (),
+            12,
+            "tradier-request-3",
+        ),
+    ]
+
+
+class TestAuthenticationAndValidation:
+    def test_without_authorization_header_is_404(self) -> None:
+        response = _client().post("/api/v1/screening/skew_momentum/AAPL/refresh")
+        assert response.status_code == 404
+
+    def test_unknown_signal_is_404(self) -> None:
+        response = _client().post(
+            "/api/v1/screening/not_a_real_signal/AAPL/refresh", headers=_auth()
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"]["error_code"] == "UNKNOWN_SIGNAL"
+
+    def test_symbol_outside_approved_live_universe_is_422(self) -> None:
+        response = _client().post(
+            "/api/v1/screening/skew_momentum/NOTREAL/refresh", headers=_auth()
+        )
+        assert response.status_code == 422
+        assert response.json()["detail"]["error_code"] == "UNSUPPORTED_SYMBOL"
+
+    def test_no_live_provider_configured_is_503(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No ASA_TRADIER_ENABLED/ASA_FINNHUB_ENABLED/ASA_ALPHA_VANTAGE_ENABLED set
+        # -- every provider is disabled by default.
+        for name in (
+            "ASA_TRADIER_ENABLED",
+            "ASA_FINNHUB_ENABLED",
+            "ASA_ALPHA_VANTAGE_ENABLED",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        response = _client().post("/api/v1/screening/skew_momentum/AAPL/refresh", headers=_auth())
+        assert response.status_code == 503
+        assert response.json()["detail"]["error_code"] == "NO_LIVE_PROVIDER_CONFIGURED"
+
+
+class TestSuccessfulRefresh:
+    def test_refresh_persists_and_returns_a_result_with_request_accounting(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+        monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+        expiration = (date.today() + timedelta(days=7)).isoformat()
+        responses = _tradier_refresh_responses(expiration)
+        client = _client(transport_factory=lambda _provider_id: ScriptedTransport(responses))
+
+        response = client.post("/api/v1/screening/skew_momentum/AAPL/refresh", headers=_auth())
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["signal_id"] == "skew_momentum"
+        assert body["symbol"] == "AAPL"
+        assert body["request_count"] >= 1
+        assert body["updated_at"] is not None
+        assert body["age_seconds"] >= 0
+        # "sandbox-secret-token" must never appear in the response.
+        assert "sandbox-secret-token" not in response.text
+
+    def test_refresh_result_is_then_visible_via_get(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+        monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+        expiration = (date.today() + timedelta(days=7)).isoformat()
+        responses = _tradier_refresh_responses(expiration)
+        client = _client(transport_factory=lambda _provider_id: ScriptedTransport(responses))
+
+        client.post("/api/v1/screening/skew_momentum/AAPL/refresh", headers=_auth())
+        follow_up = client.get("/api/v1/screening/skew_momentum/AAPL", headers=_auth())
+
+        assert follow_up.status_code == 200
+        assert follow_up.json()["symbol"] == "AAPL"


### PR DESCRIPTION
## Summary

Implements API-004 from SPRINT-008: `POST /api/v1/screening/{signal}/{symbol}/refresh`, the one deliberate write-triggering exception to the otherwise read-only screening API surface. It triggers exactly one live provider acquisition for one signal/symbol pair — never a whole signal or the whole universe.

- Reuses `screening.service.refresh()` directly, per the sprint's shared-execution-graph principle (CLI and API must call the same `screening/` functions, never duplicate logic).
- Promoted `screening/cli.py`'s private `_live_only_config()`/`APPROVED_LIVE_UNIVERSE` to public (`screening/live_acquisition.py`). This is the guard that force-disables the `deterministic_fixture` provider so a "live" refresh can never silently be served offline fixture data (the fixture provider defaults to enabled and sorts alphabetically first) — reusing this safety-critical logic rather than duplicating it in the API layer was not optional.
- Added `build_fulfillment_service_with_accounting()` returning `(service, budget_manager)`, since `CapabilityFulfillmentService`'s `RequestBudgetManager` is a private `__slots__` attribute with no public getter, and the refresh response needs to report `request_count`. `build_fulfillment_service()` becomes a thin wrapper around it — zero change for the existing CLI caller.
- Validation order: unknown signal → 404 `UNKNOWN_SIGNAL`, symbol outside `APPROVED_LIVE_UNIVERSE` → 422 `UNSUPPORTED_SYMBOL`, no live provider enabled → 503 `NO_LIVE_PROVIDER_CONFIGURED`.
- Fresh clock and fulfillment service built per request (budget managers accumulate internal state, so nothing is cached/shared across requests).

## Test plan

- [x] `tests/asa/test_screening_refresh_route.py` (6 tests): auth/validation failure paths, and a full happy-path exercising `skew_momentum`'s real 3-step live acquisition chain (quote → expirations → option chain) against a scripted transport, confirming the result persists, is then visible via GET, and the provider credential never appears in the response body.
- [x] `ruff check` / `mypy` clean on changed files
- [x] Full scoped suite (`tests/`, excluding `pos`/`deployment_observer`): 1716 passed, 17 skipped, no regressions
- [x] `tests/asa/test_boundaries.py`'s "strategy"-word ban still holds (5 passed)
- [x] OpenAPI schema confirms the new route

🤖 Generated with [Claude Code](https://claude.com/claude-code)