### PR TITLE
REL-001: repair earnings calendar capability

### DIFF
--- a/market_data/finnhub.py
+++ b/market_data/finnhub.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import cast
 
@@ -316,24 +316,33 @@ class FinnhubProvider:
             SecurityAssetType.EQUITY,
             "US",
         )
-        earnings_values = tuple(
-            EarningsEvent(
-                f"finnhub:{row['symbol']}:{row['date']}",
-                security,
-                datetime.fromisoformat(str(row["date"])).date(),
-                {
-                    "bmo": AnnouncementTime.BEFORE_OPEN,
-                    "amc": AnnouncementTime.AFTER_CLOSE,
-                    "dmh": AnnouncementTime.DURING_MARKET,
-                }.get(str(row.get("hour")), AnnouncementTime.UNKNOWN),
-                None,
-                True,
-                (),
-                self._dependencies.clock.now(),
-                _evidence(response),
+        earnings_values: list[EarningsEvent] = []
+        for row in rows:
+            provider_symbol = str(row["symbol"]).upper()
+            event_date = datetime.fromisoformat(str(row["date"])).date()
+            if provider_symbol != security.symbol.upper():
+                continue
+            if not request.effective_start.date() <= event_date <= request.effective_end.date():
+                continue
+            earnings_values.append(
+                EarningsEvent(
+                    f"finnhub:{provider_symbol}:{event_date.isoformat()}",
+                    security,
+                    event_date,
+                    {
+                        "bmo": AnnouncementTime.BEFORE_OPEN,
+                        "amc": AnnouncementTime.AFTER_CLOSE,
+                        "dmh": AnnouncementTime.DURING_MARKET,
+                    }.get(str(row.get("hour")), AnnouncementTime.UNKNOWN),
+                    None,
+                    True,
+                    (),
+                    self._dependencies.clock.now(),
+                    _evidence(response),
+                )
             )
-            for row in rows
-        )
+        if not earnings_values:
+            raise _NoData
         return tuple(
             self._observation(request, subject, value, value.observed_at, response)
             for value in earnings_values
@@ -347,7 +356,7 @@ class FinnhubProvider:
         effective: datetime,
         response: ReadOnlyHttpResponse,
     ) -> MarketObservation:
-        received = self._dependencies.clock.now().astimezone(timezone.utc)
+        received = self._dependencies.clock.now().astimezone(UTC)
         age = max(0, int((received - effective).total_seconds()))
         present = tuple(field for field in request.required_fields if _present(field, value))
         missing = tuple(field for field in request.required_fields if field not in present)
@@ -453,7 +462,7 @@ def _decimal(value: object) -> Decimal:
 def _timestamp(value: object) -> datetime:
     if not isinstance(value, (int, float)):
         raise TypeError("timestamp must be numeric")
-    return datetime.fromtimestamp(value, tz=timezone.utc)
+    return datetime.fromtimestamp(value, tz=UTC)
 
 
 def _array(body: Mapping[str, object], key: str) -> Sequence[object]:

--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -29,7 +29,7 @@ every expiration.
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 
 from analytics.expiration_selection import (
@@ -37,7 +37,14 @@ from analytics.expiration_selection import (
     select_earnings_relative_expiration_pair,
     select_expiration_pair,
 )
-from domain import DomainInvariantError, EarningsEvent, MarketCapability, OptionChain, OptionType, Quote
+from domain import (
+    DomainInvariantError,
+    EarningsEvent,
+    MarketCapability,
+    OptionChain,
+    OptionType,
+    Quote,
+)
 from market_data import CapabilityFulfillmentService, FulfillmentStatus
 from screening.clock import Clock
 from screening.context_builders import (
@@ -82,6 +89,7 @@ EARNINGS_CALENDAR_DTE_POLICY = {
     "back_min_dte": 22,
     "back_max_dte": 75,
 }
+EARNINGS_CALENDAR_LOOKAHEAD_DAYS = EARNINGS_CALENDAR_DTE_POLICY["back_max_dte"]
 
 
 def _outcome_status_for_verdict(verdict: str) -> ScreeningOutcomeStatus:
@@ -126,29 +134,47 @@ def _acquire_or_raise(
     required_fields: tuple[str, ...],
     *,
     expiration: date | None = None,
+    effective_start: datetime | None = None,
+    effective_end: datetime | None = None,
 ) -> object:
+    request_start = effective_start or now
+    request_end = effective_end or now
     subject = build_capability_subject(
-        symbol, capability, now, required_fields=required_fields, expiration=expiration
+        symbol,
+        capability,
+        now,
+        effective_start=request_start,
+        effective_end=request_end,
+        required_fields=required_fields,
+        expiration=expiration,
     )
     try:
         result = acquire_capability(
             fulfillment,
             capability,
             subject,
-            effective_start=now,
-            effective_end=now,
+            effective_start=request_start,
+            effective_end=request_end,
             required_fields=required_fields,
             maximum_age_seconds=3600,
         )
     except DomainInvariantError as exc:
         raise StrategyAdapterError(
-            ScreeningOutcomeStatus.MISSING_DATA, classify_domain_invariant_error(exc, capability, symbol)
+            ScreeningOutcomeStatus.MISSING_DATA,
+            classify_domain_invariant_error(exc, capability, symbol),
         ) from exc
-    if result.status is not FulfillmentStatus.FULFILLED or not result.observations:
+    if result.status is FulfillmentStatus.FAILED or not result.observations:
+        attempt_summary = ", ".join(
+            f"{attempt.provider_id}:{attempt.error.code.value}"
+            for attempt in result.attempts
+            if attempt.error is not None
+        )
         detail = (
             f"a valid request for live {capability.value} for {symbol} "
             "could not be completed or normalized"
         )
+        if attempt_summary:
+            detail += f"; provider outcomes: {attempt_summary}"
         if expiration is not None:
             detail += f" at expiration {expiration.isoformat()}"
         raise StrategyAdapterError(ScreeningOutcomeStatus.MISSING_DATA, detail)
@@ -214,7 +240,9 @@ def build_live_forward_factor_adapter(
         chain = _acquire_combined_chain(
             fulfillment, symbol, now, (front.expiration_date, back.expiration_date)
         )
-        strike = select_atm_strike_at_expiration(chain, front.expiration_date, spot_price, OptionType.CALL)
+        strike = select_atm_strike_at_expiration(
+            chain, front.expiration_date, spot_price, OptionType.CALL
+        )
         context = build_forward_factor_context(
             chain, available_expirations, as_of, strike=strike, option_type=OptionType.CALL
         )
@@ -242,7 +270,12 @@ def build_live_earnings_calendar_adapter(
         now = clock.now()
         as_of = now.date()
         event = _acquire_or_raise(
-            fulfillment, symbol, MarketCapability.EARNINGS_CALENDAR_V1, now, ("earnings_date",)
+            fulfillment,
+            symbol,
+            MarketCapability.EARNINGS_CALENDAR_V1,
+            now,
+            ("earnings_date",),
+            effective_end=now + timedelta(days=EARNINGS_CALENDAR_LOOKAHEAD_DAYS),
         )
         quote = _acquire_or_raise(
             fulfillment, symbol, MarketCapability.REAL_TIME_QUOTE_V1, now, ("last",)

--- a/screening/live_context.py
+++ b/screening/live_context.py
@@ -174,6 +174,8 @@ def build_capability_subject(
     capability: MarketCapability,
     as_of: datetime,
     *,
+    effective_start: datetime | None = None,
+    effective_end: datetime | None = None,
     provider_symbol_window_days: int = 2,
     required_fields: tuple[str, ...] | None = None,
     expiration: date | None = None,
@@ -211,7 +213,11 @@ def build_capability_subject(
         MarketCapability.EARNINGS_CALENDAR_V1: MarketDataSubjectType.EARNINGS_SECURITY,
     }.get(capability, MarketDataSubjectType.INSTRUMENT)
     evidence = (EvidenceReference(EvidenceKind.OBSERVATION, f"screening:live:{symbol}"),)
-    window_start = as_of - timedelta(days=provider_symbol_window_days)
+    semantic_start = effective_start or as_of
+    semantic_end = effective_end or as_of
+    if semantic_start > semantic_end:
+        raise ValueError("capability subject time window is inverted")
+    window_start = min(semantic_start, as_of - timedelta(days=provider_symbol_window_days))
     projections = tuple(
         ProviderAddressProjection(provider_id, "v1", "symbol", symbol, window_start, None, evidence)
         for provider_id in KNOWN_PROVIDER_IDS
@@ -242,7 +248,9 @@ def build_capability_subject(
         instrument,
         subject_type,
         capability,
-        MarketDataRequestContext(as_of, as_of, required_fields, projections, evidence),
+        MarketDataRequestContext(
+            semantic_start, semantic_end, required_fields, projections, evidence
+        ),
     )
 
 

--- a/tests/market_data/test_finnhub.py
+++ b/tests/market_data/test_finnhub.py
@@ -79,25 +79,44 @@ def response(body: dict[str, object], status: int = 200) -> ReadOnlyHttpResponse
     return ReadOnlyHttpResponse(status, body, (), 9, "finnhub-request-1")
 
 
-def subject(capability: MarketCapability, fields: tuple[str, ...]) -> MarketDataSubject:
+def subject(
+    capability: MarketCapability, fields: tuple[str, ...], symbol: str = "AAPL"
+) -> MarketDataSubject:
     kind = (
         MarketDataSubjectType.EARNINGS_SECURITY
         if capability is MarketCapability.EARNINGS_CALENDAR_V1
         else MarketDataSubjectType.INSTRUMENT
     )
     projection = ProviderAddressProjection(
-        "finnhub", "v1", "symbol", "AAPL", NOW - timedelta(days=30), None, EVIDENCE
+        "finnhub", "v1", "symbol", symbol, NOW - timedelta(days=30), None, EVIDENCE
+    )
+    semantic_start = NOW if capability is MarketCapability.EARNINGS_CALENDAR_V1 else NOW - timedelta(days=5)
+    semantic_end = (
+        NOW + timedelta(days=75)
+        if capability is MarketCapability.EARNINGS_CALENDAR_V1
+        else NOW
     )
     return MarketDataSubject(
-        INSTRUMENT,
+        INSTRUMENT
+        if symbol == "AAPL"
+        else Instrument(
+            CanonicalInstrumentIdentity("symbol", symbol),
+            InstrumentKind.EQUITY,
+            symbol,
+            "USD",
+        ),
         kind,
         capability,
-        MarketDataRequestContext(NOW - timedelta(days=5), NOW, fields, (projection,), EVIDENCE),
+        MarketDataRequestContext(
+            semantic_start, semantic_end, fields, (projection,), EVIDENCE
+        ),
     )
 
 
-def request(capability: MarketCapability, fields: tuple[str, ...]) -> CapabilityRequest:
-    item = subject(capability, fields)
+def request(
+    capability: MarketCapability, fields: tuple[str, ...], symbol: str = "AAPL"
+) -> CapabilityRequest:
+    item = subject(capability, fields, symbol)
     return CapabilityRequest(
         capability,
         (item,),
@@ -156,15 +175,54 @@ def test_candle_success_validates_status_arrays_and_utc_timestamps() -> None:
     assert dict(transport.requests[0].query)["resolution"] == "D"
 
 
-def test_earnings_success_normalizes_calendar_event() -> None:
+@pytest.mark.parametrize(
+    ("symbol", "event_date", "hour"),
+    (("AAPL", "2026-08-01", "amc"), ("NVDA", "2026-08-19", "bmo")),
+)
+def test_provider_shaped_upcoming_earnings_normalize_calendar_event(
+    symbol: str, event_date: str, hour: str
+) -> None:
     transport = Transport(
-        (response({"earningsCalendar": [{"symbol": "AAPL", "date": "2026-08-01", "hour": "amc"}]}),)
+        (response({"earningsCalendar": [{"symbol": symbol, "date": event_date, "hour": hour}]}),)
     )
     adapter, _ = provider(transport)
     result = adapter.fetch(
-        request(MarketCapability.EARNINGS_CALENDAR_V1, ("earnings_date",)), authorization()
+        request(MarketCapability.EARNINGS_CALENDAR_V1, ("earnings_date",), symbol),
+        authorization(),
     )
     assert result.error is None and isinstance(result.observations[0].value, EarningsEvent)
+    assert result.observations[0].value.earnings_date.isoformat() == event_date
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    (
+        ({"earningsCalendar": []}, ProviderErrorCode.EMPTY_PAYLOAD),
+        ({"earningsCalendar": [{"symbol": "AAPL"}]}, ProviderErrorCode.SCHEMA_MISMATCH),
+    ),
+)
+def test_earnings_no_event_and_malformed_payload_are_distinct(
+    body: dict[str, object], expected: ProviderErrorCode
+) -> None:
+    adapter, _ = provider(Transport((response(body),)))
+    result = adapter.fetch(
+        request(MarketCapability.EARNINGS_CALENDAR_V1, ("earnings_date",)), authorization()
+    )
+    assert result.error is not None and result.error.code is expected
+
+
+def test_earnings_wrong_symbol_or_outside_requested_window_is_no_data() -> None:
+    body = {
+        "earningsCalendar": [
+            {"symbol": "MSFT", "date": "2026-08-01", "hour": "amc"},
+            {"symbol": "AAPL", "date": "2027-01-01", "hour": "amc"},
+        ]
+    }
+    adapter, _ = provider(Transport((response(body),)))
+    result = adapter.fetch(
+        request(MarketCapability.EARNINGS_CALENDAR_V1, ("earnings_date",)), authorization()
+    )
+    assert result.error is not None and result.error.code is ProviderErrorCode.NO_DATA
 
 
 @pytest.mark.parametrize(

--- a/tests/screening/test_live_adapters.py
+++ b/tests/screening/test_live_adapters.py
@@ -198,6 +198,14 @@ class MultiExpirationFixtureProvider(DeterministicFixtureProvider):
         )
 
 
+class CapturingMultiExpirationFixtureProvider(MultiExpirationFixtureProvider):
+    requests: list[object] = []
+
+    def fetch(self, request, budget):  # noqa: ANN001
+        type(self).requests.append(request)
+        return super().fetch(request, budget)
+
+
 def _no_transport(_provider_id: str) -> object:
     return object()
 
@@ -293,6 +301,24 @@ class TestForwardFactorAndEarningsCalendarNeedTwoExpirations:
         )
         assert result.outcome_status in (ScreeningOutcomeStatus.PASS, ScreeningOutcomeStatus.NO_SIGNAL)
         assert result.subject_identity == f"symbol:{SYMBOL}"
+
+    def test_earnings_calendar_requests_the_complete_upcoming_policy_window(self) -> None:
+        CapturingMultiExpirationFixtureProvider.requests.clear()
+        fulfillment, clock = _fulfillment(CapturingMultiExpirationFixtureProvider)
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        run_screening(
+            TARGET_STRATEGY_REGISTRY,
+            adapters,
+            clock,
+            strategy_ids=("earnings_calendar",),
+        )
+        request = next(
+            item
+            for item in CapturingMultiExpirationFixtureProvider.requests
+            if item.capability is MarketCapability.EARNINGS_CALENDAR_V1  # type: ignore[attr-defined]
+        )
+        assert request.effective_end - request.effective_start == timedelta(days=75)  # type: ignore[attr-defined]
+        assert request.subjects[0].request_context.semantic_end == request.effective_end  # type: ignore[attr-defined]
 
 
 class TestCapabilityNotOfferedByAnyEnabledProvider:


### PR DESCRIPTION
## Ticket
REL-001 — Repair earnings calendar capability

## Root cause
The live strategy requested `earnings_calendar_v1` with a zero-width `now -> now` semantic window. Upcoming events therefore appeared missing. The adapter also rejected a valid fallback result because fulfillment labels fallback success as `degraded`. Finnhub normalization did not enforce subject-symbol and requested-date boundaries.

## Changed behavior
- Earnings Calendar requests its existing 75-day policy horizon.
- Generic subject construction preserves explicit semantic windows.
- Successful, audited fallback observations are accepted.
- Failure details expose only provider IDs and normalized error categories.
- Finnhub accepts only the requested symbol and date window.

## Frozen architecture compliance
No capability, public contract, provider boundary, strategy rule, schema, or persistence change.

## Security and network behavior
No secrets, raw payloads, provider exception text, new network path, or unbounded call behavior. Tests are offline.

## Tests
- Target/provider/adapter: 40 passed.
- Full repository: 2,536 passed, 23 skipped.
- `mypy asa`: green.
- Ruff on changed production modules: green.
- Lean entrypoints, integrity, pre-push, and `git diff --check`: green.

## Production result
Live production proof is pending merge/deployment availability. No credentials were accessed and no deployment was performed by this ticket.

## Risks and rollback
Low. Roll back this commit to restore the prior zero-width request behavior.

## Explicit exclusions
No strategy-specific shared-runtime behavior, database, API, frontend, scheduling, provider credentials, or deployment changes.

## Auto-merge authority
Founder-approved SPRINT-010 delegated merge authority applies after required checks pass.