### PR TITLE
EPIC-R2: rich universal result model with typed metrics/economics (SPRINT-009R)

### DIFF
--- a/asa/integrations/universal_screening_postgres.py
+++ b/asa/integrations/universal_screening_postgres.py
@@ -27,6 +27,7 @@ from sqlalchemy import Engine, text
 from sqlalchemy.engine import RowMapping
 
 from strategy_runtime.persistence import UniversalSignalRow
+from strategy_runtime.values import TypedValue
 
 
 class PostgresLatestResultRepository:
@@ -120,8 +121,8 @@ def _to_params(row: UniversalSignalRow) -> dict[str, object]:
         "lifecycle_stage": row.lifecycle_stage,
         "recommendation_state": row.recommendation_state,
         "data_quality": row.data_quality,
-        "metrics": json.dumps(row.metrics),
-        "economics": json.dumps(row.economics),
+        "metrics": json.dumps({key: value.to_json() for key, value in row.metrics.items()}),
+        "economics": json.dumps({key: value.to_json() for key, value in row.economics.items()}),
         "blockers": json.dumps(list(row.blockers)),
         "warnings": json.dumps(list(row.warnings)),
         "provenance": json.dumps(list(row.provenance)),
@@ -142,8 +143,10 @@ def _to_row(mapping: RowMapping) -> UniversalSignalRow:
         lifecycle_stage=mapping["lifecycle_stage"],
         recommendation_state=mapping["recommendation_state"],
         data_quality=mapping["data_quality"],
-        metrics=dict(mapping["metrics"]),
-        economics=dict(mapping["economics"]),
+        metrics={key: TypedValue.from_json(value) for key, value in mapping["metrics"].items()},
+        economics={
+            key: TypedValue.from_json(value) for key, value in mapping["economics"].items()
+        },
         blockers=tuple(mapping["blockers"]),
         warnings=tuple(mapping["warnings"]),
         provenance=tuple(mapping["provenance"]),

--- a/strategy_runtime/__init__.py
+++ b/strategy_runtime/__init__.py
@@ -90,6 +90,7 @@ from strategy_runtime.result import (
     compute_observation_id,
 )
 from strategy_runtime.validation import validate_result
