### PR TITLE
TEMP-001: make quote freshness session-aware

### DIFF
--- a/docs/market-data/session-aware-freshness.md
+++ b/docs/market-data/session-aware-freshness.md
@@ -1,0 +1,18 @@
+# Session-aware quote freshness
+
+Quote age and quote usability are separate.
+
+- Within the caller's maximum age, a quote is `fresh`.
+- Outside that age while the exchange is closed, a quote from the latest
+  completed US equity session is `prior_session`.
+- A quote older than the latest completed session is `stale`.
+- Missing or malformed provider timestamps fail schema validation.
+
+`prior_session` observations remain canonical provider evidence and may satisfy
+non-intraday acquisition with an explicit quality label. No provider, symbol,
+or strategy name participates in this policy. Session semantics use
+`America/New_York`, including weekends, modern exchange holidays, DST, and
+early closes.
+
+Rollback: revert the TEMP-001 commit. Existing latest results remain intact;
+there is no schema migration or destructive data action.

--- a/domain/market_data.py
+++ b/domain/market_data.py
@@ -80,6 +80,7 @@ class MarketDataSubjectType(str, Enum):
 
 class FreshnessStatus(str, Enum):
     FRESH = "fresh"
+    PRIOR_SESSION = "prior_session"
     STALE = "stale"
     UNKNOWN = "unknown"
 
@@ -357,6 +358,11 @@ class FreshnessMetadata:
             raise DomainInvariantError("stale evidence cannot report freshness status fresh")
         if self.status is FreshnessStatus.STALE and self.age_seconds <= self.threshold_seconds:
             raise DomainInvariantError("fresh evidence cannot report freshness status stale")
+        if (
+            self.status is FreshnessStatus.PRIOR_SESSION
+            and self.age_seconds <= self.threshold_seconds
+        ):
+            raise DomainInvariantError("recent evidence cannot report prior-session freshness")
 
 
 @dataclass(frozen=True, slots=True)

--- a/market_data/finnhub.py
+++ b/market_data/finnhub.py
@@ -50,6 +50,7 @@ from market_data.providers import (
     ValidationCheckStatus,
     normalized_provider_error,
 )
+from market_data.session_calendar import classify_quote_freshness
 from market_data.transport import (
     ReadOnlyHttpRequest,
     ReadOnlyHttpResponse,
@@ -373,14 +374,20 @@ class FinnhubProvider:
             value,
             "v1",
             provenance,
-            FreshnessMetadata(
-                received,
-                effective,
-                request.maximum_age_seconds,
-                age,
-                FreshnessStatus.FRESH
-                if age <= request.maximum_age_seconds
-                else FreshnessStatus.STALE,
+            (
+                classify_quote_freshness(
+                    received, effective, request.maximum_age_seconds
+                )
+                if isinstance(value, Quote)
+                else FreshnessMetadata(
+                    received,
+                    effective,
+                    request.maximum_age_seconds,
+                    age,
+                    FreshnessStatus.FRESH
+                    if age <= request.maximum_age_seconds
+                    else FreshnessStatus.STALE,
+                )
             ),
             CompletenessMetadata(request.required_fields, present, missing),
         )

--- a/market_data/fulfillment.py
+++ b/market_data/fulfillment.py
@@ -170,7 +170,8 @@ class CapabilityFulfillmentService:
         request: CapabilityRequest,
         observations: tuple[MarketObservation, ...],
     ) -> NormalizedProviderError | None:
-        if any(value.freshness.status is not FreshnessStatus.FRESH for value in observations):
+        usable_freshness = {FreshnessStatus.FRESH, FreshnessStatus.PRIOR_SESSION}
+        if any(value.freshness.status not in usable_freshness for value in observations):
             return normalized_provider_error(
                 ProviderErrorCode.STALE_DATA,
                 "provider observations do not satisfy the requested freshness requirement",

--- a/market_data/session_calendar.py
+++ b/market_data/session_calendar.py
@@ -1,0 +1,155 @@
+"""Provider-neutral US equity session semantics for temporal quality."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from enum import StrEnum
+from zoneinfo import ZoneInfo
+
+from domain import FreshnessMetadata, FreshnessStatus
+from domain.values import DomainInvariantError, require_tz_aware
+
+NEW_YORK = ZoneInfo("America/New_York")
+
+
+class MarketSessionStatus(StrEnum):
+    PREMARKET = "premarket"
+    OPEN = "open"
+    AFTER_HOURS = "after_hours"
+    WEEKEND = "weekend"
+    HOLIDAY = "holiday"
+
+
+@dataclass(frozen=True, slots=True)
+class MarketSession:
+    trading_date: date
+    opens_at: datetime
+    closes_at: datetime
+    early_close: bool
+
+
+class UsEquitySessionCalendar:
+    """Modern NYSE session calendar without provider or wall-clock state."""
+
+    def session(self, trading_date: date) -> MarketSession | None:
+        if trading_date.weekday() >= 5 or trading_date in _holidays(trading_date.year):
+            return None
+        close_time = time(13) if trading_date in _early_closes(trading_date.year) else time(16)
+        return MarketSession(
+            trading_date,
+            datetime.combine(trading_date, time(9, 30), NEW_YORK).astimezone(UTC),
+            datetime.combine(trading_date, close_time, NEW_YORK).astimezone(UTC),
+            close_time.hour == 13,
+        )
+
+    def status_at(self, instant: datetime) -> MarketSessionStatus:
+        require_tz_aware(instant, "UsEquitySessionCalendar", "status_at")
+        local = instant.astimezone(NEW_YORK)
+        session = self.session(local.date())
+        if session is None:
+            return (
+                MarketSessionStatus.WEEKEND
+                if local.weekday() >= 5
+                else MarketSessionStatus.HOLIDAY
+            )
+        if instant < session.opens_at:
+            return MarketSessionStatus.PREMARKET
+        if instant <= session.closes_at:
+            return MarketSessionStatus.OPEN
+        return MarketSessionStatus.AFTER_HOURS
+
+    def latest_completed_session(self, instant: datetime) -> MarketSession:
+        require_tz_aware(instant, "UsEquitySessionCalendar", "latest_completed_session")
+        candidate = instant.astimezone(NEW_YORK).date()
+        for _ in range(10):
+            session = self.session(candidate)
+            if session is not None and session.closes_at <= instant.astimezone(UTC):
+                return session
+            candidate -= timedelta(days=1)
+        raise DomainInvariantError("no completed US equity session found in bounded lookback")
+
+
+def classify_quote_freshness(
+    as_of: datetime,
+    effective_time: datetime,
+    threshold_seconds: int,
+    *,
+    calendar: UsEquitySessionCalendar | None = None,
+) -> FreshnessMetadata:
+    """Classify age without rejecting expected closed-session evidence."""
+    require_tz_aware(as_of, "classify_quote_freshness", "as_of")
+    require_tz_aware(effective_time, "classify_quote_freshness", "effective_time")
+    age = max(0, int((as_of - effective_time).total_seconds()))
+    if age <= threshold_seconds:
+        status = FreshnessStatus.FRESH
+    else:
+        completed = (calendar or UsEquitySessionCalendar()).latest_completed_session(as_of)
+        status = (
+            FreshnessStatus.PRIOR_SESSION
+            if effective_time.astimezone(NEW_YORK).date() == completed.trading_date
+            else FreshnessStatus.STALE
+        )
+    return FreshnessMetadata(as_of, effective_time, threshold_seconds, age, status)
+
+
+def _observed(day: date) -> date:
+    if day.weekday() == 5:
+        return day - timedelta(days=1)
+    if day.weekday() == 6:
+        return day + timedelta(days=1)
+    return day
+
+
+def _nth_weekday(year: int, month: int, weekday: int, n: int) -> date:
+    value = date(year, month, 1)
+    return value + timedelta(days=(weekday - value.weekday()) % 7 + 7 * (n - 1))
+
+
+def _last_weekday(year: int, month: int, weekday: int) -> date:
+    value = date(year, month + 1, 1) - timedelta(days=1) if month < 12 else date(year, 12, 31)
+    return value - timedelta(days=(value.weekday() - weekday) % 7)
+
+
+def _easter(year: int) -> date:
+    # Gregorian computus.
+    a, b, c = year % 19, year // 100, year % 100
+    d, e = b // 4, b % 4
+    g = (b - (b + 8) // 25 + 1) // 3
+    h = (19 * a + b - d - g + 15) % 30
+    i, k = c // 4, c % 4
+    length = (32 + 2 * e + 2 * i - h - k) % 7
+    m = (a + 11 * h + 22 * length) // 451
+    month = (h + length - 7 * m + 114) // 31
+    return date(year, month, (h + length - 7 * m + 114) % 31 + 1)
+
+
+def _holidays(year: int) -> frozenset[date]:
+    values = {
+        _observed(date(year, 1, 1)),
+        _nth_weekday(year, 1, 0, 3),
+        _nth_weekday(year, 2, 0, 3),
+        _easter(year) - timedelta(days=2),
+        _last_weekday(year, 5, 0),
+        _observed(date(year, 7, 4)),
+        _nth_weekday(year, 9, 0, 1),
+        _nth_weekday(year, 11, 3, 4),
+        _observed(date(year, 12, 25)),
+    }
+    if year >= 2022:
+        values.add(_observed(date(year, 6, 19)))
+    # New Year's Day may be observed in the prior calendar year.
+    values.add(_observed(date(year + 1, 1, 1)))
+    return frozenset(values)
+
+
+def _early_closes(year: int) -> frozenset[date]:
+    thanksgiving = _nth_weekday(year, 11, 3, 4)
+    values = {thanksgiving + timedelta(days=1)}
+    christmas_eve = date(year, 12, 24)
+    if christmas_eve.weekday() < 5 and christmas_eve not in _holidays(year):
+        values.add(christmas_eve)
+    july_third = date(year, 7, 3)
+    if july_third.weekday() < 5 and july_third not in _holidays(year):
+        values.add(july_third)
+    return frozenset(values)

--- a/market_data/tradier.py
+++ b/market_data/tradier.py
@@ -53,6 +53,7 @@ from market_data.providers import (
     ValidationCheckStatus,
     normalized_provider_error,
 )
+from market_data.session_calendar import classify_quote_freshness
 from market_data.transport import (
     ReadOnlyHttpRequest,
     ReadOnlyHttpResponse,
@@ -310,18 +311,26 @@ class TradierProvider:
             effective = value.end_at
         elif isinstance(value, OptionChain):
             effective = value.observed_at
+        elif isinstance(value, Quote):
+            effective = _required_observed_at(row)
         else:
             effective = _observed_at(row, received)
         evidence = _evidence(response)
         present = tuple(field for field in request.required_fields if _field_present(field, value))
         missing = tuple(field for field in request.required_fields if field not in present)
         age = max(0, int((received - effective).total_seconds()))
-        freshness = FreshnessMetadata(
-            received,
-            effective,
-            request.maximum_age_seconds,
-            age,
-            FreshnessStatus.FRESH if age <= request.maximum_age_seconds else FreshnessStatus.STALE,
+        freshness = (
+            classify_quote_freshness(received, effective, request.maximum_age_seconds)
+            if isinstance(value, Quote)
+            else FreshnessMetadata(
+                received,
+                effective,
+                request.maximum_age_seconds,
+                age,
+                FreshnessStatus.FRESH
+                if age <= request.maximum_age_seconds
+                else FreshnessStatus.STALE,
+            )
         )
         provenance = ProviderProvenance("tradier", response.request_reference, evidence)
         identity = market_observation_identity(
@@ -425,6 +434,13 @@ def _observed_at(row: Mapping[str, object], fallback: datetime) -> datetime:
     if isinstance(raw, str):
         return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(UTC)
     return fallback
+
+
+def _required_observed_at(row: Mapping[str, object]) -> datetime:
+    raw = row.get("trade_date") or row.get("timestamp")
+    if raw is None:
+        raise ValueError("quote timestamp is required")
+    return _observed_at(row, datetime.min.replace(tzinfo=UTC))
 
 
 def _evidence(response: ReadOnlyHttpResponse) -> tuple[EvidenceReference, ...]:

--- a/tests/asa/market_data_ops/test_market_data_validate.py
+++ b/tests/asa/market_data_ops/test_market_data_validate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -156,8 +158,9 @@ def test_tradier_option_chain_live_run_completes_instead_of_crashing(
                         "ask": "189.20",
                         "last": "189.15",
                         "bidsize": 1,
-                        "asksize": 1,
-                        "volume": 100,
+                            "asksize": 1,
+                            "volume": 100,
+                            "trade_date": int(datetime.now(UTC).timestamp() * 1000),
                     }
                 }
             },

--- a/tests/market_data/test_finnhub.py
+++ b/tests/market_data/test_finnhub.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -38,7 +38,7 @@ from market_data.transport import (
     ReadOnlyTransportTimeout,
 )
 
-NOW = datetime(2026, 7, 21, 16, 0, tzinfo=timezone.utc)
+NOW = datetime(2026, 7, 21, 16, 0, tzinfo=UTC)
 EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "instrument-reference:AAPL"),)
 INSTRUMENT = Instrument(
     CanonicalInstrumentIdentity("figi", "BBG000B9XRY4"), InstrumentKind.EQUITY, "AAPL", "USD"
@@ -47,8 +47,10 @@ INSTRUMENT = Instrument(
 
 @dataclass(frozen=True)
 class Clock:
+    value: datetime = NOW
+
     def now(self) -> datetime:
-        return NOW
+        return self.value
 
 
 class Budget:
@@ -90,7 +92,11 @@ def subject(
     projection = ProviderAddressProjection(
         "finnhub", "v1", "symbol", symbol, NOW - timedelta(days=30), None, EVIDENCE
     )
-    semantic_start = NOW if capability is MarketCapability.EARNINGS_CALENDAR_V1 else NOW - timedelta(days=5)
+    semantic_start = (
+        NOW
+        if capability is MarketCapability.EARNINGS_CALENDAR_V1
+        else NOW - timedelta(days=5)
+    )
     semantic_end = (
         NOW + timedelta(days=75)
         if capability is MarketCapability.EARNINGS_CALENDAR_V1
@@ -127,14 +133,20 @@ def request(
     )
 
 
-def provider(transport: Transport, budget: Budget | None = None) -> tuple[FinnhubProvider, Budget]:
+def provider(
+    transport: Transport,
+    budget: Budget | None = None,
+    clock: Clock | None = None,
+) -> tuple[FinnhubProvider, Budget]:
     config = load_market_data_config(
         {"ASA_FINNHUB_ENABLED": "true", "ASA_FINNHUB_API_KEY": "test-key"}
     )
     selected = next(item for item in config.providers if item.provider_id == "finnhub")
     authorizer = budget or Budget()
     return (
-        FinnhubProvider(selected, ProviderDependencies(transport, Clock(), authorizer)),
+        FinnhubProvider(
+            selected, ProviderDependencies(transport, clock or Clock(), authorizer)
+        ),
         authorizer,
     )
 
@@ -151,6 +163,22 @@ def test_quote_success_requires_semantic_price_and_timestamp() -> None:
     assert transport.requests[0].path == "/api/v1/quote"
     assert transport.requests[0].query == (("symbol", "AAPL"),)
     assert "test-key" not in repr(transport.requests[0])
+
+
+def test_weekend_quote_from_friday_session_is_prior_session() -> None:
+    friday_close = datetime(2026, 7, 24, 20, tzinfo=UTC)
+    saturday = datetime(2026, 7, 25, 16, tzinfo=UTC)
+    transport = Transport(
+        (response({"c": 620.5, "t": int(friday_close.timestamp())}),)
+    )
+    adapter, _ = provider(transport, clock=Clock(saturday))
+    requested = replace(
+        request(MarketCapability.REAL_TIME_QUOTE_V1, ("last",)),
+        maximum_age_seconds=3600,
+    )
+    result = adapter.fetch(requested, authorization())
+    assert result.error is None
+    assert result.observations[0].freshness.status.value == "prior_session"
 
 
 def test_candle_success_validates_status_arrays_and_utc_timestamps() -> None:
@@ -171,7 +199,7 @@ def test_candle_success_validates_status_arrays_and_utc_timestamps() -> None:
         authorization(),
     )
     assert result.error is None and isinstance(result.observations[0].value, OHLCVBar)
-    assert result.observations[0].value.start_at.tzinfo is timezone.utc
+    assert result.observations[0].value.start_at.tzinfo is UTC
     assert dict(transport.requests[0].query)["resolution"] == "D"
 
 

--- a/tests/market_data/test_fulfillment.py
+++ b/tests/market_data/test_fulfillment.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from domain import (
     CanonicalInstrumentIdentity,
     EvidenceKind,
     EvidenceReference,
+    FreshnessMetadata,
+    FreshnessStatus,
     Instrument,
     InstrumentKind,
     MarketCapability,
@@ -237,6 +239,49 @@ def test_stale_primary_uses_fresh_secondary_without_silent_fallback() -> None:
     assert result.selected_provider == "secondary"
     assert result.attempts[0].error is not None
     assert result.attempts[0].error.code is ProviderErrorCode.STALE_DATA
+
+
+def test_prior_session_quote_is_usable_without_fallback() -> None:
+    primary = provider("primary")
+    original_fetch = primary.fetch
+
+    def prior_session_fetch(
+        capability_request: CapabilityRequest, budget: RequestBudgetAuthorization
+    ) -> ProviderFetchResult:
+        fetched = original_fetch(capability_request, budget)
+        observation = fetched.observations[0]
+        effective = observation.effective_time - timedelta(days=3)
+        freshness = FreshnessMetadata(
+            observation.recorded_time,
+            effective,
+            60,
+            int((observation.recorded_time - effective).total_seconds()),
+            FreshnessStatus.PRIOR_SESSION,
+        )
+        return dataclasses.replace(
+            fetched,
+            observations=(
+                dataclasses.replace(
+                    observation,
+                    effective_time=effective,
+                    freshness=freshness,
+                    observation_id=market_observation_identity(
+                        observation.provenance.provider_id,
+                        observation.capability,
+                        observation.subject,
+                        effective,
+                        observation.value,
+                        observation.schema_version,
+                    ),
+                ),
+            ),
+        )
+
+    primary.fetch = prior_session_fetch  # type: ignore[method-assign]
+    fulfillment, _ = service(primary, provider("secondary"))
+    result = fulfillment.fulfill(request())
+    assert result.status is FulfillmentStatus.FULFILLED
+    assert result.selected_provider == "primary"
 
 
 def test_exhausted_budget_is_recorded_and_duplicate_request_is_not_reissued() -> None:

--- a/tests/market_data/test_provider_compliance.py
+++ b/tests/market_data/test_provider_compliance.py
@@ -20,7 +20,17 @@ def test_tradier_passes_shared_supported_capability_suite() -> None:
         tradier.Transport(
             (
                 tradier.response(
-                    {"quotes": {"quote": {"symbol": "AAPL", "last": 210, "bid": 209, "ask": 211}}}
+                    {
+                        "quotes": {
+                            "quote": {
+                                "symbol": "AAPL",
+                                "last": 210,
+                                "bid": 209,
+                                "ask": 211,
+                                "trade_date": int(tradier.NOW.timestamp() * 1000),
+                            }
+                        }
+                    }
                 ),
             )
         )

--- a/tests/market_data/test_session_calendar.py
+++ b/tests/market_data/test_session_calendar.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+
+from domain import FreshnessStatus
+from domain.values import DomainInvariantError
+from market_data.session_calendar import (
+    MarketSessionStatus,
+    UsEquitySessionCalendar,
+    classify_quote_freshness,
+)
+
+
+def _utc(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+class TestSessionAwareFreshness:
+    @pytest.mark.parametrize(
+        ("evaluated_at", "latest_session"),
+        (
+            (_utc(2026, 7, 25, 16), date(2026, 7, 24)),  # Saturday
+            (_utc(2026, 7, 26, 16), date(2026, 7, 24)),  # Sunday
+            (_utc(2026, 7, 27, 12), date(2026, 7, 24)),  # Monday 08:00 ET
+            (_utc(2026, 7, 3, 16), date(2026, 7, 2)),  # Independence holiday
+        ),
+    )
+    def test_latest_completed_session_quote_is_prior_session(
+        self, evaluated_at: datetime, latest_session: date
+    ) -> None:
+        effective = datetime(
+            latest_session.year,
+            latest_session.month,
+            latest_session.day,
+            20,
+            tzinfo=UTC,
+        )
+        result = classify_quote_freshness(evaluated_at, effective, 3600)
+        assert result.status is FreshnessStatus.PRIOR_SESSION
+
+    def test_same_day_after_close_is_prior_session(self) -> None:
+        result = classify_quote_freshness(
+            _utc(2026, 7, 24, 23), _utc(2026, 7, 24, 20), 3600
+        )
+        assert result.status is FreshnessStatus.PRIOR_SESSION
+
+    def test_market_open_recent_quote_is_fresh(self) -> None:
+        result = classify_quote_freshness(
+            _utc(2026, 7, 24, 15), _utc(2026, 7, 24, 14, 59), 3600
+        )
+        assert result.status is FreshnessStatus.FRESH
+
+    def test_market_open_expired_quote_is_stale(self) -> None:
+        result = classify_quote_freshness(
+            _utc(2026, 7, 24, 18), _utc(2026, 7, 24, 16), 3600
+        )
+        assert result.status is FreshnessStatus.STALE
+
+    def test_quote_older_than_latest_completed_session_is_stale(self) -> None:
+        result = classify_quote_freshness(
+            _utc(2026, 7, 26, 16), _utc(2026, 7, 23, 20), 3600
+        )
+        assert result.status is FreshnessStatus.STALE
+
+    def test_naive_time_is_rejected(self) -> None:
+        with pytest.raises(DomainInvariantError):
+            classify_quote_freshness(
+                datetime(2026, 7, 25, 16), _utc(2026, 7, 24, 20), 3600
+            )
+
+
+class TestSessionCalendar:
+    def test_early_close_uses_actual_close(self) -> None:
+        session = UsEquitySessionCalendar().session(date(2026, 11, 27))
+        assert session is not None
+        assert session.early_close is True
+        assert session.closes_at == _utc(2026, 11, 27, 18)
+
+    def test_holiday_and_weekend_status_are_distinct(self) -> None:
+        calendar = UsEquitySessionCalendar()
+        assert calendar.status_at(_utc(2026, 7, 3, 16)) is MarketSessionStatus.HOLIDAY
+        assert calendar.status_at(_utc(2026, 7, 4, 16)) is MarketSessionStatus.WEEKEND

--- a/tests/market_data/test_tradier.py
+++ b/tests/market_data/test_tradier.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -30,7 +30,7 @@ from market_data.providers import ProviderErrorCode
 from market_data.tradier import TradierProvider
 from market_data.transport import ReadOnlyHttpRequest, ReadOnlyHttpResponse
 
-NOW = datetime(2026, 7, 21, 16, 0, tzinfo=timezone.utc)
+NOW = datetime(2026, 7, 21, 16, 0, tzinfo=UTC)
 EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "instrument-reference:AAPL"),)
 INSTRUMENT = Instrument(
     CanonicalInstrumentIdentity("figi", "BBG000B9XRY4"), InstrumentKind.EQUITY, "AAPL", "USD"
@@ -39,8 +39,10 @@ INSTRUMENT = Instrument(
 
 @dataclass(frozen=True)
 class Clock:
+    value: datetime = NOW
+
     def now(self) -> datetime:
-        return NOW
+        return self.value
 
 
 class Budget:
@@ -113,12 +115,14 @@ def request(
     )
 
 
-def provider(transport: Transport) -> TradierProvider:
+def provider(transport: Transport, clock: Clock | None = None) -> TradierProvider:
     config = load_market_data_config(
         {"ASA_TRADIER_ENABLED": "true", "ASA_TRADIER_ACCESS_TOKEN": "test-token"}
     )
     tradier = next(item for item in config.providers if item.provider_id == "tradier")
-    return TradierProvider(tradier, ProviderDependencies(transport, Clock(), Budget()))
+    return TradierProvider(
+        tradier, ProviderDependencies(transport, clock or Clock(), Budget())
+    )
 
 
 def authorization() -> RequestBudgetAuthorization:
@@ -139,6 +143,7 @@ def test_quote_normalization_uses_only_read_market_endpoint_and_redacts_repr() -
                             "bidsize": 100,
                             "asksize": 120,
                             "volume": 1000000,
+                            "trade_date": int(NOW.timestamp() * 1000),
                         }
                     }
                 }
@@ -152,6 +157,35 @@ def test_quote_normalization_uses_only_read_market_endpoint_and_redacts_repr() -
     assert transport.requests[0].path == "/v1/markets/quotes"
     assert transport.requests[0].query == (("greeks", "false"), ("symbols", "AAPL"))
     assert "test-token" not in repr(transport.requests[0])
+
+
+def test_weekend_quote_from_friday_session_is_prior_session() -> None:
+    friday_close = datetime(2026, 7, 24, 20, tzinfo=UTC)
+    saturday = datetime(2026, 7, 25, 16, tzinfo=UTC)
+    transport = Transport(
+        (
+            response(
+                {
+                    "quotes": {
+                        "quote": {
+                            "symbol": "SPY",
+                            "bid": 620,
+                            "ask": 621,
+                            "last": 620.5,
+                            "trade_date": int(friday_close.timestamp() * 1000),
+                        }
+                    }
+                }
+            ),
+        )
+    )
+    requested = replace(
+        request(MarketCapability.REAL_TIME_QUOTE_V1, ("bid", "ask", "last")),
+        maximum_age_seconds=3600,
+    )
+    result = provider(transport, Clock(saturday)).fetch(requested, authorization())
+    assert result.error is None
+    assert result.observations[0].freshness.status.value == "prior_session"
 
 
 def test_daily_history_normalizes_decimal_ohlcv() -> None:
@@ -285,6 +319,7 @@ def test_empty_valued_ratelimit_header_is_dropped_instead_of_crashing() -> None:
                             "bidsize": 100,
                             "asksize": 120,
                             "volume": 1000000,
+                            "trade_date": int(NOW.timestamp() * 1000),
                         }
                     }
                 },


### PR DESCRIPTION
## Root cause
Fulfillment treated every observation older than wall-clock `maximum_age_seconds` as unusable, even when a quote was the newest verified data from the latest completed exchange session.

## Changed behavior
- add provider-neutral modern US equity session calendar using America/New_York
- classify latest completed-session quotes as `prior_session`
- allow `prior_session` observations through fulfillment
- retain hard rejection for older-session and malformed/missing-timestamp quotes
- apply identical policy to Finnhub and Tradier without provider branches

## Tests
- weekend/holiday/premarket/after-hours/open/old/early-close temporal regressions
- provider-shaped Finnhub and Tradier weekend quotes
- fulfillment prior-session usability
- focused: 65 passed
- full repository: 2541 passed, 15 skipped
- mypy, Ruff changed paths, Lean pre-push, diff check: green

## Rollback
Revert this commit. No schema or destructive data change; latest known results remain intact.

## Scope
No strategy logic, provider replacement, execution, persistence, UI, governance, or scheduling change.

Delegated PATCH-010A auto-merge authority applies after all CI is green.
