### PR TITLE
SURFACE-001: make screening surface actionable and generic

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -9,7 +9,7 @@ timestamped").
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from asa.api.agent_models import TimestampedResource
 from screening.registry import SignalDefinition
@@ -40,6 +40,10 @@ def _wire_metrics(result: UniversalScreeningResult) -> dict[str, str]:
     byte-identical to the pre-EPIC-R2 str(strategy_native_score) wire value.
     """
     return {key: str(value.native()) for key, value in result.metrics.items()}
+
+
+def _wire_values(result: dict[str, object]) -> dict[str, str]:
+    return {key: str(value) for key, value in result.items()}
 
 
 def _wire_explanation(result: UniversalScreeningResult) -> str | None:
@@ -73,6 +77,20 @@ class ScreeningResultResponse(TimestampedResource):
     outcome: str
     explanation: str | None
     metrics: dict[str, str]
+    observation_id: str | None = None
+    opportunity_id: str | None = None
+    opportunity_history_url: str | None = None
+    row_type: str | None = None
+    lifecycle_stage: str | None = None
+    status: str | None = None
+    data_quality: str | None = None
+    freshness: str | None = None
+    economics: dict[str, str] = Field(default_factory=dict)
+    metric_types: dict[str, str] = Field(default_factory=dict)
+    economics_types: dict[str, str] = Field(default_factory=dict)
+    blockers: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    provenance: list[str] = Field(default_factory=list)
 
     @classmethod
     def from_record(cls, record: ScreeningStateRecord) -> ScreeningResultResponse:
@@ -93,6 +111,7 @@ class ScreeningResultResponse(TimestampedResource):
         from_record() -- same public response shape, sourced from
         UniversalScreeningResult instead of the legacy ScreeningStateRecord.
         """
+        age_seconds = TimestampedResource.age_seconds_since(result.observed_at)
         return cls(
             signal_id=result.strategy_id,
             signal_version=result.strategy_version,
@@ -100,8 +119,32 @@ class ScreeningResultResponse(TimestampedResource):
             outcome=_OUTCOME_WIRE_VALUES[result.evaluation_state],
             explanation=_wire_explanation(result),
             metrics=_wire_metrics(result),
+            observation_id=result.observation_id,
+            opportunity_id=result.opportunity_id,
+            opportunity_history_url=(
+                f"/api/v1/screening/opportunities/{result.opportunity_id}/history"
+                if result.opportunity_id is not None
+                else None
+            ),
+            row_type=result.row_type.value,
+            lifecycle_stage=result.lifecycle_stage,
+            status=result.recommendation_state,
+            data_quality=result.data_quality,
+            freshness="fresh" if age_seconds <= 86_400 else "stale",
+            economics=_wire_values(
+                {key: value.native() for key, value in result.economics.items()}
+            ),
+            metric_types={
+                key: value.value_type.value for key, value in result.metrics.items()
+            },
+            economics_types={
+                key: value.value_type.value for key, value in result.economics.items()
+            },
+            blockers=list(result.blockers),
+            warnings=list(result.warnings),
+            provenance=list(result.provenance),
             updated_at=result.observed_at,
-            age_seconds=TimestampedResource.age_seconds_since(result.observed_at),
+            age_seconds=age_seconds,
         )
 
 

--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -30,6 +30,8 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Literal
 
 from fastapi import APIRouter, Depends, Query, Request
 
@@ -57,11 +59,12 @@ from strategy_runtime.persistence import (
     replay_opportunity_history,
 )
 from strategy_runtime.registry import StrategyRegistry
-from strategy_runtime.result import UniversalScreeningResult
+from strategy_runtime.result import EvaluationState, UniversalScreeningResult
 from strategy_runtime.service import get_state, record_opportunity_observation, refresh
 
 DEFAULT_LIMIT = 100
 MAX_LIMIT = 500
+FRESHNESS_THRESHOLD_SECONDS = 86_400
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -76,6 +79,102 @@ def _paginate(
 ) -> tuple[tuple[UniversalScreeningResult, ...], int]:
     total = len(records)
     return records[offset : offset + limit], total
