### PR TITLE
EPIC-3: shared data planning

### DIFF
--- a/strategy_runtime/__init__.py
+++ b/strategy_runtime/__init__.py
@@ -17,7 +17,11 @@ strategy runs through, with error isolation, diagnostics, and metrics) --
 together, the one place a strategy executes without a strategy-specific
 conditional anywhere in this package. EPIC-6 (Universal Screening Result)
 lives in strategy_runtime.result: the one canonical result envelope every
-strategy's adapter returns.
+strategy's adapter returns. EPIC-3 (Shared Data Planning) lives in
+strategy_runtime.market_data_planning: one market_data.
+CapabilityFulfillmentService per subject, shared by every strategy that
+evaluates it within a run, threaded through RuntimeContext.fulfillment by
+run_strategies()'s own optional fulfillment_by_subject parameter.
 """
 
 from __future__ import annotations
@@ -43,6 +47,10 @@ from strategy_runtime.execution import (
     RuntimeExecutionSummary,
     StrategyExecutionResult,
     run_strategies,
+)
+from strategy_runtime.market_data_planning import (
+    SubjectMarketDataAccess,
+    build_shared_market_data_access,
 )
 from strategy_runtime.registry import StrategyAdapter, StrategyRegistry
 from strategy_runtime.result import (
@@ -73,8 +81,10 @@ __all__ = [
     "StrategyExecutionResult",
     "StrategyRegistry",
     "StructureKind",
+    "SubjectMarketDataAccess",
     "UniversalScreeningResult",
     "UnknownStrategyIdError",
+    "build_shared_market_data_access",
     "compute_observation_id",
     "run_strategies",
 ]

--- a/strategy_runtime/context.py
+++ b/strategy_runtime/context.py
@@ -1,17 +1,23 @@
-"""Strategy execution context (SPRINT-009/EPIC-1).
+"""Strategy execution context (SPRINT-009/EPIC-1, extended by EPIC-3).
 
-What a strategy adapter receives to evaluate one subject. Deliberately
-minimal today: EPIC-3 (Shared Data Planning) will extend this with
-acquired-data access once it exists, by adding a field here, not by
-changing an adapter's own signature -- an adapter always receives "the
-context" as a whole, never its fields positionally, so it gains new
-capability without needing to be rewritten when the context grows.
+What a strategy adapter receives to evaluate one subject. ``fulfillment``
+is EPIC-3's own extension (Shared Data Planning): the
+market_data.CapabilityFulfillmentService shared by every strategy in the
+same run that evaluates the same subject, so an identical CapabilityRequest
+two strategies both make is only ever fulfilled once
+(strategy_runtime.market_data_planning). None for a strategy contract
+that declares no market_data/option_data/earnings requirement, or when a
+caller runs strategies without shared data planning at all (EPIC-1's own
+run_strategies() remains fully usable without it) -- a strategy that
+needs it should assert it is not None itself, since only that strategy's
+own contract can know it always will be for a correctly-run pipeline.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
+from market_data import CapabilityFulfillmentService
 from strategy_runtime.clock import Clock
 from strategy_runtime.contract import StrategyContract
 
@@ -22,3 +28,4 @@ class RuntimeContext:
     subject: str
     clock: Clock
     run_id: str
+    fulfillment: CapabilityFulfillmentService | None = None

--- a/strategy_runtime/execution.py
+++ b/strategy_runtime/execution.py
@@ -16,11 +16,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import Generic, TypeVar
 
+from market_data import CapabilityFulfillmentService
 from strategy_runtime.clock import Clock
 from strategy_runtime.context import RuntimeContext
 from strategy_runtime.registry import StrategyRegistry
@@ -101,10 +103,12 @@ def _run_one(
     subject: str,
     clock: Clock,
     run_id: str,
+    fulfillment_by_subject: Mapping[str, CapabilityFulfillmentService] | None,
 ) -> StrategyExecutionResult[TResult]:
     adapter = registry.adapter_for(strategy_id)
     contract = registry.contract_for(strategy_id)
-    context = RuntimeContext(contract, subject, clock, run_id)
+    fulfillment = fulfillment_by_subject.get(subject) if fulfillment_by_subject else None
+    context = RuntimeContext(contract, subject, clock, run_id, fulfillment)
     started_at = clock.now()
     try:
         result = adapter(context)
@@ -137,6 +141,7 @@ def run_strategies(
     *,
     subjects: tuple[str, ...],
     strategy_ids: tuple[str, ...] | None = None,
+    fulfillment_by_subject: Mapping[str, CapabilityFulfillmentService] | None = None,
 ) -> tuple[StrategyExecutionResult[TResult], ...]:
     """Run every requested registered strategy against every requested
     subject, independently. One (strategy, subject) pair's adapter
