### PR TITLE
LIFE-001: activate opportunity observation history

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from asa.api.agent_models import TimestampedResource
 from screening.registry import SignalDefinition
 from screening.state import ScreeningStateRecord
+from strategy_runtime.lifecycle import OpportunityHistory, OpportunityObservation
 from strategy_runtime.result import EvaluationState, UniversalScreeningResult
 
 # SPRINT-009R/EPIC-R5: the public wire vocabulary predates strategy_runtime and must not
@@ -136,3 +137,48 @@ class RefreshResultResponse(ScreeningResultResponse):
     ) -> RefreshResultResponse:
         base = ScreeningResultResponse.from_universal_result(result)
         return cls(request_count=request_count, **base.model_dump())
+
+
+class OpportunityObservationResponse(BaseModel):
+    opportunity_id: str
+    signal_id: str
+    symbol: str
+    lifecycle_stage: str
+    verdict: str
+    recommended_action: str
+    observed_at: str
+
+    @classmethod
+    def from_observation(
+        cls, observation: OpportunityObservation
+    ) -> OpportunityObservationResponse:
+        return cls(
+            opportunity_id=observation.opportunity_id,
+            signal_id=observation.strategy_id,
+            symbol=observation.symbol,
+            lifecycle_stage=observation.lifecycle_stage,
+            verdict=observation.verdict,
+            recommended_action=observation.recommended_action.value,
+            observed_at=observation.observed_at.isoformat(),
+        )
+
+
+class OpportunityHistoryResponse(BaseModel):
+    opportunity_id: str
+    observations: list[OpportunityObservationResponse]
+    total: int
+    limit: int
+    offset: int
+
+    @classmethod
+    def from_history(
+        cls, history: OpportunityHistory, *, limit: int, offset: int
+    ) -> OpportunityHistoryResponse:
+        page = history.observations[offset : offset + limit]
+        return cls(
+            opportunity_id=history.opportunity_id,
+            observations=[OpportunityObservationResponse.from_observation(item) for item in page],
+            total=len(history.observations),
+            limit=limit,
+            offset=offset,
+        )

