### PR TITLE
EPIC-6: universal screening result

### DIFF
--- a/strategy_runtime/__init__.py
+++ b/strategy_runtime/__init__.py
@@ -15,7 +15,9 @@ discovery), strategy_runtime.context (what an adapter receives), and
 strategy_runtime.execution (the one execution pipeline every registered
 strategy runs through, with error isolation, diagnostics, and metrics) --
 together, the one place a strategy executes without a strategy-specific
-conditional anywhere in this package.
+conditional anywhere in this package. EPIC-6 (Universal Screening Result)
+lives in strategy_runtime.result: the one canonical result envelope every
+strategy's adapter returns.
 """
 
 from __future__ import annotations
@@ -43,16 +45,26 @@ from strategy_runtime.execution import (
     run_strategies,
 )
 from strategy_runtime.registry import StrategyAdapter, StrategyRegistry
+from strategy_runtime.result import (
+    SUCCESS_EVALUATION_STATES,
+    EvaluationState,
+    RowType,
+    UniversalScreeningResult,
+    compute_observation_id,
+)
 
 __all__ = [
     "NO_LIFECYCLE",
+    "SUCCESS_EVALUATION_STATES",
     "DataRequirement",
     "DuplicateStrategyRegistrationError",
+    "EvaluationState",
     "ExecutionStatus",
     "LifecycleDeclaration",
     "LifecycleModel",
     "OutputKind",
     "RequirementCategory",
+    "RowType",
     "RuntimeContext",
     "RuntimeExecutionSummary",
     "StrategyAdapter",
@@ -61,6 +73,8 @@ __all__ = [
     "StrategyExecutionResult",
     "StrategyRegistry",
     "StructureKind",
+    "UniversalScreeningResult",
     "UnknownStrategyIdError",
+    "compute_observation_id",
     "run_strategies",
 ]

--- a/strategy_runtime/result.py
+++ b/strategy_runtime/result.py
@@ -1,0 +1,137 @@
+"""Universal Screening Result (SPRINT-009/EPIC-6).
+
+One canonical result envelope every strategy emits, regardless of what
+that strategy evaluates. Generalizes screening.results.ScreeningResult's
+own outcome_status/signal_classification split -- evaluation_state and
+verdict here play the same two roles (execution-level outcome vs. a
+strategy's own business classification) -- and adds the lifecycle/
+opportunity/recommendation fields ScreeningResult never needed, since no
+currently-shipped strategy tracks lifecycle. That is EPIC-5's own
+generalization target; this module defines the envelope shape only, not
+how a lifecycle-aware strategy populates it.
+
+Strategy-specific data belongs only inside metrics and economics -- this
+sprint's own EPIC-6 acceptance criterion ("strategy-specific data
+contained within metrics/economics namespaces") is enforced structurally:
+this envelope has no strategy-named field anywhere, only these two open,
+string-keyed namespaces every strategy writes its own values into.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+def compute_observation_id(run_id: str, strategy_id: str, symbol: str) -> str:
+    """Deterministic identity for one (run, strategy, symbol) observation
+    -- reproducible for identical inputs, matching the same sha256-hash
+    convention screening/runner.py's own run_id and
+    strategy_runtime.execution's own run_id already use, rather than a
+    random UUID that would make two independently-computed observations
+    of the identical run impossible to compare or deduplicate.
+    """
+    payload = {"run_id": run_id, "strategy_id": strategy_id, "symbol": symbol}
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _normalized_text(value: str, owner: str, field_name: str) -> None:
+    if not value or value != value.strip():
+        raise ValueError(f"{owner}.{field_name} must be non-empty normalized text")
+
+
+def _require_tz_aware(value: datetime, owner: str, field_name: str) -> None:
+    if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+        raise ValueError(f"{owner}.{field_name} must be timezone-aware")
+
+
+class RowType(str, Enum):
+    """A single strategy's own evaluation produces exactly one RESULT row
+    today -- every currently-shipped and every EPIC-7 migration-target
+    strategy. Left open (not a bare bool) so a future strategy that emits
+    more than one row per observation (e.g. one row per option leg) has
+    somewhere to declare that without a new envelope field.
+    """
+
+    RESULT = "result"
+
+
+class EvaluationState(str, Enum):
+    """Generalizes screening.results.ScreeningOutcomeStatus -- the
+    execution-level outcome for one (strategy, subject) evaluation,
+    independent of the strategy's own business verdict. ADAPTER_EXCEPTION
+    matches strategy_runtime.execution.ExecutionStatus's own vocabulary
+    for the same concept (an unhandled adapter exception), not
+    screening's older STRATEGY_EXCEPTION name -- one consistent name
+    within this package rather than two for the same thing.
+    """
+
+    PASS = "pass"
+    NO_SIGNAL = "no_signal"
+    MISSING_DATA = "missing_data"
+    MALFORMED_OUTPUT = "malformed_output"
+    ADAPTER_EXCEPTION = "adapter_exception"
+
+
+SUCCESS_EVALUATION_STATES = frozenset({EvaluationState.PASS, EvaluationState.NO_SIGNAL})
+
+
+@dataclass(frozen=True, slots=True)
+class UniversalScreeningResult:
+    strategy_id: str
+    strategy_version: str
+    symbol: str
+    observation_id: str
+    opportunity_id: str | None
+    row_type: RowType
+    verdict: str | None
+    evaluation_state: EvaluationState
+    lifecycle_stage: str | None
+    recommendation_state: str | None
+    data_quality: str | None
+    metrics: dict[str, str]
+    economics: dict[str, str]
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    provenance: tuple[str, ...]
+    observed_at: datetime
+
+    def __post_init__(self) -> None:
+        for name in ("strategy_id", "strategy_version", "symbol", "observation_id"):
+            _normalized_text(getattr(self, name), "UniversalScreeningResult", name)
+        _require_tz_aware(self.observed_at, "UniversalScreeningResult", "observed_at")
+
+        is_success = self.evaluation_state in SUCCESS_EVALUATION_STATES
+        if is_success:
+            if self.verdict is None:
+                raise ValueError(
+                    "UniversalScreeningResult requires verdict for a successful evaluation_state"
+                )
+        elif self.verdict is not None:
+            raise ValueError(
+                "UniversalScreeningResult must not carry verdict for a non-success "
+                "evaluation_state"
+            )
+        if self.verdict is not None:
+            _normalized_text(self.verdict, "UniversalScreeningResult", "verdict")
+
+        if (self.opportunity_id is None) != (self.lifecycle_stage is None):
+            raise ValueError(
+                "UniversalScreeningResult.opportunity_id and lifecycle_stage must both be "
+                "present or both be absent -- a lifecycle stage with no tracked opportunity, "
+                "or an opportunity with no stage, is not a valid state"
+            )
+        if self.opportunity_id is not None:
+            _normalized_text(self.opportunity_id, "UniversalScreeningResult", "opportunity_id")
+        if self.lifecycle_stage is not None:
+            _normalized_text(self.lifecycle_stage, "UniversalScreeningResult", "lifecycle_stage")
+        if self.recommendation_state is not None:
+            _normalized_text(
+                self.recommendation_state, "UniversalScreeningResult", "recommendation_state"
+            )
+        if self.data_quality is not None:
+            _normalized_text(self.data_quality, "UniversalScreeningResult", "data_quality")

--- a/tests/strategy_runtime/test_result.py
+++ b/tests/strategy_runtime/test_result.py
@@ -1,0 +1,94 @@
+"""SPRINT-009/EPIC-6: UniversalScreeningResult validation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from strategy_runtime.result import (
+    EvaluationState,
+    RowType,
+    UniversalScreeningResult,
+    compute_observation_id,
+)
+
+
+def _result(**overrides: object) -> UniversalScreeningResult:
+    defaults: dict[str, object] = {
+        "strategy_id": "example",
+        "strategy_version": "1.0.0",
+        "symbol": "AAPL",
+        "observation_id": "obs-1",
+        "opportunity_id": None,
+        "row_type": RowType.RESULT,
+        "verdict": "pass",
+        "evaluation_state": EvaluationState.PASS,
+        "lifecycle_stage": None,
+        "recommendation_state": None,
+        "data_quality": None,
+        "metrics": {},
+        "economics": {},
+        "blockers": (),
+        "warnings": (),
+        "provenance": (),
+        "observed_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    return UniversalScreeningResult(**defaults)  # type: ignore[arg-type]
+
+
+class TestComputeObservationId:
+    def test_deterministic_for_identical_inputs(self) -> None:
+        assert compute_observation_id("run-1", "alpha", "AAPL") == compute_observation_id(
+            "run-1", "alpha", "AAPL"
+        )
+
+    def test_differs_when_any_input_differs(self) -> None:
+        base = compute_observation_id("run-1", "alpha", "AAPL")
+        assert compute_observation_id("run-2", "alpha", "AAPL") != base
+        assert compute_observation_id("run-1", "beta", "AAPL") != base
+        assert compute_observation_id("run-1", "alpha", "MSFT") != base
+
+
+class TestUniversalScreeningResult:
+    def test_success_state_requires_verdict(self) -> None:
+        with pytest.raises(ValueError, match="requires verdict"):
+            _result(evaluation_state=EvaluationState.PASS, verdict=None)
+
+    def test_non_success_state_rejects_verdict(self) -> None:
+        with pytest.raises(ValueError, match="must not carry verdict"):
+            _result(evaluation_state=EvaluationState.MISSING_DATA, verdict="pass")
+
+    def test_no_signal_is_also_a_success_state_requiring_verdict(self) -> None:
+        result = _result(evaluation_state=EvaluationState.NO_SIGNAL, verdict="no_signal")
+        assert result.verdict == "no_signal"
+
+    def test_adapter_exception_state_with_no_verdict_is_valid(self) -> None:
+        result = _result(evaluation_state=EvaluationState.ADAPTER_EXCEPTION, verdict=None)
+        assert result.verdict is None
+
+    def test_opportunity_id_without_lifecycle_stage_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must both be present or both be absent"):
+            _result(opportunity_id="opp-1", lifecycle_stage=None)
+
+    def test_lifecycle_stage_without_opportunity_id_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must both be present or both be absent"):
+            _result(opportunity_id=None, lifecycle_stage="watching")
+
+    def test_both_opportunity_id_and_lifecycle_stage_present_is_valid(self) -> None:
+        result = _result(opportunity_id="opp-1", lifecycle_stage="watching")
+        assert result.opportunity_id == "opp-1"
+        assert result.lifecycle_stage == "watching"
+
+    def test_both_absent_is_valid_the_common_no_lifecycle_case(self) -> None:
+        result = _result(opportunity_id=None, lifecycle_stage=None)
+        assert result.opportunity_id is None
+
+    def test_naive_datetime_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="timezone-aware"):
+            _result(observed_at=datetime(2026, 1, 1))  # noqa: DTZ001
+
+    def test_blank_strategy_id_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="strategy_id"):
+            _result(strategy_id="  ")

--- a/tests/strategy_runtime/test_result_migration_targets.py
+++ b/tests/strategy_runtime/test_result_migration_targets.py
@@ -1,0 +1,91 @@
+"""SPRINT-009/EPIC-6: proves the universal envelope fits all three
+EPIC-7 migration targets without a field that only makes sense for one
+of them -- EPIC-6's own acceptance criterion. forward_factor and
+skew_momentum_vertical share an identical shape (no lifecycle);
+earnings_calendar is deliberately the one that populates the
+lifecycle-specific fields, proving the same envelope handles both cases
+without a strategy-specific branch anywhere in this module -- these are
+just three different sets of field values on one dataclass.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from strategy_runtime.result import (
+    EvaluationState,
+    RowType,
+    UniversalScreeningResult,
+    compute_observation_id,
+)
+
+_RUN_ID = "example-run-id"
+_OBSERVED_AT = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _no_lifecycle_result(strategy_id: str, strategy_version: str) -> UniversalScreeningResult:
+    return UniversalScreeningResult(
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        symbol="AAPL",
+        observation_id=compute_observation_id(_RUN_ID, strategy_id, "AAPL"),
+        opportunity_id=None,
+        row_type=RowType.RESULT,
+        verdict="pass",
+        evaluation_state=EvaluationState.PASS,
+        lifecycle_stage=None,
+        recommendation_state=None,
+        data_quality="fresh",
+        metrics={"strategy_native_score": "0.42"},
+        economics={"debit": "1.25"},
+        blockers=(),
+        warnings=(),
+        provenance=("tradier:option_chain_v1",),
+        observed_at=_OBSERVED_AT,
+    )
+
+
+def test_forward_factor_fits_the_universal_envelope() -> None:
+    result = _no_lifecycle_result("forward_factor", "1.1.0")
+    assert result.opportunity_id is None
+    assert result.lifecycle_stage is None
+    assert result.metrics["strategy_native_score"] == "0.42"
+
+
+def test_skew_momentum_vertical_fits_the_universal_envelope() -> None:
+    result = _no_lifecycle_result("skew_momentum", "1.0.0")
+    assert result.opportunity_id is None
+    assert result.lifecycle_stage is None
+
+
+def test_earnings_calendar_fits_the_universal_envelope_including_lifecycle_fields() -> None:
+    strategy_id = "earnings_calendar"
+    observation_id = compute_observation_id(_RUN_ID, strategy_id, "AAPL")
+    result = UniversalScreeningResult(
+        strategy_id=strategy_id,
+        strategy_version="1.0.0",
+        symbol="AAPL",
+        observation_id=observation_id,
+        opportunity_id=f"opportunity:{strategy_id}:AAPL:2026-02-01",
+        row_type=RowType.RESULT,
+        verdict="true_earnings_iv_crush_calendar",
+        evaluation_state=EvaluationState.PASS,
+        lifecycle_stage="watching",
+        recommendation_state=None,
+        data_quality="fresh",
+        metrics={"strategy_native_score": "0.71"},
+        economics={"debit": "0.85"},
+        blockers=(),
+        warnings=("earnings_timestamp_unconfirmed",),
+        provenance=("tradier:option_chain_v1", "finnhub:earnings_calendar_v1"),
+        observed_at=_OBSERVED_AT,
+    )
+    assert result.opportunity_id is not None
+    assert result.lifecycle_stage == "watching"
+    assert result.verdict == "true_earnings_iv_crush_calendar"
+
+
+def test_all_three_share_the_same_envelope_type_not_three_different_shapes() -> None:
+    forward_factor = _no_lifecycle_result("forward_factor", "1.1.0")
+    skew_momentum = _no_lifecycle_result("skew_momentum", "1.0.0")
+    assert type(forward_factor) is type(skew_momentum) is UniversalScreeningResult


### PR DESCRIPTION
## Summary

Adds `strategy_runtime/result.py`: `UniversalScreeningResult`, one canonical result envelope every strategy's adapter returns, implementing the sprint's own `core_fields` list directly.

Generalizes `screening.results.ScreeningResult`'s own established `outcome_status`/`signal_classification` split into `evaluation_state`/`verdict` here, carrying over its exact validation invariant (verdict required for success, forbidden otherwise) rather than inventing a new rule. Adds the lifecycle/opportunity/recommendation fields `ScreeningResult` never needed — EPIC-5's own generalization target. `EvaluationState.ADAPTER_EXCEPTION` deliberately matches EPIC-1's own `ExecutionStatus` naming for the same concept, rather than screening's older `STRATEGY_EXCEPTION` name.

`opportunity_id` and `lifecycle_stage` are enforced as a pair (both present or both absent). `compute_observation_id()` derives a deterministic identity from `(run_id, strategy_id, symbol)`, matching the sha256-hash convention already used throughout this sprint's own code, rather than a random UUID.

**Strategy-specific data belongs only inside `metrics`/`economics`** — enforced structurally: this envelope has no strategy-named field anywhere.

`tests/strategy_runtime/test_result_migration_targets.py` proves EPIC-6's own acceptance criterion directly: `forward_factor` and `skew_momentum_vertical` (identical shape, no lifecycle) and `earnings_calendar` (the one that populates `opportunity_id`/`lifecycle_stage`) all construct the same envelope type with no strategy-specific field needed for either case — not merely asserted, actually constructed and validated.

Nothing here touches `screening/`, any currently-shipped strategy, or the existing `/api/v1/screening*` surface — existing behavior is completely unchanged.

## Test plan

- [x] 16 new tests (56 total in `strategy_runtime`, up from 40), all passing
- [x] Full scoped suite (`tests/`, excluding `pos`/`deployment_observer`): 1779 passed, 17 skipped, no regressions
- [x] `ruff check strategy_runtime tests/strategy_runtime` / `mypy strategy_runtime` — clean (matching this ticket's own established conventions for the pattern-matched warnings that remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)