### PR TITLE
OPS-001: harden authenticated screening operations

### DIFF
--- a/asa/bootstrap.py
+++ b/asa/bootstrap.py
@@ -87,7 +87,7 @@ def build_application(
         CORSMiddleware,
         allow_origins=[origin.strip() for origin in settings.cors_origins.split(",")],
         allow_methods=["GET", "POST"],
-        allow_headers=["Content-Type", "X-Request-ID"],
+        allow_headers=["Authorization", "Content-Type", "X-Request-ID"],
     )
     app.include_router(
         build_router(

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -117,3 +117,14 @@ After deployment:
 6. With `ASA_AGENT_API_TOKEN` set, confirm `GET /api/v1/capabilities` with a correct bearer token returns 200 and lists the registered signals, and that an omitted or incorrect token returns 404.
 
 Robinhood authentication is an unofficial integration and may require interactive approval. ASA remains synchronous and preserves the prior successful publication if authentication or acquisition fails.
+
+Run the bounded authenticated smoke without placing the token on the command line:
+
+```bash
+ASA_AGENT_API_TOKEN='<configured-outside-shell-history>' \
+  python tools/screening_smoke.py https://<host> --signal skew_momentum --symbol AAPL
+```
+
+The harness prints only methods, paths, and status codes. It never prints response bodies,
+request headers, or the token. It checks health, readiness, capabilities, aggregate screening,
+one bounded refresh, and read-after-write.

--- a/tests/asa/test_screening_operations.py
+++ b/tests/asa/test_screening_operations.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from asa.bootstrap import DependencyOverrides, build_application
+from asa.config import Settings
+from tests.asa.fakes import InMemoryLatestResultRepository, InMemoryObservationRepository
+from tools.screening_smoke import run_smoke
+
+
+def test_cors_preflight_allows_authorization_for_screening_routes() -> None:
+    app = build_application(
+        Settings(
+            agent_api_token=SecretStr("correct-token"),
+            cors_origins="https://agent.example",
+            _env_file=None,
+        ),
+        DependencyOverrides(
+            repository=InMemoryObservationRepository(),
+            screening_state_repository=InMemoryLatestResultRepository(),
+        ),
+    )
+    response = TestClient(app).options(
+        "/api/v1/screening",
+        headers={
+            "Origin": "https://agent.example",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Authorization",
+        },
+    )
+    assert response.status_code == 200
+    assert "authorization" in response.headers["access-control-allow-headers"].lower()
+
+
+@dataclass(frozen=True)
+class _Response:
+    status: int = 200
+
+
+def test_smoke_harness_covers_required_paths_without_printing_token(capsys) -> None:  # noqa: ANN001
+    requests = []
+
+    def opener(request, *, timeout):  # noqa: ANN001
+        requests.append((request, timeout))
+        return _Response()
+
+    token = "never-print-this-token"
+    assert run_smoke("https://asa.example", token, "skew_momentum", "AAPL", opener=opener) == 0
+    output = capsys.readouterr()
+    assert token not in output.out + output.err
+    assert [request.full_url for request, _ in requests] == [
+        "https://asa.example/api/v1/health",
+        "https://asa.example/api/v1/readiness",
+        "https://asa.example/api/v1/capabilities",
+        "https://asa.example/api/v1/screening",
+        "https://asa.example/api/v1/screening/skew_momentum/AAPL/refresh",
+        "https://asa.example/api/v1/screening/skew_momentum/AAPL",
+    ]
+    assert "Authorization" not in output.out
+
+
+def test_smoke_harness_fails_closed_without_exposing_response_body(capsys) -> None:  # noqa: ANN001
+    class Failure:
+        status = 503
+
+    assert (
+        run_smoke(
+            "https://asa.example",
+            "secret",
+            "skew_momentum",
+            "AAPL",
+            opener=lambda request, timeout: Failure(),  # noqa: ARG005
+        )
+        == 1
+    )
+    output = capsys.readouterr()
+    assert "secret" not in output.out + output.err
+    assert "status=503" in output.out

--- a/tools/screening_smoke.py
+++ b/tools/screening_smoke.py
@@ -1,0 +1,91 @@
+"""Secret-safe authenticated screening production smoke.
+
+The bearer token is accepted only through an environment variable. Output
+contains request paths and status codes, never headers, bodies, or token values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True, slots=True)
+class SmokeStep:
+    method: str
+    path: str
+    expected_status: int
+
+
+STEPS = (
+    SmokeStep("GET", "/api/v1/health", 200),
+    SmokeStep("GET", "/api/v1/readiness", 200),
+    SmokeStep("GET", "/api/v1/capabilities", 200),
+    SmokeStep("GET", "/api/v1/screening", 200),
+    SmokeStep("POST", "/api/v1/screening/{signal}/{symbol}/refresh", 200),
+    SmokeStep("GET", "/api/v1/screening/{signal}/{symbol}", 200),
+)
+
+
+def run_smoke(
+    base_url: str,
+    token: str,
+    signal: str,
+    symbol: str,
+    *,
+    opener: Callable[..., object] = urlopen,
+) -> int:
+    if not base_url.startswith(("https://", "http://")):
+        print("FAIL base URL must use http or https", file=sys.stderr)
+        return 2
+    if not token:
+        print("FAIL configured token is empty", file=sys.stderr)
+        return 2
+    auth = {"Authorization": f"Bearer {token}"}
+    failed = False
+    for step in STEPS:
+        path = step.path.format(signal=signal, symbol=symbol)
+        headers = {} if path in {"/api/v1/health", "/api/v1/readiness"} else auth
+        request = Request(
+            base_url.rstrip("/") + path,
+            headers=headers,
+            method=step.method,
+            data=b"" if step.method == "POST" else None,
+        )
+        try:
+            response = opener(request, timeout=30)
+            status = int(response.status)  # type: ignore[attr-defined]
+        except HTTPError as error:
+            status = error.code
+        except (URLError, TimeoutError):
+            status = 0
+        outcome = "PASS" if status == step.expected_status else "FAIL"
+        print(f"{outcome} {step.method} {path} status={status}")
+        failed = failed or outcome == "FAIL"
+    return 1 if failed else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("base_url")
+    parser.add_argument("--signal", default="skew_momentum")
+    parser.add_argument("--symbol", default="AAPL")
+    parser.add_argument("--token-env", default="ASA_AGENT_API_TOKEN")
+    args = parser.parse_args(argv)
+    token = os.environ.get(args.token_env, "")
+    if not token:
+        print(
+            f"FAIL required token environment variable {args.token_env} is not set",
+            file=sys.stderr,
+        )
+        return 2
+    return run_smoke(args.base_url, token, args.signal, args.symbol)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Ticket
OPS-001 — Harden authenticated screening operations

## Summary
- Permit the `Authorization` header in configured CORS preflight.
- Add a reusable bounded smoke harness for health, readiness, capabilities, aggregate list, one refresh, and read-after-write.
- Accept token only through a named environment variable.
- Print only method, path, and status. Never print headers, bodies, or token.
- Document Railway usage.

## Security
Existing missing/wrong-token 404 behavior remains. No token CLI argument. No secret persistence or response-body logging.

## Network behavior
Harness performs exactly six sequential requests, including one bounded refresh. Runtime application behavior changes only in CORS allow-headers.

## Tests
- Target auth/composition/operations: 12 passed.
- Full repository: 2,541 passed, 23 skipped.
- `mypy asa`, Ruff, Lean entrypoints/integrity/pre-push, `git diff --check`: green.

## Production result
Authenticated production smoke pending merged deployment and configured token. No credential accessed; no deployment performed.

## Exclusions
No auth-model change, provider change, API payload change, persistence, UI, scheduling, or deployment.

## Auto-merge authority
Founder-approved SPRINT-010 delegated merge authority applies after CI passes.