### PR TITLE
EPIC-5: universal opportunity model

### DIFF
--- a/strategy_runtime/__init__.py
+++ b/strategy_runtime/__init__.py
@@ -27,7 +27,14 @@ own already-validated OptionLeg/OptionStructure adopted directly as the
 canonical option package representation, analytics.expiration_selection's
 own already-generalized expiration-pairing re-exported for discoverability,
 and liquidity/debit calculations ported from strategies/
-stonk_components.py's own graph components to plain functions.
+stonk_components.py's own graph components to plain functions. EPIC-5
+(Universal Opportunity Model) lives in strategy_runtime.lifecycle:
+compute_opportunity_id() for stable cross-observation identity,
+OpportunityObservation/OpportunityHistory for an opportunity's evolution,
+RecommendedAction as the vocabulary UniversalScreeningResult.
+recommendation_state holds, and validate_lifecycle_stage() as the one
+guardrail keeping the engine strategy-agnostic (a reported stage must be
+one the strategy's own contract actually declared).
 """
 
 from __future__ import annotations

--- a/strategy_runtime/lifecycle.py
+++ b/strategy_runtime/lifecycle.py
@@ -1,0 +1,146 @@
+"""Universal Opportunity Model (SPRINT-009/EPIC-5).
+
+Generalizes the lifecycle/verdict/opportunity-identity concepts the mature
+Stonk Calendar implementation already has
+(/Users/jaiafoster/Claude/stonk/app/services/) into strategy-agnostic
+infrastructure -- the engine, not any specific strategy's transition
+rules. Reconciling exactly which stages Calendar moves through and when
+is EPIC-7's own migration job; this module only guarantees the engine
+those rules run on is generic, and enforces the one thing that must be
+true regardless of which strategy uses it: a lifecycle_stage a strategy
+reports must be one its own StrategyContract actually declared
+(strategy_runtime.contract.LifecycleDeclaration.supported_states) --
+never invented ad hoc at observation time.
+
+compute_opportunity_id() is deliberately independent of any one
+observation or run: strategy_runtime.result.compute_observation_id()
+identifies *this* observation event; this function identifies the
+*opportunity being observed*, which must stay the same across many
+separate observations over time for history (EPIC-8) to mean anything.
+The caller supplies whatever fields make an opportunity the same
+opportunity for its own strategy (e.g. earnings_calendar's own confirmed
+earnings date) -- this module has no opinion on what those fields are,
+only that they are hashed the same deterministic way every other identity
+in this sprint already is.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from strategy_runtime.contract import LifecycleModel, StrategyContract
+from strategy_runtime.errors import StrategyContractError
+
+
+def compute_opportunity_id(strategy_id: str, symbol: str, *identity_components: str) -> str:
+    """Deterministic, stable identity for one tracked opportunity --
+    reproducible for identical inputs, matching the same sha256-hash
+    convention every other identity in this sprint already uses
+    (strategy_runtime.execution's own run_id,
+    strategy_runtime.result.compute_observation_id()). Two observations
+    of the same real-world opportunity must call this with the same
+    identity_components every time; two observations of genuinely
+    different opportunities (e.g. two different confirmed earnings dates
+    for the same symbol) must not.
+    """
+    payload = {
+        "strategy_id": strategy_id,
+        "symbol": symbol,
+        "identity_components": list(identity_components),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class RecommendedAction(str, Enum):
+    """The vocabulary strategy_runtime.result.UniversalScreeningResult's
+    own recommendation_state field holds as a string
+    (RecommendedAction.MONITOR.value, etc.) -- kept as a real enum here,
+    not a bare string, so a strategy author picks from a closed,
+    documented set rather than inventing ad hoc action names per
+    strategy. Deliberately not a ranking or priority order across
+    actions -- this sprint's own non_goals rule out cross-strategy
+    ranking; MONITOR is not "worse" than ENTER, only different.
+    """
+
+    MONITOR = "monitor"
+    ENTER = "enter"
+    HOLD = "hold"
+    EXIT = "exit"
+    NO_ACTION = "no_action"
+
+
+@dataclass(frozen=True, slots=True)
+class OpportunityObservation:
+    """One point-in-time snapshot in a tracked opportunity's evolution --
+    the unit strategy_runtime.result.UniversalScreeningResult's own
+    lifecycle-related fields (opportunity_id, lifecycle_stage) already
+    carry on a single result, gathered here as their own type so EPIC-8
+    (Persistence & History) has one clear unit to append to an
+    opportunity's history, rather than persisting a full
+    UniversalScreeningResult (with its metrics/economics namespaces) for
+    every historical point.
+    """
+
+    opportunity_id: str
+    strategy_id: str
+    symbol: str
+    lifecycle_stage: str
+    verdict: str
+    recommended_action: RecommendedAction
+    observed_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class OpportunityHistory:
+    """An ordered, append-only sequence of observations for one
+    opportunity_id -- ordered by observed_at, oldest first, matching
+    "history replay" (EPIC-8's own acceptance criterion: a caller can
+    reconstruct an opportunity's evolution from persisted observations).
+    """
+
+    opportunity_id: str
+    observations: tuple[OpportunityObservation, ...]
+
+    def __post_init__(self) -> None:
+        if not self.observations:
+            raise ValueError("OpportunityHistory requires at least one observation")
+        if any(item.opportunity_id != self.opportunity_id for item in self.observations):
+            raise ValueError(
+                "OpportunityHistory.observations must all share the same opportunity_id"
+            )
+        ordered = tuple(sorted(self.observations, key=lambda item: item.observed_at))
+        object.__setattr__(self, "observations", ordered)
+
+    @property
+    def current(self) -> OpportunityObservation:
+        return self.observations[-1]
+
+    def append(self, observation: OpportunityObservation) -> OpportunityHistory:
+        if observation.opportunity_id != self.opportunity_id:
+            raise ValueError("appended observation must share this history's own opportunity_id")
+        return OpportunityHistory(self.opportunity_id, (*self.observations, observation))
+
+
+def validate_lifecycle_stage(contract: StrategyContract, stage: str) -> None:
+    """The one guardrail that keeps this engine strategy-agnostic: a
+    reported lifecycle_stage must be one the strategy's own contract
+    actually declared, for a contract that declares lifecycle support at
+    all. Raises for a NONE-lifecycle contract (nothing to validate a
+    stage against) or an undeclared stage -- never silently accepts an
+    ad hoc value.
+    """
+    if contract.lifecycle.lifecycle_model is LifecycleModel.NONE:
+        raise StrategyContractError(
+            f"{contract.strategy_id!r} declares no lifecycle model; it cannot report a "
+            "lifecycle_stage"
+        )
+    if stage not in contract.lifecycle.supported_states:
+        raise StrategyContractError(
+            f"{stage!r} is not a lifecycle_stage {contract.strategy_id!r} declared "
+            f"(declared: {contract.lifecycle.supported_states})"
+        )

--- a/tests/strategy_runtime/test_lifecycle.py
+++ b/tests/strategy_runtime/test_lifecycle.py
@@ -1,0 +1,185 @@
+"""SPRINT-009/EPIC-5: universal opportunity model.
+
+Uses a fake, generically-named lifecycle-tracking strategy ("watched_event")
+throughout -- proving the engine is genuinely strategy-agnostic, the same
+way EPIC-1's own tests never named a real strategy either. Reconciling
+this engine against the mature Stonk Calendar implementation's own real
+states is EPIC-7's job, not this ticket's.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from strategy_runtime import (
+    DataRequirement,
+    LifecycleDeclaration,
+    LifecycleModel,
+    OutputKind,
+    RequirementCategory,
+    StrategyContract,
+    StrategyContractError,
+    StructureKind,
+)
+from strategy_runtime.lifecycle import (
+    OpportunityHistory,
+    OpportunityObservation,
+    RecommendedAction,
+    compute_opportunity_id,
+    validate_lifecycle_stage,
+)
+
+NOW = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _lifecycle_contract() -> StrategyContract:
+    return StrategyContract(
+        strategy_id="watched_event",
+        version="1.0.0",
+        category="test",
+        description="A fake lifecycle-tracking strategy for EPIC-5 tests.",
+        requirements=(DataRequirement(RequirementCategory.CUSTOM, identifier="none"),),
+        lifecycle=LifecycleDeclaration(
+            LifecycleModel.OPPORTUNITY,
+            supported_states=("watching", "confirmed", "closed"),
+            observation_type="watched_event",
+        ),
+        structure=StructureKind.NONE,
+        outputs=(OutputKind.METRICS, OutputKind.LIFECYCLE),
+    )
+
+
+def _no_lifecycle_contract() -> StrategyContract:
+    from strategy_runtime import NO_LIFECYCLE
+
+    return StrategyContract(
+        strategy_id="stateless",
+        version="1.0.0",
+        category="test",
+        description="A fake stateless strategy for EPIC-5 tests.",
+        requirements=(DataRequirement(RequirementCategory.CUSTOM, identifier="none"),),
+        lifecycle=NO_LIFECYCLE,
+        structure=StructureKind.NONE,
+        outputs=(OutputKind.METRICS,),
+    )
+
+
+def _observation(
+    opportunity_id: str, stage: str, action: RecommendedAction, observed_at: datetime
+) -> OpportunityObservation:
+    return OpportunityObservation(
+        opportunity_id=opportunity_id,
+        strategy_id="watched_event",
+        symbol="AAPL",
+        lifecycle_stage=stage,
+        verdict="pass",
+        recommended_action=action,
+        observed_at=observed_at,
+    )
+
+
+class TestComputeOpportunityId:
+    def test_deterministic_for_identical_inputs(self) -> None:
+        assert compute_opportunity_id(
+            "watched_event", "AAPL", "2026-02-01"
+        ) == compute_opportunity_id("watched_event", "AAPL", "2026-02-01")
+
+    def test_differs_when_identity_components_differ(self) -> None:
+        base = compute_opportunity_id("watched_event", "AAPL", "2026-02-01")
+        assert compute_opportunity_id("watched_event", "AAPL", "2026-03-01") != base
+        assert compute_opportunity_id("watched_event", "MSFT", "2026-02-01") != base
+
+    def test_differs_from_a_differently_scoped_observation_id(self) -> None:
+        # An opportunity_id must never accidentally collide with a
+        # per-observation identity -- different hash inputs entirely.
+        from strategy_runtime.result import compute_observation_id
+
+        opportunity_id = compute_opportunity_id("watched_event", "AAPL", "2026-02-01")
+        observation_id = compute_observation_id("run-1", "watched_event", "AAPL")
+        assert opportunity_id != observation_id
+
+
+class TestValidateLifecycleStage:
+    def test_undeclared_stage_is_rejected(self) -> None:
+        with pytest.raises(StrategyContractError, match="not a lifecycle_stage"):
+            validate_lifecycle_stage(_lifecycle_contract(), "expired")
+
+    def test_declared_stage_is_accepted(self) -> None:
+        validate_lifecycle_stage(_lifecycle_contract(), "watching")  # does not raise
+
+    def test_none_lifecycle_contract_rejects_any_stage(self) -> None:
+        with pytest.raises(StrategyContractError, match="declares no lifecycle model"):
+            validate_lifecycle_stage(_no_lifecycle_contract(), "watching")
+
+
+class TestOpportunityHistory:
+    def test_requires_at_least_one_observation(self) -> None:
+        with pytest.raises(ValueError, match="at least one observation"):
+            OpportunityHistory("opp-1", ())
+
+    def test_mismatched_opportunity_id_is_rejected(self) -> None:
+        observation = _observation("opp-1", "watching", RecommendedAction.MONITOR, NOW)
+        with pytest.raises(ValueError, match="same opportunity_id"):
+            OpportunityHistory("opp-2", (observation,))
+
+    def test_observations_are_ordered_oldest_first_regardless_of_input_order(self) -> None:
+        early = _observation("opp-1", "watching", RecommendedAction.MONITOR, NOW)
+        late = _observation(
+            "opp-1", "confirmed", RecommendedAction.ENTER, NOW + timedelta(days=1)
+        )
+        history = OpportunityHistory("opp-1", (late, early))
+        assert history.observations == (early, late)
+        assert history.current is late
+
+    def test_append_returns_a_new_history_with_the_new_observation_last(self) -> None:
+        first = _observation("opp-1", "watching", RecommendedAction.MONITOR, NOW)
+        history = OpportunityHistory("opp-1", (first,))
+
+        second = _observation(
+            "opp-1", "confirmed", RecommendedAction.ENTER, NOW + timedelta(days=1)
+        )
+        updated = history.append(second)
+
+        assert updated.observations == (first, second)
+        assert updated.current is second
+        assert history.observations == (first,)  # original untouched -- immutable
+
+    def test_append_rejects_a_mismatched_opportunity_id(self) -> None:
+        first = _observation("opp-1", "watching", RecommendedAction.MONITOR, NOW)
+        history = OpportunityHistory("opp-1", (first,))
+        other = _observation("opp-2", "watching", RecommendedAction.MONITOR, NOW)
+        with pytest.raises(ValueError, match="own opportunity_id"):
+            history.append(other)
+
+
+class TestEndToEndFakeLifecycleStrategy:
+    def test_a_generic_strategy_can_build_a_full_evolution_history(self) -> None:
+        contract = _lifecycle_contract()
+        opportunity_id = compute_opportunity_id(
+            contract.strategy_id, "AAPL", "watched-event-2026-02-01"
+        )
+
+        for stage in contract.lifecycle.supported_states:
+            validate_lifecycle_stage(contract, stage)  # every declared stage is valid
+
+        watching = _observation(opportunity_id, "watching", RecommendedAction.MONITOR, NOW)
+        history = OpportunityHistory(opportunity_id, (watching,))
+
+        confirmed = _observation(
+            opportunity_id, "confirmed", RecommendedAction.ENTER, NOW + timedelta(days=3)
+        )
+        history = history.append(confirmed)
+
+        closed = _observation(
+            opportunity_id, "closed", RecommendedAction.EXIT, NOW + timedelta(days=10)
+        )
+        history = history.append(closed)
+
+        assert [item.lifecycle_stage for item in history.observations] == [
+            "watching",
+            "confirmed",
+            "closed",
+        ]
+        assert history.current.recommended_action is RecommendedAction.EXIT


### PR DESCRIPTION
## Summary

Adds `strategy_runtime/lifecycle.py`, generalizing the lifecycle/verdict/opportunity-identity concepts the mature Stonk Calendar implementation already has into strategy-agnostic infrastructure — the engine, not any specific strategy's transition rules. Reconciling exactly which stages Calendar moves through and when is EPIC-7's own migration job; this ticket guarantees the engine those rules will run on is generic.

- `compute_opportunity_id()` is deliberately independent of any one observation or run: EPIC-6's `compute_observation_id()` identifies one observation event; this identifies the opportunity being observed, which must stay the same across many separate observations for history (EPIC-8) to mean anything. A dedicated test confirms an opportunity_id and an observation_id for the same (strategy, symbol) never collide.
- `RecommendedAction` is the closed vocabulary EPIC-6's `UniversalScreeningResult.recommendation_state` field holds as a string — MONITOR/ENTER/HOLD/EXIT/NO_ACTION, deliberately not a ranking (this sprint's own non-goals rule out cross-strategy ranking).
- `OpportunityObservation`/`OpportunityHistory` are the persistence-ready unit EPIC-8 will append to and read back: an ordered, append-only sequence of observations, always sorted oldest-first, with `.append()` returning a new immutable history.
- `validate_lifecycle_stage()` is the one guardrail that keeps this engine strategy-agnostic in practice: a reported `lifecycle_stage` must be one the strategy's own `StrategyContract` actually declared — never invented ad hoc, and rejected outright for a NONE-lifecycle contract.

Every test uses a fake, generically-named lifecycle-tracking strategy (`watched_event`) — proving the engine is genuinely strategy-agnostic. The end-to-end test builds a full three-observation evolution history using only this module's own generic pieces, with zero calendar-specific code anywhere in `lifecycle.py`.

Nothing here touches `screening/`, `strategies/`, any currently-shipped strategy, or the existing `/api/v1/screening*` surface.

## Test plan

- [x] 12 new tests (85 total in `strategy_runtime`, up from 73), all passing
- [x] Full scoped suite (`tests/`, excluding `pos`/`deployment_observer`): 1808 passed, 17 skipped, no regressions
- [x] `ruff check strategy_runtime tests/strategy_runtime` / `mypy strategy_runtime` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)