--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -26,6 +26,7 @@ data source -- see docs/strategy_runtime/legacy-runtime-deprecation-plan.md.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -35,6 +36,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from asa.api.agent_models import agent_api_error
 from asa.api.screening_models import (
     CapabilitiesResponse,
+    OpportunityHistoryResponse,
     RefreshResultResponse,
     ScreeningResultResponse,
     ScreeningResultsEnvelope,
@@ -44,17 +46,23 @@ from market_data import load_market_data_config_from_environment
 from market_data.live_transport import build_live_transport
 from screening.live_acquisition import APPROVED_LIVE_UNIVERSE, live_only_config
 from screening.registry import ScreeningRegistry, signal_catalog
+from strategy_runtime.lifecycle import RecommendedAction
 from strategy_runtime.market_data_planning import (
     build_shared_market_data_access,
     enabled_provider_configs,
 )
-from strategy_runtime.persistence import LatestResultRepository
+from strategy_runtime.persistence import (
+    LatestResultRepository,
+    ObservationHistoryRepository,
+    replay_opportunity_history,
+)
 from strategy_runtime.registry import StrategyRegistry
 from strategy_runtime.result import UniversalScreeningResult
-from strategy_runtime.service import get_state, refresh
+from strategy_runtime.service import get_state, record_opportunity_observation, refresh
 
 DEFAULT_LIMIT = 100
 MAX_LIMIT = 500
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,6 +85,7 @@ def build_screening_router(
     transport_factory: Callable[[str], object] = build_live_transport,
     *,
     capabilities_registry: ScreeningRegistry,
+    history_repository: ObservationHistoryRepository,
 ) -> APIRouter:
     router = APIRouter(prefix="/api/v1", dependencies=[Depends(authorize)])
 
@@ -105,6 +114,26 @@ def build_screening_router(
             total=total,
             limit=limit,
             offset=offset,
+        )
+
+    @router.get(
+        "/screening/opportunities/{opportunity_id}/history",
+        response_model=OpportunityHistoryResponse,
+    )
+    def opportunity_history(
+        opportunity_id: str,
+        limit: int = Query(default=DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+        offset: int = Query(default=0, ge=0),
+    ) -> OpportunityHistoryResponse:
+        history = replay_opportunity_history(history_repository, opportunity_id)
+        if history is None:
+            raise agent_api_error(
+                404,
+                "NO_OPPORTUNITY_HISTORY",
+                f"No opportunity history for {opportunity_id!r}",
+            )
+        return OpportunityHistoryResponse.from_history(
+            history, limit=limit, offset=offset
         )
 
     @router.get("/screening/{signal}", response_model=ScreeningResultsEnvelope)
@@ -164,6 +193,25 @@ def build_screening_router(
             symbol=symbol,
             fulfillment_by_subject={symbol: subject_access.fulfillment},
         )
+        if result.opportunity_id is not None:
+            try:
+                record_opportunity_observation(
+                    registry,
+                    history_repository,
+                    result,
+                    recommended_action=RecommendedAction.NO_ACTION,
+                )
+            except Exception:
+                # Latest state is already committed. History is additive and
+                # must never corrupt or roll back the canonical latest result.
+                _LOGGER.warning(
+                    "opportunity history append failed",
+                    extra={
+                        "signal_id": result.strategy_id,
+                        "symbol": result.symbol,
+                        "opportunity_id": result.opportunity_id,
+                    },
+                )
         return RefreshResultResponse.from_universal_result(
             result, request_count=len(subject_access.budget_manager.accounting)
         )

--- a/asa/bootstrap.py
+++ b/asa/bootstrap.py
@@ -21,6 +21,7 @@ from asa.application.ports.repositories import MarketObservationRepository
 from asa.application.ports.runs import RunPublicationRepository
 from asa.application.use_cases import MarketQuoteService
 from asa.config import Settings
+from asa.integrations.observation_history_postgres import PostgresObservationHistoryRepository
 from asa.integrations.postgres import PostgresMarketObservationRepository, create_postgres_engine
 from asa.integrations.providers.deterministic_fake import DeterministicFakeQuoteProvider
 from asa.integrations.providers.deterministic_fake_broker import (
@@ -34,7 +35,7 @@ from asa.market_data_ops.routes import build_operations_router
 from market_data.live_transport import build_live_transport as build_transport_for_provider
 from screening import SIGNAL_REGISTRY
 from strategy_runtime.adapters import build_migrated_strategy_registry
-from strategy_runtime.persistence import LatestResultRepository
+from strategy_runtime.persistence import LatestResultRepository, ObservationHistoryRepository
 
 
 @dataclass(frozen=True)
@@ -46,6 +47,7 @@ class DependencyOverrides:
     engine_factory: Callable[[str], Engine] | None = None
     market_data_transport_factory: Callable[[str], object] | None = None
     screening_state_repository: LatestResultRepository | None = None
+    observation_history_repository: ObservationHistoryRepository | None = None
 
 
 def build_application(
@@ -69,6 +71,10 @@ def build_application(
         or PostgresLatestResultRepository(engine_factory(settings.database_url))
     )
     screening_registry = build_migrated_strategy_registry()
+    observation_history_repository = (
+        selected.observation_history_repository
+        or PostgresObservationHistoryRepository(engine_factory(settings.database_url))
+    )
     agent_authorize = build_agent_authorizer(settings.agent_api_token)
     quote_service = MarketQuoteService(
         provider=provider,
@@ -113,6 +119,7 @@ def build_application(
             agent_authorize,
             selected.market_data_transport_factory or build_transport_for_provider,
             capabilities_registry=SIGNAL_REGISTRY,
+            history_repository=observation_history_repository,
         )
     )
 
@@ -145,6 +152,7 @@ def build_application(
         "portfolio_runner": portfolio_runner,
         "portfolio_query": portfolio_query,
         "screening_state_repository": screening_state_repository,
+        "observation_history_repository": observation_history_repository,
         "agent_authorize": agent_authorize,
     }
     return app

--- a/asa/integrations/observation_history_postgres.py
+++ b/asa/integrations/observation_history_postgres.py
@@ -35,8 +35,13 @@ class PostgresObservationHistoryRepository:
                         opportunity_id, signal_id, symbol, lifecycle_stage,
                         verdict, recommended_action, observed_at
                     ) SELECT
-                        :opportunity_id, :signal_id, :symbol, :lifecycle_stage,
-                        :verdict, :recommended_action, :observed_at
+                        CAST(:opportunity_id AS VARCHAR(128)),
+                        CAST(:signal_id AS VARCHAR(64)),
+                        CAST(:symbol AS VARCHAR(32)),
+                        CAST(:lifecycle_stage AS VARCHAR(64)),
+                        CAST(:verdict AS TEXT),
+                        CAST(:recommended_action AS VARCHAR(32)),
+                        CAST(:observed_at AS TIMESTAMP WITH TIME ZONE)
                     WHERE NOT EXISTS (
                         SELECT 1 FROM opportunity_observation_history
                         WHERE opportunity_id = :opportunity_id

--- a/asa/integrations/observation_history_postgres.py
+++ b/asa/integrations/observation_history_postgres.py
@@ -34,9 +34,18 @@ class PostgresObservationHistoryRepository:
                     INSERT INTO opportunity_observation_history (
                         opportunity_id, signal_id, symbol, lifecycle_stage,
                         verdict, recommended_action, observed_at
-                    ) VALUES (
+                    ) SELECT
                         :opportunity_id, :signal_id, :symbol, :lifecycle_stage,
                         :verdict, :recommended_action, :observed_at
+                    WHERE NOT EXISTS (
+                        SELECT 1 FROM opportunity_observation_history
+                        WHERE opportunity_id = :opportunity_id
+                          AND signal_id = :signal_id
+                          AND symbol = :symbol
+                          AND lifecycle_stage = :lifecycle_stage
+                          AND verdict = :verdict
+                          AND recommended_action = :recommended_action
+                          AND observed_at = :observed_at
                     )
                 """),
                 {
@@ -55,7 +64,7 @@ class PostgresObservationHistoryRepository:
             rows = connection.execute(
                 text(
                     "SELECT * FROM opportunity_observation_history "
-                    "WHERE opportunity_id = :opportunity_id ORDER BY observed_at"
+                    "WHERE opportunity_id = :opportunity_id ORDER BY observed_at, id"
                 ),
                 {"opportunity_id": opportunity_id},
             ).mappings()

--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -31,12 +31,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from asa.config import Settings
+from asa.integrations.observation_history_postgres import PostgresObservationHistoryRepository
 from asa.integrations.postgres import create_postgres_engine
 from asa.integrations.universal_screening_postgres import PostgresLatestResultRepository
 from market_data import load_market_data_config_from_environment
@@ -44,12 +46,13 @@ from market_data.live_transport import build_live_transport
 from screening import APPROVED_LIVE_UNIVERSE
 from screening.live_acquisition import live_only_config
 from strategy_runtime.adapters import build_migrated_strategy_registry
+from strategy_runtime.lifecycle import RecommendedAction
 from strategy_runtime.market_data_planning import (
     build_shared_market_data_access,
     enabled_provider_configs,
 )
-from strategy_runtime.persistence import LatestResultRepository
-from strategy_runtime.service import refresh
+from strategy_runtime.persistence import LatestResultRepository, ObservationHistoryRepository
+from strategy_runtime.service import record_opportunity_observation, refresh
 
 # The initial production screening universe
 # (project/reports/SPRINT-008D-SCREENING-UNIVERSE.md, PROD-001): the two
@@ -64,6 +67,7 @@ PRODUCTION_SCREENING_UNIVERSE: tuple[tuple[str, str], ...] = tuple(
     for signal_id in ("forward_factor", "skew_momentum")
     for symbol in APPROVED_LIVE_UNIVERSE
 )
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,6 +89,7 @@ def run_scheduled_refresh(
     universe: tuple[tuple[str, str], ...] = PRODUCTION_SCREENING_UNIVERSE,
     *,
     repository: LatestResultRepository | None = None,
+    history_repository: ObservationHistoryRepository | None = None,
     transport_factory: Callable[[str], object] = build_live_transport,
 ) -> tuple[PairOutcome, ...]:
     """Run one bounded refresh per pair in ``universe``, in order,
@@ -101,6 +106,9 @@ def run_scheduled_refresh(
     uses.
     """
     resolved_repository = repository or PostgresLatestResultRepository(
+        create_postgres_engine(Settings().database_url)
+    )
+    resolved_history_repository = history_repository or PostgresObservationHistoryRepository(
         create_postgres_engine(Settings().database_url)
     )
     registry = build_migrated_strategy_registry()
@@ -124,6 +132,23 @@ def run_scheduled_refresh(
                 symbol=symbol,
                 fulfillment_by_subject={symbol: subject_access.fulfillment},
             )
+            if result.opportunity_id is not None:
+                try:
+                    record_opportunity_observation(
+                        registry,
+                        resolved_history_repository,
+                        result,
+                        recommended_action=RecommendedAction.NO_ACTION,
+                    )
+                except Exception:
+                    _LOGGER.warning(
+                        "scheduled opportunity history append failed",
+                        extra={
+                            "signal_id": result.strategy_id,
+                            "symbol": result.symbol,
+                            "opportunity_id": result.opportunity_id,
+                        },
+                    )
             outcomes.append(
                 PairOutcome(
                     signal_id,

--- a/docs/strategy_runtime/opportunity-history.md
+++ b/docs/strategy_runtime/opportunity-history.md
@@ -1,0 +1,13 @@
+# Opportunity history
+
+Lifecycle-capable screening results are appended after their latest-state upsert. History is
+separate, additive evidence: an append failure is logged with safe identifiers and never rolls
+back or corrupts the canonical latest result.
+
+`GET /api/v1/screening/opportunities/{opportunity_id}/history` returns one opportunity only,
+oldest first, with bounded `limit`/`offset` pagination. Reads never call market-data providers.
+
+An exact duplicate—same opportunity, signal, symbol, stage, verdict, action, and timestamp—is a
+no-op. A later refresh with a different timestamp remains a new observation even when its stage
+and verdict are unchanged. Screening records `no_action`; it observes analytical lifecycle state
+but does not create an execution recommendation.

--- a/tests/asa/fakes.py
+++ b/tests/asa/fakes.py
@@ -1,5 +1,6 @@
 from asa.contracts.market import MarketObservation
 from screening.state import ScreeningStateRecord
+from strategy_runtime.lifecycle import OpportunityHistory, OpportunityObservation
 from strategy_runtime.persistence import UniversalSignalRow
 
 
@@ -67,3 +68,17 @@ class InMemoryLatestResultRepository:
 
     def get_one(self, signal_id: str, symbol: str) -> UniversalSignalRow | None:
         return self._rows.get((signal_id, symbol))
+
+
+class InMemoryObservationHistoryRepository:
+    def __init__(self) -> None:
+        self._observations: dict[str, list[OpportunityObservation]] = {}
+
+    def append(self, observation: OpportunityObservation) -> None:
+        values = self._observations.setdefault(observation.opportunity_id, [])
+        if observation not in values:
+            values.append(observation)
+
+    def history_for(self, opportunity_id: str) -> OpportunityHistory | None:
+        values = self._observations.get(opportunity_id)
+        return OpportunityHistory(opportunity_id, tuple(values)) if values else None

--- a/tests/asa/test_observation_history_postgres_integration.py
+++ b/tests/asa/test_observation_history_postgres_integration.py
@@ -140,6 +140,33 @@ def test_recorded_observations_replay_in_order_through_real_postgres(
     assert history.current == confirmed
 
 
+def test_exact_duplicate_append_is_idempotent_in_real_postgres(
+    repository: PostgresObservationHistoryRepository,
+) -> None:
+    registry = StrategyRegistry(((_contract(), _adapter),))
+    result = _result(
+        "watching",
+        "monitoring",
+        "same-run",
+        datetime(2026, 7, 23, 16, 0, tzinfo=UTC),
+    )
+    first = record_opportunity_observation(
+        registry,
+        repository,
+        result,
+        recommended_action=RecommendedAction.NO_ACTION,
+    )
+    record_opportunity_observation(
+        registry,
+        repository,
+        result,
+        recommended_action=RecommendedAction.NO_ACTION,
+    )
+    history = replay_opportunity_history(repository, first.opportunity_id)
+    assert history is not None
+    assert history.observations == (first,)
+
+
 def test_replay_of_an_unknown_opportunity_returns_none(
     repository: PostgresObservationHistoryRepository,
 ) -> None:

--- a/tests/asa/test_opportunity_history_routes.py
+++ b/tests/asa/test_opportunity_history_routes.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from asa.bootstrap import DependencyOverrides, build_application
+from asa.config import Settings
+from market_data import load_market_data_config
+from strategy_runtime.lifecycle import OpportunityObservation, RecommendedAction
+from strategy_runtime.persistence import UniversalSignalRow
+from strategy_runtime.result import EvaluationState, RowType, UniversalScreeningResult
+from tests.asa.fakes import (
+    InMemoryLatestResultRepository,
+    InMemoryObservationHistoryRepository,
+)
+from tests.asa.market_data_ops.fakes import ScriptedTransport
+
+NOW = datetime(2026, 7, 27, 12, 0, tzinfo=UTC)
+AUTH = {"Authorization": "Bearer correct-token"}
+
+
+def _observation(offset: int, stage: str) -> OpportunityObservation:
+    return OpportunityObservation(
+        "opportunity-1",
+        "earnings_calendar",
+        "AAPL",
+        stage,
+        "PASS",
+        RecommendedAction.NO_ACTION,
+        NOW + timedelta(minutes=offset),
+    )
+
+
+def _client(history_repository) -> TestClient:  # noqa: ANN001
+    return TestClient(
+        build_application(
+            Settings(agent_api_token=SecretStr("correct-token"), _env_file=None),
+            DependencyOverrides(
+                screening_state_repository=InMemoryLatestResultRepository(),
+                observation_history_repository=history_repository,
+            ),
+        )
+    )
+
+
+def test_history_is_oldest_first_bounded_and_opportunity_scoped() -> None:
+    history = InMemoryObservationHistoryRepository()
+    history.append(_observation(2, "confirmed"))
+    history.append(_observation(1, "watching"))
+    response = _client(history).get(
+        "/api/v1/screening/opportunities/opportunity-1/history",
+        headers=AUTH,
+        params={"limit": 1, "offset": 1},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    assert [item["lifecycle_stage"] for item in body["observations"]] == ["confirmed"]
+    assert body["opportunity_id"] == "opportunity-1"
+
+
+def test_identical_observation_append_is_idempotent() -> None:
+    history = InMemoryObservationHistoryRepository()
+    observation = _observation(1, "watching")
+    history.append(observation)
+    history.append(observation)
+    response = _client(history).get(
+        "/api/v1/screening/opportunities/opportunity-1/history", headers=AUTH
+    )
+    assert response.json()["total"] == 1
+
+
+def test_missing_history_and_missing_auth_fail_closed() -> None:
+    client = _client(InMemoryObservationHistoryRepository())
+    path = "/api/v1/screening/opportunities/missing/history"
+    assert client.get(path).status_code == 404
+    response = client.get(path, headers=AUTH)
+    assert response.status_code == 404
+    assert response.json()["detail"]["error_code"] == "NO_OPPORTUNITY_HISTORY"
+
+
+def test_history_append_failure_does_not_rollback_latest_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest = InMemoryLatestResultRepository()
+
+    class FailingHistory:
+        def append(self, observation):  # noqa: ANN001, ARG002
+            raise RuntimeError("history unavailable")
+
+        def history_for(self, opportunity_id):  # noqa: ANN001, ARG002
+            return None
+
+    result = UniversalScreeningResult(
+        strategy_id="earnings_calendar",
+        strategy_version="1.0.0",
+        symbol="AAPL",
+        observation_id="observation-1",
+        opportunity_id="opportunity-1",
+        row_type=RowType.RESULT,
+        verdict="PASS",
+        evaluation_state=EvaluationState.PASS,
+        lifecycle_stage="confirmed",
+        recommendation_state=None,
+        data_quality=None,
+        metrics={},
+        economics={},
+        blockers=(),
+        warnings=(),
+        provenance=(),
+        observed_at=NOW,
+    )
+
+    def successful_refresh(registry, repository, clock, **kwargs):  # noqa: ANN001, ARG001
+        repository.upsert(UniversalSignalRow.from_result(result))
+        return result
+
+    monkeypatch.setattr("asa.api.screening_routes.refresh", successful_refresh)
+    monkeypatch.setattr(
+        "asa.api.screening_routes.load_market_data_config_from_environment",
+        lambda: load_market_data_config(
+            {"ASA_TRADIER_ENABLED": "true", "ASA_TRADIER_ACCESS_TOKEN": "test-token"}
+        ),
+    )
+    app = build_application(
+        Settings(agent_api_token=SecretStr("correct-token"), _env_file=None),
+        DependencyOverrides(
+            screening_state_repository=latest,
+            observation_history_repository=FailingHistory(),
+            market_data_transport_factory=lambda provider_id: ScriptedTransport([]),  # noqa: ARG005
+        ),
+    )
+    response = TestClient(app).post(
+        "/api/v1/screening/earnings_calendar/AAPL/refresh", headers=AUTH
+    )
+    assert response.status_code == 200
+    assert latest.get_one("earnings_calendar", "AAPL") is not None


### PR DESCRIPTION
## Ticket
LIFE-001 — Activate opportunity observation history

## Summary
- Compose the existing Postgres history repository in `build_application`.
- Append lifecycle-capable refresh results after latest-state persistence.
- Wire scheduled refresh through the same generic history service.
- Add authenticated bounded oldest-first opportunity history retrieval.
- Make exact duplicate observations a database no-op.
- Isolate append failure from canonical latest state; log only safe identifiers.

## Canonical semantics
History is additive. Exact duplicate tuple = no-op; later timestamps = new observations. Screening records `no_action` because it observes lifecycle but does not issue execution recommendations.

## API
`GET /api/v1/screening/opportunities/{opportunity_id}/history?limit=&offset=`. Existing v1 fields/routes unchanged. Read path makes no provider call.

## Security/network
Existing agent bearer auth applies. No secrets, provider calls, new background work, or unbounded reads.

## Tests
- Full repository: 2,545 passed, 24 skipped.
- Route tests cover pagination, ordering, scoping, idempotency, auth, not-found, and append-failure isolation.
- Real Postgres idempotency test added; CI PostgreSQL job supplies execution evidence.
- `mypy asa`, Ruff, Lean entrypoints/integrity/pre-push, `git diff --check`: green.

## Production result
Pending merged deployment. No credential accessed and no deployment performed.

## Rollback
Revert commit. Existing table remains additive and compatible.

## Exclusions
No schema migration, strategy branching, recommendation engine, provider change, UI, backfill, or deployment.

## Auto-merge authority
Founder-approved SPRINT-010 delegated merge authority applies after all CI passes.