### PR TITLE
EPIC-R5: cut production Screening API over to strategy_runtime (SPRINT-009R)

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -14,6 +14,35 @@ from pydantic import BaseModel
 from asa.api.agent_models import TimestampedResource
 from screening.registry import SignalDefinition
 from screening.state import ScreeningStateRecord
+from strategy_runtime.result import EvaluationState, UniversalScreeningResult
+
+# SPRINT-009R/EPIC-R5: the public wire vocabulary predates strategy_runtime and must not
+# change under callers -- EvaluationState.ADAPTER_EXCEPTION is the same execution-level
+# outcome screening.results.ScreeningOutcomeStatus.STRATEGY_EXCEPTION already named, just
+# renamed internally (strategy_runtime.execution's own vocabulary, see execution.py's own
+# ExecutionStatus.ADAPTER_EXCEPTION). Translate it back at this one boundary so the response
+# body a caller already parses never changes.
+_OUTCOME_WIRE_VALUES = {
+    EvaluationState.PASS: "pass",
+    EvaluationState.NO_SIGNAL: "no_signal",
+    EvaluationState.MISSING_DATA: "missing_data",
+    EvaluationState.MALFORMED_OUTPUT: "malformed_output",
+    EvaluationState.ADAPTER_EXCEPTION: "strategy_exception",
+}
+
+
+def _wire_metrics(result: UniversalScreeningResult) -> dict[str, str]:
+    """TypedValue -> str, reproducing exactly the plain-string wire format
+    every caller of this API already parses. A Decimal's str() form
+    round-trips exactly through TypedValue.of_decimal()/.native() (Python's
+    own Decimal.__str__ is stable under that round trip), so this is
+    byte-identical to the pre-EPIC-R2 str(strategy_native_score) wire value.
+    """
+    return {key: str(value.native()) for key, value in result.metrics.items()}
+
+
+def _wire_explanation(result: UniversalScreeningResult) -> str | None:
+    return result.verdict or (result.blockers[0] if result.blockers else None)
 
 
 class SignalCapabilityResponse(BaseModel):
@@ -57,6 +86,23 @@ class ScreeningResultResponse(TimestampedResource):
             age_seconds=TimestampedResource.age_seconds_since(record.updated_at),
         )
 
+    @classmethod
+    def from_universal_result(cls, result: UniversalScreeningResult) -> ScreeningResultResponse:
+        """SPRINT-009R/EPIC-R5: the strategy_runtime-backed equivalent of
+        from_record() -- same public response shape, sourced from
+        UniversalScreeningResult instead of the legacy ScreeningStateRecord.
+        """
+        return cls(
+            signal_id=result.strategy_id,
+            signal_version=result.strategy_version,
+            symbol=result.symbol,
+            outcome=_OUTCOME_WIRE_VALUES[result.evaluation_state],
+            explanation=_wire_explanation(result),
+            metrics=_wire_metrics(result),
+            updated_at=result.observed_at,
+            age_seconds=TimestampedResource.age_seconds_since(result.observed_at),
+        )
+
 
 class ScreeningResultsEnvelope(BaseModel):
     results: list[ScreeningResultResponse]
@@ -82,4 +128,11 @@ class RefreshResultResponse(ScreeningResultResponse):
         cls, record: ScreeningStateRecord, *, request_count: int
     ) -> RefreshResultResponse:
         base = ScreeningResultResponse.from_record(record)
+        return cls(request_count=request_count, **base.model_dump())
+
+    @classmethod
+    def from_universal_result(  # type: ignore[override]
+        cls, result: UniversalScreeningResult, *, request_count: int
+    ) -> RefreshResultResponse:
+        base = ScreeningResultResponse.from_universal_result(result)
         return cls(request_count=request_count, **base.model_dump())

--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -1,14 +1,27 @@
 """GET /api/v1/capabilities, GET /api/v1/screening[/{signal}[/{symbol}]],
 POST /api/v1/screening/{signal}/{symbol}/refresh (API-003, API-004,
-SPRINT-008).
+SPRINT-008, cut over to strategy_runtime in SPRINT-009R/EPIC-R5).
 
-Read endpoints call only screening.service.get_state(), which itself only
-ever reads through the injected repository and never triggers a provider
-request (screening/service.py's own documented guarantee) -- proven at
-this layer too by tests/asa/test_screening_routes.py, not merely inferred
-from get_state()'s own docstring. The refresh endpoint is the one deliberate
-exception: it calls screening.service.refresh() for exactly the one
-requested signal/symbol pair, never a whole universe or a whole signal.
+Read endpoints call only strategy_runtime.service.get_state(), which
+itself only ever reads through the injected LatestResultRepository and
+never triggers a provider request (matching screening.service.get_state()'s
+own guarantee before this cutover) -- proven at this layer too by
+tests/asa/test_screening_routes.py, not merely inferred. The refresh
+endpoint is the one deliberate exception: it calls
+strategy_runtime.service.refresh() for exactly the one requested
+signal/symbol pair, never a whole universe or a whole signal.
+
+The public response shape (ScreeningResultResponse/RefreshResultResponse/
+CapabilitiesResponse) is byte-for-byte unchanged by this cutover -- see
+asa/api/screening_models.py's own from_universal_result() translation and
+tests/asa/test_screening_engine_parity.py, which proves the legacy
+screening.service-backed path and this strategy_runtime-backed path
+produce an identical wire response for the same deterministic input.
+
+/capabilities is deliberately NOT cut over: it serves static catalog
+metadata (including manifest_id, which StrategyContract has no field for)
+and executes nothing, so screening.registry.signal_catalog() remains its
+data source -- see docs/strategy_runtime/legacy-runtime-deprecation-plan.md.
 """
 
 from __future__ import annotations
@@ -29,15 +42,16 @@ from asa.api.screening_models import (
 )
 from market_data import load_market_data_config_from_environment
 from market_data.live_transport import build_live_transport
-from screening.live_acquisition import (
-    APPROVED_LIVE_UNIVERSE,
-    build_fulfillment_service_with_accounting,
-    enabled_provider_configs,
-    live_only_config,
-)
+from screening.live_acquisition import APPROVED_LIVE_UNIVERSE, live_only_config
 from screening.registry import ScreeningRegistry, signal_catalog
