### PR TITLE
EPIC-8: persistence and history

### DIFF
--- a/strategy_runtime/__init__.py
+++ b/strategy_runtime/__init__.py
@@ -34,7 +34,12 @@ OpportunityObservation/OpportunityHistory for an opportunity's evolution,
 RecommendedAction as the vocabulary UniversalScreeningResult.
 recommendation_state holds, and validate_lifecycle_stage() as the one
 guardrail keeping the engine strategy-agnostic (a reported stage must be
-one the strategy's own contract actually declared).
+one the strategy's own contract actually declared). EPIC-8 (Persistence &
+History) lives in strategy_runtime.persistence: two pure Protocols
+(LatestResultRepository, ObservationHistoryRepository), no infrastructure
+imports -- a concrete implementation is EPIC-7's own job, matching
+screening/state.py's own established convention that this package never
+imports a database driver itself.
 """
 
 from __future__ import annotations

--- a/strategy_runtime/persistence.py
+++ b/strategy_runtime/persistence.py
@@ -1,0 +1,79 @@
+"""Persistence & History (SPRINT-009/EPIC-8).
+
+Two pure Protocols, no infrastructure imports -- matching
+screening/state.py's own established convention exactly (that module's
+own docstring: "A concrete repository implementation ... is dependency-
+injected by whatever caller constructs one; screening/ itself never
+imports one"). This module follows the identical rule for the same
+reason: strategy_runtime is root-level, deployable-application-independent
+infrastructure, and a database driver is asa/'s own concern to own, not
+this package's.
+
+LatestResultRepository generalizes screening.state.ScreeningStateRepository
+to EPIC-6's own UniversalScreeningResult rather than the narrower,
+screening-specific ScreeningStateRecord -- same upsert-only,
+latest-state-per-key shape, same guarantee (a symbol a run never touches
+keeps whatever was already stored; nothing is ever silently cleared just
+because a run happened). The existing screening_state table and its own
+Postgres implementation (asa/integrations/screening_postgres.py) are
+unchanged by this ticket -- EPIC-7's own migration is the point at which a
+strategy first needs a concrete UniversalScreeningResult-shaped
+implementation of this protocol, and that concrete implementation
+(and its own Alembic migration) belongs there, not here, matching this
+sprint's own precedent of deferring infrastructure to the point a real
+consumer actually needs it (EPIC-3's own documented deferral of unifying
+provider-wiring with screening/live_acquisition.py; EPIC-4's own
+documented deferral of a payoff calculator with no proven need yet).
+
+ObservationHistoryRepository is genuinely new: append-only storage for
+strategy_runtime.lifecycle.OpportunityObservation, keyed by opportunity_id
+-- "append-only" enforced by this protocol's own shape (no update, no
+delete, only append() and read), not merely by convention.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from strategy_runtime.lifecycle import OpportunityHistory, OpportunityObservation
+from strategy_runtime.result import UniversalScreeningResult
+
+
+class LatestResultRepository(Protocol):
+    """Stores only the latest UniversalScreeningResult per (strategy_id,
+    symbol) -- upsert() always overwrites any existing result for the
+    same pair, never accumulates history (ObservationHistoryRepository's
+    own job). A symbol a given run never touches is never removed by that
+    run -- "empty run never exposes stale data" means a caller sees
+    exactly what was last actually computed, not nothing, and never a
+    silently fabricated absence.
+    """
+
+    def upsert(self, result: UniversalScreeningResult) -> None: ...
+
+    def get_all(self) -> tuple[UniversalScreeningResult, ...]: ...
+
+    def get_for_strategy(self, strategy_id: str) -> tuple[UniversalScreeningResult, ...]: ...
+
+    def get_one(self, strategy_id: str, symbol: str) -> UniversalScreeningResult | None: ...
+
+
+class ObservationHistoryRepository(Protocol):
+    """Append-only: append() adds one observation to the history for its
+    own opportunity_id; nothing in this protocol updates or removes a
+    previously appended observation. history_for() returns the full,
+    ordered evolution for one opportunity_id -- "history replay
+    supported" means exactly this: every observation ever appended for
+    that opportunity, oldest first, reconstructable at any time.
+
+    One strategy's observations are isolated from every other strategy's
+    by construction, not by a runtime check here: opportunity_id itself
+    already encodes strategy_id (strategy_runtime.lifecycle.
+    compute_opportunity_id()'s own first argument), so two different
+    strategies can never collide on the same opportunity_id even when
+    both write through the same repository instance.
+    """
+
+    def append(self, observation: OpportunityObservation) -> None: ...
+
+    def history_for(self, opportunity_id: str) -> OpportunityHistory | None: ...

