### PR TITLE
EPIC-2: declarative strategy contract

### DIFF
--- a/.github/workflows/validate-architecture.yml
+++ b/.github/workflows/validate-architecture.yml
@@ -19,6 +19,7 @@ on:
       - 'presentation/**'
       - 'domain/**'
       - 'market_data/**'
+      - 'strategy_runtime/**'
       - 'asa/**'
       - 'docs/providers/**'
       - 'architecture/**'
@@ -36,6 +37,7 @@ on:
       - 'tests/position_proposals/**'
       - 'tests/portfolio/**'
       - 'tests/execution_planning/**'
+      - 'tests/strategy_runtime/**'
   workflow_dispatch:
 
 jobs:
@@ -71,6 +73,7 @@ jobs:
           tests/position_proposals
           tests/portfolio
           tests/execution_planning
+          tests/strategy_runtime
           -v
 
       - name: Check generated provider documentation drift

--- a/strategy_runtime/__init__.py
+++ b/strategy_runtime/__init__.py
@@ -1,0 +1,41 @@
+"""Universal Strategy Runtime (SPRINT-009).
+
+Root-level, deployable-application-independent infrastructure -- a plain
+sibling of screening/, market_data/, and domain/, following the same
+one-directional dependency rule asa/'s own consolidation established
+(ARCH-MONOREPO-001): this package and everything under it may be imported
+by asa/, but must never import asa/ itself
+(tests/architecture/test_asa_dependency_direction.py enforces this
+automatically for every root-level package, this one included).
+
+EPIC-2 (Declarative Strategy Contract) lives in strategy_runtime.contract:
+the one shape every strategy declares itself through, and the one thing
+the runtime (EPIC-1, added on top of this package as later tickets land)
+reads to execute a strategy without a strategy-specific conditional.
+"""
+
+from __future__ import annotations
+
+from strategy_runtime.contract import (
+    NO_LIFECYCLE,
+    DataRequirement,
+    LifecycleDeclaration,
+    LifecycleModel,
+    OutputKind,
+    RequirementCategory,
+    StrategyContract,
+    StructureKind,
+)
+from strategy_runtime.errors import StrategyContractError
+
+__all__ = [
+    "NO_LIFECYCLE",
+    "DataRequirement",
+    "LifecycleDeclaration",
+    "LifecycleModel",
+    "OutputKind",
+    "RequirementCategory",
+    "StrategyContract",
+    "StrategyContractError",
+    "StructureKind",
+]

