### PR TITLE
EPIC-4: universal options framework

### DIFF
--- a/strategy_runtime/__init__.py
+++ b/strategy_runtime/__init__.py
@@ -21,7 +21,13 @@ strategy's adapter returns. EPIC-3 (Shared Data Planning) lives in
 strategy_runtime.market_data_planning: one market_data.
 CapabilityFulfillmentService per subject, shared by every strategy that
 evaluates it within a run, threaded through RuntimeContext.fulfillment by
-run_strategies()'s own optional fulfillment_by_subject parameter.
+run_strategies()'s own optional fulfillment_by_subject parameter. EPIC-4
+(Universal Options Framework) lives in strategy_runtime.options: domain's
+own already-validated OptionLeg/OptionStructure adopted directly as the
+canonical option package representation, analytics.expiration_selection's
+own already-generalized expiration-pairing re-exported for discoverability,
+and liquidity/debit calculations ported from strategies/
+stonk_components.py's own graph components to plain functions.
 """
 
 from __future__ import annotations

--- a/strategy_runtime/options.py
+++ b/strategy_runtime/options.py
@@ -1,0 +1,155 @@
+"""Universal Options Framework (SPRINT-009/EPIC-4).
+
+Adopts domain.financial's own OptionLeg/OptionStructure/OptionStructureType/
+OptionLegPosition directly as this sprint's canonical option package
+representation -- already fully generalized and already validated on
+construction (OptionStructure.__post_init__'s own _validate_shape(),
+domain/financial.py, unmodified by this ticket): exactly two legs sharing
+an expiration for VERTICAL, exactly two legs sharing a strike for
+CALENDAR, and so on for every structure kind domain/ already knows about.
+Not rebuilt here, and not re-exported through this module either --
+strategy_runtime adapters import these directly from domain, the same way
+every other root package already does.
+
+Re-exports analytics.expiration_selection's own already-generalized
+expiration-pairing helpers (ExpirationCandidate, select_expiration_pair,
+select_earnings_relative_expiration_pair, ANALYTICS-002) for discoverability
+under strategy_runtime's own namespace -- the logic itself lives in and is
+owned by analytics/, unmodified.
+
+What is genuinely new here: standalone liquidity and debit calculations
+operating directly on domain.OptionLeg/OptionStructure/OptionContract, for
+a strategy_runtime adapter to call without going through strategies/'s own
+manifest-graph execution engine at all (this sprint's adapters are meant
+to bypass that graph entirely, per the declarative_strategies/
+strategies_own_thesis principles). Both are ported, not reinvented, from
+strategies/stonk_components.py's own OptionLegLiquidity and
+OptionStructureDebit graph components -- the identical formula, so a
+migrated strategy computes the same result the graph-based version
+already proved correct.
+
+Deliberately excluded: a payoff-at-expiration calculator. No existing
+component anywhere in this codebase computes one to generalize from (only
+debit/mark), and none of EPIC-7's three migration targets need one for
+their own current verdict logic (forward_factor and skew_momentum score
+from implied volatility/skew inputs, not a payoff diagram). Inventing
+options-payoff math with no reference implementation and no proven
+migration-target need is exactly the kind of speculative complexity this
+sprint's own generalize_before_specialize principle argues against --
+recorded as a deliberate scope decision, not an oversight.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from analytics.expiration_selection import (
+    ExpirationCandidate,
+    select_earnings_relative_expiration_pair,
+    select_expiration_pair,
+)
+from domain import OptionContract, OptionLeg, OptionLegPosition, OptionStructure
+
+__all__ = [
+    "ExpirationCandidate",
+    "LiquidityPolicy",
+    "StructureDebit",
+    "compute_structure_debit",
+    "is_liquid",
+    "liquidity_blockers",
+    "select_earnings_relative_expiration_pair",
+    "select_expiration_pair",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class LiquidityPolicy:
+    maximum_spread_ratio: Decimal
+    minimum_open_interest: int
+    minimum_volume: int
+
+    def __post_init__(self) -> None:
+        if (
+            self.maximum_spread_ratio < 0
+            or self.minimum_open_interest < 0
+            or self.minimum_volume < 0
+        ):
+            raise ValueError("LiquidityPolicy thresholds cannot be negative")
+
+
+def is_liquid(contract: OptionContract, policy: LiquidityPolicy) -> bool:
+    """Quote-width, open-interest, and volume check -- the same formula
+    strategies/stonk_components.py::OptionLegLiquidity already established
+    (spread = (ask - bid) / mark), ported to a standalone function.
+    Missing data (no bid/ask/mark/open_interest/volume, or a non-positive
+    mark) is never liquid and never raises -- the same fail-closed
+    convention the original component uses.
+    """
+    if (
+        contract.bid is None
+        or contract.ask is None
+        or contract.mark is None
+        or contract.mark <= 0
+        or contract.open_interest is None
+        or contract.volume is None
+    ):
+        return False
+    spread = (contract.ask - contract.bid) / contract.mark
+    return (
+        spread <= policy.maximum_spread_ratio
+        and contract.open_interest >= policy.minimum_open_interest
+        and contract.volume >= policy.minimum_volume
+    )
+
+
+def liquidity_blockers(structure: OptionStructure, policy: LiquidityPolicy) -> tuple[str, ...]:
+    """One blocker string per illiquid leg in ``structure``, empty if every
+    leg passes -- shaped to feed directly into
+    strategy_runtime.result.UniversalScreeningResult.blockers.
+    """
+    return tuple(
+        f"leg {leg.role} ({leg.contract.option_type.value} {leg.contract.strike} "
+        f"{leg.contract.expiration.isoformat()}) fails liquidity policy"
+        for leg in structure.legs
+        if not is_liquid(leg.contract, policy)
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class StructureDebit:
+    mid_debit: Decimal | None
+    conservative_debit: Decimal | None
+
+
+def _sum_signed(
+    legs: tuple[OptionLeg, ...], values: tuple[Decimal | None, ...]
+) -> Decimal | None:
+    if any(value is None for value in values):
+        return None
+    total = Decimal(0)
+    for leg, value in zip(legs, values, strict=True):
+        assert value is not None  # narrowed by the check above
+        sign = Decimal(1) if leg.position is OptionLegPosition.LONG else Decimal(-1)
+        total += value * leg.quantity * sign
+    return total
+
+
+def compute_structure_debit(structure: OptionStructure) -> StructureDebit:
+    """The same two-variant debit calculation
+    strategies/stonk_components.py::OptionStructureDebit already
+    established: ``mid_debit`` from each leg's own mark (None if any leg
+    lacks one), ``conservative_debit`` from the worse-case fill price per
+    leg's own position (the ask for a long leg, the bid for a short one).
+    A positive debit means a net cost to open; a negative value is a net
+    credit -- unchanged from the original component's own convention.
+    """
+    marks = tuple(leg.contract.mark for leg in structure.legs)
+    conservative_values = tuple(
+        leg.contract.ask if leg.position is OptionLegPosition.LONG else leg.contract.bid
+        for leg in structure.legs
+    )
+    return StructureDebit(
+        mid_debit=_sum_signed(structure.legs, marks),
+        conservative_debit=_sum_signed(structure.legs, conservative_values),
+    )

--- a/tests/strategy_runtime/test_options.py
+++ b/tests/strategy_runtime/test_options.py
@@ -1,0 +1,249 @@
+"""SPRINT-009/EPIC-4: universal options framework.
+
+Builds real domain.OptionContract/OptionLeg/OptionStructure instances
+(domain/financial.py's own already-validated types) rather than fakes --
+proving strategy_runtime.options works against the real, already-shipped
+option package representation, not a stand-in.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+
+from domain import (
+    CanonicalInstrumentIdentity,
+    EvidenceKind,
+    EvidenceReference,
+    Instrument,
+    InstrumentKind,
+    OptionContract,
+    OptionLeg,
+    OptionLegPosition,
+    OptionStructure,
+    OptionStructureType,
+    OptionType,
+    Security,
+    SecurityAssetType,
+)
+from strategy_runtime.options import (
+    ExpirationCandidate,
+    LiquidityPolicy,
+    compute_structure_debit,
+    is_liquid,
+    liquidity_blockers,
+    select_earnings_relative_expiration_pair,
+    select_expiration_pair,
+)
+
+NOW = datetime(2026, 7, 21, 16, 0, tzinfo=UTC)
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "observation-1"),)
+
+
+def _security(symbol: str = "AAPL") -> Security:
+    instrument = Instrument(
+        CanonicalInstrumentIdentity("figi", f"figi-{symbol}"), InstrumentKind.EQUITY, symbol, "USD"
+    )
+    return Security(instrument, symbol, SecurityAssetType.EQUITY, "XNAS")
+
+
+def _contract(
+    *,
+    expiration: date = date(2026, 8, 21),
+    strike: Decimal = Decimal("200"),
+    option_type: OptionType = OptionType.CALL,
+    bid: Decimal | None = Decimal("4.10"),
+    ask: Decimal | None = Decimal("4.30"),
+    mark: Decimal | None = Decimal("4.20"),
+    volume: int | None = 100,
+    open_interest: int | None = 500,
+    suffix: str = "1",
+) -> OptionContract:
+    return OptionContract(
+        CanonicalInstrumentIdentity("asa-option-v1", f"option-{suffix}"),
+        _security(),
+        expiration,
+        strike,
+        option_type,
+        bid,
+        ask,
+        mark,
+        volume,
+        open_interest,
+        Decimal("0.50"),
+        Decimal("0.03"),
+        Decimal("-0.08"),
+        Decimal("0.12"),
+        Decimal("0.01"),
+        Decimal("0.35"),
+        NOW,
+        EVIDENCE,
+    )
+
+
+def _leg(contract: OptionContract, position: OptionLegPosition, role: str) -> OptionLeg:
+    return OptionLeg(contract, position, Decimal(1), role)
+
+
+_POLICY = LiquidityPolicy(
+    maximum_spread_ratio=Decimal("0.10"), minimum_open_interest=50, minimum_volume=10
+)
+
+
+class TestLiquidityPolicy:
+    def test_negative_threshold_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cannot be negative"):
+            LiquidityPolicy(Decimal("-0.1"), 0, 0)
+
+
+class TestIsLiquid:
+    def test_within_thresholds_is_liquid(self) -> None:
+        assert is_liquid(_contract(), _POLICY)
+
+    def test_missing_bid_is_not_liquid(self) -> None:
+        assert not is_liquid(_contract(bid=None), _POLICY)
+
+    def test_zero_mark_is_not_liquid(self) -> None:
+        assert not is_liquid(_contract(mark=Decimal("0")), _POLICY)
+
+    def test_wide_spread_is_not_liquid(self) -> None:
+        # (ask - bid) / mark = (5.00 - 3.00) / 4.00 = 0.50 > 0.10
+        assert not is_liquid(_contract(bid=Decimal("3.00"), ask=Decimal("5.00")), _POLICY)
+
+    def test_low_open_interest_is_not_liquid(self) -> None:
+        assert not is_liquid(_contract(open_interest=1), _POLICY)
+
+    def test_low_volume_is_not_liquid(self) -> None:
+        assert not is_liquid(_contract(volume=1), _POLICY)
+
+
+class TestLiquidityBlockers:
+    def test_all_legs_liquid_returns_no_blockers(self) -> None:
+        long_leg = _leg(
+            _contract(strike=Decimal("200"), suffix="long"), OptionLegPosition.LONG, "long"
+        )
+        short_leg = _leg(
+            _contract(strike=Decimal("210"), suffix="short"), OptionLegPosition.SHORT, "short"
+        )
+        structure = OptionStructure(
+            "structure-1",
+            OptionStructureType.VERTICAL,
+            _security(),
+            (long_leg, short_leg),
+            NOW,
+            EVIDENCE,
+        )
+        assert liquidity_blockers(structure, _POLICY) == ()
+
+    def test_one_illiquid_leg_produces_one_blocker(self) -> None:
+        long_leg = _leg(
+            _contract(strike=Decimal("200"), suffix="long"), OptionLegPosition.LONG, "long"
+        )
+        illiquid_short = _leg(
+            _contract(strike=Decimal("210"), suffix="short", volume=1),
+            OptionLegPosition.SHORT,
+            "short",
+        )
+        structure = OptionStructure(
+            "structure-2",
+            OptionStructureType.VERTICAL,
+            _security(),
+            (long_leg, illiquid_short),
+            NOW,
+            EVIDENCE,
+        )
+        blockers = liquidity_blockers(structure, _POLICY)
+        assert len(blockers) == 1
+        assert "short" in blockers[0]
+
+
+class TestComputeStructureDebit:
+    def test_vertical_debit_from_marks_and_conservative_fills(self) -> None:
+        long_leg = _leg(
+            _contract(
+                strike=Decimal("200"),
+                suffix="long",
+                bid=Decimal("4.00"),
+                ask=Decimal("4.20"),
+                mark=Decimal("4.10"),
+            ),
+            OptionLegPosition.LONG,
+            "long",
+        )
+        short_leg = _leg(
+            _contract(
+                strike=Decimal("210"),
+                suffix="short",
+                bid=Decimal("1.80"),
+                ask=Decimal("2.00"),
+                mark=Decimal("1.90"),
+            ),
+            OptionLegPosition.SHORT,
+            "short",
+        )
+        structure = OptionStructure(
+            "structure-3",
+            OptionStructureType.VERTICAL,
+            _security(),
+            (long_leg, short_leg),
+            NOW,
+            EVIDENCE,
+        )
+
+        debit = compute_structure_debit(structure)
+
+        # mid: +4.10 (long mark) - 1.90 (short mark) = 2.20
+        assert debit.mid_debit == Decimal("2.20")
+        # conservative: +4.20 (long ask) - 1.80 (short bid) = 2.40
+        assert debit.conservative_debit == Decimal("2.40")
+
+    def test_missing_mark_on_any_leg_yields_none_mid_debit(self) -> None:
+        long_leg = _leg(
+            _contract(strike=Decimal("200"), suffix="long", mark=None),
+            OptionLegPosition.LONG,
+            "long",
+        )
+        short_leg = _leg(
+            _contract(strike=Decimal("210"), suffix="short"), OptionLegPosition.SHORT, "short"
+        )
+        structure = OptionStructure(
+            "structure-4",
+            OptionStructureType.VERTICAL,
+            _security(),
+            (long_leg, short_leg),
+            NOW,
+            EVIDENCE,
+        )
+
+        debit = compute_structure_debit(structure)
+
+        assert debit.mid_debit is None
+        assert debit.conservative_debit is not None  # bid/ask were still present
+
+
+class TestExpirationPairingReExport:
+    def test_select_expiration_pair_is_the_analytics_module_re_export(self) -> None:
+        candidates = (
+            ExpirationCandidate(date(2026, 8, 21), 30),
+            ExpirationCandidate(date(2026, 9, 18), 58),
+        )
+        selected = select_expiration_pair(
+            candidates,
+            front_min_dte=20,
+            front_max_dte=40,
+            back_min_dte=50,
+            back_max_dte=70,
+            minimum_gap_days=10,
+            maximum_gap_days=40,
+            target_front_dte=30,
+            target_gap_days=28,
+        )
+        assert selected is not None
+        front, back = selected
+        assert front.expiration_date == date(2026, 8, 21)
+        assert back.expiration_date == date(2026, 9, 18)
+
+    def test_select_earnings_relative_expiration_pair_is_importable(self) -> None:
+        assert callable(select_earnings_relative_expiration_pair)


### PR DESCRIPTION
## Summary

Adds `strategy_runtime/options.py` — but mostly by **adopting and re-exporting infrastructure this codebase had already generalized in prior sprints**, not by building a new one, per this sprint's own `generalize_before_specialize` principle applied literally: found it already done before assuming it needed doing.

**Discovered during research, not assumed:**
- `domain.financial`'s own `OptionLeg`/`OptionStructure`/`OptionStructureType`/`OptionLegPosition` (`domain/financial.py`) are already a complete, already-validated option package representation — `OptionStructure.__post_init__`'s own `_validate_shape()` already enforces correct leg counts/relationships for VERTICAL, CALENDAR, DIAGONAL, STRADDLE, STRANGLE, SINGLE_LEG, COVERED_CALL, and CASH_SECURED_PUT. Adopted directly — EPIC-4's own "option package representation" and "structure validation" deliverables are both already satisfied by code already in production.
- `analytics/expiration_selection.py` (ANALYTICS-002) already generalized expiration-pair selection, independent of any specific strategy. Re-exported through `strategy_runtime.options` for discoverability; logic unmodified, still owned by `analytics/`.

**What's genuinely new**: `is_liquid()`/`liquidity_blockers()` and `compute_structure_debit()` — standalone functions operating directly on `domain.OptionLeg`/`OptionStructure`/`OptionContract`, for a strategy_runtime adapter to call without the manifest-graph execution engine at all. Both are **ported, not reinvented**, from `strategies/stonk_components.py`'s own `OptionLegLiquidity` and `OptionStructureDebit` graph components — read directly from that source, the identical formula, so a migrated strategy computes the same result the graph-based version already proved correct.

**Deliberately excluded**: a payoff-at-expiration calculator — no existing component computes one to generalize from, and none of EPIC-7's three migration targets need one for their current verdict logic. Recorded as a deliberate scope decision in the module's own docstring, not a silent omission.

Tests build real `domain.OptionContract`/`OptionLeg`/`OptionStructure` instances (not fakes), proving this works against the actual, already-shipped types.

Nothing here touches `screening/`, `strategies/`, any currently-shipped strategy, or the existing `/api/v1/screening*` surface.

## Test plan

- [x] 13 new tests (73 total in `strategy_runtime`, up from 60), all passing
- [x] Full scoped suite (`tests/`, excluding `pos`/`deployment_observer`): 1796 passed, 17 skipped, no regressions
- [x] `ruff check strategy_runtime tests/strategy_runtime` / `mypy strategy_runtime` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)