### PR TITLE
EPIC-R3: complete opportunity lifecycle with persistent observations (SPRINT-009R)

### DIFF
--- a/asa/integrations/observation_history_postgres.py
+++ b/asa/integrations/observation_history_postgres.py
@@ -1,0 +1,75 @@
+"""Postgres-backed ObservationHistoryRepository (SPRINT-009R/EPIC-R3).
+
+Implements strategy_runtime.persistence.ObservationHistoryRepository --
+raw SQL through sqlalchemy.Engine/text(), no ORM, matching this codebase's
+established PostgresLatestResultRepository pattern
+(asa/integrations/universal_screening_postgres.py) exactly. append() only
+ever inserts a new row -- there is no update or delete path anywhere in
+this module, enforcing "append-only" structurally, not merely by
+convention. history_for() reconstructs the full, ordered
+strategy_runtime.lifecycle.OpportunityHistory for one opportunity_id, or
+None if that opportunity has never been observed.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Engine, text
+from sqlalchemy.engine import RowMapping
+
+from strategy_runtime.lifecycle import (
+    OpportunityHistory,
+    OpportunityObservation,
+    RecommendedAction,
+)
+
+
+class PostgresObservationHistoryRepository:
+    def __init__(self, engine: Engine) -> None:
+        self._engine = engine
+
+    def append(self, observation: OpportunityObservation) -> None:
+        with self._engine.begin() as connection:
+            connection.execute(
+                text("""
+                    INSERT INTO opportunity_observation_history (
+                        opportunity_id, signal_id, symbol, lifecycle_stage,
+                        verdict, recommended_action, observed_at
+                    ) VALUES (
+                        :opportunity_id, :signal_id, :symbol, :lifecycle_stage,
+                        :verdict, :recommended_action, :observed_at
+                    )
+                """),
+                {
+                    "opportunity_id": observation.opportunity_id,
+                    "signal_id": observation.strategy_id,
+                    "symbol": observation.symbol,
+                    "lifecycle_stage": observation.lifecycle_stage,
+                    "verdict": observation.verdict,
+                    "recommended_action": observation.recommended_action.value,
+                    "observed_at": observation.observed_at,
+                },
+            )
+
+    def history_for(self, opportunity_id: str) -> OpportunityHistory | None:
+        with self._engine.connect() as connection:
+            rows = connection.execute(
+                text(
+                    "SELECT * FROM opportunity_observation_history "
+                    "WHERE opportunity_id = :opportunity_id ORDER BY observed_at"
+                ),
+                {"opportunity_id": opportunity_id},
+            ).mappings()
+            observations = tuple(_to_observation(row) for row in rows)
+            return OpportunityHistory(opportunity_id, observations) if observations else None
+
+
+def _to_observation(mapping: RowMapping) -> OpportunityObservation:
+    return OpportunityObservation(
+        opportunity_id=mapping["opportunity_id"],
+        strategy_id=mapping["signal_id"],
+        symbol=mapping["symbol"],
+        lifecycle_stage=mapping["lifecycle_stage"],
+        verdict=mapping["verdict"],
+        recommended_action=RecommendedAction(mapping["recommended_action"]),
+        observed_at=mapping["observed_at"],
+    )

--- a/migrations/versions/0006_opportunity_observation_history.py
+++ b/migrations/versions/0006_opportunity_observation_history.py
@@ -1,0 +1,53 @@
+"""Create opportunity_observation_history -- append-only observation
+history for lifecycle-tracked strategy_runtime opportunities (SPRINT-009R/
+EPIC-R3).
+
+Additive only, mirrors 0005's own naming rationale: no primary key on
+(opportunity_id) alone since this table accumulates one row per
+observation, not one row per opportunity -- an auto-incrementing surrogate
+key plus an index on opportunity_id (every read strategy_runtime.
+persistence.ObservationHistoryRepository.history_for() needs) instead.
+Column names avoid "strategy" for the same asa/ boundary reason 0004/0005
+already established (tests/asa/test_boundaries.py::
+test_forbidden_legacy_technologies_are_absent).
+
+Revision ID: 0006
+Revises: 0005
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "opportunity_observation_history",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("opportunity_id", sa.String(length=128), nullable=False),
+        sa.Column("signal_id", sa.String(length=64), nullable=False),
+        sa.Column("symbol", sa.String(length=32), nullable=False),
+        sa.Column("lifecycle_stage", sa.String(length=64), nullable=False),
+        sa.Column("verdict", sa.Text(), nullable=False),
+        sa.Column("recommended_action", sa.String(length=32), nullable=False),
+        sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "ix_opportunity_observation_history_opportunity_id",
+        "opportunity_observation_history",
+        ["opportunity_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_opportunity_observation_history_opportunity_id",
+        table_name="opportunity_observation_history",
+    )
+    op.drop_table("opportunity_observation_history")

