### PR TITLE
TEMP-003: expose authoritative temporal refresh state

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -9,6 +9,8 @@ timestamped").
 
 from __future__ import annotations
 
+from datetime import date, datetime
+
 from pydantic import BaseModel, Field
 
 from asa.api.agent_models import TimestampedResource
@@ -90,11 +92,42 @@ class ScreeningResultResponse(TimestampedResource):
     blockers: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
     provenance: list[str] = Field(default_factory=list)
+    observed_at: datetime
+    received_at: datetime
+    evaluated_at: datetime
+    persisted_at: datetime
+    market_session_date: date | None = None
+    market_session_status: str = "unknown"
+    last_refresh_attempt_at: datetime
+    last_successful_refresh_at: datetime
+    next_refresh_at: datetime | None = None
+    data_advanced_on_last_refresh: bool = False
+    freshness_status: str = "unknown"
+    usability_status: str = "rejected"
+    usability_reason: str = "temporal metadata unavailable"
+    warning_codes: list[str] = Field(default_factory=list)
+    acquisition_started_at: datetime
+    acquisition_completed_at: datetime
+    input_time_skew_seconds: int = Field(ge=0, default=0)
 
     @classmethod
     def from_universal_result(cls, result: UniversalScreeningResult) -> ScreeningResultResponse:
         """Build the public response from the canonical universal result."""
-        age_seconds = TimestampedResource.age_seconds_since(result.observed_at)
+        temporal = result.temporal
+        observed_at = temporal.observed_at if temporal is not None else result.observed_at
+        received_at = temporal.received_at if temporal is not None else result.observed_at
+        evaluated_at = temporal.evaluated_at if temporal is not None else result.observed_at
+        persisted_at = temporal.persisted_at if temporal is not None else result.observed_at
+        canonical_age = (
+            temporal.age_seconds
+            if temporal is not None
+            else TimestampedResource.age_seconds_since(observed_at)
+        )
+        freshness_status = (
+            temporal.freshness_status
+            if temporal is not None
+            else ("live" if canonical_age <= 86_400 else "stale")
+        )
         return cls(
             signal_id=result.strategy_id,
             signal_version=result.strategy_version,
@@ -113,7 +146,11 @@ class ScreeningResultResponse(TimestampedResource):
             lifecycle_stage=result.lifecycle_stage,
             status=result.recommendation_state,
             data_quality=result.data_quality,
-            freshness="fresh" if age_seconds <= 86_400 else "stale",
+            freshness=(
+                "fresh"
+                if freshness_status in {"fresh", "live", "prior_session"}
+                else "stale"
+            ),
             economics=_wire_values(
                 {key: value.native() for key, value in result.economics.items()}
             ),
@@ -127,7 +164,60 @@ class ScreeningResultResponse(TimestampedResource):
             warnings=list(result.warnings),
             provenance=list(result.provenance),
             updated_at=result.observed_at,
-            age_seconds=age_seconds,
+            age_seconds=canonical_age,
+            observed_at=observed_at,
+            received_at=received_at,
+            evaluated_at=evaluated_at,
+            persisted_at=persisted_at,
+            market_session_date=(
+                temporal.market_session_date if temporal is not None else None
+            ),
+            market_session_status=(
+                temporal.market_session_status if temporal is not None else "unknown"
+            ),
+            last_refresh_attempt_at=(
+                temporal.last_refresh_attempt_at
+                if temporal is not None
+                else result.observed_at
+            ),
+            last_successful_refresh_at=(
+                temporal.last_successful_refresh_at
+                if temporal is not None
+                else result.observed_at
+            ),
+            next_refresh_at=(
+                temporal.next_refresh_at if temporal is not None else None
+            ),
+            data_advanced_on_last_refresh=(
+                temporal.data_advanced_on_last_refresh
+                if temporal is not None
+                else False
+            ),
+            freshness_status=freshness_status,
+            usability_status=(
+                temporal.usability_status if temporal is not None else "rejected"
+            ),
+            usability_reason=(
+                temporal.usability_reason
+                if temporal is not None
+                else "temporal metadata unavailable"
+            ),
+            warning_codes=(
+                list(temporal.warning_codes) if temporal is not None else []
+            ),
+            acquisition_started_at=(
+                temporal.acquisition_started_at
+                if temporal is not None
+                else result.observed_at
+            ),
+            acquisition_completed_at=(
+                temporal.acquisition_completed_at
+                if temporal is not None
+                else result.observed_at
+            ),
+            input_time_skew_seconds=(
+                temporal.input_time_skew_seconds if temporal is not None else 0
+            ),
         )
 
 
