### PR TITLE
PROD-002: scheduled screening execution and persistence (code)

### DIFF
--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -1,0 +1,173 @@
+"""SPRINT-008D/PROD-002: scheduled production screening execution.
+
+Calls screening.service.refresh() -- the same shared execution graph
+POST /api/v1/screening/{signal}/{symbol}/refresh already calls, and that
+screening/cli.py's own machinery underlies -- once per (signal, symbol)
+pair in the production screening universe
+(project/reports/SPRINT-008D-SCREENING-UNIVERSE.md), persisting through
+the real PostgresScreeningStateRepository. No signal-selection or
+acquisition logic is reimplemented here.
+
+Not a background daemon: this module has no loop, no in-process scheduler,
+no timer. It runs the full universe once per invocation and exits.
+Scheduling -- how often this runs -- is deliberately kept external (a
+Railway Cron Schedule or any equivalent externally-triggered invocation),
+per this sprint's own architecture_principles.
+
+Usage: python -m asa.scheduled_screening [--json]
+Exit code: 0 if every pair completed without an unexpected exception (any
+isolated per-signal failure outcome, e.g. missing data, is still a
+completed, persisted result, not a failure of this runner); 1 if any
+pair raised an exception this runner had to isolate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from asa.config import Settings
+from asa.integrations.postgres import create_postgres_engine
+from asa.integrations.screening_postgres import PostgresScreeningStateRepository
+from market_data import load_market_data_config_from_environment
+from market_data.live_transport import build_live_transport
+from screening import SIGNAL_REGISTRY
+from screening.live_acquisition import (
+    build_fulfillment_service_with_accounting,
+    enabled_provider_configs,
+    live_only_config,
+)
+from screening.service import refresh
+from screening.state import ScreeningStateRepository
+
+# The initial production screening universe
+# (project/reports/SPRINT-008D-SCREENING-UNIVERSE.md, PROD-001): the two
+# signals whose data requirements are met entirely by Tradier, across the
+# full APPROVED_LIVE_UNIVERSE. earnings_calendar is deliberately excluded
+# pending PROD-004's own provider validation. This tuple is the one place
+# the scheduled universe is declared -- change it only alongside a
+# rescoped universe definition, never silently.
+PRODUCTION_SCREENING_UNIVERSE: tuple[tuple[str, str], ...] = tuple(
+    (signal_id, symbol)
+    for signal_id in ("forward_factor", "skew_momentum")
+    for symbol in ("AAPL", "MSFT", "NVDA", "AMD", "SPY", "QQQ")
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _SystemClock:
+    def now(self) -> datetime:
+        return datetime.now(UTC)
+
+
+@dataclass(frozen=True, slots=True)
+class PairOutcome:
+    signal_id: str
+    symbol: str
+    outcome: str | None
+    request_count: int | None
+    error: str | None
+
+
+def run_scheduled_refresh(
+    universe: tuple[tuple[str, str], ...] = PRODUCTION_SCREENING_UNIVERSE,
+    *,
+    repository: ScreeningStateRepository | None = None,
+    transport_factory: Callable[[str], object] = build_live_transport,
+) -> tuple[PairOutcome, ...]:
+    """Run one bounded refresh per pair in ``universe``, in order,
+    persisting every result. One pair's failure never stops the others --
+    a fresh CapabilityFulfillmentService (and its own request budget) is
+    built per pair, exactly matching the per-request pattern
+    asa/api/screening_routes.py already uses, never shared or cached
+    across pairs.
+
+    ``repository`` and ``transport_factory`` are injectable (default:
+    the real Postgres repository and the real live transport) so this
+    function is directly testable without a live database or network,
+    the same DependencyOverrides-style pattern asa/bootstrap.py already
+    uses.
+    """
+    resolved_repository = repository or PostgresScreeningStateRepository(
+        create_postgres_engine(Settings().database_url)
+    )
+    config = live_only_config(load_market_data_config_from_environment())
+    if not enabled_provider_configs(config):
+        raise RuntimeError(
+            "scheduled refresh requires at least one enabled live market data "
+            "provider; none are enabled"
+        )
+    clock = _SystemClock()
+    outcomes: list[PairOutcome] = []
+    for signal_id, symbol in universe:
+        fulfillment, budget_manager = build_fulfillment_service_with_accounting(
+            config, transport_factory, clock
+        )
+        try:
+            record = refresh(
+                resolved_repository,
+                SIGNAL_REGISTRY,
+                fulfillment,
+                clock,
+                signal_id=signal_id,
+                symbol=symbol,
+            )
+            outcomes.append(
+                PairOutcome(
+                    signal_id, symbol, record.outcome, len(budget_manager.accounting), None
+                )
+            )
+        except Exception as exc:
+            outcomes.append(PairOutcome(signal_id, symbol, None, None, str(exc)))
+    return tuple(outcomes)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m asa.scheduled_screening",
+        description="Run one bounded refresh per pair in the production screening universe.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit only machine-readable JSON.")
+    args = parser.parse_args(argv)
+
+    outcomes = run_scheduled_refresh()
+    failures = [item for item in outcomes if item.error is not None]
+
+    if not args.json:
+        print(f"SCHEDULED SCREENING RUN -- {len(outcomes)} pairs")
+        for item in outcomes:
+            if item.error is not None:
+                print(f"  {item.signal_id:<18} {item.symbol:<6} FAILED: {item.error}")
+            else:
+                print(
+                    f"  {item.signal_id:<18} {item.symbol:<6} {item.outcome} "
+                    f"(requests={item.request_count})"
+                )
+
+    print(
+        json.dumps(
+            {
+                "total": len(outcomes),
+                "failed": len(failures),
+                "results": [
+                    {
+                        "signal_id": item.signal_id,
+                        "symbol": item.symbol,
+                        "outcome": item.outcome,
+                        "request_count": item.request_count,
+                        "error": item.error,
+                    }
+                    for item in outcomes
+                ],
+            }
+        )
+    )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -1,0 +1,152 @@
+"""SPRINT-008D/PROD-002: scheduled production screening execution."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from asa.scheduled_screening import (
+    PRODUCTION_SCREENING_UNIVERSE,
+    run_scheduled_refresh,
+)
+from market_data.transport import ReadOnlyHttpResponse
+from tests.asa.fakes import InMemoryScreeningStateRepository
+from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
+
+
+def _tradier_refresh_responses(expiration: str) -> list[ReadOnlyHttpResponse]:
+    return [
+        tradier_quote_response(),
+        ReadOnlyHttpResponse(
+            200, {"expirations": {"date": [expiration]}}, (), 12, "tradier-request-2"
+        ),
+        ReadOnlyHttpResponse(
+            200,
+            {
+                "options": {
+                    "option": [
+                        {
+                            "symbol": "TEST_CALL",
+                            "underlying": "AAPL",
+                            "expiration_date": expiration,
+                            "strike": "190",
+                            "option_type": "call",
+                            "bid": "4.9",
+                            "ask": "5.1",
+                            "last": "5",
+                            "volume": 1000,
+                            "open_interest": 5000,
+                            "greeks": {
+                                "delta": "0.5",
+                                "gamma": "0.03",
+                                "theta": "-0.1",
+                                "vega": "0.2",
+                                "rho": "0.01",
+                            },
+                        }
+                    ]
+                }
+            },
+            (),
+            12,
+            "tradier-request-3",
+        ),
+    ]
+
+
+def test_production_universe_is_forward_factor_and_skew_momentum_only() -> None:
+    signal_ids = {signal_id for signal_id, _symbol in PRODUCTION_SCREENING_UNIVERSE}
+    assert signal_ids == {"forward_factor", "skew_momentum"}
+    assert len(PRODUCTION_SCREENING_UNIVERSE) == 12
+    assert len(set(PRODUCTION_SCREENING_UNIVERSE)) == 12  # no duplicate pairs
+
+
+def test_no_enabled_provider_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("ASA_TRADIER_ENABLED", "ASA_FINNHUB_ENABLED", "ASA_ALPHA_VANTAGE_ENABLED"):
+        monkeypatch.delenv(name, raising=False)
+    with pytest.raises(RuntimeError, match="at least one enabled live market data provider"):
+        run_scheduled_refresh(repository=InMemoryScreeningStateRepository())
+
+
+def test_runs_every_pair_and_persists_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    repository = InMemoryScreeningStateRepository()
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+    # One universe pair, scripted with enough responses for one full acquisition.
+    universe = (("skew_momentum", "AAPL"),)
+    responses = _tradier_refresh_responses(expiration)
+
+    outcomes = run_scheduled_refresh(
+        universe,
+        repository=repository,
+        transport_factory=lambda _provider_id: ScriptedTransport(responses),
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].signal_id == "skew_momentum"
+    assert outcomes[0].symbol == "AAPL"
+    assert outcomes[0].error is None
+    assert outcomes[0].outcome is not None
+    assert outcomes[0].request_count is not None and outcomes[0].request_count >= 1
+    # Actually persisted through the injected repository -- not just returned.
+    assert repository.get_one("skew_momentum", "AAPL") is not None
+
+
+class _RepositoryThatFailsForOneSymbol:
+    """Wraps a real InMemoryScreeningStateRepository, raising only for one
+    chosen symbol's upsert -- isolates the *runner's own* failure boundary
+    (a genuinely unexpected infrastructure error) from screening's already
+    thoroughly-tested per-signal acquisition isolation (any acquisition
+    problem is already converted to a persisted failure outcome inside
+    screening.service.refresh() itself, never an exception -- see
+    screening/runner.py::_run_one -- so it cannot be used to exercise this
+    module's own outer boundary)."""
+
+    def __init__(self, delegate: InMemoryScreeningStateRepository, failing_symbol: str) -> None:
+        self._delegate = delegate
+        self._failing_symbol = failing_symbol
+
+    def upsert(self, record: object) -> None:
+        if getattr(record, "symbol", None) == self._failing_symbol:
+            raise RuntimeError("simulated infrastructure failure")
+        self._delegate.upsert(record)  # type: ignore[arg-type]
+
+    def get_all(self) -> tuple[object, ...]:
+        return self._delegate.get_all()
+
+    def get_for_signal(self, signal_id: str) -> tuple[object, ...]:
+        return self._delegate.get_for_signal(signal_id)
+
+    def get_one(self, signal_id: str, symbol: str) -> object | None:
+        return self._delegate.get_one(signal_id, symbol)
+
+
+def test_one_pairs_infrastructure_failure_does_not_abort_the_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    delegate = InMemoryScreeningStateRepository()
+    repository = _RepositoryThatFailsForOneSymbol(delegate, failing_symbol="AAPL")
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+    universe = (("skew_momentum", "AAPL"), ("skew_momentum", "MSFT"))
+
+    outcomes = run_scheduled_refresh(
+        universe,
+        repository=repository,  # type: ignore[arg-type]
+        transport_factory=lambda _provider_id: ScriptedTransport(
+            _tradier_refresh_responses(expiration)
+        ),
+    )
+
+    assert len(outcomes) == 2
+    assert outcomes[0].symbol == "AAPL"
+    assert outcomes[0].error is not None
+    assert "simulated infrastructure failure" in outcomes[0].error
+    assert outcomes[1].symbol == "MSFT"
+    assert outcomes[1].error is None
+    # The failing pair never persisted; the succeeding one did.
+    assert delegate.get_one("skew_momentum", "AAPL") is None
+    assert delegate.get_one("skew_momentum", "MSFT") is not None