--- a/tests/strategy_runtime/test_persistence.py
+++ b/tests/strategy_runtime/test_persistence.py
@@ -1,0 +1,182 @@
+"""SPRINT-009/EPIC-8: persistence and history.
+
+Defines in-memory fakes for LatestResultRepository/ObservationHistoryRepository
+directly in this test module (matching tests/asa/fakes.py's own
+InMemoryScreeningStateRepository convention) and proves both protocols'
+own guarantees against them: append-only history replay, strategy run
+isolation, and "empty run never exposes stale data" for latest results.
+A concrete Postgres implementation is EPIC-7's own job (see
+strategy_runtime/persistence.py's own module docstring for why) -- these
+fakes are what proves the *protocol* is sufficient in the meantime, the
+same role InMemoryScreeningStateRepository already plays for
+screening.state.ScreeningStateRepository.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from strategy_runtime.lifecycle import (
+    OpportunityHistory,
+    OpportunityObservation,
+    RecommendedAction,
+    compute_opportunity_id,
+)
+from strategy_runtime.persistence import LatestResultRepository, ObservationHistoryRepository
+from strategy_runtime.result import EvaluationState, RowType, UniversalScreeningResult
+
+NOW = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+class InMemoryLatestResultRepository:
+    def __init__(self) -> None:
+        self._results: dict[tuple[str, str], UniversalScreeningResult] = {}
+
+    def upsert(self, result: UniversalScreeningResult) -> None:
+        self._results[(result.strategy_id, result.symbol)] = result
+
+    def get_all(self) -> tuple[UniversalScreeningResult, ...]:
+        return tuple(
+            sorted(self._results.values(), key=lambda item: (item.strategy_id, item.symbol))
+        )
+
+    def get_for_strategy(self, strategy_id: str) -> tuple[UniversalScreeningResult, ...]:
+        return tuple(
+            sorted(
+                (item for item in self._results.values() if item.strategy_id == strategy_id),
+                key=lambda item: item.symbol,
+            )
+        )
+
+    def get_one(self, strategy_id: str, symbol: str) -> UniversalScreeningResult | None:
+        return self._results.get((strategy_id, symbol))
+
+
+class InMemoryObservationHistoryRepository:
+    def __init__(self) -> None:
+        self._histories: dict[str, OpportunityHistory] = {}
+
+    def append(self, observation: OpportunityObservation) -> None:
+        existing = self._histories.get(observation.opportunity_id)
+        self._histories[observation.opportunity_id] = (
+            existing.append(observation)
+            if existing is not None
+            else OpportunityHistory(observation.opportunity_id, (observation,))
+        )
+
+    def history_for(self, opportunity_id: str) -> OpportunityHistory | None:
+        return self._histories.get(opportunity_id)
+
+
+def _result(strategy_id: str, symbol: str, verdict: str = "pass") -> UniversalScreeningResult:
+    return UniversalScreeningResult(
+        strategy_id=strategy_id,
+        strategy_version="1.0.0",
+        symbol=symbol,
+        observation_id=f"{strategy_id}-{symbol}-obs",
+        opportunity_id=None,
+        row_type=RowType.RESULT,
+        verdict=verdict,
+        evaluation_state=EvaluationState.PASS,
+        lifecycle_stage=None,
+        recommendation_state=None,
+        data_quality="fresh",
+        metrics={},
+        economics={},
+        blockers=(),
+        warnings=(),
+        provenance=(),
+        observed_at=NOW,
+    )
+
+
+def _observation(
+    opportunity_id: str, strategy_id: str, stage: str, at: datetime
+) -> OpportunityObservation:
+    return OpportunityObservation(
+        opportunity_id=opportunity_id,
+        strategy_id=strategy_id,
+        symbol="AAPL",
+        lifecycle_stage=stage,
+        verdict="pass",
+        recommended_action=RecommendedAction.MONITOR,
+        observed_at=at,
+    )
+
+
+class TestLatestResultRepositoryProtocolContract:
+    def test_conforms_structurally_to_the_protocol(self) -> None:
+        repository: LatestResultRepository = InMemoryLatestResultRepository()
+        assert repository.get_all() == ()
+
+    def test_upsert_overwrites_the_same_strategy_symbol_pair(self) -> None:
+        repository = InMemoryLatestResultRepository()
+        repository.upsert(_result("alpha", "AAPL", verdict="pass"))
+        repository.upsert(_result("alpha", "AAPL", verdict="no_signal"))
+
+        assert repository.get_one("alpha", "AAPL").verdict == "no_signal"
+        assert len(repository.get_all()) == 1  # never accumulates history
+
+    def test_a_run_that_never_touches_a_symbol_leaves_its_stored_result_untouched(self) -> None:
+        repository = InMemoryLatestResultRepository()
+        repository.upsert(_result("alpha", "AAPL"))
+        repository.upsert(_result("alpha", "MSFT"))
+
+        # Simulates a later run that only refreshes AAPL -- MSFT's own
+        # previously-stored result must remain exactly as it was, not be
+        # cleared just because this run never mentioned it.
+        repository.upsert(_result("alpha", "AAPL", verdict="no_signal"))
+
+        msft_result = repository.get_one("alpha", "MSFT")
+        assert msft_result is not None
+        assert msft_result.verdict == "pass"
+
+    def test_get_for_strategy_isolates_strategies(self) -> None:
+        repository = InMemoryLatestResultRepository()
+        repository.upsert(_result("alpha", "AAPL"))
+        repository.upsert(_result("beta", "AAPL"))
+
+        assert {item.strategy_id for item in repository.get_for_strategy("alpha")} == {"alpha"}
+
+
+class TestObservationHistoryRepositoryProtocolContract:
+    def test_conforms_structurally_to_the_protocol(self) -> None:
+        repository: ObservationHistoryRepository = InMemoryObservationHistoryRepository()
+        assert repository.history_for("nonexistent") is None
+
+    def test_append_only_history_supports_full_replay(self) -> None:
+        repository = InMemoryObservationHistoryRepository()
+        opportunity_id = compute_opportunity_id("watched_event", "AAPL", "2026-02-01")
+
+        repository.append(_observation(opportunity_id, "watched_event", "watching", NOW))
+        repository.append(
+            _observation(opportunity_id, "watched_event", "confirmed", NOW + timedelta(days=3))
+        )
+        repository.append(
+            _observation(opportunity_id, "watched_event", "closed", NOW + timedelta(days=10))
+        )
+
+        history = repository.history_for(opportunity_id)
+        assert history is not None
+        assert [item.lifecycle_stage for item in history.observations] == [
+            "watching",
+            "confirmed",
+            "closed",
+        ]
+        assert history.current.lifecycle_stage == "closed"
+
+    def test_two_strategies_never_collide_even_through_the_same_repository(self) -> None:
+        repository = InMemoryObservationHistoryRepository()
+        alpha_opportunity = compute_opportunity_id("alpha", "AAPL", "component-1")
+        beta_opportunity = compute_opportunity_id("beta", "AAPL", "component-1")
+        assert alpha_opportunity != beta_opportunity  # distinct identity, same symbol/component
+
+        repository.append(_observation(alpha_opportunity, "alpha", "watching", NOW))
+        repository.append(_observation(beta_opportunity, "beta", "confirmed", NOW))
+
+        alpha_history = repository.history_for(alpha_opportunity)
+        beta_history = repository.history_for(beta_opportunity)
+        assert alpha_history is not None and beta_history is not None
+        assert alpha_history.current.strategy_id == "alpha"
+        assert beta_history.current.strategy_id == "beta"
+        assert len(alpha_history.observations) == 1  # beta's append never touched alpha's history


### PR DESCRIPTION
## Summary

Adds `strategy_runtime/persistence.py`: two pure Protocols, no infrastructure imports — matching `screening/state.py`'s own established convention exactly (a concrete repository implementation is dependency-injected by whatever caller constructs one; this package itself never imports one).

- **`LatestResultRepository`** generalizes `screening.state.ScreeningStateRepository` to EPIC-6's `UniversalScreeningResult` — same upsert-only, latest-state-per-key shape, same guarantee (a symbol a run never touches keeps whatever was already stored). The existing `screening_state` table is unchanged.
- **`ObservationHistoryRepository`** is genuinely new: append-only storage for `OpportunityObservation`, keyed by `opportunity_id` — "append-only" enforced by the protocol's own shape (no update, no delete, only `append()` and read).

**Deliberately defers a concrete Postgres implementation** (and its own Alembic migration) to EPIC-7 — that's the point a strategy first actually needs one, continuing this sprint's own pattern of deferring infrastructure to where a real consumer needs it (EPIC-3's provider-wiring deferral, EPIC-4's payoff-calculator deferral). In-memory fakes defined in this ticket's own test module prove both protocols' contracts are sufficient in the meantime: append-only history replay, a "run that never touches a symbol never clears its stored result" guarantee, and strategy run isolation — including a test confirming two different strategies' `opportunity_id`s for the same symbol/component never collide.

Nothing here touches `screening/`, `strategies/`, any currently-shipped strategy, or the existing `/api/v1/screening*` surface.

## Test plan

- [x] 7 new tests (92 total in `strategy_runtime`, up from 85), all passing
- [x] Full scoped suite (`tests/`, excluding `pos`/`deployment_observer`): 1815 passed, 17 skipped, no regressions
- [x] `ruff check strategy_runtime tests/strategy_runtime` / `mypy strategy_runtime` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)