@@ -149,13 +239,30 @@ class RefreshResultResponse(ScreeningResultResponse):
     """
 
     request_count: int
+    provider_contacted: bool
+    result_changed: bool
+    refresh_failed: bool
 
     @classmethod
     def from_universal_result(  # type: ignore[override]
-        cls, result: UniversalScreeningResult, *, request_count: int
+        cls,
+        result: UniversalScreeningResult,
+        *,
+        request_count: int,
+        provider_contacted: bool | None = None,
+        result_changed: bool = True,
+        refresh_failed: bool = False,
     ) -> RefreshResultResponse:
         base = ScreeningResultResponse.from_universal_result(result)
-        return cls(request_count=request_count, **base.model_dump())
+        return cls(
+            request_count=request_count,
+            provider_contacted=(
+                request_count > 0 if provider_contacted is None else provider_contacted
+            ),
+            result_changed=result_changed,
+            refresh_failed=refresh_failed,
+            **base.model_dump(),
+        )
 
 
 class OpportunityObservationResponse(BaseModel):

--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -309,14 +309,26 @@ def build_screening_router(
         clock = _SystemClock()
         access = build_shared_market_data_access(config, transport_factory, clock, (symbol,))
         subject_access = access[symbol]
-        result = refresh(
-            registry,
-            repository,
-            clock,
-            strategy_id=signal,
-            symbol=symbol,
-            fulfillment_by_subject={symbol: subject_access.fulfillment},
-        )
+        prior = repository.get_one(signal, symbol)
+        try:
+            result = refresh(
+                registry,
+                repository,
+                clock,
+                strategy_id=signal,
+                symbol=symbol,
+                fulfillment_by_subject={symbol: subject_access.fulfillment},
+            )
+        except RuntimeError:
+            if prior is None:
+                raise
+            prior_result = prior.to_result()
+            return RefreshResultResponse.from_universal_result(
+                prior_result,
+                request_count=len(subject_access.budget_manager.accounting),
+                result_changed=False,
+                refresh_failed=True,
+            )
         if result.opportunity_id is not None:
             try:
                 record_opportunity_observation(
@@ -337,7 +349,10 @@ def build_screening_router(
                     },
                 )
         return RefreshResultResponse.from_universal_result(
-            result, request_count=len(subject_access.budget_manager.accounting)
+            result,
+            request_count=len(subject_access.budget_manager.accounting),
+            result_changed=prior is None or prior.to_result() != result,
+            refresh_failed=False,
         )
 
     return router

--- a/asa/integrations/universal_screening_postgres.py
+++ b/asa/integrations/universal_screening_postgres.py
@@ -21,11 +21,13 @@ docstring for the full rationale.
 from __future__ import annotations
 
 import json
+from datetime import date, datetime
 
 from sqlalchemy import Engine, text
 from sqlalchemy.engine import RowMapping
 
 from strategy_runtime.persistence import UniversalSignalRow
+from strategy_runtime.result import ResultTemporalMetadata
 from strategy_runtime.values import TypedValue
 
 
@@ -41,12 +43,14 @@ class PostgresLatestResultRepository:
                         signal_id, symbol, signal_version, observation_id,
                         opportunity_id, row_type, verdict, evaluation_state,
                         lifecycle_stage, recommendation_state, data_quality,
-                        metrics, economics, blockers, warnings, provenance, observed_at
+                        metrics, economics, blockers, warnings, provenance, observed_at,
+                        temporal
                     ) VALUES (
                         :signal_id, :symbol, :signal_version, :observation_id,
                         :opportunity_id, :row_type, :verdict, :evaluation_state,
                         :lifecycle_stage, :recommendation_state, :data_quality,
-                        :metrics, :economics, :blockers, :warnings, :provenance, :observed_at
+                        :metrics, :economics, :blockers, :warnings, :provenance, :observed_at,
+                        :temporal
                     )
                     ON CONFLICT (signal_id, symbol) DO UPDATE SET
                         signal_version = EXCLUDED.signal_version,
@@ -63,7 +67,8 @@ class PostgresLatestResultRepository:
                         blockers = EXCLUDED.blockers,
                         warnings = EXCLUDED.warnings,
                         provenance = EXCLUDED.provenance,
-                        observed_at = EXCLUDED.observed_at
+                        observed_at = EXCLUDED.observed_at,
+                        temporal = EXCLUDED.temporal
                 """),
                 _to_params(row),
             )