--- a/strategy_runtime/contract.py
+++ b/strategy_runtime/contract.py
@@ -1,0 +1,186 @@
+"""Declarative Strategy Contract (SPRINT-009/EPIC-2).
+
+A StrategyContract is a strategy's complete self-description: metadata,
+data requirements, lifecycle model, option structure, and output shape.
+It is the one thing the universal runtime (EPIC-1, built on top of this
+module) reads to execute a strategy, and the one thing a new strategy's
+author must write. No runtime decision should ever need to know a
+strategy_id by name -- every runtime decision this sprint's
+architecture_principles call for ("runtime contains no strategy-named
+conditional") should be derivable from a StrategyContract's own fields
+instead.
+
+This module deliberately does not execute anything, register anything, or
+know about any specific strategy (earnings_calendar, skew_momentum_vertical,
+forward_factor, or otherwise) -- registration and discovery are EPIC-1's own
+job. See tests/strategy_runtime/test_migration_target_contracts.py for
+those three strategies' own draft contracts, proving this schema is
+sufficient to describe each of them, without wiring any of them into a
+runtime yet (EPIC-7's own job).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from domain import MarketCapability
+from strategy_runtime.errors import StrategyContractError
+
+
+def _normalized_text(value: str, owner: str, field_name: str) -> None:
+    if not value or value != value.strip():
+        raise StrategyContractError(f"{owner}.{field_name} must be non-empty normalized text")
+
+
+class RequirementCategory(str, Enum):
+    MARKET_DATA = "market_data"
+    OPTION_DATA = "option_data"
+    EARNINGS = "earnings"
+    FUNDAMENTALS = "fundamentals"
+    TECHNICALS = "technicals"
+    MACRO = "macro"
+    CUSTOM = "custom"
+
+
+# Categories whose data is acquired through the existing, canonical
+# MarketCapability system (domain/market_data.py, market_data/) -- a
+# DataRequirement filed under one of these must name at least one real
+# capability, not merely a category label. fundamentals/technicals/macro
+# are declarable today (so a future strategy can adopt one without a
+# contract-schema change) but have no capability system behind them yet;
+# custom requirements identify themselves by name instead of a capability.
+_CAPABILITY_BACKED_CATEGORIES = frozenset(
+    {RequirementCategory.MARKET_DATA, RequirementCategory.OPTION_DATA, RequirementCategory.EARNINGS}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DataRequirement:
+    category: RequirementCategory
+    capabilities: tuple[MarketCapability, ...] = ()
+    identifier: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.category in _CAPABILITY_BACKED_CATEGORIES and not self.capabilities:
+            raise StrategyContractError(
+                f"a {self.category.value!r} DataRequirement must declare at least one "
+                "MarketCapability"
+            )
+        if self.category is RequirementCategory.CUSTOM and not self.identifier:
+            raise StrategyContractError("a custom DataRequirement must declare an identifier")
+        if len(set(self.capabilities)) != len(self.capabilities):
+            raise StrategyContractError("DataRequirement.capabilities must be unique")
+        if self.identifier is not None:
+            _normalized_text(self.identifier, "DataRequirement", "identifier")
+
+
+class LifecycleModel(str, Enum):
+    NONE = "none"
+    OPPORTUNITY = "opportunity"
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleDeclaration:
+    """NONE means the strategy has no persistent identity across
+    observations -- each evaluation stands alone, matching every strategy
+    this repository has ever run before this sprint. OPPORTUNITY means the
+    strategy tracks a specific opportunity's evolution across repeated
+    observations (EPIC-5's own generalization of the mature Stonk Calendar
+    implementation's lifecycle) and must declare which states that
+    opportunity can be in and what kind of thing is being observed.
+    """
+
+    lifecycle_model: LifecycleModel
+    supported_states: tuple[str, ...] = ()
+    observation_type: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.lifecycle_model is LifecycleModel.NONE:
+            if self.supported_states or self.observation_type is not None:
+                raise StrategyContractError(
+                    "a NONE LifecycleDeclaration must not declare supported_states or "
+                    "observation_type"
+                )
+            return
+        if not self.supported_states:
+            raise StrategyContractError(
+                "an OPPORTUNITY LifecycleDeclaration must declare at least one supported state"
+            )
+        if len(set(self.supported_states)) != len(self.supported_states):
+            raise StrategyContractError("LifecycleDeclaration.supported_states must be unique")
+        for state in self.supported_states:
+            _normalized_text(state, "LifecycleDeclaration", "supported_states entry")
+        if not self.observation_type:
+            raise StrategyContractError(
+                "an OPPORTUNITY LifecycleDeclaration must declare its observation_type"
+            )
+        _normalized_text(self.observation_type, "LifecycleDeclaration", "observation_type")
+
+
+NO_LIFECYCLE = LifecycleDeclaration(LifecycleModel.NONE)
+
+
+class StructureKind(str, Enum):
+    NONE = "none"
+    VERTICAL = "vertical"
+    CALENDAR = "calendar"
+    CUSTOM = "custom"
+
+
+class OutputKind(str, Enum):
+    METRICS = "metrics"
+    ECONOMICS = "economics"
+    LIFECYCLE = "lifecycle"
+    RECOMMENDATION_SUPPORT = "recommendation_support"
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyContract:
+    strategy_id: str
+    version: str
+    category: str
+    description: str
+    requirements: tuple[DataRequirement, ...]
+    lifecycle: LifecycleDeclaration
+    structure: StructureKind
+    outputs: tuple[OutputKind, ...]
+
+    def __post_init__(self) -> None:
+        for name in ("strategy_id", "version", "category", "description"):
+            _normalized_text(getattr(self, name), "StrategyContract", name)
+        if not self.requirements:
+            raise StrategyContractError("StrategyContract.requirements cannot be empty")
+        if len(set(self.requirements)) != len(self.requirements):
+            raise StrategyContractError(
+                "StrategyContract.requirements must not repeat an identical requirement"
+            )
+        if not self.outputs:
+            raise StrategyContractError("StrategyContract.outputs cannot be empty")
+        if len(set(self.outputs)) != len(self.outputs):
+            raise StrategyContractError("StrategyContract.outputs must be unique")
+        if (
+            OutputKind.LIFECYCLE in self.outputs
+            and self.lifecycle.lifecycle_model is LifecycleModel.NONE
+        ):
+            raise StrategyContractError(
+                "a StrategyContract declaring LIFECYCLE output must declare a non-NONE "
+                "lifecycle_model"
+            )
+
+    def requirements_in(self, category: RequirementCategory) -> tuple[DataRequirement, ...]:
+        return tuple(item for item in self.requirements if item.category is category)
+
+    def required_capabilities(self) -> tuple[MarketCapability, ...]:
+        """Every distinct MarketCapability this contract's requirements
+        name, across every capability-backed category, deterministically
+        ordered. The single place a future EPIC-1 execution pipeline (or
+        EPIC-3's shared data planner) should read a strategy's capability
+        needs from -- never re-deriving them from a strategy's own
+        adapter code.
+        """
+        seen: dict[MarketCapability, None] = {}
+        for requirement in self.requirements:
+            for capability in requirement.capabilities:
+                seen[capability] = None
+        return tuple(sorted(seen, key=lambda item: item.value))

--- a/strategy_runtime/errors.py
+++ b/strategy_runtime/errors.py
@@ -1,0 +1,7 @@
+"""Errors for strategy_runtime (SPRINT-009)."""
+
+from __future__ import annotations
+
+
+class StrategyContractError(ValueError):
+    """Raised when a StrategyContract or one of its nested declarations is invalid."""

--- a/tests/strategy_runtime/__init__.py
+++ b/tests/strategy_runtime/__init__.py
@@ -1,0 +1,1 @@
+"""strategy_runtime test package."""

--- a/tests/strategy_runtime/test_contract.py
+++ b/tests/strategy_runtime/test_contract.py
@@ -1,0 +1,166 @@
+"""SPRINT-009/EPIC-2: StrategyContract validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain import MarketCapability
+from strategy_runtime import (
+    NO_LIFECYCLE,
+    DataRequirement,
+    LifecycleDeclaration,
+    LifecycleModel,
+    OutputKind,
+    RequirementCategory,
+    StrategyContract,
+    StrategyContractError,
+    StructureKind,
+)
+
+
+def _requirement(
+    category: RequirementCategory = RequirementCategory.MARKET_DATA,
+) -> DataRequirement:
+    return DataRequirement(category, capabilities=(MarketCapability.REAL_TIME_QUOTE_V1,))
+
+
+def _contract(**overrides: object) -> StrategyContract:
+    defaults: dict[str, object] = {
+        "strategy_id": "example_strategy",
+        "version": "1.0.0",
+        "category": "options",
+        "description": "An example strategy for contract validation tests.",
+        "requirements": (_requirement(),),
+        "lifecycle": NO_LIFECYCLE,
+        "structure": StructureKind.NONE,
+        "outputs": (OutputKind.METRICS,),
+    }
+    defaults.update(overrides)
+    return StrategyContract(**defaults)  # type: ignore[arg-type]
+
+
+class TestDataRequirement:
+    def test_capability_backed_category_without_a_capability_is_rejected(self) -> None:
+        with pytest.raises(StrategyContractError, match="must declare at least one"):
+            DataRequirement(RequirementCategory.OPTION_DATA)
+
+    def test_custom_category_without_an_identifier_is_rejected(self) -> None:
+        with pytest.raises(StrategyContractError, match="custom DataRequirement"):
+            DataRequirement(RequirementCategory.CUSTOM)
+
+    def test_custom_category_with_an_identifier_is_accepted(self) -> None:
+        requirement = DataRequirement(RequirementCategory.CUSTOM, identifier="proprietary_signal")
+        assert requirement.identifier == "proprietary_signal"
+
+    def test_fundamentals_category_is_declarable_with_no_capability_system_yet(self) -> None:
+        # Not capability-backed today (no MarketCapability exists for it),
+        # so it is declarable with neither capabilities nor an identifier --
+        # future-proofing without inventing an unused data model now.
+        requirement = DataRequirement(RequirementCategory.FUNDAMENTALS)
+        assert requirement.capabilities == ()
+
+    def test_duplicate_capabilities_are_rejected(self) -> None:
+        with pytest.raises(StrategyContractError, match="unique"):
+            DataRequirement(
+                RequirementCategory.MARKET_DATA,
+                capabilities=(
+                    MarketCapability.REAL_TIME_QUOTE_V1,
+                    MarketCapability.REAL_TIME_QUOTE_V1,
+                ),
+            )
+
+
+class TestLifecycleDeclaration:
+    def test_none_model_rejects_supported_states(self) -> None:
+        with pytest.raises(StrategyContractError, match="NONE LifecycleDeclaration"):
+            LifecycleDeclaration(LifecycleModel.NONE, supported_states=("watching",))
+
+    def test_opportunity_model_requires_supported_states(self) -> None:
+        with pytest.raises(StrategyContractError, match="at least one supported state"):
+            LifecycleDeclaration(LifecycleModel.OPPORTUNITY, observation_type="spread")
+
+    def test_opportunity_model_requires_observation_type(self) -> None:
+        with pytest.raises(StrategyContractError, match="observation_type"):
+            LifecycleDeclaration(LifecycleModel.OPPORTUNITY, supported_states=("watching",))
+
+    def test_opportunity_model_rejects_duplicate_states(self) -> None:
+        with pytest.raises(StrategyContractError, match="unique"):
+            LifecycleDeclaration(
+                LifecycleModel.OPPORTUNITY,
+                supported_states=("watching", "watching"),
+                observation_type="spread",
+            )
+
+    def test_valid_opportunity_declaration_is_accepted(self) -> None:
+        declaration = LifecycleDeclaration(
+            LifecycleModel.OPPORTUNITY,
+            supported_states=("watching", "confirmed", "closed"),
+            observation_type="calendar_spread",
+        )
+        assert declaration.supported_states == ("watching", "confirmed", "closed")
+
+
+class TestStrategyContract:
+    def test_empty_requirements_is_rejected(self) -> None:
+        with pytest.raises(StrategyContractError, match="requirements cannot be empty"):
+            _contract(requirements=())
+
+    def test_duplicate_requirements_are_rejected(self) -> None:
+        with pytest.raises(StrategyContractError, match="must not repeat"):
+            _contract(requirements=(_requirement(), _requirement()))
+
+    def test_empty_outputs_is_rejected(self) -> None:
+        with pytest.raises(StrategyContractError, match="outputs cannot be empty"):
+            _contract(outputs=())
+
+    def test_duplicate_outputs_are_rejected(self) -> None:
+        with pytest.raises(StrategyContractError, match="outputs must be unique"):
+            _contract(outputs=(OutputKind.METRICS, OutputKind.METRICS))
+
+    def test_lifecycle_output_without_an_opportunity_lifecycle_model_is_rejected(self) -> None:
+        with pytest.raises(StrategyContractError, match="non-NONE lifecycle_model"):
+            _contract(outputs=(OutputKind.LIFECYCLE,), lifecycle=NO_LIFECYCLE)
+
+    def test_lifecycle_output_with_an_opportunity_lifecycle_model_is_accepted(self) -> None:
+        contract = _contract(
+            outputs=(OutputKind.METRICS, OutputKind.LIFECYCLE),
+            lifecycle=LifecycleDeclaration(
+                LifecycleModel.OPPORTUNITY,
+                supported_states=("watching", "closed"),
+                observation_type="spread",
+            ),
+        )
+        assert OutputKind.LIFECYCLE in contract.outputs
+
+    def test_blank_metadata_fields_are_rejected(self) -> None:
+        with pytest.raises(StrategyContractError, match="strategy_id"):
+            _contract(strategy_id="  ")
+
+    def test_required_capabilities_deduplicates_across_requirements(self) -> None:
+        contract = _contract(
+            requirements=(
+                DataRequirement(
+                    RequirementCategory.MARKET_DATA,
+                    capabilities=(MarketCapability.REAL_TIME_QUOTE_V1,),
+                ),
+                DataRequirement(
+                    RequirementCategory.OPTION_DATA,
+                    capabilities=(
+                        MarketCapability.OPTION_CHAIN_V1,
+                        MarketCapability.REAL_TIME_QUOTE_V1,
+                    ),
+                ),
+            )
+        )
+        assert contract.required_capabilities() == (
+            MarketCapability.OPTION_CHAIN_V1,
+            MarketCapability.REAL_TIME_QUOTE_V1,
+        )
+
+    def test_requirements_in_filters_by_category(self) -> None:
+        option_requirement = DataRequirement(
+            RequirementCategory.OPTION_DATA, capabilities=(MarketCapability.OPTION_CHAIN_V1,)
+        )
+        contract = _contract(requirements=(_requirement(), option_requirement))
+        assert contract.requirements_in(RequirementCategory.OPTION_DATA) == (option_requirement,)
+        assert contract.requirements_in(RequirementCategory.EARNINGS) == ()

--- a/tests/strategy_runtime/test_migration_target_contracts.py
+++ b/tests/strategy_runtime/test_migration_target_contracts.py
@@ -1,0 +1,152 @@
+"""SPRINT-009/EPIC-2: draft StrategyContract declarations for the three
+migration-target strategies (forward_factor, skew_momentum_vertical,
+earnings_calendar).
+
+These prove the contract schema is sufficient to describe all three real
+strategies EPIC-7 will eventually migrate -- EPIC-2's own acceptance
+criterion. They are drafts, not production wiring: nothing here is
+registered with any runtime (EPIC-1 does not exist yet), and none of it
+replaces screening/registry.py's existing ScreeningStrategyDefinition,
+which continues to drive the currently-shipped screening/ and asa/ surface
+unchanged until EPIC-7 actually migrates each strategy.
+
+Capability requirements are drawn directly from
+screening/live_adapters.py's real live-acquisition code (confirmed during
+SPRINT-008D/PROD-004's own data-requirement audit,
+project/reports/SPRINT-008D-PROVIDER-VALIDATION.md): every one of the
+three strategies acquires a real-time quote for spot price *and* an
+option chain, even though screening/registry.py's own
+required_capabilities today under-declares this (PROD-004 recommended,
+but did not implement, fixing that declaration -- this draft reflects the
+corrected, complete requirement set from the start).
+
+earnings_calendar's lifecycle states below are a provisional placeholder
+(watching -> confirmed -> active -> closed, with expired as a terminal
+state a calendar spread can reach without ever becoming active) -- a
+defensible first draft, not yet reconciled against the mature Stonk
+Calendar implementation's own actual state vocabulary
+(/Users/jaiafoster/Claude/stonk/app/services/). That reconciliation is
+EPIC-5's own job (Universal Opportunity Model); this test only proves the
+*shape* (LifecycleModel.OPPORTUNITY with named states and an
+observation_type) is sufficient to describe calendar's lifecycle, not
+that these exact five states are the final, authoritative set.
+"""
+
+from __future__ import annotations
+
+from domain import MarketCapability
+from strategy_runtime import (
+    NO_LIFECYCLE,
+    DataRequirement,
+    LifecycleDeclaration,
+    LifecycleModel,
+    OutputKind,
+    RequirementCategory,
+    StrategyContract,
+    StructureKind,
+)
+
+FORWARD_FACTOR_CONTRACT = StrategyContract(
+    strategy_id="forward_factor",
+    version="1.1.0",
+    category="options_volatility",
+    description="Source-qualified forward factor with a delta-selected double calendar.",
+    requirements=(
+        DataRequirement(
+            RequirementCategory.MARKET_DATA, capabilities=(MarketCapability.REAL_TIME_QUOTE_V1,)
+        ),
+        DataRequirement(
+            RequirementCategory.OPTION_DATA, capabilities=(MarketCapability.OPTION_CHAIN_V1,)
+        ),
+    ),
+    lifecycle=NO_LIFECYCLE,
+    structure=StructureKind.CALENDAR,
+    outputs=(OutputKind.METRICS, OutputKind.ECONOMICS),
+)
+
+SKEW_MOMENTUM_VERTICAL_CONTRACT = StrategyContract(
+    strategy_id="skew_momentum",
+    version="1.0.0",
+    category="options_momentum",
+    description=(
+        "Delta-selected vertical with explicit liquidity inputs, debit, score, and verdict."
+    ),
+    requirements=(
+        DataRequirement(
+            RequirementCategory.MARKET_DATA, capabilities=(MarketCapability.REAL_TIME_QUOTE_V1,)
+        ),
+        DataRequirement(
+            RequirementCategory.OPTION_DATA, capabilities=(MarketCapability.OPTION_CHAIN_V1,)
+        ),
+    ),
+    lifecycle=NO_LIFECYCLE,
+    structure=StructureKind.VERTICAL,
+    outputs=(OutputKind.METRICS, OutputKind.ECONOMICS),
+)
+
+EARNINGS_CALENDAR_CONTRACT = StrategyContract(
+    strategy_id="earnings_calendar",
+    version="1.0.0",
+    category="options_earnings",
+    description=(
+        "Confirmed earnings window with a nearest-common-strike calendar and explicit debit."
+    ),
+    requirements=(
+        DataRequirement(
+            RequirementCategory.MARKET_DATA, capabilities=(MarketCapability.REAL_TIME_QUOTE_V1,)
+        ),
+        DataRequirement(
+            RequirementCategory.OPTION_DATA, capabilities=(MarketCapability.OPTION_CHAIN_V1,)
+        ),
+        DataRequirement(
+            RequirementCategory.EARNINGS, capabilities=(MarketCapability.EARNINGS_CALENDAR_V1,)
+        ),
+    ),
+    lifecycle=LifecycleDeclaration(
+        LifecycleModel.OPPORTUNITY,
+        supported_states=("watching", "confirmed", "active", "closed", "expired"),
+        observation_type="earnings_calendar_spread",
+    ),
+    structure=StructureKind.CALENDAR,
+    outputs=(OutputKind.METRICS, OutputKind.ECONOMICS, OutputKind.LIFECYCLE),
+)
+
+
+def test_forward_factor_contract_is_valid() -> None:
+    assert FORWARD_FACTOR_CONTRACT.structure is StructureKind.CALENDAR
+    assert FORWARD_FACTOR_CONTRACT.required_capabilities() == (
+        MarketCapability.OPTION_CHAIN_V1,
+        MarketCapability.REAL_TIME_QUOTE_V1,
+    )
+
+
+def test_skew_momentum_vertical_contract_is_valid() -> None:
+    assert SKEW_MOMENTUM_VERTICAL_CONTRACT.structure is StructureKind.VERTICAL
+    assert SKEW_MOMENTUM_VERTICAL_CONTRACT.required_capabilities() == (
+        MarketCapability.OPTION_CHAIN_V1,
+        MarketCapability.REAL_TIME_QUOTE_V1,
+    )
+
+
+def test_earnings_calendar_contract_is_valid() -> None:
+    assert EARNINGS_CALENDAR_CONTRACT.lifecycle.lifecycle_model is LifecycleModel.OPPORTUNITY
+    assert OutputKind.LIFECYCLE in EARNINGS_CALENDAR_CONTRACT.outputs
+    assert EARNINGS_CALENDAR_CONTRACT.required_capabilities() == (
+        MarketCapability.EARNINGS_CALENDAR_V1,
+        MarketCapability.OPTION_CHAIN_V1,
+        MarketCapability.REAL_TIME_QUOTE_V1,
+    )
+
+
+def test_all_three_contracts_share_the_same_market_data_and_option_data_requirements() -> None:
+    # Confirms EPIC-3's own shared-data-planning premise at the contract
+    # level: these three strategies genuinely do overlap in what they
+    # need, which is exactly what makes cross-strategy request
+    # deduplication worth building.
+    for contract in (
+        FORWARD_FACTOR_CONTRACT,
+        SKEW_MOMENTUM_VERTICAL_CONTRACT,
+        EARNINGS_CALENDAR_CONTRACT,
+    ):
+        assert MarketCapability.REAL_TIME_QUOTE_V1 in contract.required_capabilities()
+        assert MarketCapability.OPTION_CHAIN_V1 in contract.required_capabilities()


### PR DESCRIPTION
## Summary

Adds `strategy_runtime/`, a new root-level package (a plain sibling of `screening/`, `market_data/`, `domain/`) defining `StrategyContract`: a strategy's complete self-description (metadata, data requirements, lifecycle model, option structure, output shape). This is the one thing the runtime (EPIC-1, not yet built) will read to execute a strategy, and the one thing a new strategy's author will write — once EPIC-1 exists, no runtime decision should need to know a `strategy_id` by name.

**Design, each validated by a dedicated test:**
- `DataRequirement` ties a requirement to a category (`market_data`, `option_data`, `earnings`, `fundamentals`, `technicals`, `macro`, `custom`). Categories with an existing `MarketCapability` system must name a real capability — no vague declaration accepted. `fundamentals`/`technicals`/`macro` are declarable today with no capability system yet, so a future strategy can adopt one without a schema change.
- `LifecycleDeclaration` is `NONE` (every strategy this repo has run before this sprint) or `OPPORTUNITY` (tracks an opportunity's evolution across observations — EPIC-5's own generalization target), with internal consistency enforced both ways.
- `StrategyContract` rejects empty/duplicate requirements and outputs, and rejects declaring `LIFECYCLE` output without an `OPPORTUNITY` lifecycle backing it.

**Drafts real contracts for all three EPIC-7 migration targets** (`tests/strategy_runtime/test_migration_target_contracts.py`), satisfying EPIC-2's own acceptance criterion without wiring anything into a runtime yet. Capability requirements are drawn directly from `screening/live_adapters.py`'s real code (confirmed during SPRINT-008D/PROD-004's data-requirement audit) — correcting the capability under-declaration PROD-004 found but didn't fix in `screening/registry.py`. Also confirms real overlap in what these three strategies need — direct evidence for EPIC-3's own shared-data-planning work. `earnings_calendar`'s lifecycle states are an explicitly labeled provisional placeholder pending EPIC-5's reconciliation against the mature Stonk implementation.

Nothing in this ticket touches `screening/registry.py`, any currently-shipped strategy, or the existing `/api/v1/screening*` surface — existing behavior is completely unchanged.

## Test plan

- [x] 23 new tests, all passing
- [x] Full scoped suite (`tests/`, excluding `pos`/`deployment_observer`): 1746 passed, 17 skipped, no regressions
- [x] `tests/architecture` (443 tests, auto-includes the new package): passes
- [x] `ruff check strategy_runtime tests/strategy_runtime` / `mypy strategy_runtime tests/strategy_runtime` — clean (matching the codebase's own pre-existing `str`+`Enum` convention rather than introducing `enum.StrEnum` inconsistently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)