+
+
+def _filter_and_sort(
+    records: tuple[UniversalScreeningResult, ...],
+    *,
+    signal: str | None,
+    symbol: str | None,
+    outcome: str | None,
+    lifecycle_stage: str | None,
+    freshness: Literal["fresh", "stale"] | None,
+    status: str | None,
+    sort_by: str | None,
+    sort_order: Literal["asc", "desc"],
+) -> tuple[UniversalScreeningResult, ...]:
+    now = datetime.now(UTC)
+    selected = tuple(
+        item
+        for item in records
+        if (signal is None or item.strategy_id == signal)
+        and (symbol is None or item.symbol == symbol)
+        and (outcome is None or _OUTCOME_FILTER_VALUES[item.evaluation_state] == outcome)
+        and (lifecycle_stage is None or item.lifecycle_stage == lifecycle_stage)
+        and (status is None or item.recommendation_state == status)
+        and (
+            freshness is None
+            or (
+                "fresh"
+                if max(0, int((now - item.observed_at).total_seconds()))
+                <= FRESHNESS_THRESHOLD_SECONDS
+                else "stale"
+            )
+            == freshness
+        )
+    )
+    reverse = sort_order == "desc"
+    if sort_by is None:
+        return selected
+    if sort_by == "observed_at":
+        return tuple(
+            sorted(
+                selected,
+                key=lambda item: (item.observed_at, item.strategy_id, item.symbol),
+                reverse=reverse,
+            )
+        )
+    if sort_by == "age_seconds":
+        return tuple(
+            sorted(
+                selected,
+                key=lambda item: (
+                    max(0, int((now - item.observed_at).total_seconds())),
+                    item.strategy_id,
+                    item.symbol,
+                ),
+                reverse=reverse,
+            )
+        )
+    if sort_by.startswith("metrics."):
+        metric_name = sort_by.removeprefix("metrics.")
+        if not metric_name:
+            raise agent_api_error(422, "INVALID_SORT", "Metric sort requires a metric name")
+        numeric: list[tuple[Decimal, UniversalScreeningResult]] = []
+        missing: list[UniversalScreeningResult] = []
+        for item in selected:
+            value = item.metrics.get(metric_name)
+            if value is None:
+                missing.append(item)
+                continue
+            native = value.native()
+            if isinstance(native, bool) or not isinstance(native, (int, Decimal)):
+                raise agent_api_error(
+                    422,
+                    "NON_NUMERIC_SORT_METRIC",
+                    f"Metric {metric_name!r} is not numeric",
+                )
+            numeric.append((Decimal(native), item))
+        numeric.sort(
+            key=lambda pair: (pair[0], pair[1].strategy_id, pair[1].symbol),
+            reverse=reverse,
+        )
+        missing.sort(key=lambda item: (item.strategy_id, item.symbol))
+        return tuple(item for _, item in numeric) + tuple(missing)
+    raise agent_api_error(
+        422,
+        "INVALID_SORT",
+        "sort_by must be observed_at, age_seconds, or metrics.<name>",
+    )
+
+
+_OUTCOME_FILTER_VALUES = {
+    EvaluationState.PASS: "pass",
+    EvaluationState.NO_SIGNAL: "no_signal",
+    EvaluationState.MISSING_DATA: "missing_data",
+    EvaluationState.MALFORMED_OUTPUT: "malformed_output",
+    EvaluationState.ADAPTER_EXCEPTION: "strategy_exception",
+}
 
 
 def build_screening_router(
@@ -106,8 +205,26 @@ def build_screening_router(
     def list_screening(
         limit: int = Query(default=DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
         offset: int = Query(default=0, ge=0),
+        signal: str | None = None,
+        symbol: str | None = None,
+        outcome: str | None = None,
+        lifecycle_stage: str | None = None,
+        freshness: Literal["fresh", "stale"] | None = None,
+        status: str | None = None,
+        sort_by: str | None = None,
+        sort_order: Literal["asc", "desc"] = "desc",
     ) -> ScreeningResultsEnvelope:
-        records = get_state(repository)
+        records = _filter_and_sort(
+            get_state(repository),
+            signal=signal,
+            symbol=symbol,
+            outcome=outcome,
+            lifecycle_stage=lifecycle_stage,
+            freshness=freshness,
+            status=status,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
         page, total = _paginate(records, limit, offset)
         return ScreeningResultsEnvelope(
             results=[ScreeningResultResponse.from_universal_result(item) for item in page],
@@ -141,9 +258,26 @@ def build_screening_router(
         signal: str,
         limit: int = Query(default=DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
         offset: int = Query(default=0, ge=0),
+        symbol: str | None = None,
+        outcome: str | None = None,
+        lifecycle_stage: str | None = None,
+        freshness: Literal["fresh", "stale"] | None = None,
+        status: str | None = None,
+        sort_by: str | None = None,
+        sort_order: Literal["asc", "desc"] = "desc",
     ) -> ScreeningResultsEnvelope:
         _require_registered_signal(signal)
-        records = get_state(repository, strategy_id=signal)
+        records = _filter_and_sort(
+            get_state(repository, strategy_id=signal),
+            signal=None,
+            symbol=symbol,
+            outcome=outcome,
+            lifecycle_stage=lifecycle_stage,
+            freshness=freshness,
+            status=status,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
         page, total = _paginate(records, limit, offset)
         return ScreeningResultsEnvelope(
             results=[ScreeningResultResponse.from_universal_result(item) for item in page],

--- a/docs/api/agent-api-examples.md
+++ b/docs/api/agent-api-examples.md
@@ -46,10 +46,17 @@ curl -sS https://<host>/api/v1/capabilities \
 
 ## `GET /api/v1/screening` — all current results, paginated
 
-`?limit=` (default 100, max 500) and `?offset=` (default 0) are both optional. This route (and
-the two below) only ever reads through the injected repository — it never triggers a provider
-request, verified by test (`tests/asa/test_screening_routes.py::TestReadsNeverComputeOrPersist`),
-not merely by inspection.
+This UI-ready surface supports pagination plus strategy-neutral query controls:
+
+- `limit` (default 100, max 500) and `offset`;
+- exact filters `signal`, `symbol`, `outcome`, `lifecycle_stage`, and `status`
+  (`status` is the universal recommendation state);
+- `freshness=fresh|stale`, using the public 86,400-second display threshold;
+- `sort_by=observed_at|age_seconds|metrics.<name>` and `sort_order=asc|desc`.
+
+Metric sorting accepts only declared decimal or integer metrics. Missing values sort last. These
+controls order observations; they do not rank investments across strategies. This route (and the
+two below) only reads through the injected repository and never triggers a provider request.
 
 ```bash
 curl -sS "https://<host>/api/v1/screening?limit=50" \
@@ -67,7 +74,21 @@ curl -sS "https://<host>/api/v1/screening?limit=50" \
       "symbol": "AAPL",
       "outcome": "pass",
       "explanation": "calendar richness within bounds",
-      "metrics": { "strategy_native_score": "0.42" }
+      "metrics": { "strategy_native_score": "0.42" },
+      "observation_id": "d9bc...",
+      "opportunity_id": null,
+      "opportunity_history_url": null,
+      "row_type": "result",
+      "lifecycle_stage": null,
+      "status": null,
+      "data_quality": "complete",
+      "freshness": "fresh",
+      "economics": {},
+      "metric_types": { "strategy_native_score": "decimal" },
+      "economics_types": {},
+      "blockers": [],
+      "warnings": [],
+      "provenance": ["tradier:quote"]
     }
   ],
   "total": 1,
@@ -76,10 +97,14 @@ curl -sS "https://<host>/api/v1/screening?limit=50" \
 }
 ```
 
-`updated_at` and `age_seconds` (computed server-side at request time) appear on every screening
-result — this API deliberately exposes only the raw ingredient for a freshness decision, never an
-opinion about what counts as "stale." `GET /api/v1/screening/{signal}` narrows the same envelope to
-one signal across all symbols.
+`updated_at` and `age_seconds` remain the exact raw freshness inputs. `freshness` is a generic
+display/query classification using the documented 24-hour threshold, not a strategy signal.
+`metrics` keeps its original string-valued shape for v1 callers; `metric_types` preserves the
+declared universal type. `economics` follows the same paired value/type convention. A tracked
+opportunity links directly to its paginated history endpoint.
+
+`GET /api/v1/screening/{signal}` supports the same filters, sorting, and pagination except that the
+signal is fixed by the path.
 
 ## `GET /api/v1/screening/{signal}/{symbol}` — one result
 

--- a/tests/asa/test_screening_engine_parity.py
+++ b/tests/asa/test_screening_engine_parity.py
@@ -130,4 +130,35 @@ def test_legacy_and_strategy_runtime_refresh_produce_the_identical_wire_response
         universal_result, request_count=len(subject_access.budget_manager.accounting)
     )
 
-    assert universal_response.model_dump() == legacy_response.model_dump()
+    # SURFACE-001 adds universal-only fields while preserving every legacy
+    # core field. Compatibility is therefore a projection, not full-model
+    # equality.
+    legacy_payload = legacy_response.model_dump()
+    universal_payload = universal_response.model_dump()
+    assert {
+        key: universal_payload[key]
+        for key in (
+            "updated_at",
+            "age_seconds",
+            "signal_id",
+            "signal_version",
+            "symbol",
+            "outcome",
+            "explanation",
+            "metrics",
+            "request_count",
+        )
+    } == {
+        key: legacy_payload[key]
+        for key in (
+            "updated_at",
+            "age_seconds",
+            "signal_id",
+            "signal_version",
+            "symbol",
+            "outcome",
+            "explanation",
+            "metrics",
+            "request_count",
+        )
+    }

--- a/tests/asa/test_screening_routes.py
+++ b/tests/asa/test_screening_routes.py
@@ -4,7 +4,7 @@ LatestResultRepository, proving the public response shape is unchanged)."""
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 from fastapi.testclient import TestClient
@@ -20,25 +20,35 @@ from tests.asa.fakes import InMemoryLatestResultRepository
 NOW = datetime(2026, 7, 23, 16, 0, tzinfo=UTC)
 
 
-def _record(signal_id: str, symbol: str, outcome: str = "pass") -> UniversalSignalRow:
+def _record(
+    signal_id: str,
+    symbol: str,
+    outcome: str = "pass",
+    *,
+    observed_at: datetime = NOW,
+    opportunity_id: str | None = None,
+    lifecycle_stage: str | None = None,
+    recommendation_state: str | None = None,
+    score: Decimal = Decimal("75"),
+) -> UniversalSignalRow:
     return UniversalSignalRow(
         signal_id=signal_id,
         signal_version="1.0.0",
         symbol=symbol,
         observation_id=f"{signal_id}-{symbol}-obs",
-        opportunity_id=None,
+        opportunity_id=opportunity_id,
         row_type=RowType.RESULT.value,
         verdict="PASS",
         evaluation_state=EvaluationState(outcome).value,
-        lifecycle_stage=None,
-        recommendation_state=None,
-        data_quality=None,
-        metrics={"strategy_native_score": TypedValue.of_decimal(Decimal("75"))},
-        economics={},
-        blockers=(),
-        warnings=(),
-        provenance=(),
-        observed_at=NOW,
+        lifecycle_stage=lifecycle_stage,
+        recommendation_state=recommendation_state,
+        data_quality="complete",
+        metrics={"strategy_native_score": TypedValue.of_decimal(score)},
+        economics={"estimated_return": TypedValue.of_decimal(Decimal("0.12"))},
+        blockers=("capital unavailable",),
+        warnings=("monitor liquidity",),
+        provenance=("fixture:screening",),
+        observed_at=observed_at,
     )
 
 
@@ -144,6 +154,114 @@ class TestListScreening:
             "/api/v1/screening", headers=_auth(), params={"limit": 501}
         )
         assert response.status_code == 422
+
+    def test_exposes_complete_generic_result_semantics_and_history_link(self) -> None:
+        repository = InMemoryLatestResultRepository()
+        repository.upsert(
+            _record(
+                "earnings_calendar",
+                "AAPL",
+                opportunity_id="opportunity-1",
+                lifecycle_stage="watching",
+                recommendation_state="monitor",
+            )
+        )
+        result = _client(repository).get("/api/v1/screening", headers=_auth()).json()[
+            "results"
+        ][0]
+        assert result["observation_id"] == "earnings_calendar-AAPL-obs"
+        assert result["opportunity_id"] == "opportunity-1"
+        assert result["opportunity_history_url"].endswith(
+            "/opportunities/opportunity-1/history"
+        )
+        assert result["lifecycle_stage"] == "watching"
+        assert result["status"] == "monitor"
+        assert result["data_quality"] == "complete"
+        assert result["freshness"] in {"fresh", "stale"}
+        assert result["metrics"]["strategy_native_score"] == "75"
+        assert result["metric_types"]["strategy_native_score"] == "decimal"
+        assert result["economics"]["estimated_return"] == "0.12"
+        assert result["economics_types"]["estimated_return"] == "decimal"
+        assert result["blockers"] == ["capital unavailable"]
+        assert result["warnings"] == ["monitor liquidity"]
+        assert result["provenance"] == ["fixture:screening"]
+
+    def test_generic_filters_compose_before_pagination(self) -> None:
+        repository = InMemoryLatestResultRepository()
+        repository.upsert(
+            _record(
+                "earnings_calendar",
+                "AAPL",
+                opportunity_id="opportunity-1",
+                lifecycle_stage="watching",
+                recommendation_state="monitor",
+            )
+        )
+        repository.upsert(_record("forward_factor", "MSFT"))
+        response = _client(repository).get(
+            "/api/v1/screening",
+            headers=_auth(),
+            params={
+                "signal": "earnings_calendar",
+                "symbol": "AAPL",
+                "outcome": "pass",
+                "lifecycle_stage": "watching",
+                "status": "monitor",
+                "limit": 1,
+            },
+        )
+        body = response.json()
+        assert body["total"] == 1
+        assert body["results"][0]["opportunity_id"] == "opportunity-1"
+
+    def test_freshness_filter_uses_documented_display_threshold(self) -> None:
+        repository = InMemoryLatestResultRepository()
+        repository.upsert(
+            _record(
+                "forward_factor",
+                "AAPL",
+                observed_at=datetime.now(UTC) - timedelta(minutes=5),
+            )
+        )
+        repository.upsert(
+            _record(
+                "forward_factor",
+                "MSFT",
+                observed_at=datetime.now(UTC) - timedelta(days=2),
+            )
+        )
+        fresh = _client(repository).get(
+            "/api/v1/screening",
+            headers=_auth(),
+            params={"freshness": "fresh"},
+        )
+        stale = _client(repository).get(
+            "/api/v1/screening",
+            headers=_auth(),
+            params={"freshness": "stale"},
+        )
+        assert [item["symbol"] for item in fresh.json()["results"]] == ["AAPL"]
+        assert [item["symbol"] for item in stale.json()["results"]] == ["MSFT"]
+
+    def test_numeric_metric_sort_is_deterministic_and_missing_values_are_last(self) -> None:
+        repository = InMemoryLatestResultRepository()
+        repository.upsert(_record("forward_factor", "AAPL", score=Decimal("20")))
+        repository.upsert(_record("forward_factor", "MSFT", score=Decimal("90")))
+        response = _client(repository).get(
+            "/api/v1/screening/forward_factor",
+            headers=_auth(),
+            params={"sort_by": "metrics.strategy_native_score", "sort_order": "desc"},
+        )
+        assert [item["symbol"] for item in response.json()["results"]] == ["MSFT", "AAPL"]
+
+    def test_invalid_sort_is_actionable(self) -> None:
+        response = _client().get(
+            "/api/v1/screening",
+            headers=_auth(),
+            params={"sort_by": "verdict"},
+        )
+        assert response.status_code == 422
+        assert response.json()["detail"]["error_code"] == "INVALID_SORT"
 
 
 class TestListScreeningForSignal:


### PR DESCRIPTION
## Ticket
SURFACE-001

## Summary
- expose the complete universal screening envelope additively while preserving every existing v1 core field
- add generic aggregate and signal-level filters, deterministic sorting, and existing pagination
- link lifecycle-aware results to opportunity history
- document the UI-ready contract and its non-ranking freshness semantics

## Architecture and safety
- no strategy-named response fields or conditionals
- no cross-strategy investment ranking
- no provider calls or writes on read paths
- metric sorting is limited to declared decimal/integer metrics
- existing core response fields remain compatible

## Validation
- pytest: 2550 passed, 24 skipped
- targeted API/OpenAPI/parity/history: 32 passed
- ruff: pass
- mypy: pass
- Lean entrypoints/integrity/pre-push: pass
- git diff --check: pass

## Exclusions
No strategy logic, persistence, provider, deployment, governance, or constitutional changes.

## Merge authority
Delegated SPRINT-010 auto-merge authority applies after all CI is green.