@@ -150,6 +155,16 @@ def run_strategies(
     derived only from those inputs, never randomness, matching the
     determinism guarantee screening/runner.py's own run_screening()
     already provides for its own narrower scope.
+
+    ``fulfillment_by_subject`` (EPIC-3, Shared Data Planning) is optional
+    and defaults to None -- every EPIC-1 caller that never needed shared
+    market data access continues to work completely unmodified. When
+    given (typically strategy_runtime.market_data_planning.
+    build_shared_market_data_access()'s own output), every strategy
+    evaluating the same subject receives the identical
+    CapabilityFulfillmentService instance via RuntimeContext.fulfillment,
+    so an identical request any two of them make is only ever fulfilled
+    once.
     """
     requested_strategy_ids = tuple(
         sorted(strategy_ids if strategy_ids is not None else registry.strategy_ids())
@@ -163,7 +178,7 @@ def run_strategies(
     as_of = clock.now()
     run_id = _compute_run_id(requested_strategy_ids, sorted_subjects, as_of)
     return tuple(
-        _run_one(registry, strategy_id, subject, clock, run_id)
+        _run_one(registry, strategy_id, subject, clock, run_id, fulfillment_by_subject)
         for strategy_id in requested_strategy_ids
         for subject in sorted_subjects
     )

--- a/strategy_runtime/market_data_planning.py
+++ b/strategy_runtime/market_data_planning.py
@@ -1,0 +1,146 @@
+"""Shared data planning (SPRINT-009/EPIC-3).
+
+Builds one market_data.CapabilityFulfillmentService (and its own
+RequestBudgetManager) per subject for one run -- shared by every strategy
+that evaluates that subject within the run, rather than one fresh instance
+per (strategy, subject) pair the way asa/api/screening_routes.py and
+asa/scheduled_screening.py both currently build it (SPRINT-008/SPRINT-008D).
+Sharing one instance is the entire mechanism: CapabilityFulfillmentService
+already memoizes an identical CapabilityRequest within its own lifetime
+(market_data/fulfillment.py's own _results dict) -- this module does not
+reimplement that caching, it only makes sure strategies actually share one
+instance long enough for it to matter, which they never have before this
+ticket. Provider fallback and budget enforcement are entirely
+market_data.fulfillment's own, unmodified.
+
+Deliberately built from market_data/'s own public exports only, not
+imported from screening/live_acquisition.py's near-identical wiring
+(build_fulfillment_service_with_accounting) -- strategy_runtime is meant
+to be more foundational than screening (screening becomes one of its
+consumers once EPIC-7 migrates), so importing the other way around would
+be backwards, and screening/live_acquisition.py is already live,
+already-tested production code (POST /api/v1/screening/*/refresh) this
+ticket has no reason to touch. The small amount of provider-wiring logic
+duplicated here is a deliberate, documented tradeoff, not an oversight --
+EPIC-7's own migration is the natural point to fully unify them, once
+screening/'s own callers are moving onto this runtime anyway.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from domain import MarketCapability
+from market_data import (
+    CapabilityFulfillmentService,
+    CapabilityRegistry,
+    MarketDataConfig,
+    ProviderConfig,
+    ProviderDependencies,
+    ProviderFactory,
+    ProviderPriority,
+    ProviderPriorityPolicy,
+    ProviderRegistry,
+    RequestBudgetManager,
+    RequestBudgetPolicy,
+    alpha_vantage_provider_registration,
+    finnhub_provider_registration,
+    fixture_provider_registration,
+    tradier_provider_registration,
+)
+from market_data.budget import BudgetScope
+from strategy_runtime.clock import Clock
+
+PRIORITY_POLICY_VERSION = "strategy-runtime-shared-plan-v1"
+BUDGET_POLICY_VERSION = "strategy-runtime-shared-plan-v1"
+
+
+def _provider_factory() -> ProviderFactory:
+    return ProviderFactory(
+        (
+            tradier_provider_registration(),
+            finnhub_provider_registration(),
+            alpha_vantage_provider_registration(),
+            fixture_provider_registration(),
+        )
+    )
+
+
+def enabled_provider_configs(config: MarketDataConfig) -> tuple[ProviderConfig, ...]:
+    return tuple(item for item in config.providers if item.enabled)
+
+
+def _build_capability_registry(provider_registry: ProviderRegistry) -> CapabilityRegistry:
+    """Every enabled provider serves every capability it declares, in
+    deterministic provider_id order -- no editorial preference encoded
+    here, matching screening/live_acquisition.py's own identical policy.
+    """
+    capabilities: dict[MarketCapability, list[str]] = {}
+    for provider in provider_registry.providers:
+        for capability in provider.capabilities:
+            capabilities.setdefault(capability, []).append(provider.provider_id)
+    priorities = tuple(
+        ProviderPriority(capability, tuple(sorted(provider_ids)))
+        for capability, provider_ids in sorted(
+            capabilities.items(), key=lambda item: item[0].value
+        )
+    )
+    policy = ProviderPriorityPolicy(PRIORITY_POLICY_VERSION, priorities)
+    return CapabilityRegistry(provider_registry, policy)
+
+
+def _build_request_budget_manager(
+    enabled_configs: tuple[ProviderConfig, ...], clock: Clock
+) -> RequestBudgetManager:
+    policies = tuple(
+        RequestBudgetPolicy(
+            item.provider_id,
+            BudgetScope.RUNTIME,
+            item.request_budget.max_requests_per_run,
+            item.request_budget.burst_limit,
+            item.retry.max_retries,
+            BUDGET_POLICY_VERSION,
+        )
+        for item in enabled_configs
+    )
+    return RequestBudgetManager(policies, clock)
+
+
+@dataclass(frozen=True, slots=True)
+class SubjectMarketDataAccess:
+    fulfillment: CapabilityFulfillmentService
+    budget_manager: RequestBudgetManager
+
+
+def build_shared_market_data_access(
+    config: MarketDataConfig,
+    transport_factory: Callable[[str], object],
+    clock: Clock,
+    subjects: tuple[str, ...],
+) -> dict[str, SubjectMarketDataAccess]:
+    """One SubjectMarketDataAccess per subject in ``subjects`` -- never one
+    shared across subjects (no request in this sprint's migration targets
+    is ever shared between two different subjects, so there is no
+    deduplication opportunity there to capture), and never one per
+    (strategy, subject) pair.
+    """
+    enabled_configs = enabled_provider_configs(config)
+    result: dict[str, SubjectMarketDataAccess] = {}
+    for subject in subjects:
+        budget_manager = _build_request_budget_manager(enabled_configs, clock)
+        factory = _provider_factory()
+        providers = tuple(
+            factory.create(
+                item,
+                ProviderDependencies(transport_factory(item.provider_id), clock, budget_manager),
+            )
+            for item in enabled_configs
+        )
+        provider_registry = ProviderRegistry(providers)
+        capability_registry = _build_capability_registry(provider_registry)
+        fulfillment = CapabilityFulfillmentService(
+            provider_registry, capability_registry, budget_manager
+        )
+        result[subject] = SubjectMarketDataAccess(fulfillment, budget_manager)
+    return result

--- a/tests/strategy_runtime/test_market_data_planning.py
+++ b/tests/strategy_runtime/test_market_data_planning.py
@@ -1,0 +1,157 @@
+"""SPRINT-009/EPIC-3: shared data planning.
+
+Uses market_data's own real, offline DeterministicFixtureProvider (via
+market_data.load_market_data_config({}), which enables only the fixture
+provider by its own documented default -- no live network, no fake
+provider written for this test) to prove real, end-to-end request
+deduplication through the actual CapabilityFulfillmentService machinery,
+not merely that two dict lookups return the same Python object.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from domain import (
+    CanonicalInstrumentIdentity,
+    EvidenceKind,
+    EvidenceReference,
+    Instrument,
+    InstrumentKind,
+    MarketCapability,
+    MarketDataRequestContext,
+    MarketDataSubject,
+    MarketDataSubjectType,
+    ProviderAddressProjection,
+)
+from market_data import CapabilityRequest, load_market_data_config
+from strategy_runtime import (
+    NO_LIFECYCLE,
+    DataRequirement,
+    OutputKind,
+    RequirementCategory,
+    RuntimeContext,
+    StrategyContract,
+    StrategyRegistry,
+    StructureKind,
+    build_shared_market_data_access,
+    run_strategies,
+)
+
+NOW = datetime(2026, 1, 1, tzinfo=UTC)
+CAPABILITY = MarketCapability.REAL_TIME_QUOTE_V1
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "instrument-reference:AAPL"),)
+INSTRUMENT = Instrument(
+    CanonicalInstrumentIdentity("figi", "BBG000B9XRY4"), InstrumentKind.EQUITY, "AAPL", "USD"
+)
+
+
+@dataclass
+class _FixedClock:
+    value: datetime = NOW
+
+    def now(self) -> datetime:
+        return self.value
+
+
+def _quote_request() -> CapabilityRequest:
+    fields = ("last",)
+    projection = ProviderAddressProjection(
+        "deterministic_fixture", "v1", "symbol", "AAPL", NOW, None, EVIDENCE
+    )
+    subject = MarketDataSubject(
+        INSTRUMENT,
+        MarketDataSubjectType.INSTRUMENT,
+        CAPABILITY,
+        MarketDataRequestContext(NOW, NOW, fields, (projection,), EVIDENCE),
+    )
+    return CapabilityRequest(CAPABILITY, (subject,), NOW, NOW, fields, 60)
+
+
+def _no_transport_needed(_provider_id: str) -> object:
+    # DeterministicFixtureProvider never touches this -- it is fixture-driven,
+    # not network-driven -- but ProviderDependencies still requires a value.
+    return object()
+
+
+class TestBuildSharedMarketDataAccess:
+    def test_one_access_per_subject(self) -> None:
+        config = load_market_data_config({})
+        access = build_shared_market_data_access(
+            config, _no_transport_needed, _FixedClock(), ("AAPL", "MSFT")
+        )
+        assert set(access) == {"AAPL", "MSFT"}
+        assert access["AAPL"].fulfillment is not access["MSFT"].fulfillment
+        assert access["AAPL"].budget_manager is not access["MSFT"].budget_manager
+
+    def test_identical_request_is_fulfilled_once_per_shared_service(self) -> None:
+        # This is the actual mechanism EPIC-3 relies on: real
+        # CapabilityFulfillmentService memoization, not a test double.
+        config = load_market_data_config({})
+        access = build_shared_market_data_access(
+            config, _no_transport_needed, _FixedClock(), ("AAPL",)
+        )
+        fulfillment = access["AAPL"].fulfillment
+        request = _quote_request()
+
+        first = fulfillment.fulfill(request)
+        second = fulfillment.fulfill(request)
+
+        assert first is second  # identical object back -- genuinely not re-fetched
+
+
+class TestRunStrategiesWithSharedMarketData:
+    def _contract(self, strategy_id: str) -> StrategyContract:
+        return StrategyContract(
+            strategy_id=strategy_id,
+            version="1.0.0",
+            category="test",
+            description="A test contract needing a real-time quote.",
+            requirements=(
+                DataRequirement(RequirementCategory.MARKET_DATA, capabilities=(CAPABILITY,)),
+            ),
+            lifecycle=NO_LIFECYCLE,
+            structure=StructureKind.NONE,
+            outputs=(OutputKind.METRICS,),
+        )
+
+    def test_two_strategies_sharing_a_subject_get_the_same_fulfillment_result_object(
+        self,
+    ) -> None:
+        request = _quote_request()
+
+        def _adapter(context: RuntimeContext) -> object:
+            assert context.fulfillment is not None
+            return context.fulfillment.fulfill(request)
+
+        registry = StrategyRegistry(
+            ((self._contract("alpha"), _adapter), (self._contract("beta"), _adapter))
+        )
+        config = load_market_data_config({})
+        clock = _FixedClock()
+        access = build_shared_market_data_access(config, _no_transport_needed, clock, ("AAPL",))
+        fulfillment_by_subject = {symbol: item.fulfillment for symbol, item in access.items()}
+
+        results = run_strategies(
+            registry, clock, subjects=("AAPL",), fulfillment_by_subject=fulfillment_by_subject
+        )
+
+        assert len(results) == 2
+        alpha_result = next(item for item in results if item.strategy_id == "alpha").result
+        beta_result = next(item for item in results if item.strategy_id == "beta").result
+        assert alpha_result is beta_result  # both adapters actually shared one fulfillment
+
+    def test_no_fulfillment_by_subject_leaves_context_fulfillment_none(self) -> None:
+        seen: list[object] = []
+
+        def _adapter(context: RuntimeContext) -> str:
+            seen.append(context.fulfillment)
+            return "ok"
+
+        registry = StrategyRegistry(((self._contract("alpha"), _adapter),))
+        clock = _FixedClock()
+
+        run_strategies(registry, clock, subjects=("AAPL",))  # no fulfillment_by_subject at all
+
+        assert seen == [None]


### PR DESCRIPTION
## Summary

Adds `strategy_runtime/market_data_planning.py`: one `market_data.CapabilityFulfillmentService` (and its own `RequestBudgetManager`) per subject for a run, shared by every strategy that evaluates that subject — rather than one fresh instance per (strategy, subject) pair the way `asa/api/screening_routes.py` and `asa/scheduled_screening.py` both currently build it.

Sharing one instance is the entire mechanism: `CapabilityFulfillmentService` already memoizes an identical `CapabilityRequest` within its own lifetime — this ticket doesn't reimplement that caching, it makes sure strategies actually share one instance long enough for it to matter, which they never have before now. Provider fallback and budget enforcement are entirely `market_data.fulfillment`'s own, unmodified.

Deliberately built from `market_data/`'s own public exports only, not imported from `screening/live_acquisition.py`'s near-identical wiring — `strategy_runtime` is meant to be more foundational than `screening` (which becomes one of its consumers once EPIC-7 migrates), and `screening/live_acquisition.py` is already live, already-tested production code this ticket has no reason to touch. The small amount of duplicated provider-wiring logic (~60 lines, using only `market_data`'s own public API) is a documented, deliberate tradeoff — EPIC-7's own migration is the natural point to unify them.

Extends EPIC-1's `RuntimeContext` with one new optional field (`fulfillment`) and `run_strategies()` with one new optional keyword parameter (`fulfillment_by_subject`) — every existing EPIC-1 caller and test continues to work completely unmodified (all 56 pre-existing tests pass unchanged).

Tests use `market_data`'s own real, offline `DeterministicFixtureProvider` to prove genuine, end-to-end request deduplication through the actual `CapabilityFulfillmentService` machinery — not a mocked stand-in.

Nothing here touches `screening/`, any currently-shipped strategy, or the existing `/api/v1/screening*` surface.

## Test plan

- [x] 4 new tests (60 total in `strategy_runtime`, up from 56), all passing
- [x] Full scoped suite (`tests/`, excluding `pos`/`deployment_observer`): 1783 passed, 17 skipped, no regressions
- [x] `ruff check strategy_runtime tests/strategy_runtime` / `mypy strategy_runtime` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)