-from screening.service import get_state, refresh
-from screening.state import ScreeningStateRecord, ScreeningStateRepository
+from strategy_runtime.market_data_planning import (
+    build_shared_market_data_access,
+    enabled_provider_configs,
+)
+from strategy_runtime.persistence import LatestResultRepository
+from strategy_runtime.registry import StrategyRegistry
+from strategy_runtime.result import UniversalScreeningResult
+from strategy_runtime.service import get_state, refresh
 
 DEFAULT_LIMIT = 100
 MAX_LIMIT = 500
@@ -50,17 +64,19 @@ class _SystemClock:
 
 
 def _paginate(
-    records: tuple[ScreeningStateRecord, ...], limit: int, offset: int
-) -> tuple[tuple[ScreeningStateRecord, ...], int]:
+    records: tuple[UniversalScreeningResult, ...], limit: int, offset: int
+) -> tuple[tuple[UniversalScreeningResult, ...], int]:
     total = len(records)
     return records[offset : offset + limit], total
 
 
 def build_screening_router(
-    repository: ScreeningStateRepository,
-    registry: ScreeningRegistry,
+    repository: LatestResultRepository,
+    registry: StrategyRegistry[UniversalScreeningResult],
     authorize: Callable[[Request], None],
     transport_factory: Callable[[str], object] = build_live_transport,
+    *,
+    capabilities_registry: ScreeningRegistry,
 ) -> APIRouter:
     router = APIRouter(prefix="/api/v1", dependencies=[Depends(authorize)])
 
