### PR TITLE
TEMP-002: add canonical temporal quality policy

### DIFF
--- a/docs/market-data/session-aware-freshness.md
+++ b/docs/market-data/session-aware-freshness.md
@@ -14,5 +14,10 @@ or strategy name participates in this policy. Session semantics use
 `America/New_York`, including weekends, modern exchange holidays, DST, and
 early closes.
 
-Rollback: revert the TEMP-001 commit. Existing latest results remain intact;
-there is no schema migration or destructive data action.
+Strategy contracts carry a `FreshnessRequirement`. The default accepts
+prior-session data. An intraday strategy can require an open session, reject
+prior-session evidence, or declare a tighter maximum age. Shared runtime policy
+evaluates these fields; it never branches on a strategy name.
+
+Rollback: revert the TEMP-001/TEMP-002 commits. Existing latest results remain
+intact; there is no schema migration or destructive data action.

--- a/market_data/temporal.py
+++ b/market_data/temporal.py
@@ -1,0 +1,78 @@
+"""Canonical freshness-to-usability policy, independent of providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from domain import FreshnessMetadata, FreshnessStatus
+
+
+class UsabilityStatus(StrEnum):
+    USABLE = "usable"
+    USABLE_WITH_WARNING = "usable_with_warning"
+    REJECTED = "rejected"
+
+
+class TemporalWarningCode(StrEnum):
+    DELAYED_DATA = "delayed_data"
+    PRIOR_SESSION_DATA = "prior_session_data"
+
+
+@dataclass(frozen=True, slots=True)
+class FreshnessRequirement:
+    require_open_session: bool = False
+    allow_prior_session: bool = True
+    maximum_age_seconds: int | None = None
+    maximum_input_skew_seconds: int | None = None
+
+    def __post_init__(self) -> None:
+        for name in ("maximum_age_seconds", "maximum_input_skew_seconds"):
+            value = getattr(self, name)
+            if value is not None and (type(value) is not int or value < 0):
+                raise ValueError(f"FreshnessRequirement.{name} must be non-negative")
+
+
+DEFAULT_FRESHNESS_REQUIREMENT = FreshnessRequirement()
+
+
+@dataclass(frozen=True, slots=True)
+class TemporalUsabilityDecision:
+    status: UsabilityStatus
+    reason: str
+    warning_codes: tuple[TemporalWarningCode, ...] = ()
+
+
+def evaluate_temporal_usability(
+    freshness: FreshnessMetadata,
+    requirement: FreshnessRequirement = DEFAULT_FRESHNESS_REQUIREMENT,
+    *,
+    market_is_open: bool,
+) -> TemporalUsabilityDecision:
+    if requirement.require_open_session and not market_is_open:
+        return TemporalUsabilityDecision(
+            UsabilityStatus.REJECTED, "strategy requires an open market session"
+        )
+    if (
+        requirement.maximum_age_seconds is not None
+        and freshness.age_seconds > requirement.maximum_age_seconds
+        and freshness.status is not FreshnessStatus.PRIOR_SESSION
+    ):
+        return TemporalUsabilityDecision(
+            UsabilityStatus.REJECTED, "observation exceeds strategy maximum age"
+        )
+    if freshness.status is FreshnessStatus.PRIOR_SESSION:
+        if not requirement.allow_prior_session:
+            return TemporalUsabilityDecision(
+                UsabilityStatus.REJECTED, "strategy rejects prior-session observations"
+            )
+        return TemporalUsabilityDecision(
+            UsabilityStatus.USABLE_WITH_WARNING,
+            "latest verified observation is from the prior completed session",
+            (TemporalWarningCode.PRIOR_SESSION_DATA,),
+        )
+    if freshness.status is FreshnessStatus.FRESH:
+        return TemporalUsabilityDecision(UsabilityStatus.USABLE, "observation is current")
+    return TemporalUsabilityDecision(
+        UsabilityStatus.REJECTED, "observation freshness is unusable"
+    )

--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -46,6 +46,13 @@ from domain import (
     Quote,
 )
 from market_data import CapabilityFulfillmentService, FulfillmentStatus
+from market_data.session_calendar import MarketSessionStatus, UsEquitySessionCalendar
+from market_data.temporal import (
+    DEFAULT_FRESHNESS_REQUIREMENT,
+    FreshnessRequirement,
+    UsabilityStatus,
+    evaluate_temporal_usability,
+)
 from screening.clock import Clock
 from screening.context_builders import (
     FORWARD_FACTOR_DTE_POLICY,
@@ -137,6 +144,7 @@ def _acquire_or_raise(
     expiration: date | None = None,
     effective_start: datetime | None = None,
     effective_end: datetime | None = None,
+    freshness_requirement: FreshnessRequirement = DEFAULT_FRESHNESS_REQUIREMENT,
 ) -> object:
     request_start = effective_start or now
     request_end = effective_end or now
@@ -179,7 +187,21 @@ def _acquire_or_raise(
         if expiration is not None:
             detail += f" at expiration {expiration.isoformat()}"
         raise StrategyAdapterError(ScreeningOutcomeStatus.MISSING_DATA, detail)
-    return result.observations[0].value
+    observation = result.observations[0]
+    market_is_open = (
+        UsEquitySessionCalendar().status_at(now) is MarketSessionStatus.OPEN
+    )
+    usability = evaluate_temporal_usability(
+        observation.freshness,
+        freshness_requirement,
+        market_is_open=market_is_open,
+    )
+    if usability.status is UsabilityStatus.REJECTED:
+        raise StrategyAdapterError(
+            ScreeningOutcomeStatus.MISSING_DATA,
+            f"{capability.value} for {symbol} is not usable: {usability.reason}",
+        )
+    return observation.value
 
 
 def _acquire_combined_chain(
@@ -215,7 +237,10 @@ def _spot_price(quote: Quote) -> Decimal:
 
 
 def build_live_forward_factor_adapter(
-    symbol: str, fulfillment: CapabilityFulfillmentService
+    symbol: str,
+    fulfillment: CapabilityFulfillmentService,
+    *,
+    freshness_requirement: FreshnessRequirement = DEFAULT_FRESHNESS_REQUIREMENT,
 ) -> StrategyAdapter:
     def _run(
         definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
@@ -223,7 +248,12 @@ def build_live_forward_factor_adapter(
         now = clock.now()
         as_of = now.date()
         quote = _acquire_or_raise(
-            fulfillment, symbol, MarketCapability.REAL_TIME_QUOTE_V1, now, ("last",)
+            fulfillment,
+            symbol,
+            MarketCapability.REAL_TIME_QUOTE_V1,
+            now,
+            ("last",),
+            freshness_requirement=freshness_requirement,
         )
         spot_price = _spot_price(quote)  # type: ignore[arg-type]
         available_expirations = acquire_expirations(fulfillment, symbol, now)
@@ -286,7 +316,10 @@ def build_live_forward_factor_adapter(
 
 
 def build_live_earnings_calendar_adapter(
-    symbol: str, fulfillment: CapabilityFulfillmentService
+    symbol: str,
+    fulfillment: CapabilityFulfillmentService,
+    *,
+    freshness_requirement: FreshnessRequirement = DEFAULT_FRESHNESS_REQUIREMENT,
 ) -> StrategyAdapter:
     def _run(
         definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
@@ -302,7 +335,12 @@ def build_live_earnings_calendar_adapter(
             effective_end=now + timedelta(days=EARNINGS_CALENDAR_LOOKAHEAD_DAYS),
         )
         quote = _acquire_or_raise(
-            fulfillment, symbol, MarketCapability.REAL_TIME_QUOTE_V1, now, ("last",)
+            fulfillment,
+            symbol,
+            MarketCapability.REAL_TIME_QUOTE_V1,
+            now,
+            ("last",),
+            freshness_requirement=freshness_requirement,
         )
         spot_price = _spot_price(quote)  # type: ignore[arg-type]
         available_expirations = acquire_expirations(fulfillment, symbol, now)
@@ -363,7 +401,10 @@ def build_live_earnings_calendar_adapter(
 
 
 def build_live_skew_momentum_adapter(
-    symbol: str, fulfillment: CapabilityFulfillmentService
+    symbol: str,
+    fulfillment: CapabilityFulfillmentService,
+    *,
+    freshness_requirement: FreshnessRequirement = DEFAULT_FRESHNESS_REQUIREMENT,
 ) -> StrategyAdapter:
     def _run(
         definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
@@ -371,7 +412,12 @@ def build_live_skew_momentum_adapter(
         now = clock.now()
         as_of = now.date()
         quote = _acquire_or_raise(
-            fulfillment, symbol, MarketCapability.REAL_TIME_QUOTE_V1, now, ("last",)
+            fulfillment,
+            symbol,
+            MarketCapability.REAL_TIME_QUOTE_V1,
+            now,
+            ("last",),
+            freshness_requirement=freshness_requirement,
         )
         spot_price = _spot_price(quote)  # type: ignore[arg-type]
         available_expirations = acquire_expirations(fulfillment, symbol, now)

--- a/strategy_runtime/adapters/earnings_calendar.py
+++ b/strategy_runtime/adapters/earnings_calendar.py
@@ -107,7 +107,11 @@ def earnings_calendar_adapter(context: RuntimeContext) -> UniversalScreeningResu
             "earnings_calendar requires shared market data access "
             "(strategy_runtime.market_data_planning, EPIC-3) -- RuntimeContext.fulfillment is None"
         )
-    live_adapter = build_live_earnings_calendar_adapter(context.subject, context.fulfillment)
+    live_adapter = build_live_earnings_calendar_adapter(
+        context.subject,
+        context.fulfillment,
+        freshness_requirement=context.contract.freshness_requirement,
+    )
     (result,) = run_screening(
         TARGET_STRATEGY_REGISTRY,
         {"earnings_calendar": live_adapter},

--- a/strategy_runtime/adapters/forward_factor.py
+++ b/strategy_runtime/adapters/forward_factor.py
@@ -67,7 +67,11 @@ def forward_factor_adapter(context: RuntimeContext) -> UniversalScreeningResult:
             "forward_factor requires shared market data access "
             "(strategy_runtime.market_data_planning, EPIC-3) -- RuntimeContext.fulfillment is None"
         )
-    live_adapter = build_live_forward_factor_adapter(context.subject, context.fulfillment)
+    live_adapter = build_live_forward_factor_adapter(
+        context.subject,
+        context.fulfillment,
+        freshness_requirement=context.contract.freshness_requirement,
+    )
     (result,) = run_screening(
         TARGET_STRATEGY_REGISTRY,
         {"forward_factor": live_adapter},

--- a/strategy_runtime/adapters/skew_momentum_vertical.py
+++ b/strategy_runtime/adapters/skew_momentum_vertical.py
@@ -66,7 +66,11 @@ def skew_momentum_adapter(context: RuntimeContext) -> UniversalScreeningResult:
             "skew_momentum requires shared market data access "
             "(strategy_runtime.market_data_planning, EPIC-3) -- RuntimeContext.fulfillment is None"
         )
-    live_adapter = build_live_skew_momentum_adapter(context.subject, context.fulfillment)
+    live_adapter = build_live_skew_momentum_adapter(
+        context.subject,
+        context.fulfillment,
+        freshness_requirement=context.contract.freshness_requirement,
+    )
     (result,) = run_screening(
         TARGET_STRATEGY_REGISTRY,
         {"skew_momentum": live_adapter},

--- a/strategy_runtime/contract.py
+++ b/strategy_runtime/contract.py
@@ -25,6 +25,10 @@ from dataclasses import dataclass
 from enum import Enum
 
 from domain import MarketCapability
+from market_data.temporal import (
+    DEFAULT_FRESHNESS_REQUIREMENT,
+    FreshnessRequirement,
+)
 from strategy_runtime.errors import StrategyContractError
 
 
@@ -165,6 +169,7 @@ class StrategyContract:
     structure: StructureKind
     outputs: tuple[OutputKind, ...]
     capabilities: tuple[StrategyCapability, ...] = ()
+    freshness_requirement: FreshnessRequirement = DEFAULT_FRESHNESS_REQUIREMENT
 
     def __post_init__(self) -> None:
         for name in ("strategy_id", "version", "category", "description"):
@@ -181,6 +186,10 @@ class StrategyContract:
             raise StrategyContractError("StrategyContract.outputs must be unique")
         if len(set(self.capabilities)) != len(self.capabilities):
             raise StrategyContractError("StrategyContract.capabilities must be unique")
+        if not isinstance(self.freshness_requirement, FreshnessRequirement):
+            raise StrategyContractError(
+                "StrategyContract.freshness_requirement must be FreshnessRequirement"
+            )
         if (
             OutputKind.LIFECYCLE in self.outputs
             and self.lifecycle.lifecycle_model is LifecycleModel.NONE

--- a/tests/market_data/test_temporal_policy.py
+++ b/tests/market_data/test_temporal_policy.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from domain import FreshnessMetadata, FreshnessStatus
+from market_data.temporal import (
+    FreshnessRequirement,
+    TemporalWarningCode,
+    UsabilityStatus,
+    evaluate_temporal_usability,
+)
+
+NOW = datetime(2026, 7, 25, 16, tzinfo=UTC)
+
+
+def _freshness(status: FreshnessStatus, age: int) -> FreshnessMetadata:
+    return FreshnessMetadata(
+        NOW,
+        datetime.fromtimestamp(NOW.timestamp() - age, tz=UTC),
+        3600,
+        age,
+        status,
+    )
+
+
+def test_default_policy_accepts_prior_session_with_warning() -> None:
+    decision = evaluate_temporal_usability(
+        _freshness(FreshnessStatus.PRIOR_SESSION, 72_000),
+        market_is_open=False,
+    )
+    assert decision.status is UsabilityStatus.USABLE_WITH_WARNING
+    assert decision.warning_codes == (TemporalWarningCode.PRIOR_SESSION_DATA,)
+
+
+def test_contract_can_reject_prior_session_without_named_branch() -> None:
+    decision = evaluate_temporal_usability(
+        _freshness(FreshnessStatus.PRIOR_SESSION, 72_000),
+        FreshnessRequirement(allow_prior_session=False),
+        market_is_open=False,
+    )
+    assert decision.status is UsabilityStatus.REJECTED
+
+
+def test_contract_can_require_open_session() -> None:
+    decision = evaluate_temporal_usability(
+        _freshness(FreshnessStatus.FRESH, 60),
+        FreshnessRequirement(require_open_session=True),
+        market_is_open=False,
+    )
+    assert decision.status is UsabilityStatus.REJECTED
+
+
+def test_invalid_policy_limits_fail_fast() -> None:
+    with pytest.raises(ValueError):
+        FreshnessRequirement(maximum_age_seconds=-1)


### PR DESCRIPTION
## Summary
- add immutable freshness requirements and canonical usability decisions
- make prior-session data usable with explicit warning by default
- propagate per-strategy freshness policy through all current live adapters
- document temporal quality semantics

## Validation
- `pytest -q`: 2545 passed, 15 skipped
- `mypy asa`: passed
- `ruff check asa tests/asa`: passed
- Lean pre-push: passed
- `git diff --check`: passed

## Scope
No provider, symbol, strategy-specific shared policy, database, or API changes.