@@ -126,10 +131,87 @@ def _to_params(row: UniversalSignalRow) -> dict[str, object]:
         "warnings": json.dumps(list(row.warnings)),
         "provenance": json.dumps(list(row.provenance)),
         "observed_at": row.observed_at,
+        "temporal": (
+            None
+            if row.temporal is None
+            else json.dumps(
+                {
+                    "observed_at": row.temporal.observed_at.isoformat(),
+                    "received_at": row.temporal.received_at.isoformat(),
+                    "evaluated_at": row.temporal.evaluated_at.isoformat(),
+                    "persisted_at": row.temporal.persisted_at.isoformat(),
+                    "market_session_date": row.temporal.market_session_date.isoformat(),
+                    "market_session_status": row.temporal.market_session_status,
+                    "age_seconds": row.temporal.age_seconds,
+                    "last_refresh_attempt_at": row.temporal.last_refresh_attempt_at.isoformat(),
+                    "last_successful_refresh_at": (
+                        row.temporal.last_successful_refresh_at.isoformat()
+                    ),
+                    "next_refresh_at": (
+                        None
+                        if row.temporal.next_refresh_at is None
+                        else row.temporal.next_refresh_at.isoformat()
+                    ),
+                    "data_advanced_on_last_refresh": (
+                        row.temporal.data_advanced_on_last_refresh
+                    ),
+                    "freshness_status": row.temporal.freshness_status,
+                    "usability_status": row.temporal.usability_status,
+                    "usability_reason": row.temporal.usability_reason,
+                    "warning_codes": list(row.temporal.warning_codes),
+                    "acquisition_started_at": (
+                        row.temporal.acquisition_started_at.isoformat()
+                    ),
+                    "acquisition_completed_at": (
+                        row.temporal.acquisition_completed_at.isoformat()
+                    ),
+                    "input_time_skew_seconds": row.temporal.input_time_skew_seconds,
+                }
+            )
+        ),
     }
 
 
 def _to_row(mapping: RowMapping) -> UniversalSignalRow:
+    temporal_data = mapping.get("temporal")
+    temporal = (
+        None
+        if temporal_data is None
+        else ResultTemporalMetadata(
+            observed_at=datetime.fromisoformat(temporal_data["observed_at"]),
+            received_at=datetime.fromisoformat(temporal_data["received_at"]),
+            evaluated_at=datetime.fromisoformat(temporal_data["evaluated_at"]),
+            persisted_at=datetime.fromisoformat(temporal_data["persisted_at"]),
+            market_session_date=date.fromisoformat(temporal_data["market_session_date"]),
+            market_session_status=temporal_data["market_session_status"],
+            age_seconds=temporal_data["age_seconds"],
+            last_refresh_attempt_at=datetime.fromisoformat(
+                temporal_data["last_refresh_attempt_at"]
+            ),
+            last_successful_refresh_at=datetime.fromisoformat(
+                temporal_data["last_successful_refresh_at"]
+            ),
+            next_refresh_at=(
+                None
+                if temporal_data["next_refresh_at"] is None
+                else datetime.fromisoformat(temporal_data["next_refresh_at"])
+            ),
+            data_advanced_on_last_refresh=temporal_data[
+                "data_advanced_on_last_refresh"
+            ],
+            freshness_status=temporal_data["freshness_status"],
+            usability_status=temporal_data["usability_status"],
+            usability_reason=temporal_data["usability_reason"],
+            warning_codes=tuple(temporal_data["warning_codes"]),
+            acquisition_started_at=datetime.fromisoformat(
+                temporal_data["acquisition_started_at"]
+            ),
+            acquisition_completed_at=datetime.fromisoformat(
+                temporal_data["acquisition_completed_at"]
+            ),
+            input_time_skew_seconds=temporal_data["input_time_skew_seconds"],
+        )
+    )
     return UniversalSignalRow(
         signal_id=mapping["signal_id"],
         signal_version=mapping["signal_version"],
@@ -150,4 +232,5 @@ def _to_row(mapping: RowMapping) -> UniversalSignalRow:
         warnings=tuple(mapping["warnings"]),
         provenance=tuple(mapping["provenance"]),
         observed_at=mapping["observed_at"],
+        temporal=temporal,
     )

--- a/docs/api/temporal-quality.md
+++ b/docs/api/temporal-quality.md
@@ -1,0 +1,24 @@
+# Temporal quality contract
+
+Screening responses preserve existing fields and also expose the timing and
+quality of the evidence used to compute the result.
+
+- `observed_at` is the newest source-effective time in the input snapshot.
+- `received_at` is the latest provider-recorded receipt time.
+- `evaluated_at` is when ASA evaluated the signal.
+- `persisted_at` is when ASA prepared the canonical latest-state write.
+- `market_session_date` and `market_session_status` use
+  `America/New_York` exchange semantics.
+- `freshness_status` is one of `live`, `delayed`, `prior_session`, `stale`,
+  `unknown`, or `unavailable`.
+- `usability_status` is `usable`, `usable_with_warning`, or `rejected`;
+  `usability_reason` and `warning_codes` explain the decision.
+- `input_time_skew_seconds` exposes the material time span among inputs.
+
+Refresh responses additionally distinguish `provider_contacted`,
+`data_advanced_on_last_refresh`, `result_changed`, and `refresh_failed`.
+When a refresh fails after a prior successful write, ASA returns the persisted
+last-known-good result with `refresh_failed: true`; the failure never erases it.
+
+`next_refresh_at` is nullable until the session-relative scheduling policy has
+selected the next eligible run.

--- a/domain/market_data.py
+++ b/domain/market_data.py
@@ -80,9 +80,11 @@ class MarketDataSubjectType(str, Enum):
 
 class FreshnessStatus(str, Enum):
     FRESH = "fresh"
+    DELAYED = "delayed"
     PRIOR_SESSION = "prior_session"
     STALE = "stale"
     UNKNOWN = "unknown"
+    UNAVAILABLE = "unavailable"
 
 
 class ProviderErrorKind(str, Enum):

--- a/market_data/fulfillment.py
+++ b/market_data/fulfillment.py
@@ -164,13 +164,34 @@ class CapabilityFulfillmentService:
         self._results[key] = result
         return result
 
+    @property
+    def completed_results(self) -> tuple[CapabilityFulfillmentResult, ...]:
+        """Return deterministic, immutable evidence from this acquisition run."""
+        return tuple(
+            self._results[key]
+            for key in sorted(
+                self._results,
+                key=lambda item: (
+                    item[0].capability.value,
+                    tuple(
+                        subject.subject_identity for subject in item[0].subjects
+                    ),
+                    item[1],
+                ),
+            )
+        )
+
     @staticmethod
     def _quality_error(
         provider_id: str,
         request: CapabilityRequest,
         observations: tuple[MarketObservation, ...],
     ) -> NormalizedProviderError | None:
-        usable_freshness = {FreshnessStatus.FRESH, FreshnessStatus.PRIOR_SESSION}
+        usable_freshness = {
+            FreshnessStatus.FRESH,
+            FreshnessStatus.DELAYED,
+            FreshnessStatus.PRIOR_SESSION,
+        }
         if any(value.freshness.status not in usable_freshness for value in observations):
             return normalized_provider_error(
                 ProviderErrorCode.STALE_DATA,

--- a/market_data/temporal.py
+++ b/market_data/temporal.py
@@ -71,6 +71,12 @@ def evaluate_temporal_usability(
             "latest verified observation is from the prior completed session",
             (TemporalWarningCode.PRIOR_SESSION_DATA,),
         )
+    if freshness.status is FreshnessStatus.DELAYED:
+        return TemporalUsabilityDecision(
+            UsabilityStatus.USABLE_WITH_WARNING,
+            "observation is delayed",
+            (TemporalWarningCode.DELAYED_DATA,),
+        )
     if freshness.status is FreshnessStatus.FRESH:
         return TemporalUsabilityDecision(UsabilityStatus.USABLE, "observation is current")
     return TemporalUsabilityDecision(

--- a/migrations/versions/0008_screening_temporal_metadata.py
+++ b/migrations/versions/0008_screening_temporal_metadata.py
@@ -1,0 +1,26 @@
+"""Add canonical temporal audit metadata to latest screening state.
+
+Revision ID: 0008
+Revises: 0007
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008"
+down_revision: str | None = "0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "universal_screening_state",
+        sa.Column("temporal", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("universal_screening_state", "temporal")

--- a/strategy_runtime/persistence.py
+++ b/strategy_runtime/persistence.py
@@ -53,7 +53,12 @@ from datetime import datetime
 from typing import Protocol
 
 from strategy_runtime.lifecycle import OpportunityHistory, OpportunityObservation
-from strategy_runtime.result import EvaluationState, RowType, UniversalScreeningResult
+from strategy_runtime.result import (
+    EvaluationState,
+    ResultTemporalMetadata,
+    RowType,
+    UniversalScreeningResult,
+)
 from strategy_runtime.values import TypedValue
 
 
@@ -84,6 +89,7 @@ class UniversalSignalRow:
     warnings: tuple[str, ...]
     provenance: tuple[str, ...]
     observed_at: datetime
+    temporal: ResultTemporalMetadata | None = None
 
     @classmethod
     def from_result(cls, result: UniversalScreeningResult) -> UniversalSignalRow:
@@ -105,6 +111,7 @@ class UniversalSignalRow:
             warnings=result.warnings,
             provenance=result.provenance,
             observed_at=result.observed_at,
+            temporal=result.temporal,
         )
 
     def to_result(self) -> UniversalScreeningResult:
@@ -126,6 +133,7 @@ class UniversalSignalRow:
             warnings=self.warnings,
             provenance=self.provenance,
             observed_at=self.observed_at,
+            temporal=self.temporal,
         )
 
 

--- a/strategy_runtime/result.py
+++ b/strategy_runtime/result.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 
 from strategy_runtime.values import TypedValue
@@ -83,6 +83,57 @@ SUCCESS_EVALUATION_STATES = frozenset({EvaluationState.PASS, EvaluationState.NO_
 
 
 @dataclass(frozen=True, slots=True)
+class ResultTemporalMetadata:
+    """Provider-neutral temporal audit data for one computed result."""
+
+    observed_at: datetime
+    received_at: datetime
+    evaluated_at: datetime
+    persisted_at: datetime
+    market_session_date: date
+    market_session_status: str
+    age_seconds: int
+    last_refresh_attempt_at: datetime
+    last_successful_refresh_at: datetime
+    next_refresh_at: datetime | None
+    data_advanced_on_last_refresh: bool
+    freshness_status: str
+    usability_status: str
+    usability_reason: str
+    warning_codes: tuple[str, ...]
+    acquisition_started_at: datetime
+    acquisition_completed_at: datetime
+    input_time_skew_seconds: int
+
+    def __post_init__(self) -> None:
+        for name in (
+            "observed_at",
+            "received_at",
+            "evaluated_at",
+            "persisted_at",
+            "last_refresh_attempt_at",
+            "last_successful_refresh_at",
+            "acquisition_started_at",
+            "acquisition_completed_at",
+        ):
+            _require_tz_aware(getattr(self, name), "ResultTemporalMetadata", name)
+        if self.next_refresh_at is not None:
+            _require_tz_aware(
+                self.next_refresh_at, "ResultTemporalMetadata", "next_refresh_at"
+            )
+        for name in ("age_seconds", "input_time_skew_seconds"):
+            if type(getattr(self, name)) is not int or getattr(self, name) < 0:
+                raise ValueError(f"ResultTemporalMetadata.{name} must be non-negative")
+        for name in (
+            "market_session_status",
+            "freshness_status",
+            "usability_status",
+            "usability_reason",
+        ):
+            _normalized_text(getattr(self, name), "ResultTemporalMetadata", name)
+
+
+@dataclass(frozen=True, slots=True)
 class UniversalScreeningResult:
     strategy_id: str
     strategy_version: str
@@ -101,11 +152,18 @@ class UniversalScreeningResult:
     warnings: tuple[str, ...]
     provenance: tuple[str, ...]
     observed_at: datetime
+    temporal: ResultTemporalMetadata | None = None
 
     def __post_init__(self) -> None:
         for name in ("strategy_id", "strategy_version", "symbol", "observation_id"):
             _normalized_text(getattr(self, name), "UniversalScreeningResult", name)
         _require_tz_aware(self.observed_at, "UniversalScreeningResult", "observed_at")
+        if self.temporal is not None and not isinstance(
+            self.temporal, ResultTemporalMetadata
+        ):
+            raise ValueError(
+                "UniversalScreeningResult.temporal must be ResultTemporalMetadata"
+            )
 
         is_success = self.evaluation_state in SUCCESS_EVALUATION_STATES
         if is_success:

--- a/strategy_runtime/service.py
+++ b/strategy_runtime/service.py
@@ -25,8 +25,17 @@ sprint's own explicit non_goal, deliberately never invented here).
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import replace
+from datetime import UTC, datetime
 
+from domain import FreshnessStatus, MarketObservation
 from market_data import CapabilityFulfillmentService
+from market_data.session_calendar import NEW_YORK, UsEquitySessionCalendar
+from market_data.temporal import (
+    TemporalUsabilityDecision,
+    UsabilityStatus,
+    evaluate_temporal_usability,
+)
 from strategy_runtime.clock import Clock
 from strategy_runtime.execution import ExecutionStatus, run_strategies
 from strategy_runtime.lifecycle import (
@@ -40,7 +49,97 @@ from strategy_runtime.persistence import (
     UniversalSignalRow,
 )
 from strategy_runtime.registry import StrategyRegistry
-from strategy_runtime.result import UniversalScreeningResult
+from strategy_runtime.result import ResultTemporalMetadata, UniversalScreeningResult
+
+_FRESHNESS_PRIORITY = {
+    FreshnessStatus.FRESH: 0,
+    FreshnessStatus.DELAYED: 1,
+    FreshnessStatus.PRIOR_SESSION: 2,
+    FreshnessStatus.STALE: 3,
+    FreshnessStatus.UNKNOWN: 4,
+    FreshnessStatus.UNAVAILABLE: 5,
+}
+_USABILITY_PRIORITY = {
+    UsabilityStatus.USABLE: 0,
+    UsabilityStatus.USABLE_WITH_WARNING: 1,
+    UsabilityStatus.REJECTED: 2,
+}
+
+
+def _temporal_metadata(
+    registry: StrategyRegistry[UniversalScreeningResult],
+    strategy_id: str,
+    evaluated_at: datetime,
+    fulfillment: CapabilityFulfillmentService,
+    previous: UniversalSignalRow | None,
+) -> ResultTemporalMetadata | None:
+    evaluated = evaluated_at.astimezone(UTC)
+    observations: tuple[MarketObservation, ...] = tuple(
+        observation
+        for completed in fulfillment.completed_results
+        for observation in completed.observations
+    )
+    if not observations:
+        return None
+    effective_times = tuple(item.effective_time.astimezone(UTC) for item in observations)
+    recorded_times = tuple(item.recorded_time.astimezone(UTC) for item in observations)
+    observed = max(effective_times)
+    received = max(recorded_times)
+    calendar = UsEquitySessionCalendar()
+    session_status = calendar.status_at(evaluated)
+    session = calendar.session(evaluated.astimezone(NEW_YORK).date())
+    session_date = (
+        session.trading_date
+        if session is not None and session.opens_at <= evaluated
+        else calendar.latest_completed_session(evaluated).trading_date
+    )
+    requirement = registry.contract_for(strategy_id).freshness_requirement
+    decisions: tuple[TemporalUsabilityDecision, ...] = tuple(
+        evaluate_temporal_usability(
+            item.freshness,
+            requirement,
+            market_is_open=session_status.value == "open",
+        )
+        for item in observations
+    )
+    usability = max(decisions, key=lambda item: _USABILITY_PRIORITY[item.status])
+    freshness = max(
+        (item.freshness.status for item in observations),
+        key=lambda item: _FRESHNESS_PRIORITY[item],
+    )
+    previous_observed = (
+        previous.temporal.observed_at
+        if previous is not None and previous.temporal is not None
+        else None
+    )
+    return ResultTemporalMetadata(
+        observed_at=observed,
+        received_at=received,
+        evaluated_at=evaluated,
+        persisted_at=evaluated,
+        market_session_date=session_date,
+        market_session_status=session_status.value,
+        age_seconds=max(0, int((evaluated - min(effective_times)).total_seconds())),
+        last_refresh_attempt_at=evaluated,
+        last_successful_refresh_at=evaluated,
+        next_refresh_at=None,
+        data_advanced_on_last_refresh=(
+            previous_observed is None or observed > previous_observed
+        ),
+        freshness_status=(
+            "live" if freshness is FreshnessStatus.FRESH else freshness.value
+        ),
+        usability_status=usability.status.value,
+        usability_reason=usability.reason,
+        warning_codes=tuple(
+            sorted({code.value for decision in decisions for code in decision.warning_codes})
+        ),
+        acquisition_started_at=min(recorded_times),
+        acquisition_completed_at=max(recorded_times),
+        input_time_skew_seconds=max(
+            0, int((max(effective_times) - min(effective_times)).total_seconds())
+        ),
+    )
 
 
 def get_state(
@@ -70,6 +169,7 @@ def refresh(
     existing migrated adapters, then persist and return the new state --
     never a whole-universe or whole-strategy-set refresh.
     """
+    previous = repository.get_one(strategy_id, symbol)
     (execution_result,) = run_strategies(
         registry,
         clock,
@@ -85,8 +185,19 @@ def refresh(
             f"refresh({strategy_id!r}, {symbol!r}) failed unexpectedly: "
             f"{execution_result.error_detail}"
         )
-    repository.upsert(UniversalSignalRow.from_result(execution_result.result))
-    return execution_result.result
+    result = execution_result.result
+    fulfillment = fulfillment_by_subject.get(symbol)
+    temporal = (
+        None
+        if fulfillment is None
+        else _temporal_metadata(
+            registry, strategy_id, result.observed_at, fulfillment, previous
+        )
+    )
+    if temporal is not None:
+        result = replace(result, temporal=temporal)
+    repository.upsert(UniversalSignalRow.from_result(result))
+    return result
 
 
 def record_opportunity_observation(

--- a/tests/asa/market_data_ops/fakes.py
+++ b/tests/asa/market_data_ops/fakes.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
+from market_data.session_calendar import UsEquitySessionCalendar
 from market_data.transport import ReadOnlyHttpRequest, ReadOnlyHttpResponse
 
 
@@ -16,6 +19,9 @@ class ScriptedTransport:
 
 
 def tradier_quote_response() -> ReadOnlyHttpResponse:
+    latest_close = UsEquitySessionCalendar().latest_completed_session(
+        datetime.now(UTC)
+    ).closes_at
     return ReadOnlyHttpResponse(
         200,
         {
@@ -28,7 +34,7 @@ def tradier_quote_response() -> ReadOnlyHttpResponse:
                     "bidsize": 1,
                     "asksize": 1,
                     "volume": 100,
-                    "trade_date": 1753113600000,
+                    "trade_date": int(latest_close.timestamp() * 1000),
                 }
             }
         },

--- a/tests/asa/test_ai_agent_workflow.py
+++ b/tests/asa/test_ai_agent_workflow.py
@@ -227,7 +227,8 @@ def test_ai_agent_workflow_discovers_reads_refreshes_and_briefs(
     transcript.append(updated_response)
     assert updated_response.status_code == 200
     updated = updated_response.json()
-    assert updated["age_seconds"] < STALE_THRESHOLD_SECONDS
+    assert updated["freshness_status"] in {"live", "prior_session"}
+    assert updated["usability_status"] in {"usable", "usable_with_warning"}
     assert updated["updated_at"] != target["updated_at"]
 
     # deterministic_responses: an unchanged GET immediately after returns

--- a/tests/asa/test_config.py
+++ b/tests/asa/test_config.py
@@ -135,5 +135,12 @@ def test_openapi_has_no_robinhood_secret_fields() -> None:
             DependencyOverrides(repository=InMemoryObservationRepository()),
         ).openapi()
     )
-    for secret_name in ("username", "password", "totp", "session", "cookie", "token"):
+    for secret_name in (
+        "username",
+        "password",
+        "totp",
+        "session_token",
+        "cookie",
+        "access_token",
+    ):
         assert secret_name not in schema.lower()

--- a/tests/asa/test_screening_refresh_route.py
+++ b/tests/asa/test_screening_refresh_route.py
@@ -124,8 +124,26 @@ class TestSuccessfulRefresh:
         assert body["signal_id"] == "skew_momentum"
         assert body["symbol"] == "AAPL"
         assert body["request_count"] >= 1
+        assert body["provider_contacted"] is True
+        assert body["refresh_failed"] is False
         assert body["updated_at"] is not None
         assert body["age_seconds"] >= 0
+        assert body["observed_at"] is not None
+        assert body["received_at"] is not None
+        assert body["evaluated_at"] is not None
+        assert body["persisted_at"] is not None
+        assert body["market_session_date"] is not None
+        assert body["market_session_status"] in {
+            "premarket",
+            "open",
+            "after_hours",
+            "weekend",
+            "holiday",
+        }
+        assert body["freshness_status"] in {"live", "prior_session"}
+        assert body["usability_status"] in {"usable", "usable_with_warning"}
+        assert isinstance(body["warning_codes"], list)
+        assert body["input_time_skew_seconds"] >= 0
         # "sandbox-secret-token" must never appear in the response.
         assert "sandbox-secret-token" not in response.text
 
@@ -143,3 +161,8 @@ class TestSuccessfulRefresh:
 
         assert follow_up.status_code == 200
         assert follow_up.json()["symbol"] == "AAPL"
+        assert follow_up.json()["observed_at"] is not None
+        assert follow_up.json()["usability_status"] in {
+            "usable",
+            "usable_with_warning",
+        }


### PR DESCRIPTION
## Summary
- persist and expose source observation, receipt, evaluation, persistence, session, freshness, usability, warnings, and input-skew metadata
- distinguish provider contact, data advancement, result change, and refresh failure
- preserve and return last-known-good state when a refresh fails
- add additive nullable JSON temporal column and public contract documentation

## Validation
- `pytest -q`: 2545 passed, 15 skipped
- `mypy asa strategy_runtime market_data domain`: passed
- `ruff check asa tests/asa`: passed
- Lean pre-push: passed
- `git diff --check`: passed
- local PostgreSQL round trip unavailable: Docker CLI absent; Product CI owns migration round trip

## Rollback
Revert this PR. Migration downgrade removes only the additive temporal column; existing latest results remain intact.