+from strategy_runtime.values import TypedValue, ValueType
 
 __all__ = [
     "NO_LIFECYCLE",
@@ -114,8 +115,10 @@ __all__ = [
     "StrategyRegistry",
     "StructureKind",
     "SubjectMarketDataAccess",
+    "TypedValue",
     "UniversalScreeningResult",
     "UnknownStrategyIdError",
+    "ValueType",
     "build_shared_market_data_access",
     "compute_observation_id",
     "run_strategies",

--- a/strategy_runtime/adapters/_screening_bridge.py
+++ b/strategy_runtime/adapters/_screening_bridge.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from screening.results import ScreeningOutcomeStatus, ScreeningResult
 from strategy_runtime.result import EvaluationState, RowType, UniversalScreeningResult
+from strategy_runtime.values import TypedValue
 
 _EVALUATION_STATE_BY_OUTCOME: dict[ScreeningOutcomeStatus, EvaluationState] = {
     ScreeningOutcomeStatus.PASS: EvaluationState.PASS,
@@ -53,7 +54,7 @@ def translate_screening_result(
     """
     is_success = result.outcome_status in _SUCCESS_OUTCOMES
     metrics = (
-        {"strategy_native_score": str(result.strategy_native_score)}
+        {"strategy_native_score": TypedValue.of_decimal(result.strategy_native_score)}
         if result.strategy_native_score is not None
         else {}
     )

--- a/strategy_runtime/persistence.py
+++ b/strategy_runtime/persistence.py
@@ -54,6 +54,7 @@ from typing import Protocol
 
 from strategy_runtime.lifecycle import OpportunityHistory, OpportunityObservation
 from strategy_runtime.result import EvaluationState, RowType, UniversalScreeningResult
+from strategy_runtime.values import TypedValue
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,8 +78,8 @@ class UniversalSignalRow:
     lifecycle_stage: str | None
     recommendation_state: str | None
     data_quality: str | None
-    metrics: dict[str, str]
-    economics: dict[str, str]
+    metrics: dict[str, TypedValue]
+    economics: dict[str, TypedValue]
     blockers: tuple[str, ...]
     warnings: tuple[str, ...]
     provenance: tuple[str, ...]

--- a/strategy_runtime/result.py
+++ b/strategy_runtime/result.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 
+from strategy_runtime.values import TypedValue
+
 
 def compute_observation_id(run_id: str, strategy_id: str, symbol: str) -> str:
     """Deterministic identity for one (run, strategy, symbol) observation
@@ -93,8 +95,8 @@ class UniversalScreeningResult:
     lifecycle_stage: str | None
     recommendation_state: str | None
     data_quality: str | None
-    metrics: dict[str, str]
-    economics: dict[str, str]
+    metrics: dict[str, TypedValue]
+    economics: dict[str, TypedValue]
     blockers: tuple[str, ...]
     warnings: tuple[str, ...]
     provenance: tuple[str, ...]

--- a/strategy_runtime/values.py
+++ b/strategy_runtime/values.py
@@ -1,0 +1,149 @@
+"""Rich Universal Result values (SPRINT-009R/EPIC-R2).
+
+TypedValue is the one thing every strategy's own metrics/economics
+namespace entry is, regardless of what that strategy computes -- the same
+generalize_before_specialize principle EPIC-6's own UniversalScreeningResult
+already applies to the envelope shape, applied here to the value inside it.
+A strategy that used to have to render a Decimal, bool, or datetime down to
+a bare str (losing type information at the boundary) now wraps it in a
+TypedValue instead, and the exact original value comes back out unchanged
+through ``native()`` -- "universal results preserve complete strategy
+outputs" is enforced by round-tripping through this module, not merely
+documented.
+
+Deliberately closed to seven kinds, matching EPIC-R2's own
+supported_types list exactly: decimal, integer, boolean, string, datetime,
+duration, and structured (a JSON-shaped mapping or sequence of any mix of
+the other six, nested arbitrarily deep, for a strategy whose native output
+is not a single scalar).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from enum import Enum
+from typing import Union
+
+from domain.values import DomainInvariantError, require_tz_aware
+
+JsonScalar = str | int | float | bool | None
+# X | Y syntax cannot hold a forward-reference string operand at runtime (this is a value
+# assignment, not an annotation -- `from __future__ import annotations` does not defer it).
+JsonValue = Union[JsonScalar, "list[JsonValue]", "dict[str, JsonValue]"]  # noqa: UP007
+
+
+class ValueType(str, Enum):
+    DECIMAL = "decimal"
+    INTEGER = "integer"
+    BOOLEAN = "boolean"
+    STRING = "string"
+    DATETIME = "datetime"
+    DURATION = "duration"
+    STRUCTURED = "structured"
+
+
+@dataclass(frozen=True, slots=True)
+class TypedValue:
+    """``encoded`` is always this value's own canonical string form -- for
+    every kind but STRUCTURED, decoding it is a single stdlib constructor
+    call; STRUCTURED's ``encoded`` is a sort_keys=True JSON document, so two
+    TypedValues built from an equal structured value are always
+    byte-identical, matching this codebase's established canonicalization
+    convention (domain/canonicalization.py's own json.dumps(...,
+    sort_keys=True, separators=(",", ":")) idiom) rather than inventing a
+    second one here.
+    """
+
+    value_type: ValueType
+    encoded: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value_type, ValueType):
+            raise DomainInvariantError("TypedValue.value_type must be a ValueType")
+        if self.encoded == "" and self.value_type is not ValueType.STRING:
+            raise DomainInvariantError(
+                f"TypedValue.encoded must be non-empty for {self.value_type.value}"
+            )
+        # Round-trip now, at construction time, rather than deferring the failure to
+        # whatever caller eventually calls native() -- an invalid TypedValue must never
+        # be constructible in the first place.
+        self.native()
+
+    @classmethod
+    def of_decimal(cls, value: Decimal) -> TypedValue:
+        return cls(ValueType.DECIMAL, str(value))
+
+    @classmethod
+    def of_integer(cls, value: int) -> TypedValue:
+        return cls(ValueType.INTEGER, str(value))
+
+    @classmethod
+    def of_boolean(cls, value: bool) -> TypedValue:
+        return cls(ValueType.BOOLEAN, "true" if value else "false")
+
+    @classmethod
+    def of_string(cls, value: str) -> TypedValue:
+        return cls(ValueType.STRING, value)
+
+    @classmethod
+    def of_datetime(cls, value: datetime) -> TypedValue:
+        require_tz_aware(value, "TypedValue", "of_datetime")
+        return cls(ValueType.DATETIME, value.isoformat())
+
+    @classmethod
+    def of_duration(cls, value: timedelta) -> TypedValue:
+        return cls(ValueType.DURATION, str(value.total_seconds()))
+
+    @classmethod
+    def of_structured(cls, value: Mapping[str, JsonValue] | Sequence[JsonValue]) -> TypedValue:
+        encoded = json.dumps(value, sort_keys=True, separators=(",", ":"))
+        return cls(ValueType.STRUCTURED, encoded)
+
+    def native(self) -> object:
+        """Decode back to the exact kind of Python value the ``of_*``
+        constructor was given -- the one place every reader of a TypedValue
+        should go through, so a decoding rule is written once, not
+        re-implemented at every call site.
+        """
+        try:
+            if self.value_type is ValueType.DECIMAL:
+                return Decimal(self.encoded)
+            if self.value_type is ValueType.INTEGER:
+                return int(self.encoded)
+            if self.value_type is ValueType.BOOLEAN:
+                if self.encoded not in ("true", "false"):
+                    raise DomainInvariantError("TypedValue boolean encoding must be true/false")
+                return self.encoded == "true"
+            if self.value_type is ValueType.STRING:
+                return self.encoded
+            if self.value_type is ValueType.DATETIME:
+                value = datetime.fromisoformat(self.encoded)
+                require_tz_aware(value, "TypedValue", "native")
+                return value
+            if self.value_type is ValueType.DURATION:
+                return timedelta(seconds=float(self.encoded))
+            return json.loads(self.encoded)
+        except (InvalidOperation, ValueError) as exc:
+            raise DomainInvariantError(
+                f"TypedValue.encoded is not a valid {self.value_type.value}"
+            ) from exc
+
+    def to_json(self) -> dict[str, str]:
+        """The one JSON-shaped encoding this module hands to a storage
+        boundary (strategy_runtime.persistence's own concrete Postgres
+        implementation lives in asa/, not here) -- plain str/str so it
+        survives an ordinary json.dumps() with no custom encoder.
+        """
+        return {"type": self.value_type.value, "value": self.encoded}
+
+    @classmethod
+    def from_json(cls, data: Mapping[str, str]) -> TypedValue:
+        try:
+            value_type = ValueType(data["type"])
+        except ValueError as exc:
+            raise DomainInvariantError(f"Unknown TypedValue type {data.get('type')!r}") from exc
+        return cls(value_type, data["value"])

--- a/tests/asa/test_universal_screening_postgres_encoding.py
+++ b/tests/asa/test_universal_screening_postgres_encoding.py
@@ -1,0 +1,92 @@
+"""SPRINT-009R/EPIC-R2: PostgresLatestResultRepository's own JSON encoding
+of TypedValue metrics/economics -- exercised as pure functions, without a
+real database (see test_universal_screening_service_postgres_integration.py
+for the real-Postgres round trip, gated behind the ``postgres`` marker).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from asa.integrations.universal_screening_postgres import _to_params, _to_row
+from strategy_runtime.persistence import UniversalSignalRow
+from strategy_runtime.values import TypedValue
+
+
+def _row(**overrides: object) -> UniversalSignalRow:
+    defaults: dict[str, object] = {
+        "signal_id": "alpha",
+        "signal_version": "1.0.0",
+        "symbol": "AAPL",
+        "observation_id": "obs-1",
+        "opportunity_id": None,
+        "row_type": "result",
+        "verdict": "pass",
+        "evaluation_state": "pass",
+        "lifecycle_stage": None,
+        "recommendation_state": None,
+        "data_quality": None,
+        "metrics": {"strategy_native_score": TypedValue.of_decimal(Decimal("0.5"))},
+        "economics": {"debit": TypedValue.of_decimal(Decimal("125.50"))},
+        "blockers": (),
+        "warnings": (),
+        "provenance": (),
+        "observed_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    return UniversalSignalRow(**defaults)  # type: ignore[arg-type]
+
+
+def test_to_params_json_encodes_typed_values() -> None:
+    params = _to_params(_row())
+
+    decoded_metrics = json.loads(params["metrics"])
+    assert decoded_metrics == {"strategy_native_score": {"type": "decimal", "value": "0.5"}}
+    decoded_economics = json.loads(params["economics"])
+    assert decoded_economics == {"debit": {"type": "decimal", "value": "125.50"}}
+
+
+def test_to_row_reconstructs_typed_values_from_a_json_shaped_mapping() -> None:
+    mapping = {
+        "signal_id": "alpha",
+        "signal_version": "1.0.0",
+        "symbol": "AAPL",
+        "observation_id": "obs-1",
+        "opportunity_id": None,
+        "row_type": "result",
+        "verdict": "pass",
+        "evaluation_state": "pass",
+        "lifecycle_stage": None,
+        "recommendation_state": None,
+        "data_quality": None,
+        "metrics": {"strategy_native_score": {"type": "decimal", "value": "0.5"}},
+        "economics": {"debit": {"type": "decimal", "value": "125.50"}},
+        "blockers": [],
+        "warnings": [],
+        "provenance": [],
+        "observed_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+
+    row = _to_row(mapping)  # type: ignore[arg-type]
+
+    assert row.metrics["strategy_native_score"] == TypedValue.of_decimal(Decimal("0.5"))
+    assert row.economics["debit"].native() == Decimal("125.50")
+
+
+def test_round_trip_through_params_and_row_preserves_typed_values() -> None:
+    original = _row()
+
+    params = _to_params(original)
+    mapping = dict(params)
+    mapping["metrics"] = json.loads(params["metrics"])
+    mapping["economics"] = json.loads(params["economics"])
+    mapping["blockers"] = []
+    mapping["warnings"] = []
+    mapping["provenance"] = []
+
+    restored = _to_row(mapping)  # type: ignore[arg-type]
+
+    assert restored.metrics == original.metrics
+    assert restored.economics == original.economics

--- a/tests/strategy_runtime/adapters/test_screening_bridge.py
+++ b/tests/strategy_runtime/adapters/test_screening_bridge.py
@@ -1,0 +1,65 @@
+"""SPRINT-009R/EPIC-R2: strategy_runtime.adapters._screening_bridge emits a
+typed strategy_native_score, not a bare str -- the production path every
+migrated strategy (forward_factor, skew_momentum, earnings_calendar)
+already runs through.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from screening.results import ScreeningOutcomeStatus, ScreeningResult
+from strategy_runtime.adapters._screening_bridge import translate_screening_result
+from strategy_runtime.values import TypedValue, ValueType
+
+NOW = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _screening_result(**overrides: object) -> ScreeningResult:
+    defaults: dict[str, object] = {
+        "run_id": "run-1",
+        "strategy_id": "alpha",
+        "strategy_version": "1.0.0",
+        "subject_identity": "AAPL",
+        "as_of": NOW,
+        "outcome_status": ScreeningOutcomeStatus.PASS,
+        "signal_classification": "bullish",
+        "strategy_native_score": Decimal("0.75"),
+        "evidence": (),
+        "input_provenance": (),
+        "completeness": None,
+        "failure_detail": None,
+    }
+    defaults.update(overrides)
+    return ScreeningResult(**defaults)  # type: ignore[arg-type]
+
+
+class TestTranslateScreeningResult:
+    def test_a_native_score_becomes_a_typed_decimal_metric(self) -> None:
+        result = translate_screening_result(
+            _screening_result(),
+            symbol="AAPL",
+            observation_id="obs-1",
+            opportunity_id=None,
+            lifecycle_stage=None,
+        )
+
+        metric = result.metrics["strategy_native_score"]
+        assert isinstance(metric, TypedValue)
+        assert metric.value_type is ValueType.DECIMAL
+        assert metric.native() == Decimal("0.75")
+
+    def test_no_native_score_produces_no_metrics(self) -> None:
+        result = translate_screening_result(
+            _screening_result(
+                outcome_status=ScreeningOutcomeStatus.NO_SIGNAL,
+                strategy_native_score=None,
+            ),
+            symbol="AAPL",
+            observation_id="obs-1",
+            opportunity_id=None,
+            lifecycle_stage=None,
+        )
+
+        assert result.metrics == {}

--- a/tests/strategy_runtime/test_values.py
+++ b/tests/strategy_runtime/test_values.py
@@ -1,0 +1,88 @@
+"""SPRINT-009R/EPIC-R2: TypedValue -- round-tripping every supported_type
+(decimal, integer, boolean, string, datetime, duration, structured)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from domain.values import DomainInvariantError
+from strategy_runtime.values import TypedValue, ValueType
+
+
+class TestRoundTrip:
+    def test_decimal_round_trips(self) -> None:
+        value = TypedValue.of_decimal(Decimal("12.50"))
+        assert value.value_type is ValueType.DECIMAL
+        assert value.native() == Decimal("12.50")
+
+    def test_integer_round_trips(self) -> None:
+        assert TypedValue.of_integer(42).native() == 42
+
+    def test_boolean_true_and_false_round_trip(self) -> None:
+        assert TypedValue.of_boolean(True).native() is True
+        assert TypedValue.of_boolean(False).native() is False
+
+    def test_string_round_trips_including_empty(self) -> None:
+        assert TypedValue.of_string("hello").native() == "hello"
+        assert TypedValue.of_string("").native() == ""
+
+    def test_datetime_round_trips(self) -> None:
+        value = datetime(2026, 1, 1, 12, 30, tzinfo=UTC)
+        assert TypedValue.of_datetime(value).native() == value
+
+    def test_naive_datetime_is_rejected(self) -> None:
+        with pytest.raises(DomainInvariantError):
+            TypedValue.of_datetime(datetime(2026, 1, 1))
+
+    def test_duration_round_trips(self) -> None:
+        value = timedelta(hours=1, minutes=30)
+        assert TypedValue.of_duration(value).native() == value
+
+    def test_structured_mapping_round_trips(self) -> None:
+        value = {"legs": [{"strike": 100, "side": "long"}], "count": 2}
+        assert TypedValue.of_structured(value).native() == value
+
+    def test_structured_sequence_round_trips(self) -> None:
+        value = [1, "two", False, None]
+        assert TypedValue.of_structured(value).native() == value
+
+
+class TestJsonEncoding:
+    def test_to_json_and_from_json_round_trip_for_every_kind(self) -> None:
+        originals = (
+            TypedValue.of_decimal(Decimal("3.14")),
+            TypedValue.of_integer(-7),
+            TypedValue.of_boolean(True),
+            TypedValue.of_string("plain"),
+            TypedValue.of_datetime(datetime(2026, 3, 4, tzinfo=UTC)),
+            TypedValue.of_duration(timedelta(seconds=90)),
+            TypedValue.of_structured({"a": 1}),
+        )
+        for original in originals:
+            restored = TypedValue.from_json(original.to_json())
+            assert restored == original
+            assert restored.native() == original.native()
+
+    def test_from_json_rejects_an_unknown_type(self) -> None:
+        with pytest.raises(DomainInvariantError):
+            TypedValue.from_json({"type": "not_a_real_type", "value": "x"})
+
+
+class TestConstructionValidation:
+    def test_invalid_decimal_encoding_is_rejected_at_construction(self) -> None:
+        with pytest.raises(DomainInvariantError):
+            TypedValue(ValueType.DECIMAL, "not-a-number")
+
+    def test_invalid_boolean_encoding_is_rejected_at_construction(self) -> None:
+        with pytest.raises(DomainInvariantError):
+            TypedValue(ValueType.BOOLEAN, "yes")
+
+    def test_empty_encoding_is_rejected_for_non_string_kinds(self) -> None:
+        with pytest.raises(DomainInvariantError):
+            TypedValue(ValueType.INTEGER, "")
+
+    def test_empty_encoding_is_accepted_for_string(self) -> None:
+        assert TypedValue(ValueType.STRING, "").native() == ""


### PR DESCRIPTION
## Objective

SPRINT-009R/EPIC-R2: represent complete strategy semantics without loss, remaining strategy-agnostic. Adds typed values for `metrics`/`economics`, supporting exactly the seven `supported_types` this epic calls for: decimal, integer, boolean, string, datetime, duration, structured objects.

**Stacked on #217 (EPIC-R1)** — this PR's base branch is `claude/sprint-009r-epic-r1-strategy-capabilities`, not `main`, so its diff only shows EPIC-R2's own changes. Retarget to `main` once #217 merges (or merge #217 first).

## Scope

- **`strategy_runtime/values.py` (new)**: `TypedValue`, a closed seven-kind tagged value with `of_decimal`/`of_integer`/`of_boolean`/`of_string`/`of_datetime`/`of_duration`/`of_structured` constructors, `.native()` to decode back to the exact original Python value, and `.to_json()`/`.from_json()` for the one JSON-shaped encoding a storage boundary needs. Validates its own encoding at construction time (round-trips through `native()` in `__post_init__`) rather than deferring the failure to whatever caller eventually reads it.
- **`UniversalScreeningResult.metrics`/`.economics`** (`strategy_runtime/result.py`) move from `dict[str, str]` to `dict[str, TypedValue]` — "universal results preserve complete strategy outputs" is enforced by round-tripping through `TypedValue`, not merely documented.
- **`strategy_runtime/persistence.py`**: `UniversalSignalRow` follows the same type change — it stays a field-for-field storage projection, unchanged in shape.
- **`strategy_runtime/adapters/_screening_bridge.py`**: the one real production producer of a metrics value today (every migrated strategy — `forward_factor`, `skew_momentum`, `earnings_calendar` — runs through it) now emits `TypedValue.of_decimal(strategy_native_score)` instead of `str(strategy_native_score)`.
- **`asa/integrations/universal_screening_postgres.py`**: the concrete Postgres boundary encodes/decodes through `TypedValue.to_json()`/`from_json()`. **No schema change** — the `metrics`/`economics` columns were already JSON/JSONB (`migrations/versions/0005_universal_screening_state.py`, untouched).

`OutputKind.ECONOMICS` is still not *populated* by any migrated strategy today (a documented EPIC-R1 deferral in `strategy_runtime/validation.py`) — this epic makes the value *type* rich; actually populating economics with real per-strategy values remains a strategy-by-strategy concern outside this platform epic.

## Files Changed

- `strategy_runtime/values.py` (new) — `TypedValue`/`ValueType`
- `strategy_runtime/result.py`, `strategy_runtime/persistence.py` — typed `metrics`/`economics`
- `strategy_runtime/adapters/_screening_bridge.py` — typed `strategy_native_score`
- `strategy_runtime/__init__.py` — exports `TypedValue`, `ValueType`
- `asa/integrations/universal_screening_postgres.py` — JSON encode/decode through `TypedValue`
- `tests/strategy_runtime/test_values.py` (new) — round-trip + JSON encoding + construction-validation tests for all seven kinds
- `tests/strategy_runtime/adapters/test_screening_bridge.py` (new) — production translation path emits a typed metric
- `tests/asa/test_universal_screening_postgres_encoding.py` (new) — Postgres JSON boundary as pure functions, no database required

## Tests Run

- `PYTHONPATH=. pytest tests/strategy_runtime tests/asa -k "not postgres"` — 259 passed
- `PYTHONPATH=. pytest tests -k "not postgres"` (full repo) — 2508 passed, 2 skipped, 30 deselected
- `PYTHONPATH=. pytest tests/architecture` — 443 passed
- `ruff check strategy_runtime asa tests/strategy_runtime tests/asa` — only the one expected new `UP042` finding for `ValueType(str, Enum)`, matching every other enum in this codebase (pre-existing pattern); one `noqa: UP007` on `JsonValue`'s `Union[...]` alias, documented inline (a runtime value assignment can't hold a string forward-reference operand in `X | Y` syntax, unlike an annotation under `from __future__ import annotations`)
- `mypy` (project config) — Success: no issues found in 40 source files
- `mypy strategy_runtime asa` (standalone) — Success: no issues found in 60 source files

## Risk Classification

Low-moderate: changes a public dataclass field's type on `UniversalScreeningResult`/`UniversalSignalRow`, but Postgres JSON/JSONB columns are unaffected in shape (no migration needed), and the only real production writer (`_screening_bridge.py`) was updated in lockstep and covered by a new test on that exact path.

## Known Limitations

- `OutputKind.ECONOMICS` remains unpopulated for all three migrated strategies (unchanged from before this PR) — populating it is future strategy-level work, not this platform epic.
- EPIC-R3 through EPIC-R5 are separate, not part of this PR.

## Founder Decision Required

No — continuing epic-by-epic per SPRINT-009R with delegated execution.


---
_Generated by [Claude Code](https://claude.ai/code/session_0171U6QSQe39nnsDLYLbmbG1)_