### PR TITLE
REL-002: repair forward factor expiration resolution

### DIFF
--- a/analytics/expiration_selection.py
+++ b/analytics/expiration_selection.py
@@ -107,6 +107,39 @@ def select_expiration_pair(
     when no candidate pair satisfies the policy -- an expected, non-
     exceptional outcome the caller must handle explicitly, not a defect.
     """
+    ranked = rank_expiration_pairs(
+        candidates,
+        front_min_dte=front_min_dte,
+        front_max_dte=front_max_dte,
+        back_min_dte=back_min_dte,
+        back_max_dte=back_max_dte,
+        minimum_gap_days=minimum_gap_days,
+        maximum_gap_days=maximum_gap_days,
+        target_front_dte=target_front_dte,
+        target_gap_days=target_gap_days,
+    )
+    return ranked[0] if ranked else None
+
+
+def rank_expiration_pairs(
+    candidates: tuple[ExpirationCandidate, ...],
+    *,
+    front_min_dte: int,
+    front_max_dte: int,
+    back_min_dte: int,
+    back_max_dte: int,
+    minimum_gap_days: int,
+    maximum_gap_days: int,
+    target_front_dte: int,
+    target_gap_days: int,
+) -> tuple[tuple[ExpirationCandidate, ExpirationCandidate], ...]:
+    """Return every policy-valid pair in the same deterministic preference
+    order used by ``select_expiration_pair``.
+
+    A provider can list an expiration and then reject its chain request.
+    Callers that acquire data may therefore try the next already-listed,
+    policy-valid pair without inventing a date or changing strategy rules.
+    """
     if (
         min(
             front_min_dte,
@@ -122,7 +155,6 @@ def select_expiration_pair(
         or minimum_gap_days > maximum_gap_days
     ):
         raise ValueError("expiration selection policy is invalid")
-
     pairs = tuple(
         (front, back)
         for front in candidates
@@ -133,13 +165,18 @@ def select_expiration_pair(
         <= back.days_to_expiration - front.days_to_expiration
         <= maximum_gap_days
     )
-    return min(
-        pairs,
-        key=lambda pair: (
-            abs(pair[0].days_to_expiration - target_front_dte)
-            + abs(pair[1].days_to_expiration - pair[0].days_to_expiration - target_gap_days),
-            pair[0].expiration_date,
-            pair[1].expiration_date,
-        ),
-        default=None,
+    return tuple(
+        sorted(
+            pairs,
+            key=lambda pair: (
+                abs(pair[0].days_to_expiration - target_front_dte)
+                + abs(
+                    pair[1].days_to_expiration
+                    - pair[0].days_to_expiration
+                    - target_gap_days
+                ),
+                pair[0].expiration_date,
+                pair[1].expiration_date,
+            ),
+        )
     )

--- a/market_data/tradier.py
+++ b/market_data/tradier.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Mapping, Sequence
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import cast
 
@@ -28,8 +28,8 @@ from domain import (
     SecurityAssetType,
     market_observation_identity,
 )
-from domain.operational import CanonicalInstrumentIdentity
 from domain.market_data import MarketObservationValue
+from domain.operational import CanonicalInstrumentIdentity
 from domain.values import DomainInvariantError
 from market_data.config import ProviderConfig
 from market_data.factory import ProviderDependencies, ProviderRegistration
@@ -305,7 +305,7 @@ class TradierProvider:
         response: ReadOnlyHttpResponse,
         row: Mapping[str, object],
     ) -> MarketObservation:
-        received = self._dependencies.clock.now().astimezone(timezone.utc)
+        received = self._dependencies.clock.now().astimezone(UTC)
         if isinstance(value, OHLCVBar):
             effective = value.end_at
         elif isinstance(value, OptionChain):
@@ -421,9 +421,9 @@ def _observed_at(row: Mapping[str, object], fallback: datetime) -> datetime:
     raw = row.get("trade_date") or row.get("timestamp")
     if isinstance(raw, (int, float)):
         divisor = 1000 if raw > 10_000_000_000 else 1
-        return datetime.fromtimestamp(raw / divisor, tz=timezone.utc)
+        return datetime.fromtimestamp(raw / divisor, tz=UTC)
     if isinstance(raw, str):
-        return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(UTC)
     return fallback
 
 
@@ -446,7 +446,7 @@ def _quote(subject: MarketDataSubject, row: Mapping[str, object]) -> Quote:
 
 def _bar(subject: MarketDataSubject, row: Mapping[str, object]) -> OHLCVBar:
     day = _date(row["date"])
-    start = datetime.combine(day, time.min, tzinfo=timezone.utc)
+    start = datetime.combine(day, time.min, tzinfo=UTC)
     return OHLCVBar(
         subject.canonical_instrument,
         86400,
@@ -472,7 +472,7 @@ def _chain(
 ) -> OptionChain:
     if not rows:
         raise ValueError("empty option chain")
-    observed = _observed_at(rows[0], received_at)
+    observed = max(_observed_at(row, received_at) for row in rows)
     evidence = _evidence(response)
     symbol = str(rows[0].get("underlying") or subject.canonical_instrument.display_symbol)
     security = _security(subject, symbol)

--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -34,8 +34,8 @@ from decimal import Decimal
 
 from analytics.expiration_selection import (
     ExpirationCandidate,
+    rank_expiration_pairs,
     select_earnings_relative_expiration_pair,
-    select_expiration_pair,
 )
 from domain import (
     DomainInvariantError,
@@ -90,6 +90,7 @@ EARNINGS_CALENDAR_DTE_POLICY = {
     "back_max_dte": 75,
 }
 EARNINGS_CALENDAR_LOOKAHEAD_DAYS = EARNINGS_CALENDAR_DTE_POLICY["back_max_dte"]
+MAX_FORWARD_FACTOR_PAIR_ATTEMPTS = 5
 
 
 def _outcome_status_for_verdict(verdict: str) -> ScreeningOutcomeStatus:
@@ -230,21 +231,44 @@ def build_live_forward_factor_adapter(
             ExpirationCandidate(cycle.expiration_date, cycle.days_to_expiration)
             for cycle in available_expirations
         )
-        selected = select_expiration_pair(candidates, **FORWARD_FACTOR_DTE_POLICY)
-        if selected is None:
+        ranked_pairs = rank_expiration_pairs(candidates, **FORWARD_FACTOR_DTE_POLICY)
+        if not ranked_pairs:
             raise StrategyAdapterError(
                 ScreeningOutcomeStatus.MISSING_DATA,
                 f"no expiration pair for {symbol} satisfies Forward Factor's DTE policy",
             )
+        attempted: list[str] = []
+        chain = None
+        selected = None
+        for front, back in ranked_pairs[:MAX_FORWARD_FACTOR_PAIR_ATTEMPTS]:
+            attempted.append(
+                f"{front.expiration_date.isoformat()}/{back.expiration_date.isoformat()}"
+            )
+            try:
+                chain = _acquire_combined_chain(
+                    fulfillment, symbol, now, (front.expiration_date, back.expiration_date)
+                )
+            except StrategyAdapterError:
+                continue
+            selected = (front, back)
+            break
+        if chain is None or selected is None:
+            raise StrategyAdapterError(
+                ScreeningOutcomeStatus.MISSING_DATA,
+                f"no listed Forward Factor expiration pair for {symbol} returned usable chains; "
+                f"attempted {', '.join(attempted)}",
+            )
         front, back = selected
-        chain = _acquire_combined_chain(
-            fulfillment, symbol, now, (front.expiration_date, back.expiration_date)
-        )
         strike = select_atm_strike_at_expiration(
             chain, front.expiration_date, spot_price, OptionType.CALL
         )
+        selected_expirations = tuple(
+            cycle
+            for cycle in available_expirations
+            if cycle.expiration_date in {front.expiration_date, back.expiration_date}
+        )
         context = build_forward_factor_context(
-            chain, available_expirations, as_of, strike=strike, option_type=OptionType.CALL
+            chain, selected_expirations, as_of, strike=strike, option_type=OptionType.CALL
         )
         graph = compile_strategy_graph(FORWARD_FACTOR_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
         result = execute_strategy_graph(graph, context)

--- a/tests/analytics/test_expiration_selection.py
+++ b/tests/analytics/test_expiration_selection.py
@@ -6,6 +6,7 @@ import pytest
 
 from analytics.expiration_selection import (
     ExpirationCandidate,
+    rank_expiration_pairs,
     select_earnings_relative_expiration_pair,
     select_expiration_pair,
 )
@@ -63,6 +64,18 @@ class TestSelectExpirationPair:
         first = select_expiration_pair(candidates, **_POLICY)
         second = select_expiration_pair(candidates, **_POLICY)
         assert first == second
+
+    def test_ranks_nearest_provider_listed_alternatives_deterministically(self) -> None:
+        candidates = (
+            _candidate(61, date(2026, 9, 21)),
+            _candidate(91, date(2026, 10, 21)),
+            _candidate(68, date(2026, 9, 28)),
+            _candidate(98, date(2026, 10, 28)),
+        )
+        ranked = rank_expiration_pairs(candidates, **_POLICY)
+        assert ranked[0] == (candidates[0], candidates[1])
+        assert (candidates[2], candidates[3]) in ranked
+        assert rank_expiration_pairs(tuple(reversed(candidates)), **_POLICY) == ranked
 
     @pytest.mark.parametrize(
         "overrides",

--- a/tests/market_data/test_tradier.py
+++ b/tests/market_data/test_tradier.py
@@ -215,6 +215,31 @@ def test_option_chain_preserves_greeks_iv_and_liquidity() -> None:
     assert transport.requests[0].path == "/v1/markets/options/chains"
 
 
+def test_option_chain_freshness_uses_newest_contract_not_first_response_row() -> None:
+    old = {
+        "symbol": "AAPL260821C00210000",
+        "underlying": "AAPL",
+        "expiration_date": "2026-08-21",
+        "strike": "210",
+        "option_type": "call",
+        "last": "5",
+        "trade_date": int((NOW - timedelta(days=3)).timestamp() * 1000),
+    }
+    recent = {
+        **old,
+        "symbol": "AAPL260821C00215000",
+        "strike": "215",
+        "trade_date": int((NOW - timedelta(minutes=5)).timestamp() * 1000),
+    }
+    transport = Transport((response({"options": {"option": [old, recent]}}),))
+    result = provider(transport).fetch(
+        request(MarketCapability.OPTION_CHAIN_V1, ("contracts",), expiration=True),
+        authorization(),
+    )
+    assert result.error is None
+    assert result.observations[0].effective_time == NOW - timedelta(minutes=5)
+
+
 @pytest.mark.parametrize(
     ("status", "code"),
     (


### PR DESCRIPTION
## Ticket
REL-002 — Repair forward factor expiration resolution

## Root cause
Two provider-boundary assumptions caused false missing data: a listed exact expiration could disappear or reject the subsequent chain request, and Tradier assigned the whole chain the first response row's last-trade timestamp. One illiquid contract could therefore mark an otherwise usable chain stale (Issue #162).

## Changed behavior
- Rank every provider-listed, policy-valid expiration pair deterministically.
- Try at most five ranked pairs; never invent an expiration.
- Continue only after a normalized unusable-chain result.
- Report bounded attempted pair dates when none works.
- Compute chain effective time from the newest contract evidence, not response order.
- Pass only the successfully acquired pair to unchanged Forward Factor context logic.

## Architecture/security/network
No new capability, provider, symbol special case, public contract, secret handling, or unbounded request behavior. Maximum pair attempts: 5. Skew Momentum path unchanged.

## Tests
- Target expiration/Tradier/live-adapter suite: 40 passed.
- Full repository: 2,538 passed, 23 skipped.
- `mypy asa`, changed-module Ruff, Lean entrypoints/integrity/pre-push, and `git diff --check`: green.

## Production result
Live production proof pending merge/deployment availability. No credentials accessed. No deployment performed.

## Risk/rollback
Low bounded acquisition change. Revert this commit to restore single-pair selection and first-row freshness.

## Exclusions
No strategy semantic change, API, persistence, UI, scheduling, provider implementation expansion, or deployment.

## Auto-merge authority
Founder-approved SPRINT-010 delegated merge authority applies after CI passes.