@@ -73,7 +89,7 @@ def build_screening_router(
         return CapabilitiesResponse(
             signals=[
                 SignalCapabilityResponse.from_definition(definition)
-                for definition in signal_catalog(registry)
+                for definition in signal_catalog(capabilities_registry)
             ]
         )
 
@@ -85,7 +101,7 @@ def build_screening_router(
         records = get_state(repository)
         page, total = _paginate(records, limit, offset)
         return ScreeningResultsEnvelope(
-            results=[ScreeningResultResponse.from_record(item) for item in page],
+            results=[ScreeningResultResponse.from_universal_result(item) for item in page],
             total=total,
             limit=limit,
             offset=offset,
@@ -98,10 +114,10 @@ def build_screening_router(
         offset: int = Query(default=0, ge=0),
     ) -> ScreeningResultsEnvelope:
         _require_registered_signal(signal)
-        records = get_state(repository, signal_id=signal)
+        records = get_state(repository, strategy_id=signal)
         page, total = _paginate(records, limit, offset)
         return ScreeningResultsEnvelope(
-            results=[ScreeningResultResponse.from_record(item) for item in page],
+            results=[ScreeningResultResponse.from_universal_result(item) for item in page],
             total=total,
             limit=limit,
             offset=offset,
@@ -110,12 +126,12 @@ def build_screening_router(
     @router.get("/screening/{signal}/{symbol}", response_model=ScreeningResultResponse)
     def get_screening_result(signal: str, symbol: str) -> ScreeningResultResponse:
         _require_registered_signal(signal)
-        records = get_state(repository, signal_id=signal, symbol=symbol)
+        records = get_state(repository, strategy_id=signal, symbol=symbol)
         if not records:
             raise agent_api_error(
                 404, "NO_SCREENING_RESULT", f"No screening result for {signal!r}/{symbol!r}"
             )
-        return ScreeningResultResponse.from_record(records[0])
+        return ScreeningResultResponse.from_universal_result(records[0])
 
     @router.post(
         "/screening/{signal}/{symbol}/refresh",
@@ -138,14 +154,18 @@ def build_screening_router(
                 "No live market data provider is enabled for this deployment",
             )
         clock = _SystemClock()
-        fulfillment, budget_manager = build_fulfillment_service_with_accounting(
-            config, transport_factory, clock
+        access = build_shared_market_data_access(config, transport_factory, clock, (symbol,))
+        subject_access = access[symbol]
+        result = refresh(
+            registry,
+            repository,
+            clock,
+            strategy_id=signal,
+            symbol=symbol,
+            fulfillment_by_subject={symbol: subject_access.fulfillment},
         )
-        record = refresh(
-            repository, registry, fulfillment, clock, signal_id=signal, symbol=symbol
-        )
-        return RefreshResultResponse.from_record(
-            record, request_count=len(budget_manager.accounting)
+        return RefreshResultResponse.from_universal_result(
+            result, request_count=len(subject_access.budget_manager.accounting)
         )
 
     return router

--- a/asa/bootstrap.py
+++ b/asa/bootstrap.py
@@ -28,12 +28,13 @@ from asa.integrations.providers.deterministic_fake_broker import (
 )
 from asa.integrations.providers.robinhood import RobinhoodPortfolioProvider
 from asa.integrations.runs_postgres import PostgresRunPublicationRepository
-from asa.integrations.screening_postgres import PostgresScreeningStateRepository
+from asa.integrations.universal_screening_postgres import PostgresLatestResultRepository
 from asa.logging import configure_logging, request_id_context
 from asa.market_data_ops.routes import build_operations_router
 from market_data.live_transport import build_live_transport as build_transport_for_provider
 from screening import SIGNAL_REGISTRY
-from screening.state import ScreeningStateRepository
+from strategy_runtime.adapters import build_migrated_strategy_registry
+from strategy_runtime.persistence import LatestResultRepository
 
 
 @dataclass(frozen=True)
@@ -44,7 +45,7 @@ class DependencyOverrides:
     broker_provider: BrokerPortfolioProvider | None = None
     engine_factory: Callable[[str], Engine] | None = None
     market_data_transport_factory: Callable[[str], object] | None = None
-    screening_state_repository: ScreeningStateRepository | None = None
+    screening_state_repository: LatestResultRepository | None = None
 
 
 def build_application(
@@ -65,8 +66,9 @@ def build_application(
     broker_provider = selected.broker_provider or _build_broker_provider(settings)
     screening_state_repository = (
         selected.screening_state_repository
-        or PostgresScreeningStateRepository(engine_factory(settings.database_url))
+        or PostgresLatestResultRepository(engine_factory(settings.database_url))
     )
+    screening_registry = build_migrated_strategy_registry()
     agent_authorize = build_agent_authorizer(settings.agent_api_token)
     quote_service = MarketQuoteService(
         provider=provider,
@@ -107,9 +109,10 @@ def build_application(
     app.include_router(
         build_screening_router(
             screening_state_repository,
-            SIGNAL_REGISTRY,
+            screening_registry,
             agent_authorize,
             selected.market_data_transport_factory or build_transport_for_provider,
+            capabilities_registry=SIGNAL_REGISTRY,
         )
     )
 

--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -1,12 +1,18 @@
-"""SPRINT-008D/PROD-002: scheduled production screening execution.
+"""SPRINT-008D/PROD-002: scheduled production screening execution
+(cut over to strategy_runtime in SPRINT-009R/EPIC-R5).
 
-Calls screening.service.refresh() -- the same shared execution graph
-POST /api/v1/screening/{signal}/{symbol}/refresh already calls, and that
-screening/cli.py's own machinery underlies -- once per (signal, symbol)
-pair in the production screening universe
+Calls strategy_runtime.service.refresh() -- the same shared execution graph
+POST /api/v1/screening/{signal}/{symbol}/refresh already calls (both, in
+turn, run the exact same unmodified screening execution graph internally
+via strategy_runtime.adapters._screening_bridge) -- once per (signal,
+symbol) pair in the production screening universe
 (project/reports/SPRINT-008D-SCREENING-UNIVERSE.md), persisting through
-the real PostgresScreeningStateRepository. No signal-selection or
-acquisition logic is reimplemented here.
+the real PostgresLatestResultRepository (universal_screening_state). No
+signal-selection or acquisition logic is reimplemented here.
+
+This must write to the same table asa/api/screening_routes.py now reads
+from -- writing anywhere else would silently starve the API of fresh data
+after this cutover.
 
 Not a background daemon: this module has no loop, no in-process scheduler,
 no timer. It runs the full universe once per invocation and exits.
@@ -32,17 +38,18 @@ from datetime import UTC, datetime
 
 from asa.config import Settings
 from asa.integrations.postgres import create_postgres_engine
-from asa.integrations.screening_postgres import PostgresScreeningStateRepository
+from asa.integrations.universal_screening_postgres import PostgresLatestResultRepository
 from market_data import load_market_data_config_from_environment
 from market_data.live_transport import build_live_transport
-from screening import APPROVED_LIVE_UNIVERSE, SIGNAL_REGISTRY
-from screening.live_acquisition import (
-    build_fulfillment_service_with_accounting,
+from screening import APPROVED_LIVE_UNIVERSE
+from screening.live_acquisition import live_only_config
+from strategy_runtime.adapters import build_migrated_strategy_registry
+from strategy_runtime.market_data_planning import (
+    build_shared_market_data_access,
     enabled_provider_configs,
-    live_only_config,
 )
-from screening.service import refresh
-from screening.state import ScreeningStateRepository
+from strategy_runtime.persistence import LatestResultRepository
+from strategy_runtime.service import refresh
 
 # The initial production screening universe
 # (project/reports/SPRINT-008D-SCREENING-UNIVERSE.md, PROD-001): the two
@@ -77,7 +84,7 @@ class PairOutcome:
 def run_scheduled_refresh(
     universe: tuple[tuple[str, str], ...] = PRODUCTION_SCREENING_UNIVERSE,
     *,
-    repository: ScreeningStateRepository | None = None,
+    repository: LatestResultRepository | None = None,
     transport_factory: Callable[[str], object] = build_live_transport,
 ) -> tuple[PairOutcome, ...]:
     """Run one bounded refresh per pair in ``universe``, in order,
@@ -93,9 +100,10 @@ def run_scheduled_refresh(
     the same DependencyOverrides-style pattern asa/bootstrap.py already
     uses.
     """
-    resolved_repository = repository or PostgresScreeningStateRepository(
+    resolved_repository = repository or PostgresLatestResultRepository(
         create_postgres_engine(Settings().database_url)
     )
+    registry = build_migrated_strategy_registry()
     config = live_only_config(load_market_data_config_from_environment())
     if not enabled_provider_configs(config):
         raise RuntimeError(
@@ -105,21 +113,24 @@ def run_scheduled_refresh(
     clock = _SystemClock()
     outcomes: list[PairOutcome] = []
     for signal_id, symbol in universe:
-        fulfillment, budget_manager = build_fulfillment_service_with_accounting(
-            config, transport_factory, clock
-        )
+        access = build_shared_market_data_access(config, transport_factory, clock, (symbol,))
+        subject_access = access[symbol]
         try:
-            record = refresh(
+            result = refresh(
+                registry,
                 resolved_repository,
-                SIGNAL_REGISTRY,
-                fulfillment,
                 clock,
-                signal_id=signal_id,
+                strategy_id=signal_id,
                 symbol=symbol,
+                fulfillment_by_subject={symbol: subject_access.fulfillment},
             )
             outcomes.append(
                 PairOutcome(
-                    signal_id, symbol, record.outcome, len(budget_manager.accounting), None
+                    signal_id,
+                    symbol,
+                    result.evaluation_state.value,
+                    len(subject_access.budget_manager.accounting),
+                    None,
                 )
             )
         except Exception as exc:

--- a/docs/strategy_runtime/legacy-runtime-deprecation-plan.md
+++ b/docs/strategy_runtime/legacy-runtime-deprecation-plan.md
@@ -1,0 +1,67 @@
+# Legacy screening runtime deprecation plan
+
+SPRINT-009R/EPIC-R5. As of this cutover, `POST /api/v1/screening/{signal}/{symbol}/refresh`
+and every `GET /api/v1/screening*` read endpoint execute through `strategy_runtime` (see
+`asa/api/screening_routes.py`, `asa/bootstrap.py`, `asa/scheduled_screening.py`), reading and
+writing `universal_screening_state` (`asa/integrations/universal_screening_postgres.py`)
+instead of `screening_state`. The public HTTP contract is unchanged --
+`tests/asa/test_screening_engine_parity.py` proves the legacy and strategy_runtime-backed
+paths translate identical execution output to an identical wire response.
+
+## What is not deprecated yet
+
+`screening/` (the package) is **not removed or frozen** by this cutover:
+
+- `strategy_runtime/adapters/{forward_factor,skew_momentum_vertical,earnings_calendar}.py`
+  each still call the exact same, unmodified execution graph
+  (`screening.adapters.TARGET_STRATEGY_REGISTRY`, `screening.runner.run_screening()`) --
+  `screening/` is now infrastructure `strategy_runtime` depends on, not a parallel system.
+- `screening/cli.py` (`python -m screening`) is untouched and still fully functional, for
+  local diagnostics and the same manual workflows it has always supported.
+- `screening_state` (the Postgres table) and `PostgresScreeningStateRepository` are untouched.
+  They are simply no longer read or written by the production API or the scheduled runner as
+  of this cutover -- existing rows remain queryable directly (`psql`, an ad hoc script) for as
+  long as an operator wants historical reference, and nothing in this repository writes to
+  that table anymore going forward.
+
+## What genuinely is deprecated
+
+- `asa/integrations/screening_postgres.py`'s `PostgresScreeningStateRepository` has no more
+  production callers (`asa/bootstrap.py`, `asa/scheduled_screening.py` both moved to
+  `PostgresLatestResultRepository`). It remains only for its own direct repository tests
+  (`tests/asa/test_screening_postgres.py`) and any future ad hoc migration tooling.
+- `screening.service.get_state()`/`refresh()` have no more production callers either --
+  `strategy_runtime.service.get_state()`/`refresh()` replace them at every call site that used
+  to invoke them. `screening.service` remains directly tested
+  (`tests/asa/test_screening_service_postgres_integration.py`) and directly usable by
+  `screening/cli.py`.
+
+## Recommended follow-up (not part of this cutover)
+
+1. **Backfill or accept a cold start.** `universal_screening_state` starts empty in any
+   deployment that already had rows in `screening_state` -- the first scheduled run (or the
+   first `refresh()` call per signal/symbol) repopulates it exactly the way the very first
+   scheduled run ever did for `screening_state`. A one-time backfill script (read
+   `screening_state`, translate through `strategy_runtime.result.UniversalScreeningResult`,
+   write through `PostgresLatestResultRepository`) is straightforward if a cold start is
+   undesirable, but is intentionally not built here -- SPRINT-009R's own `non_goals` rule out
+   speculative infrastructure with no proven need yet, and a production deployment's actual
+   downtime tolerance for this is a Founder decision, not an engineering default.
+2. **Retire `screening_state`** (drop the table, delete `PostgresScreeningStateRepository` and
+   its test) once an operator confirms no deployment still needs to read the old table
+   directly. Not scheduled here -- this is a data-retention decision, not a code change this
+   sprint's own `platform_before_features` guardrail should make unilaterally.
+3. **Retire `screening.service.get_state()`/`refresh()`** (the two now-production-dead
+   functions) in the same pass as (2), once `screening/cli.py`'s own manual workflows (if
+   still wanted) are confirmed to work equally well against `strategy_runtime.service`
+   instead, or are retired alongside them.
+4. **`/api/v1/capabilities` still reads `screening.registry.signal_catalog()`** (not cut over
+   in this epic -- it serves static catalog metadata, including `manifest_id`, which
+   `strategy_runtime.contract.StrategyContract` has no field for, and it executes nothing).
+   Adding a `manifest_id`-equivalent to `StrategyContract` and cutting this one remaining
+   endpoint over is a small, separate follow-up, not blocking anything in this plan.
+
+None of the above is scheduled or required before this cutover is considered complete --
+SPRINT-009R's own success criterion is "Existing Screening API executes through
+strategy_runtime; public API contract remains unchanged; output parity is verified before
+cutover," all three of which this PR satisfies today.

--- a/tests/asa/fakes.py
+++ b/tests/asa/fakes.py
@@ -1,5 +1,6 @@
 from asa.contracts.market import MarketObservation
 from screening.state import ScreeningStateRecord
+from strategy_runtime.persistence import UniversalSignalRow
 
 
 class InMemoryObservationRepository:
@@ -38,3 +39,31 @@ class InMemoryScreeningStateRepository:
 
     def get_one(self, signal_id: str, symbol: str) -> ScreeningStateRecord | None:
         return self._records.get((signal_id, symbol))
+
+
+class InMemoryLatestResultRepository:
+    """SPRINT-009R/EPIC-R5: the strategy_runtime-backed equivalent of
+    InMemoryScreeningStateRepository above, over UniversalSignalRow instead
+    of ScreeningStateRecord -- same upsert/get_all/get_for_signal/get_one
+    shape, matching strategy_runtime.persistence.LatestResultRepository.
+    """
+
+    def __init__(self) -> None:
+        self._rows: dict[tuple[str, str], UniversalSignalRow] = {}
+
+    def upsert(self, row: UniversalSignalRow) -> None:
+        self._rows[(row.signal_id, row.symbol)] = row
+
+    def get_all(self) -> tuple[UniversalSignalRow, ...]:
+        return tuple(sorted(self._rows.values(), key=lambda item: (item.signal_id, item.symbol)))
+
+    def get_for_signal(self, signal_id: str) -> tuple[UniversalSignalRow, ...]:
+        return tuple(
+            sorted(
+                (row for row in self._rows.values() if row.signal_id == signal_id),
+                key=lambda item: item.symbol,
+            )
+        )
+
+    def get_one(self, signal_id: str, symbol: str) -> UniversalSignalRow | None:
+        return self._rows.get((signal_id, symbol))

--- a/tests/asa/test_ai_agent_workflow.py
+++ b/tests/asa/test_ai_agent_workflow.py
@@ -21,6 +21,7 @@ API-005 adds no production code.
 from __future__ import annotations
 
 from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
 
 import pytest
 from fastapi.testclient import TestClient
@@ -30,8 +31,10 @@ from pydantic import SecretStr
 from asa.bootstrap import DependencyOverrides, build_application
 from asa.config import Settings
 from market_data.transport import ReadOnlyHttpResponse
-from screening.state import ScreeningStateRecord
-from tests.asa.fakes import InMemoryScreeningStateRepository
+from strategy_runtime.persistence import UniversalSignalRow
+from strategy_runtime.result import EvaluationState, RowType
+from strategy_runtime.values import TypedValue
+from tests.asa.fakes import InMemoryLatestResultRepository
 from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
 
 # An agent-side freshness policy, not part of the API contract itself --
@@ -41,34 +44,52 @@ STALE_THRESHOLD_SECONDS = 4 * 3600
 FAKE_PROVIDER_CREDENTIAL = "sandbox-secret-token"
 
 
-def _seed_repository() -> InMemoryScreeningStateRepository:
+def _seed_repository() -> InMemoryLatestResultRepository:
     """Represents state already produced by a prior batch run: one fresh
     result an agent should leave alone, one stale result an agent should
     decide to refresh."""
-    repository = InMemoryScreeningStateRepository()
+    repository = InMemoryLatestResultRepository()
     now = datetime.now(UTC)
     repository.upsert(
-        ScreeningStateRecord(
+        UniversalSignalRow(
             signal_id="forward_factor",
             signal_version="1.0.0",
             symbol="NVDA",
-            outcome="pass",
-            explanation="calendar richness within bounds",
-            metrics={"strategy_native_score": "0.42"},
-            updated_at=now - timedelta(minutes=2),
-            dependency_timestamps={"as_of": now - timedelta(minutes=2)},
+            observation_id="forward_factor-NVDA-seed",
+            opportunity_id=None,
+            row_type=RowType.RESULT.value,
+            verdict="calendar richness within bounds",
+            evaluation_state=EvaluationState.PASS.value,
+            lifecycle_stage=None,
+            recommendation_state=None,
+            data_quality=None,
+            metrics={"strategy_native_score": TypedValue.of_decimal(Decimal("0.42"))},
+            economics={},
+            blockers=(),
+            warnings=(),
+            provenance=(),
+            observed_at=now - timedelta(minutes=2),
         )
     )
     repository.upsert(
-        ScreeningStateRecord(
+        UniversalSignalRow(
             signal_id="skew_momentum",
             signal_version="1.0.0",
             symbol="AAPL",
-            outcome="no_signal",
-            explanation="prior overnight batch result",
+            observation_id="skew_momentum-AAPL-seed",
+            opportunity_id=None,
+            row_type=RowType.RESULT.value,
+            verdict="prior overnight batch result",
+            evaluation_state=EvaluationState.NO_SIGNAL.value,
+            lifecycle_stage=None,
+            recommendation_state=None,
+            data_quality=None,
             metrics={},
-            updated_at=now - timedelta(hours=20),
-            dependency_timestamps={"as_of": now - timedelta(hours=20)},
+            economics={},
+            blockers=(),
+            warnings=(),
+            provenance=(),
+            observed_at=now - timedelta(hours=20),
         )
     )
     return repository
@@ -114,7 +135,7 @@ def _tradier_refresh_responses(expiration: str) -> list[ReadOnlyHttpResponse]:
     ]
 
 
-def _client(repository: InMemoryScreeningStateRepository) -> TestClient:
+def _client(repository: InMemoryLatestResultRepository) -> TestClient:
     expiration = (date.today() + timedelta(days=7)).isoformat()
     responses = _tradier_refresh_responses(expiration)
     return TestClient(

--- a/tests/asa/test_bootstrap_first_run.py
+++ b/tests/asa/test_bootstrap_first_run.py
@@ -18,7 +18,7 @@ from pydantic import SecretStr
 from asa.bootstrap import DependencyOverrides, build_application
 from asa.config import Settings
 from market_data.transport import ReadOnlyHttpResponse
-from tests.asa.fakes import InMemoryScreeningStateRepository
+from tests.asa.fakes import InMemoryLatestResultRepository
 from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
 
 
@@ -72,7 +72,7 @@ def _fresh_deployment_client() -> TestClient:
         build_application(
             Settings(agent_api_token=SecretStr("correct-token"), _env_file=None),
             DependencyOverrides(
-                screening_state_repository=InMemoryScreeningStateRepository(),
+                screening_state_repository=InMemoryLatestResultRepository(),
                 market_data_transport_factory=lambda _provider_id: ScriptedTransport(responses),
             ),
         )

--- a/tests/asa/test_composition.py
+++ b/tests/asa/test_composition.py
@@ -7,14 +7,14 @@ from asa.integrations.providers.deterministic_fake import DeterministicFakeQuote
 from asa.integrations.providers.deterministic_fake_broker import (
     DeterministicFakeBrokerPortfolioProvider,
 )
-from tests.asa.fakes import InMemoryObservationRepository, InMemoryScreeningStateRepository
+from tests.asa.fakes import InMemoryLatestResultRepository, InMemoryObservationRepository
 
 
 def test_build_application_activates_injected_dependencies() -> None:
     provider = DeterministicFakeQuoteProvider()
     broker_provider = DeterministicFakeBrokerPortfolioProvider()
     repository = InMemoryObservationRepository()
-    screening_state_repository = InMemoryScreeningStateRepository()
+    screening_state_repository = InMemoryLatestResultRepository()
     app = build_application(
         Settings(),
         DependencyOverrides(
@@ -39,11 +39,11 @@ def test_default_screening_state_repository_is_postgres_backed_but_lazy() -> Non
     # without a real database connection (SQLAlchemy engines connect
     # lazily), matching how run_repository/repository already behave with
     # no override in the existing test above's sibling tests.
-    from asa.integrations.screening_postgres import PostgresScreeningStateRepository
+    from asa.integrations.universal_screening_postgres import PostgresLatestResultRepository
 
     app = build_application(Settings())
     repository = app.state.dependencies["screening_state_repository"]
-    assert isinstance(repository, PostgresScreeningStateRepository)
+    assert isinstance(repository, PostgresLatestResultRepository)
 
 
 def test_api_version_header_is_present_on_every_response() -> None:

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -11,7 +11,7 @@ from asa.scheduled_screening import (
     run_scheduled_refresh,
 )
 from market_data.transport import ReadOnlyHttpResponse
-from tests.asa.fakes import InMemoryScreeningStateRepository
+from tests.asa.fakes import InMemoryLatestResultRepository
 from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
 
 
@@ -66,13 +66,13 @@ def test_no_enabled_provider_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     for name in ("ASA_TRADIER_ENABLED", "ASA_FINNHUB_ENABLED", "ASA_ALPHA_VANTAGE_ENABLED"):
         monkeypatch.delenv(name, raising=False)
     with pytest.raises(RuntimeError, match="at least one enabled live market data provider"):
-        run_scheduled_refresh(repository=InMemoryScreeningStateRepository())
+        run_scheduled_refresh(repository=InMemoryLatestResultRepository())
 
 
 def test_runs_every_pair_and_persists_results(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
     monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
-    repository = InMemoryScreeningStateRepository()
+    repository = InMemoryLatestResultRepository()
     expiration = (date.today() + timedelta(days=7)).isoformat()
     # One universe pair, scripted with enough responses for one full acquisition.
     universe = (("skew_momentum", "AAPL"),)
@@ -95,7 +95,7 @@ def test_runs_every_pair_and_persists_results(monkeypatch: pytest.MonkeyPatch) -
 
 
 class _RepositoryThatFailsForOneSymbol:
-    """Wraps a real InMemoryScreeningStateRepository, raising only for one
+    """Wraps a real InMemoryLatestResultRepository, raising only for one
     chosen symbol's upsert -- isolates the *runner's own* failure boundary
     (a genuinely unexpected infrastructure error) from screening's already
     thoroughly-tested per-signal acquisition isolation (any acquisition
@@ -104,7 +104,7 @@ class _RepositoryThatFailsForOneSymbol:
     screening/runner.py::_run_one -- so it cannot be used to exercise this
     module's own outer boundary)."""
 
-    def __init__(self, delegate: InMemoryScreeningStateRepository, failing_symbol: str) -> None:
+    def __init__(self, delegate: InMemoryLatestResultRepository, failing_symbol: str) -> None:
         self._delegate = delegate
         self._failing_symbol = failing_symbol
 
@@ -128,7 +128,7 @@ def test_one_pairs_infrastructure_failure_does_not_abort_the_batch(
 ) -> None:
     monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
     monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
-    delegate = InMemoryScreeningStateRepository()
+    delegate = InMemoryLatestResultRepository()
     repository = _RepositoryThatFailsForOneSymbol(delegate, failing_symbol="AAPL")
     expiration = (date.today() + timedelta(days=7)).isoformat()
     universe = (("skew_momentum", "AAPL"), ("skew_momentum", "MSFT"))

--- a/tests/asa/test_screening_engine_parity.py
+++ b/tests/asa/test_screening_engine_parity.py
@@ -1,0 +1,133 @@
+"""SPRINT-009R/EPIC-R5: parity verification -- the legacy screening.service-
+backed refresh path and the strategy_runtime-backed refresh path this
+cutover now uses in production must translate to the identical public
+wire response for identical inputs.
+
+Both paths ultimately run the exact same unmodified screening execution
+graph (screening.adapters.TARGET_STRATEGY_REGISTRY, via
+strategy_runtime.adapters._screening_bridge.translate_screening_result())
+against the same deterministic clock and the same scripted provider
+responses, so any wire-response difference this test would catch could
+only come from the translation layer -- ScreeningResultResponse.from_record()
+(legacy) vs .from_universal_result() (this cutover) -- not from a change
+in financial computation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+
+from asa.api.screening_models import RefreshResultResponse
+from market_data.config import load_market_data_config
+from market_data.transport import ReadOnlyHttpResponse
+from screening.adapters import TARGET_STRATEGY_REGISTRY
+from screening.live_acquisition import build_fulfillment_service_with_accounting
+from screening.service import refresh as legacy_refresh
+from screening.state import ScreeningStateRecord
+from strategy_runtime.adapters import build_migrated_strategy_registry
+from strategy_runtime.market_data_planning import build_shared_market_data_access
+from strategy_runtime.service import refresh as universal_refresh
+from tests.asa.fakes import InMemoryLatestResultRepository, InMemoryScreeningStateRepository
+from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
+
+
+@dataclass(frozen=True, slots=True)
+class _FixedClock:
+    value: datetime
+
+    def now(self) -> datetime:
+        return self.value
+
+
+def _tradier_refresh_responses(expiration: str) -> list[ReadOnlyHttpResponse]:
+    return [
+        tradier_quote_response(),
+        ReadOnlyHttpResponse(
+            200, {"expirations": {"date": [expiration]}}, (), 12, "tradier-request-2"
+        ),
+        ReadOnlyHttpResponse(
+            200,
+            {
+                "options": {
+                    "option": [
+                        {
+                            "symbol": "AAPL_TEST_CALL",
+                            "underlying": "AAPL",
+                            "expiration_date": expiration,
+                            "strike": "190",
+                            "option_type": "call",
+                            "bid": "4.9",
+                            "ask": "5.1",
+                            "last": "5",
+                            "volume": 1000,
+                            "open_interest": 5000,
+                            "greeks": {
+                                "delta": "0.5",
+                                "gamma": "0.03",
+                                "theta": "-0.1",
+                                "vega": "0.2",
+                                "rho": "0.01",
+                            },
+                        }
+                    ]
+                }
+            },
+            (),
+            12,
+            "tradier-request-3",
+        ),
+    ]
+
+
+def _config() -> object:
+    return load_market_data_config(
+        {"ASA_TRADIER_ENABLED": "true", "ASA_TRADIER_ACCESS_TOKEN": "sandbox-secret-token"}
+    )
+
+
+def test_legacy_and_strategy_runtime_refresh_produce_the_identical_wire_response() -> None:
+    clock = _FixedClock(datetime(2026, 1, 1, tzinfo=UTC))
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+
+    # -- legacy path --
+    legacy_fulfillment, legacy_budget = build_fulfillment_service_with_accounting(
+        _config(),  # type: ignore[arg-type]
+        lambda _provider_id: ScriptedTransport(_tradier_refresh_responses(expiration)),
+        clock,
+    )
+    legacy_repository: InMemoryScreeningStateRepository = InMemoryScreeningStateRepository()
+    legacy_record: ScreeningStateRecord = legacy_refresh(
+        legacy_repository,
+        TARGET_STRATEGY_REGISTRY,
+        legacy_fulfillment,
+        clock,
+        signal_id="skew_momentum",
+        symbol="AAPL",
+    )
+    legacy_response = RefreshResultResponse.from_record(
+        legacy_record, request_count=len(legacy_budget.accounting)
+    )
+
+    # -- strategy_runtime path (this cutover) --
+    access = build_shared_market_data_access(
+        _config(),  # type: ignore[arg-type]
+        lambda _provider_id: ScriptedTransport(_tradier_refresh_responses(expiration)),
+        clock,
+        ("AAPL",),
+    )
+    subject_access = access["AAPL"]
+    universal_repository = InMemoryLatestResultRepository()
+    universal_result = universal_refresh(
+        build_migrated_strategy_registry(),
+        universal_repository,
+        clock,
+        strategy_id="skew_momentum",
+        symbol="AAPL",
+        fulfillment_by_subject={"AAPL": subject_access.fulfillment},
+    )
+    universal_response = RefreshResultResponse.from_universal_result(
+        universal_result, request_count=len(subject_access.budget_manager.accounting)
+    )
+
+    assert universal_response.model_dump() == legacy_response.model_dump()

--- a/tests/asa/test_screening_refresh_route.py
+++ b/tests/asa/test_screening_refresh_route.py
@@ -12,7 +12,7 @@ from pydantic import SecretStr
 from asa.bootstrap import DependencyOverrides, build_application
 from asa.config import Settings
 from market_data.transport import ReadOnlyHttpResponse
-from tests.asa.fakes import InMemoryScreeningStateRepository
+from tests.asa.fakes import InMemoryLatestResultRepository
 from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
 
 
@@ -21,7 +21,7 @@ def _client(transport_factory: Callable[[str], object] | None = None) -> TestCli
         build_application(
             Settings(agent_api_token=SecretStr("correct-token"), _env_file=None),
             DependencyOverrides(
-                screening_state_repository=InMemoryScreeningStateRepository(),
+                screening_state_repository=InMemoryLatestResultRepository(),
                 market_data_transport_factory=transport_factory,
             ),
         )

--- a/tests/asa/test_screening_routes.py
+++ b/tests/asa/test_screening_routes.py
@@ -1,42 +1,56 @@
-"""API-003: GET /api/v1/capabilities, GET /api/v1/screening[/{signal}[/{symbol}]]."""
+"""API-003: GET /api/v1/capabilities, GET /api/v1/screening[/{signal}[/{symbol}]]
+(SPRINT-009R/EPIC-R5: exercised through the strategy_runtime-backed
+LatestResultRepository, proving the public response shape is unchanged)."""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from decimal import Decimal
 
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
 from asa.bootstrap import DependencyOverrides, build_application
 from asa.config import Settings
-from screening.state import ScreeningStateRecord
-from tests.asa.fakes import InMemoryScreeningStateRepository
+from strategy_runtime.persistence import UniversalSignalRow
+from strategy_runtime.result import EvaluationState, RowType
+from strategy_runtime.values import TypedValue
+from tests.asa.fakes import InMemoryLatestResultRepository
 
 NOW = datetime(2026, 7, 23, 16, 0, tzinfo=UTC)
 
 
-def _record(signal_id: str, symbol: str, outcome: str = "pass") -> ScreeningStateRecord:
-    return ScreeningStateRecord(
+def _record(signal_id: str, symbol: str, outcome: str = "pass") -> UniversalSignalRow:
+    return UniversalSignalRow(
         signal_id=signal_id,
         signal_version="1.0.0",
         symbol=symbol,
-        outcome=outcome,
-        explanation="PASS",
-        metrics={"strategy_native_score": "75"},
-        updated_at=NOW,
-        dependency_timestamps={"as_of": NOW},
+        observation_id=f"{signal_id}-{symbol}-obs",
+        opportunity_id=None,
+        row_type=RowType.RESULT.value,
+        verdict="PASS",
+        evaluation_state=EvaluationState(outcome).value,
+        lifecycle_stage=None,
+        recommendation_state=None,
+        data_quality=None,
+        metrics={"strategy_native_score": TypedValue.of_decimal(Decimal("75"))},
+        economics={},
+        blockers=(),
+        warnings=(),
+        provenance=(),
+        observed_at=NOW,
     )
 
 
 def _client(
-    repository: InMemoryScreeningStateRepository | None = None,
+    repository: InMemoryLatestResultRepository | None = None,
     token: str | None = "correct-token",
 ) -> TestClient:
     return TestClient(
         build_application(
             Settings(agent_api_token=SecretStr(token) if token else None, _env_file=None),
             DependencyOverrides(
-                screening_state_repository=repository or InMemoryScreeningStateRepository()
+                screening_state_repository=repository or InMemoryLatestResultRepository()
             ),
         )
     )
@@ -93,7 +107,7 @@ class TestListScreening:
         assert body == {"results": [], "total": 0, "limit": 100, "offset": 0}
 
     def test_returns_every_result_deterministically_ordered(self) -> None:
-        repository = InMemoryScreeningStateRepository()
+        repository = InMemoryLatestResultRepository()
         repository.upsert(_record("skew_momentum", "MSFT"))
         repository.upsert(_record("forward_factor", "AAPL"))
         response = _client(repository).get("/api/v1/screening", headers=_auth())
@@ -105,7 +119,7 @@ class TestListScreening:
         assert body["total"] == 2
 
     def test_every_result_exposes_updated_at_and_age_seconds(self) -> None:
-        repository = InMemoryScreeningStateRepository()
+        repository = InMemoryLatestResultRepository()
         repository.upsert(_record("forward_factor", "AAPL"))
         response = _client(repository).get("/api/v1/screening", headers=_auth())
         (result,) = response.json()["results"]
@@ -113,7 +127,7 @@ class TestListScreening:
         assert result["age_seconds"] >= 0
 
     def test_pagination_limit_and_offset(self) -> None:
-        repository = InMemoryScreeningStateRepository()
+        repository = InMemoryLatestResultRepository()
         for symbol in ["AAPL", "MSFT", "NVDA"]:
             repository.upsert(_record("forward_factor", symbol))
         response = _client(repository).get(
@@ -134,7 +148,7 @@ class TestListScreening:
 
 class TestListScreeningForSignal:
     def test_filters_to_the_requested_signal_only(self) -> None:
-        repository = InMemoryScreeningStateRepository()
+        repository = InMemoryLatestResultRepository()
         repository.upsert(_record("forward_factor", "AAPL"))
         repository.upsert(_record("skew_momentum", "AAPL"))
         response = _client(repository).get("/api/v1/screening/forward_factor", headers=_auth())
@@ -154,7 +168,7 @@ class TestListScreeningForSignal:
 
 class TestGetScreeningResult:
     def test_returns_the_single_result(self) -> None:
-        repository = InMemoryScreeningStateRepository()
+        repository = InMemoryLatestResultRepository()
         repository.upsert(_record("forward_factor", "AAPL"))
         response = _client(repository).get(
             "/api/v1/screening/forward_factor/AAPL", headers=_auth()
@@ -177,11 +191,11 @@ class TestGetScreeningResult:
         assert response.json()["detail"]["error_code"] == "NO_SCREENING_RESULT"
 
 
-class _RepositoryThatFailsOnUpsert(InMemoryScreeningStateRepository):
+class _RepositoryThatFailsOnUpsert(InMemoryLatestResultRepository):
     """Reads must never write -- any call to upsert() means a read endpoint
     tried to trigger computation instead of only reading persisted state."""
 
-    def upsert(self, record: ScreeningStateRecord) -> None:
+    def upsert(self, row: UniversalSignalRow) -> None:
         raise AssertionError("read endpoint attempted to persist a new result")
 
 


### PR DESCRIPTION
## Objective

SPRINT-009R/EPIC-R5, full cutover (per explicit instruction): promote `strategy_runtime` to become the production screening engine. `POST /api/v1/screening/{signal}/{symbol}/refresh` and every `GET /api/v1/screening*` read endpoint now execute through `strategy_runtime` instead of the legacy `screening.service`, with the public wire response byte-for-byte unchanged.

## Scope

- **`asa/api/screening_models.py`**: `ScreeningResultResponse.from_universal_result()` / `RefreshResultResponse.from_universal_result()` translate `UniversalScreeningResult` to the exact same response shape `from_record()` already produces. `EvaluationState.ADAPTER_EXCEPTION` is explicitly mapped back to the wire value `"strategy_exception"` (the pre-existing `ScreeningOutcomeStatus.STRATEGY_EXCEPTION` vocabulary) so no caller sees a changed enum string. A `Decimal` metric's `str()` form round-trips exactly through `TypedValue.of_decimal()`/`.native()` (EPIC-R2), so the wire `metrics` dict is unchanged too.
- **`asa/api/screening_routes.py`**: reads through `strategy_runtime.service.get_state()`, refreshes through `strategy_runtime.service.refresh()` and `strategy_runtime.market_data_planning.build_shared_market_data_access()`. `/capabilities` is **deliberately not cut over** — it serves static catalog metadata (`manifest_id` has no `StrategyContract` equivalent) and executes nothing, so `screening.registry.signal_catalog()` remains its source (documented in the new deprecation plan doc).
- **`asa/bootstrap.py`**: the composition root now builds `strategy_runtime.adapters.build_migrated_strategy_registry()` and `PostgresLatestResultRepository` (`universal_screening_state`) instead of `SIGNAL_REGISTRY`/`PostgresScreeningStateRepository` for the refresh/read path; `SIGNAL_REGISTRY` is kept only for the `/capabilities` catalog.
- **`asa/scheduled_screening.py`**: the production scheduled runner — the *writer* that must stay in sync with whatever table the API reads — moved to the same `strategy_runtime` path. Writing anywhere else after this cutover would silently starve the API of fresh data; this was the one correctness-critical piece easy to miss.

## Parity verification

`tests/asa/test_screening_engine_parity.py`: both the legacy path and the `strategy_runtime` path run the exact same unmodified execution graph (`screening.adapters.TARGET_STRATEGY_REGISTRY`, via `strategy_runtime.adapters._screening_bridge`, both already true before this epic — `strategy_runtime`'s three migrated adapters have always called `screening/`'s own execution graph unmodified) against the same deterministic clock and identical scripted provider responses. Asserting the two translated wire responses are field-for-field equal proves any difference could only come from the translation layer, not from a change in financial computation.

`screening/` itself is untouched by this PR — it is now infrastructure `strategy_runtime` depends on, not a parallel deprecated system. `screening_state` (the table), `PostgresScreeningStateRepository`, and `screening.service.get_state()`/`refresh()` lose their production callers but are **not deleted** — see `docs/strategy_runtime/legacy-runtime-deprecation-plan.md` for what's recommended next (backfill, table retirement) and why none of it is done here (a Founder decision on data retention, not an engineering default).

## Files Changed

- `asa/api/screening_models.py` — `from_universal_result()` translations
- `asa/api/screening_routes.py` — cut over to `strategy_runtime.service`
- `asa/bootstrap.py` — composition root wiring
- `asa/scheduled_screening.py` — production scheduled runner
- `docs/strategy_runtime/legacy-runtime-deprecation-plan.md` (new)
- `tests/asa/fakes.py` — `InMemoryLatestResultRepository` (over `UniversalSignalRow`)
- `tests/asa/test_ai_agent_workflow.py`, `test_bootstrap_first_run.py`, `test_composition.py`, `test_scheduled_screening.py`, `test_screening_refresh_route.py`, `test_screening_routes.py` — updated to the new fake/repository shape
- `tests/asa/test_screening_engine_parity.py` (new) — the parity verification test

## Tests Run

All against a **real local Postgres 16 instance**:

- `PYTHONPATH=. pytest tests` (everything) — 2552 passed, 2 skipped
- `PYTHONPATH=. pytest tests/architecture` — 443 passed
- `PYTHONPATH=. pytest tests/asa/test_screening_engine_parity.py` — 1 passed (the parity assertion itself)
- `ruff check` on every changed file — all checks passed (verified with no unrelated files touched — an earlier repo-wide `ruff check --fix .` accidentally auto-fixed ~380 pre-existing findings across unrelated packages; those were reverted before this commit, confirmed via `git status` showing only the intended files)
- `mypy` (project config) — Success: no issues found in 41 source files

## Risk Classification

**High** — this is a production cutover of a live, deployed API's execution engine, not additive platform work like EPIC-R1–R4. Mitigated by: parity verification proving identical wire output for identical input; the scheduled writer moved in lockstep with the API reader (no split-brain data source); the legacy path left fully intact and untouched (rollback is a revert, not a rebuild); full test suite (including every existing screening-route/refresh/agent-workflow/bootstrap test, updated rather than deleted) passing against a real database.

## Known Limitations

- `/capabilities` still reads from the legacy `screening.registry` catalog (documented, low-risk — no execution happens there).
- No production backfill of `universal_screening_state` from existing `screening_state` rows — first refresh/scheduled run repopulates it, same as any table's first-ever write. See the deprecation plan for the tradeoff.
- `screening_state`/`PostgresScreeningStateRepository`/`screening.service.get_state()`/`refresh()` are not deleted, per the deprecation plan's own reasoning.

## Founder Decision Required

This PR itself was explicitly authorized as a full cutover (delegated execution, SPRINT-009R). The deprecation plan's own recommended follow-ups (table retirement, backfill) are flagged as **Founder decisions**, not auto-executed here.


---
_Generated by [Claude Code](https://claude.ai/code/session_0171U6QSQe39nnsDLYLbmbG1)_