### PR DESCRIPTION
## Summary

Adds `asa/scheduled_screening.py`: a standalone, no-loop, no-daemon entrypoint (`python -m asa.scheduled_screening`) that runs one bounded refresh per (signal, symbol) pair in the production screening universe (PROD-001) and exits. Calls `screening.service.refresh()` directly — the exact same shared execution graph `POST /api/v1/screening/{signal}/{symbol}/refresh` already calls, reimplementing nothing.

- Deliberately **not** a background process: no loop, no in-process scheduler, no timer inside this module. How often it runs is left entirely external (a Railway Cron Schedule or equivalent), per this sprint's own architecture principles.
- `repository` and `transport_factory` are both injectable (default: real Postgres + real live transport), same `DependencyOverrides`-style pattern `asa/bootstrap.py` already uses — the full loop, including its own failure isolation, is directly unit-testable without a live database or network.
- One pair's failure never aborts the batch. Note: `screening.service.refresh()` itself essentially never raises — `screening/runner.py` already isolates any per-signal acquisition problem into a persisted failure *outcome*, not an exception. This module's own try/except exists for a narrower case (genuinely unexpected infrastructure failure between pairs), and the new failure-isolation test targets that specific boundary directly rather than acquisition failure (which can't reach it).

This PR contains the reusable execution code only. **Actually triggering the first production run and setting up the external scheduling mechanism are separate infrastructure-touching actions**, tracked under this same PROD-002 ticket but kept out of this PR pending explicit confirmation — matching this sprint's own established pattern (ACT-001's token fix) for any change to the live Railway deployment.

## Test plan

- [x] `pytest tests/asa/test_scheduled_screening.py -q` — 4 passed
- [x] `tests/asa/test_boundaries.py` — 5 passed (caught and fixed one "strategy" word reference in a docstring during development)
- [x] Full scoped suite (`tests/`, excluding `pos`/`deployment_observer`): 1722 passed (+4), 17 skipped, no regressions
- [x] `ruff check asa tests/asa` / `mypy asa` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)