--- a/strategy_runtime/lifecycle.py
+++ b/strategy_runtime/lifecycle.py
@@ -34,6 +34,7 @@ from enum import Enum
 
 from strategy_runtime.contract import LifecycleModel, StrategyContract
 from strategy_runtime.errors import StrategyContractError
+from strategy_runtime.result import UniversalScreeningResult
 
 
 def compute_opportunity_id(strategy_id: str, symbol: str, *identity_components: str) -> str:
@@ -144,3 +145,47 @@ def validate_lifecycle_stage(contract: StrategyContract, stage: str) -> None:
             f"{stage!r} is not a lifecycle_stage {contract.strategy_id!r} declared "
             f"(declared: {contract.lifecycle.supported_states})"
         )
+
+
+def observe_transition(
+    contract: StrategyContract,
+    result: UniversalScreeningResult,
+    *,
+    recommended_action: RecommendedAction,
+) -> OpportunityObservation:
+    """The lifecycle transition engine (SPRINT-009R/EPIC-R3): turns one
+    execution's own UniversalScreeningResult into the durable
+    OpportunityObservation EPIC-8's own ObservationHistoryRepository
+    persists. ``recommended_action`` is always supplied by the caller, never
+    derived here -- a recommendation engine is this sprint's own explicit
+    non_goal, so this engine only records whichever action its caller
+    already decided on, exactly the same way strategies_own_financial_logic
+    already keeps every other business judgment out of runtime
+    infrastructure.
+
+    "Event-scoped opportunity identity": raises unless this particular
+    result actually carries an opportunity_id/lifecycle_stage pair (the
+    same invariant strategy_runtime.result.UniversalScreeningResult.
+    __post_init__ already enforces on the result itself) -- an evaluation
+    that never identified an opportunity has no transition to record.
+    """
+    if result.opportunity_id is None or result.lifecycle_stage is None:
+        raise StrategyContractError(
+            f"{result.strategy_id!r} result for {result.symbol!r} carries no "
+            "opportunity_id/lifecycle_stage -- there is no opportunity transition to observe"
+        )
+    if result.verdict is None:
+        raise StrategyContractError(
+            f"{result.strategy_id!r} result for {result.symbol!r} carries no verdict -- an "
+            "opportunity observation always records the verdict that produced its stage"
+        )
+    validate_lifecycle_stage(contract, result.lifecycle_stage)
+    return OpportunityObservation(
+        opportunity_id=result.opportunity_id,
+        strategy_id=result.strategy_id,
+        symbol=result.symbol,
+        lifecycle_stage=result.lifecycle_stage,
+        verdict=result.verdict,
+        recommended_action=recommended_action,
+        observed_at=result.observed_at,
+    )

--- a/strategy_runtime/persistence.py
+++ b/strategy_runtime/persistence.py
@@ -167,3 +167,16 @@ class ObservationHistoryRepository(Protocol):
     def append(self, observation: OpportunityObservation) -> None: ...
 
     def history_for(self, opportunity_id: str) -> OpportunityHistory | None: ...
+
+
+def replay_opportunity_history(
+    repository: ObservationHistoryRepository, opportunity_id: str
+) -> OpportunityHistory | None:
+    """The one named "lifecycle replay" entrypoint (SPRINT-009R/EPIC-R3):
+    every observation ever appended for ``opportunity_id``, oldest first,
+    reconstructed from whatever repository a caller injects -- exactly
+    ObservationHistoryRepository's own history_for() contract, given its
+    own top-level name here so a caller reads "replay an opportunity's
+    history" rather than reaching into the repository protocol directly.
+    """
+    return repository.history_for(opportunity_id)

