### PR TITLE
TEMP-004: enforce monotonic latest result persistence

### DIFF
--- a/asa/integrations/universal_screening_postgres.py
+++ b/asa/integrations/universal_screening_postgres.py
@@ -44,13 +44,13 @@ class PostgresLatestResultRepository:
                         opportunity_id, row_type, verdict, evaluation_state,
                         lifecycle_stage, recommendation_state, data_quality,
                         metrics, economics, blockers, warnings, provenance, observed_at,
-                        temporal
+                        temporal, source_observed_at
                     ) VALUES (
                         :signal_id, :symbol, :signal_version, :observation_id,
                         :opportunity_id, :row_type, :verdict, :evaluation_state,
                         :lifecycle_stage, :recommendation_state, :data_quality,
                         :metrics, :economics, :blockers, :warnings, :provenance, :observed_at,
-                        :temporal
+                        :temporal, :source_observed_at
                     )
                     ON CONFLICT (signal_id, symbol) DO UPDATE SET
                         signal_version = EXCLUDED.signal_version,
@@ -68,7 +68,22 @@ class PostgresLatestResultRepository:
                         warnings = EXCLUDED.warnings,
                         provenance = EXCLUDED.provenance,
                         observed_at = EXCLUDED.observed_at,
-                        temporal = EXCLUDED.temporal
+                        temporal = EXCLUDED.temporal,
+                        source_observed_at = EXCLUDED.source_observed_at
+                    WHERE
+                        (
+                            COALESCE(
+                                EXCLUDED.source_observed_at,
+                                EXCLUDED.observed_at
+                            ),
+                            EXCLUDED.observation_id
+                        ) >= (
+                            COALESCE(
+                                universal_screening_state.source_observed_at,
+                                universal_screening_state.observed_at
+                            ),
+                            universal_screening_state.observation_id
+                        )
                 """),
                 _to_params(row),
             )
@@ -168,6 +183,9 @@ def _to_params(row: UniversalSignalRow) -> dict[str, object]:
                     "input_time_skew_seconds": row.temporal.input_time_skew_seconds,
                 }
             )
+        ),
+        "source_observed_at": (
+            row.temporal.observed_at if row.temporal is not None else row.observed_at
         ),
     }
 

--- a/docs/api/temporal-quality.md
+++ b/docs/api/temporal-quality.md
@@ -22,3 +22,8 @@ last-known-good result with `refresh_failed: true`; the failure never erases it.
 
 `next_refresh_at` is nullable until the session-relative scheduling policy has
 selected the next eligible run.
+
+Latest-state writes are monotonic by source `observed_at`. A late older
+observation cannot replace newer data. Equal source times use observation
+identity as a stable tie-breaker; append-only lifecycle history remains
+independent and replayable.

--- a/migrations/versions/0009_monotonic_screening_state.py
+++ b/migrations/versions/0009_monotonic_screening_state.py
@@ -1,0 +1,31 @@
+"""Add indexed source time used by monotonic latest-state writes.
+
+Revision ID: 0009
+Revises: 0008
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0009"
+down_revision: str | None = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "universal_screening_state",
+        sa.Column("source_observed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.execute(
+        "UPDATE universal_screening_state "
+        "SET source_observed_at = observed_at "
+        "WHERE source_observed_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("universal_screening_state", "source_observed_at")

--- a/strategy_runtime/persistence.py
+++ b/strategy_runtime/persistence.py
@@ -139,12 +139,12 @@ class UniversalSignalRow:
 
 class LatestResultRepository(Protocol):
     """Stores only the latest UniversalSignalRow per (signal_id,
-    symbol) -- upsert() always overwrites any existing row for the
-    same pair, never accumulates history (ObservationHistoryRepository's
-    own job). A symbol a given run never touches is never removed by that
-    run -- "empty run never exposes stale data" means a caller sees
-    exactly what was last actually computed, not nothing, and never a
-    silently fabricated absence.
+    symbol). upsert() advances that row only when the candidate's source
+    observation ordering key is not older; late arrivals never regress
+    latest state. Same-time candidates use observation identity as the
+    deterministic tie-breaker. It never accumulates history
+    (ObservationHistoryRepository's own job). A symbol a given run never
+    touches is never removed by that run.
     """
 
     def upsert(self, row: UniversalSignalRow) -> None: ...
@@ -154,6 +154,23 @@ class LatestResultRepository(Protocol):
     def get_for_signal(self, signal_id: str) -> tuple[UniversalSignalRow, ...]: ...
 
     def get_one(self, signal_id: str, symbol: str) -> UniversalSignalRow | None: ...
+
+
+def latest_ordering_key(row: UniversalSignalRow) -> tuple[datetime, str]:
+    """Canonical monotonic order: source time, then stable observation identity."""
+    source_time = (
+        row.temporal.observed_at if row.temporal is not None else row.observed_at
+    )
+    return source_time, row.observation_id
+
+
+def should_replace_latest(
+    existing: UniversalSignalRow | None, candidate: UniversalSignalRow
+) -> bool:
+    """Late older arrivals may be retained elsewhere, but never regress latest."""
+    return existing is None or latest_ordering_key(candidate) >= latest_ordering_key(
+        existing
+    )
 
 
 class ObservationHistoryRepository(Protocol):

--- a/tests/asa/fakes.py
+++ b/tests/asa/fakes.py
@@ -1,6 +1,6 @@
 from asa.contracts.market import MarketObservation
 from strategy_runtime.lifecycle import OpportunityHistory, OpportunityObservation
-from strategy_runtime.persistence import UniversalSignalRow
+from strategy_runtime.persistence import UniversalSignalRow, should_replace_latest
 
 
 class InMemoryObservationRepository:
@@ -26,7 +26,9 @@ class InMemoryLatestResultRepository:
         self._rows: dict[tuple[str, str], UniversalSignalRow] = {}
 
     def upsert(self, row: UniversalSignalRow) -> None:
-        self._rows[(row.signal_id, row.symbol)] = row
+        key = (row.signal_id, row.symbol)
+        if should_replace_latest(self._rows.get(key), row):
+            self._rows[key] = row
 
     def get_all(self) -> tuple[UniversalSignalRow, ...]:
         return tuple(sorted(self._rows.values(), key=lambda item: (item.signal_id, item.symbol)))

--- a/tests/strategy_runtime/test_persistence.py
+++ b/tests/strategy_runtime/test_persistence.py
@@ -14,6 +14,7 @@ screening.state.ScreeningStateRepository.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 
 from strategy_runtime.lifecycle import (
@@ -26,6 +27,7 @@ from strategy_runtime.persistence import (
     LatestResultRepository,
     ObservationHistoryRepository,
     UniversalSignalRow,
+    should_replace_latest,
 )
 from strategy_runtime.result import EvaluationState, RowType, UniversalScreeningResult
 
@@ -141,6 +143,27 @@ class TestLatestResultRepositoryProtocolContract:
         repository.upsert(_row("beta", "AAPL"))
 
         assert {item.signal_id for item in repository.get_for_signal("alpha")} == {"alpha"}
+
+    def test_older_late_arrival_cannot_replace_newer_latest_state(self) -> None:
+        base = _row("alpha", "AAPL")
+        newer = replace(
+            base,
+            observation_id="newer",
+            observed_at=NOW + timedelta(minutes=1),
+        )
+        older = replace(base, observation_id="older", observed_at=NOW)
+
+        assert should_replace_latest(newer, older) is False
+        assert should_replace_latest(older, newer) is True
+
+    def test_same_timestamp_uses_stable_identity_tie_breaker(self) -> None:
+        base = _row("alpha", "AAPL")
+        lower = replace(base, observation_id="aaa")
+        higher = replace(base, observation_id="bbb")
+
+        assert should_replace_latest(lower, higher) is True
+        assert should_replace_latest(higher, lower) is False
+        assert should_replace_latest(higher, higher) is True
 
 
 class TestObservationHistoryRepositoryProtocolContract:


### PR DESCRIPTION
## Summary
- order latest state by source observation time, not arrival time
- use observation identity as deterministic same-time tie-breaker
- enforce the invariant atomically in PostgreSQL
- retain append-only lifecycle history and exposed input-skew metadata

## Validation
- `pytest -q`: 2547 passed, 15 skipped
- mypy, Ruff, Lean pre-push, diff check: passed
- PostgreSQL migration round trip delegated to Product CI because local Docker CLI is unavailable

## Rollback
Revert this PR and downgrade 0009. Existing latest-state and history rows remain preserved.