--- a/strategy_runtime/service.py
+++ b/strategy_runtime/service.py
@@ -15,6 +15,13 @@ UniversalSignalRow (LatestResultRepository's own storage-boundary shape,
 see strategy_runtime/persistence.py's own docstring for why) right here
 at the repository call site -- callers of get_state()/refresh() never see
 UniversalSignalRow at all.
+
+record_opportunity_observation() (SPRINT-009R/EPIC-R3) is a separate,
+explicitly opt-in extension: refresh() itself stays unchanged and usable by
+every strategy, lifecycle-tracked or not, so this persists an opportunity's
+evolution only for a caller that actually wants it (and can supply the
+recommended_action a real recommendation engine would compute -- this
+sprint's own explicit non_goal, deliberately never invented here).
 """
 
 from __future__ import annotations
@@ -24,7 +31,16 @@ from collections.abc import Mapping
 from market_data import CapabilityFulfillmentService
 from strategy_runtime.clock import Clock
 from strategy_runtime.execution import ExecutionStatus, run_strategies
-from strategy_runtime.persistence import LatestResultRepository, UniversalSignalRow
+from strategy_runtime.lifecycle import (
+    OpportunityObservation,
+    RecommendedAction,
+    observe_transition,
+)
+from strategy_runtime.persistence import (
+    LatestResultRepository,
+    ObservationHistoryRepository,
+    UniversalSignalRow,
+)
 from strategy_runtime.registry import StrategyRegistry
 from strategy_runtime.result import UniversalScreeningResult
 
@@ -73,3 +89,24 @@ def refresh(
         )
     repository.upsert(UniversalSignalRow.from_result(execution_result.result))
     return execution_result.result
+
+
+def record_opportunity_observation(
+    registry: StrategyRegistry[UniversalScreeningResult],
+    history_repository: ObservationHistoryRepository,
+    result: UniversalScreeningResult,
+    *,
+    recommended_action: RecommendedAction,
+) -> OpportunityObservation:
+    """Persistent opportunity evolution (SPRINT-009R/EPIC-R3): given a
+    result already produced by run_strategies()/refresh() (this function
+    never executes a strategy itself), record one more durable observation
+    of that result's own opportunity. Call this after refresh() for any
+    strategy whose contract declares StrategyCapability.LIFECYCLE -- refresh()
+    itself never calls this, so a caller with no interest in history pays
+    nothing for it.
+    """
+    contract = registry.contract_for(result.strategy_id)
+    observation = observe_transition(contract, result, recommended_action=recommended_action)
+    history_repository.append(observation)
+    return observation

--- a/tests/asa/test_observation_history_postgres_integration.py
+++ b/tests/asa/test_observation_history_postgres_integration.py
@@ -1,0 +1,146 @@
+"""SPRINT-009R/EPIC-R3: strategy_runtime.service.record_opportunity_observation()
+and strategy_runtime.persistence.replay_opportunity_history() exercised end
+to end against a real (test) Postgres instance, through
+PostgresObservationHistoryRepository.
+
+Mirrors tests/asa/test_universal_screening_service_postgres_integration.py's
+own exact pattern (EPIC-9) for the same reason: proving append()/
+history_for() actually compose correctly through the real raw-SQL layer,
+not just that each works in isolation. Uses a fake, generically-named
+lifecycle-tracking strategy ("watched_event") rather than the real
+earnings_calendar adapter -- proving the persistence layer is genuinely
+strategy-agnostic, the same way tests/strategy_runtime/test_lifecycle.py
+already does for the in-memory engine.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from asa.integrations.observation_history_postgres import PostgresObservationHistoryRepository
+from strategy_runtime import (
+    DataRequirement,
+    LifecycleDeclaration,
+    LifecycleModel,
+    OutputKind,
+    RequirementCategory,
+    RowType,
+    StrategyContract,
+    StrategyRegistry,
+    StructureKind,
+    UniversalScreeningResult,
+    compute_observation_id,
+)
+from strategy_runtime.lifecycle import RecommendedAction, compute_opportunity_id
+from strategy_runtime.persistence import replay_opportunity_history
+from strategy_runtime.result import EvaluationState
+from strategy_runtime.service import record_opportunity_observation
+
+pytestmark = [
+    pytest.mark.postgres,
+    pytest.mark.skipif(
+        not os.getenv("ASA_TEST_DATABASE_URL"),
+        reason="ASA_TEST_DATABASE_URL not set",
+    ),
+]
+
+STRATEGY_ID = "watched_event"
+SYMBOL = "AAPL"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _migrated_database() -> None:
+    command.upgrade(Config("alembic.ini"), "head")
+
+
+@pytest.fixture
+def repository() -> PostgresObservationHistoryRepository:
+    database_url = os.environ["ASA_TEST_DATABASE_URL"]
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE opportunity_observation_history"))
+    return PostgresObservationHistoryRepository(engine)
+
+
+def _contract() -> StrategyContract:
+    return StrategyContract(
+        strategy_id=STRATEGY_ID,
+        version="1.0.0",
+        category="test",
+        description="A fake lifecycle-tracking strategy for EPIC-R3 integration tests.",
+        requirements=(DataRequirement(RequirementCategory.CUSTOM, identifier="none"),),
+        lifecycle=LifecycleDeclaration(
+            LifecycleModel.OPPORTUNITY,
+            supported_states=("watching", "confirmed"),
+            observation_type="watched_event",
+        ),
+        structure=StructureKind.NONE,
+        outputs=(OutputKind.METRICS, OutputKind.LIFECYCLE),
+    )
+
+
+def _adapter(context: object) -> UniversalScreeningResult:  # never invoked directly in this test
+    raise NotImplementedError
+
+
+def _result(
+    stage: str, verdict: str, run_id: str, observed_at: datetime
+) -> UniversalScreeningResult:
+    opportunity_id = compute_opportunity_id(STRATEGY_ID, SYMBOL, "event-1")
+    return UniversalScreeningResult(
+        strategy_id=STRATEGY_ID,
+        strategy_version="1.0.0",
+        symbol=SYMBOL,
+        observation_id=compute_observation_id(run_id, STRATEGY_ID, SYMBOL),
+        opportunity_id=opportunity_id,
+        row_type=RowType.RESULT,
+        verdict=verdict,
+        evaluation_state=EvaluationState.PASS,
+        lifecycle_stage=stage,
+        recommendation_state=None,
+        data_quality=None,
+        metrics={},
+        economics={},
+        blockers=(),
+        warnings=(),
+        provenance=(),
+        observed_at=observed_at,
+    )
+
+
+def test_recorded_observations_replay_in_order_through_real_postgres(
+    repository: PostgresObservationHistoryRepository,
+) -> None:
+    registry = StrategyRegistry(((_contract(), _adapter),))
+    start = datetime(2026, 7, 23, 16, 0, tzinfo=UTC)
+
+    watching = record_opportunity_observation(
+        registry,
+        repository,
+        _result("watching", "monitoring", "run-1", start),
+        recommended_action=RecommendedAction.MONITOR,
+    )
+    confirmed = record_opportunity_observation(
+        registry,
+        repository,
+        _result("confirmed", "confirmed", "run-2", start + timedelta(days=1)),
+        recommended_action=RecommendedAction.ENTER,
+    )
+
+    history = replay_opportunity_history(repository, watching.opportunity_id)
+
+    assert history is not None
+    assert history.observations == (watching, confirmed)
+    assert history.current == confirmed
+
+
+def test_replay_of_an_unknown_opportunity_returns_none(
+    repository: PostgresObservationHistoryRepository,
+) -> None:
+    assert replay_opportunity_history(repository, "no-such-opportunity") is None

--- a/tests/strategy_runtime/test_lifecycle.py
+++ b/tests/strategy_runtime/test_lifecycle.py
@@ -28,8 +28,10 @@ from strategy_runtime.lifecycle import (
     OpportunityObservation,
     RecommendedAction,
     compute_opportunity_id,
+    observe_transition,
     validate_lifecycle_stage,
 )
+from strategy_runtime.result import EvaluationState, RowType, UniversalScreeningResult
 
 NOW = datetime(2026, 1, 1, tzinfo=UTC)
 
@@ -183,3 +185,75 @@ class TestEndToEndFakeLifecycleStrategy:
             "closed",
         ]
         assert history.current.recommended_action is RecommendedAction.EXIT
+
+
+def _universal_result(**overrides: object) -> UniversalScreeningResult:
+    defaults: dict[str, object] = {
+        "strategy_id": "watched_event",
+        "strategy_version": "1.0.0",
+        "symbol": "AAPL",
+        "observation_id": "obs-1",
+        "opportunity_id": compute_opportunity_id("watched_event", "AAPL", "event-1"),
+        "row_type": RowType.RESULT,
+        "verdict": "pass",
+        "evaluation_state": EvaluationState.PASS,
+        "lifecycle_stage": "watching",
+        "recommendation_state": None,
+        "data_quality": None,
+        "metrics": {},
+        "economics": {},
+        "blockers": (),
+        "warnings": (),
+        "provenance": (),
+        "observed_at": NOW,
+    }
+    defaults.update(overrides)
+    return UniversalScreeningResult(**defaults)  # type: ignore[arg-type]
+
+
+class TestObserveTransition:
+    """SPRINT-009R/EPIC-R3: the lifecycle transition engine -- turning one
+    execution's own result into a durable OpportunityObservation, with
+    recommended_action always supplied by the caller (never derived here --
+    a recommendation engine is this sprint's own explicit non_goal).
+    """
+
+    def test_a_lifecycle_carrying_result_produces_a_matching_observation(self) -> None:
+        contract = _lifecycle_contract()
+        result = _universal_result()
+
+        observation = observe_transition(
+            contract, result, recommended_action=RecommendedAction.MONITOR
+        )
+
+        assert observation.opportunity_id == result.opportunity_id
+        assert observation.strategy_id == result.strategy_id
+        assert observation.symbol == result.symbol
+        assert observation.lifecycle_stage == result.lifecycle_stage
+        assert observation.verdict == result.verdict
+        assert observation.recommended_action is RecommendedAction.MONITOR
+        assert observation.observed_at == result.observed_at
+
+    def test_a_result_with_no_opportunity_id_is_rejected(self) -> None:
+        contract = _lifecycle_contract()
+        result = _universal_result(opportunity_id=None, lifecycle_stage=None)
+
+        with pytest.raises(StrategyContractError, match="no opportunity transition"):
+            observe_transition(contract, result, recommended_action=RecommendedAction.MONITOR)
+
+    def test_an_undeclared_lifecycle_stage_is_rejected(self) -> None:
+        contract = _lifecycle_contract()
+        result = _universal_result(lifecycle_stage="not_a_declared_stage")
+
+        with pytest.raises(StrategyContractError, match="not a lifecycle_stage"):
+            observe_transition(contract, result, recommended_action=RecommendedAction.MONITOR)
+
+    def test_recommended_action_is_never_derived_only_ever_passed_through(self) -> None:
+        contract = _lifecycle_contract()
+        result = _universal_result(lifecycle_stage="confirmed")
+
+        observation = observe_transition(
+            contract, result, recommended_action=RecommendedAction.EXIT
+        )
+
+        assert observation.recommended_action is RecommendedAction.EXIT

--- a/tests/strategy_runtime/test_service.py
+++ b/tests/strategy_runtime/test_service.py
@@ -16,6 +16,8 @@ import pytest
 from strategy_runtime import (
     NO_LIFECYCLE,
     DataRequirement,
+    LifecycleDeclaration,
+    LifecycleModel,
     OutputKind,
     RequirementCategory,
     RuntimeContext,
@@ -23,10 +25,17 @@ from strategy_runtime import (
     StrategyRegistry,
     StructureKind,
     UniversalScreeningResult,
+    compute_observation_id,
 )
-from strategy_runtime.persistence import UniversalSignalRow
+from strategy_runtime.lifecycle import (
+    OpportunityHistory,
+    OpportunityObservation,
+    RecommendedAction,
+    compute_opportunity_id,
+)
+from strategy_runtime.persistence import UniversalSignalRow, replay_opportunity_history
 from strategy_runtime.result import EvaluationState, RowType
-from strategy_runtime.service import get_state, refresh
+from strategy_runtime.service import get_state, record_opportunity_observation, refresh
 
 
 @dataclass
@@ -98,6 +107,63 @@ def _failing_adapter(context: RuntimeContext) -> UniversalScreeningResult:
     raise RuntimeError("deliberate adapter failure")
 
 
+def _lifecycle_contract(strategy_id: str) -> StrategyContract:
+    return StrategyContract(
+        strategy_id=strategy_id,
+        version="1.0.0",
+        category="test",
+        description="A test lifecycle-tracking contract.",
+        requirements=(DataRequirement(RequirementCategory.CUSTOM, identifier="none"),),
+        lifecycle=LifecycleDeclaration(
+            LifecycleModel.OPPORTUNITY,
+            supported_states=("watching", "confirmed"),
+            observation_type="event",
+        ),
+        structure=StructureKind.NONE,
+        outputs=(OutputKind.METRICS, OutputKind.LIFECYCLE),
+    )
+
+
+def _lifecycle_result(
+    strategy_id: str, stage: str, run_id: str, observed_at: datetime
+) -> UniversalScreeningResult:
+    return UniversalScreeningResult(
+        strategy_id=strategy_id,
+        strategy_version="1.0.0",
+        symbol="AAPL",
+        observation_id=compute_observation_id(run_id, strategy_id, "AAPL"),
+        opportunity_id=compute_opportunity_id(strategy_id, "AAPL", "event-1"),
+        row_type=RowType.RESULT,
+        verdict="pass",
+        evaluation_state=EvaluationState.PASS,
+        lifecycle_stage=stage,
+        recommendation_state=None,
+        data_quality=None,
+        metrics={},
+        economics={},
+        blockers=(),
+        warnings=(),
+        provenance=(),
+        observed_at=observed_at,
+    )
+
+
+class InMemoryObservationHistoryRepository:
+    def __init__(self) -> None:
+        self._history: dict[str, OpportunityHistory] = {}
+
+    def append(self, observation: OpportunityObservation) -> None:
+        existing = self._history.get(observation.opportunity_id)
+        self._history[observation.opportunity_id] = (
+            existing.append(observation)
+            if existing is not None
+            else OpportunityHistory(observation.opportunity_id, (observation,))
+        )
+
+    def history_for(self, opportunity_id: str) -> OpportunityHistory | None:
+        return self._history.get(opportunity_id)
+
+
 class TestRefresh:
     def test_refresh_persists_and_returns_the_result(self) -> None:
         registry = StrategyRegistry(((_contract("alpha"), _succeeding_adapter),))
@@ -155,3 +221,36 @@ class TestGetState:
     def test_empty_repository_returns_empty(self) -> None:
         repository = InMemoryLatestResultRepository()
         assert get_state(repository) == ()
+
+
+class TestRecordOpportunityObservation:
+    """SPRINT-009R/EPIC-R3: persistent opportunity evolution -- opt-in,
+    separate from refresh(), never invoked automatically.
+    """
+
+    def test_recorded_observations_replay_through_history_for(self) -> None:
+        registry = StrategyRegistry(((_lifecycle_contract("watched"), _succeeding_adapter),))
+        history_repository = InMemoryObservationHistoryRepository()
+        start = datetime(2026, 1, 1, tzinfo=UTC)
+
+        watching = record_opportunity_observation(
+            registry,
+            history_repository,
+            _lifecycle_result("watched", "watching", "run-1", start),
+            recommended_action=RecommendedAction.MONITOR,
+        )
+        confirmed = record_opportunity_observation(
+            registry,
+            history_repository,
+            _lifecycle_result("watched", "confirmed", "run-2", start),
+            recommended_action=RecommendedAction.ENTER,
+        )
+
+        history = replay_opportunity_history(history_repository, watching.opportunity_id)
+
+        assert history is not None
+        assert history.observations == (watching, confirmed)
+
+    def test_replay_of_an_unrecorded_opportunity_is_none(self) -> None:
+        history_repository = InMemoryObservationHistoryRepository()
+        assert replay_opportunity_history(history_repository, "never-recorded") is None


### PR DESCRIPTION
## Objective

SPRINT-009R/EPIC-R3: finish the lifecycle engine using persistent observations rather than single-evaluation state. Deliverables: event-scoped opportunity identity, observation history repository, lifecycle transition engine, lifecycle replay, persistent opportunity evolution.

**Stacked on #218 (EPIC-R2), which is stacked on #217 (EPIC-R1)** — this PR's base branch is `claude/sprint-009r-epic-r2-typed-values`. Retarget to `main` once both merge.

## Scope

EPIC-8 (SPRINT-009) already defined `strategy_runtime.persistence.ObservationHistoryRepository` as a pure Protocol, but nothing anywhere ever called `.append()` on one, and no concrete implementation existed. This epic actually wires it up:

- **`strategy_runtime/lifecycle.py::observe_transition()`** — the lifecycle transition engine. Turns one execution's own `UniversalScreeningResult` into a durable `OpportunityObservation`: validates the reported stage via the existing `validate_lifecycle_stage()`, and rejects a result carrying no `opportunity_id`/`lifecycle_stage` ("event-scoped opportunity identity" — an evaluation that never identified an opportunity has no transition to record). `recommended_action` is always supplied by the caller, **never derived here** — a recommendation engine is this sprint's own explicit `non_goal`.
- **`strategy_runtime/persistence.py::replay_opportunity_history()`** — the named "lifecycle replay" entrypoint; a thin, real wrapper around `ObservationHistoryRepository.history_for()`.
- **`strategy_runtime/service.py::record_opportunity_observation()`** — "persistent opportunity evolution." Deliberately **separate** from `refresh()` (which stays unchanged and usable by every strategy, lifecycle-tracked or not) — opt-in, so a caller with no interest in history pays nothing for it.
- **`asa/integrations/observation_history_postgres.py` (new)** — concrete `PostgresObservationHistoryRepository`, mirroring `PostgresLatestResultRepository`'s own raw-SQL pattern exactly. `append()` only ever inserts; there is no update/delete path anywhere in this module, enforcing "append-only" structurally, not merely by convention.
- **`migrations/versions/0006_opportunity_observation_history.py` (new)** — additive-only table, indexed on `opportunity_id`. **Verified against a real local Postgres 16 instance**: `upgrade head`, `downgrade base`, re-`upgrade head` all round-trip cleanly.

## Files Changed

- `strategy_runtime/lifecycle.py` — `observe_transition()`
- `strategy_runtime/persistence.py` — `replay_opportunity_history()`
- `strategy_runtime/service.py` — `record_opportunity_observation()`
- `asa/integrations/observation_history_postgres.py` (new) — `PostgresObservationHistoryRepository`
- `migrations/versions/0006_opportunity_observation_history.py` (new)
- `tests/strategy_runtime/test_lifecycle.py` — `TestObserveTransition` (4 tests: happy path, missing opportunity_id, undeclared stage, recommended_action pass-through)
- `tests/strategy_runtime/test_service.py` — `TestRecordOpportunityObservation` (in-memory round trip + replay-of-unknown-opportunity)
- `tests/asa/test_observation_history_postgres_integration.py` (new) — real-Postgres integration test, gated behind the existing `postgres` marker

## Tests Run

All run against a **real local Postgres 16 instance** (`ASA_DATABASE_URL`/`ASA_TEST_DATABASE_URL` set, not skipped):

- `PYTHONPATH=. pytest tests/strategy_runtime tests/asa` — 295 passed
- `PYTHONPATH=. pytest tests -m postgres` — 21 passed (including both new integration tests)
- `PYTHONPATH=. pytest tests` (everything) — 2546 passed, 2 skipped
- `PYTHONPATH=. pytest tests/architecture` — 443 passed
- `alembic upgrade head`, `alembic downgrade base`, `alembic upgrade head` — all clean, no errors
- `ruff check strategy_runtime asa migrations tests/strategy_runtime tests/asa` — zero new findings beyond the existing R1/R2 baseline (14 pre-existing `UP04x` findings, unchanged)
- `mypy` (project config) — Success: no issues found in 41 source files
- `mypy strategy_runtime asa` (standalone) — Success: no issues found in 61 source files

## Risk Classification

Low-moderate: additive-only schema migration (new table, indexed, no changes to existing tables), new opt-in code path (`record_opportunity_observation()`) that nothing calls automatically — `refresh()`, the only path every existing caller already uses, is completely unchanged.

## Known Limitations

- No strategy currently calls `record_opportunity_observation()` in production — `earnings_calendar` (the only lifecycle-capable migrated strategy) still only goes through `refresh()`. Wiring an actual caller (an API route, a scheduled job) is future work, not part of this platform epic.
- `recommended_action` still has no real strategy-side source (no strategy declares `StrategyCapability.RECOMMENDATIONS` yet) — by design, since building that logic is the explicitly out-of-scope "Recommendation engine" non_goal.
- EPIC-R4 and EPIC-R5 are separate, not part of this PR.

## Founder Decision Required

No — continuing epic-by-epic per SPRINT-009R with delegated execution.


---
_Generated by [Claude Code](https://claude.ai/code/session_0171U6QSQe39nnsDLYLbmbG1)_