### PR TITLE
TEMP-005: add session-relative refresh scheduling

### DIFF
--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -36,6 +36,7 @@ from asa.api.screening_models import (
 )
 from market_data import load_market_data_config_from_environment
 from market_data.live_transport import build_live_transport
+from market_data.session_schedule import ON_DEMAND_COOLDOWN
 from screening.live_acquisition import APPROVED_LIVE_UNIVERSE, live_only_config
 from strategy_runtime.catalog import SignalCatalogEntry
 from strategy_runtime.lifecycle import RecommendedAction
@@ -95,10 +96,19 @@ def _filter_and_sort(
         and (
             freshness is None
             or (
-                "fresh"
-                if max(0, int((now - item.observed_at).total_seconds()))
-                <= FRESHNESS_THRESHOLD_SECONDS
-                else "stale"
+                (
+                    "fresh"
+                    if item.temporal.usability_status
+                    in {"usable", "usable_with_warning"}
+                    else "stale"
+                )
+                if item.temporal is not None
+                else (
+                    "fresh"
+                    if max(0, int((now - item.observed_at).total_seconds()))
+                    <= FRESHNESS_THRESHOLD_SECONDS
+                    else "stale"
+                )
             )
             == freshness
         )
@@ -299,6 +309,21 @@ def build_screening_router(
                 f"Refresh is bounded to the approved live universe {APPROVED_LIVE_UNIVERSE}, "
                 f"not {symbol!r}",
             )
+        clock = _SystemClock()
+        prior = repository.get_one(signal, symbol)
+        if (
+            prior is not None
+            and prior.temporal is not None
+            and clock.now() - prior.temporal.last_refresh_attempt_at
+            < ON_DEMAND_COOLDOWN
+        ):
+            return RefreshResultResponse.from_universal_result(
+                prior.to_result(),
+                request_count=0,
+                provider_contacted=False,
+                result_changed=False,
+                refresh_failed=False,
+            )
         config = live_only_config(load_market_data_config_from_environment())
         if not enabled_provider_configs(config):
             raise agent_api_error(
@@ -306,10 +331,8 @@ def build_screening_router(
                 "NO_LIVE_PROVIDER_CONFIGURED",
                 "No live market data provider is enabled for this deployment",
             )
-        clock = _SystemClock()
         access = build_shared_market_data_access(config, transport_factory, clock, (symbol,))
         subject_access = access[symbol]
-        prior = repository.get_one(signal, symbol)
         try:
             result = refresh(
                 registry,

--- a/asa/integrations/refresh_schedule_postgres.py
+++ b/asa/integrations/refresh_schedule_postgres.py
@@ -1,0 +1,25 @@
+"""PostgreSQL-backed idempotency claims for external scheduler delivery."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Engine, text
+
+
+class PostgresRefreshScheduleClaimRepository:
+    def __init__(self, engine: Engine) -> None:
+        self._engine = engine
+
+    def claim(self, slot_id: str, claimed_at: datetime) -> bool:
+        with self._engine.begin() as connection:
+            result = connection.execute(
+                text("""
+                    INSERT INTO refresh_schedule_claims (slot_id, claimed_at)
+                    VALUES (:slot_id, :claimed_at)
+                    ON CONFLICT (slot_id) DO NOTHING
+                    RETURNING slot_id
+                """),
+                {"slot_id": slot_id, "claimed_at": claimed_at},
+            )
+            return result.first() is not None

--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -36,13 +36,18 @@ import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Protocol
 
 from asa.config import Settings
 from asa.integrations.observation_history_postgres import PostgresObservationHistoryRepository
 from asa.integrations.postgres import create_postgres_engine
+from asa.integrations.refresh_schedule_postgres import (
+    PostgresRefreshScheduleClaimRepository,
+)
 from asa.integrations.universal_screening_postgres import PostgresLatestResultRepository
 from market_data import load_market_data_config_from_environment
 from market_data.live_transport import build_live_transport
+from market_data.session_schedule import SessionRefreshSchedule
 from screening import APPROVED_LIVE_UNIVERSE
 from screening.live_acquisition import live_only_config
 from strategy_runtime.adapters import build_migrated_strategy_registry
@@ -85,12 +90,19 @@ class PairOutcome:
     error: str | None
 
 
+class RefreshScheduleClaimRepository(Protocol):
+    def claim(self, slot_id: str, claimed_at: datetime) -> bool: ...
+
+
 def run_scheduled_refresh(
     universe: tuple[tuple[str, str], ...] = PRODUCTION_SCREENING_UNIVERSE,
     *,
     repository: LatestResultRepository | None = None,
     history_repository: ObservationHistoryRepository | None = None,
     transport_factory: Callable[[str], object] = build_live_transport,
+    claim_repository: RefreshScheduleClaimRepository | None = None,
+    enforce_schedule: bool = False,
+    now: datetime | None = None,
 ) -> tuple[PairOutcome, ...]:
     """Run one bounded refresh per pair in ``universe``, in order,
     persisting every result. One pair's failure never stops the others --
@@ -105,6 +117,19 @@ def run_scheduled_refresh(
     the same DependencyOverrides-style pattern asa/bootstrap.py already
     uses.
     """
+    run_at = now or datetime.now(UTC)
+    if enforce_schedule:
+        slot = SessionRefreshSchedule().due_slot(run_at)
+        if slot is None:
+            return ()
+        resolved_claim_repository = claim_repository or (
+            PostgresRefreshScheduleClaimRepository(
+                create_postgres_engine(Settings().database_url)
+            )
+        )
+        if not resolved_claim_repository.claim(slot.slot_id, run_at):
+            return ()
+
     resolved_repository = repository or PostgresLatestResultRepository(
         create_postgres_engine(Settings().database_url)
     )
@@ -171,7 +196,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--json", action="store_true", help="Emit only machine-readable JSON.")
     args = parser.parse_args(argv)
 
-    outcomes = run_scheduled_refresh()
+    outcomes = run_scheduled_refresh(enforce_schedule=True)
     failures = [item for item in outcomes if item.error is not None]
 
     if not args.json:

--- a/docs/api/temporal-quality.md
+++ b/docs/api/temporal-quality.md
@@ -27,3 +27,12 @@ Latest-state writes are monotonic by source `observed_at`. A late older
 observation cannot replace newer data. Equal source times use observation
 identity as a stable tie-breaker; append-only lifecycle history remains
 independent and replayable.
+
+The external scheduler invokes one-shot `python -m asa.scheduled_screening`
+deliveries. ASA admits only the latest slot within a 20-minute catch-up window
+and stores one PostgreSQL claim per slot, so duplicate cron delivery executes
+once and restart never replays every missed slot. Normal sessions run at
+open+10m, 11:00, 13:00, 15:00, and close-10m New York time. Early-close slots
+are open+10m, one-third, two-thirds, and close-10m. Weekends and full holidays
+have no provider cycle. On-demand refresh has a persisted 10-minute cooldown;
+failure retry delays are bounded at 5, 15, then 30 minutes.

--- a/market_data/session_schedule.py
+++ b/market_data/session_schedule.py
@@ -1,0 +1,98 @@
+"""Exchange-calendar-relative refresh schedule and bounded retry policy."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+
+from domain.values import require_tz_aware
+from market_data.session_calendar import NEW_YORK, UsEquitySessionCalendar
+
+ON_DEMAND_COOLDOWN = timedelta(minutes=10)
+MISSED_RUN_CATCH_UP = timedelta(minutes=20)
+FAILURE_BACKOFF = (
+    timedelta(minutes=5),
+    timedelta(minutes=15),
+    timedelta(minutes=30),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ScheduledRefreshSlot:
+    scheduled_at: datetime
+    session_date: date
+    ordinal: int
+
+    @property
+    def slot_id(self) -> str:
+        payload = f"{self.session_date.isoformat()}:{self.ordinal}:{self.scheduled_at.isoformat()}"
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+
+class SessionRefreshSchedule:
+    def __init__(self, calendar: UsEquitySessionCalendar | None = None) -> None:
+        self._calendar = calendar or UsEquitySessionCalendar()
+
+    def slots_for(self, session_date: date) -> tuple[ScheduledRefreshSlot, ...]:
+        session = self._calendar.session(session_date)
+        if session is None:
+            return ()
+        instants: tuple[datetime, ...]
+        if session.early_close:
+            duration = session.closes_at - session.opens_at
+            instants = (
+                session.opens_at + timedelta(minutes=10),
+                session.opens_at + duration / 3,
+                session.opens_at + duration * 2 / 3,
+                session.closes_at - timedelta(minutes=10),
+            )
+        else:
+            instants = (
+                session.opens_at + timedelta(minutes=10),
+                session.opens_at + timedelta(hours=1, minutes=30),
+                session.opens_at + timedelta(hours=3, minutes=30),
+                session.opens_at + timedelta(hours=5, minutes=30),
+                session.closes_at - timedelta(minutes=10),
+            )
+        return tuple(
+            ScheduledRefreshSlot(instant.astimezone(UTC), session_date, index)
+            for index, instant in enumerate(instants, start=1)
+        )
+
+    def due_slot(
+        self,
+        now: datetime,
+        *,
+        catch_up_window: timedelta = MISSED_RUN_CATCH_UP,
+    ) -> ScheduledRefreshSlot | None:
+        require_tz_aware(now, "SessionRefreshSchedule", "due_slot")
+        session_date = now.astimezone(NEW_YORK).date()
+        candidates = [
+            slot
+            for day_offset in (-1, 0, 1)
+            for slot in self.slots_for(session_date + timedelta(days=day_offset))
+            if slot.scheduled_at <= now.astimezone(UTC)
+        ]
+        if not candidates:
+            return None
+        latest = max(candidates, key=lambda item: item.scheduled_at)
+        return latest if now.astimezone(UTC) - latest.scheduled_at <= catch_up_window else None
+
+    def next_slot(self, after: datetime) -> ScheduledRefreshSlot:
+        require_tz_aware(after, "SessionRefreshSchedule", "next_slot")
+        candidate_date = after.astimezone(NEW_YORK).date()
+        for day_offset in range(10):
+            slots = self.slots_for(candidate_date + timedelta(days=day_offset))
+            for slot in slots:
+                if slot.scheduled_at > after.astimezone(UTC):
+                    return slot
+        raise ValueError("no scheduled refresh slot found in bounded lookahead")
+
+
+def retry_at(failed_at: datetime, consecutive_failures: int) -> datetime:
+    require_tz_aware(failed_at, "retry_at", "failed_at")
+    if type(consecutive_failures) is not int or consecutive_failures < 1:
+        raise ValueError("consecutive_failures must be positive")
+    delay = FAILURE_BACKOFF[min(consecutive_failures - 1, len(FAILURE_BACKOFF) - 1)]
+    return failed_at.astimezone(UTC) + delay

--- a/migrations/versions/0010_refresh_schedule_claims.py
+++ b/migrations/versions/0010_refresh_schedule_claims.py
@@ -1,0 +1,27 @@
+"""Add durable idempotency claims for externally scheduled refresh slots.
+
+Revision ID: 0010
+Revises: 0009
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0010"
+down_revision: str | None = "0009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "refresh_schedule_claims",
+        sa.Column("slot_id", sa.String(length=64), primary_key=True),
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("refresh_schedule_claims")

--- a/strategy_runtime/service.py
+++ b/strategy_runtime/service.py
@@ -31,6 +31,7 @@ from datetime import UTC, datetime
 from domain import FreshnessStatus, MarketObservation
 from market_data import CapabilityFulfillmentService
 from market_data.session_calendar import NEW_YORK, UsEquitySessionCalendar
+from market_data.session_schedule import SessionRefreshSchedule
 from market_data.temporal import (
     TemporalUsabilityDecision,
     UsabilityStatus,
@@ -122,7 +123,7 @@ def _temporal_metadata(
         age_seconds=max(0, int((evaluated - min(effective_times)).total_seconds())),
         last_refresh_attempt_at=evaluated,
         last_successful_refresh_at=evaluated,
-        next_refresh_at=None,
+        next_refresh_at=SessionRefreshSchedule(calendar).next_slot(evaluated).scheduled_at,
         data_advanced_on_last_refresh=(
             previous_observed is None or observed > previous_observed
         ),

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 import pytest
 
@@ -150,3 +150,42 @@ def test_one_pairs_infrastructure_failure_does_not_abort_the_batch(
     # The failing pair never persisted; the succeeding one did.
     assert delegate.get_one("skew_momentum", "AAPL") is None
     assert delegate.get_one("skew_momentum", "MSFT") is not None
+
+
+class _SingleUseClaimRepository:
+    def __init__(self) -> None:
+        self.claimed: set[str] = set()
+
+    def claim(self, slot_id: str, claimed_at: datetime) -> bool:
+        del claimed_at
+        if slot_id in self.claimed:
+            return False
+        self.claimed.add(slot_id)
+        return True
+
+
+def test_duplicate_cron_delivery_executes_slot_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    repository = InMemoryLatestResultRepository()
+    claims = _SingleUseClaimRepository()
+    expiration = date(2026, 8, 7).isoformat()
+    run_at = datetime(2026, 7, 27, 13, 45, tzinfo=UTC)
+    arguments = {
+        "repository": repository,
+        "claim_repository": claims,
+        "enforce_schedule": True,
+        "now": run_at,
+        "transport_factory": lambda _provider_id: ScriptedTransport(
+            _tradier_refresh_responses(expiration)
+        ),
+    }
+
+    first = run_scheduled_refresh((("skew_momentum", "AAPL"),), **arguments)
+    duplicate = run_scheduled_refresh((("skew_momentum", "AAPL"),), **arguments)
+
+    assert len(first) == 1
+    assert duplicate == ()
+    assert len(claims.claimed) == 1

--- a/tests/asa/test_screening_refresh_route.py
+++ b/tests/asa/test_screening_refresh_route.py
@@ -16,12 +16,16 @@ from tests.asa.fakes import InMemoryLatestResultRepository
 from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
 
 
-def _client(transport_factory: Callable[[str], object] | None = None) -> TestClient:
+def _client(
+    transport_factory: Callable[[str], object] | None = None,
+    repository: InMemoryLatestResultRepository | None = None,
+) -> TestClient:
     return TestClient(
         build_application(
             Settings(agent_api_token=SecretStr("correct-token"), _env_file=None),
             DependencyOverrides(
-                latest_result_repository=InMemoryLatestResultRepository(),
+                latest_result_repository=repository
+                or InMemoryLatestResultRepository(),
                 market_data_transport_factory=transport_factory,
             ),
         )
@@ -166,3 +170,30 @@ class TestSuccessfulRefresh:
             "usable",
             "usable_with_warning",
         }
+
+    def test_on_demand_refresh_inside_cooldown_does_not_contact_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+        monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+        expiration = (date.today() + timedelta(days=7)).isoformat()
+        constructions = 0
+
+        def transport_factory(_provider_id: str) -> object:
+            nonlocal constructions
+            constructions += 1
+            return ScriptedTransport(_tradier_refresh_responses(expiration))
+
+        client = _client(transport_factory=transport_factory)
+        first = client.post(
+            "/api/v1/screening/skew_momentum/AAPL/refresh", headers=_auth()
+        )
+        second = client.post(
+            "/api/v1/screening/skew_momentum/AAPL/refresh", headers=_auth()
+        )
+
+        assert first.status_code == second.status_code == 200
+        assert second.json()["provider_contacted"] is False
+        assert second.json()["request_count"] == 0
+        assert second.json()["result_changed"] is False
+        assert constructions == 1

--- a/tests/market_data/test_session_schedule.py
+++ b/tests/market_data/test_session_schedule.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+from market_data.session_schedule import (
+    SessionRefreshSchedule,
+    retry_at,
+)
+
+
+def test_normal_session_has_five_exchange_relative_slots() -> None:
+    slots = SessionRefreshSchedule().slots_for(date(2026, 7, 27))
+
+    assert [item.scheduled_at.hour for item in slots] == [13, 15, 17, 19, 19]
+    assert [item.scheduled_at.minute for item in slots] == [40, 0, 0, 0, 50]
+
+
+def test_early_close_uses_actual_close_minus_ten_minutes() -> None:
+    slots = SessionRefreshSchedule().slots_for(date(2026, 11, 27))
+
+    assert len(slots) == 4
+    assert slots[-1].scheduled_at == datetime(2026, 11, 27, 17, 50, tzinfo=UTC)
+
+
+def test_weekend_and_full_holiday_have_no_provider_slots() -> None:
+    schedule = SessionRefreshSchedule()
+
+    assert schedule.slots_for(date(2026, 7, 4)) == ()
+    assert schedule.slots_for(date(2026, 12, 25)) == ()
+
+
+def test_dst_changes_utc_time_but_not_exchange_local_time() -> None:
+    schedule = SessionRefreshSchedule()
+    before_spring = schedule.slots_for(date(2026, 3, 6))[0]
+    after_spring = schedule.slots_for(date(2026, 3, 9))[0]
+    before_fall = schedule.slots_for(date(2026, 10, 30))[0]
+    after_fall = schedule.slots_for(date(2026, 11, 2))[0]
+
+    assert (before_spring.scheduled_at.hour, after_spring.scheduled_at.hour) == (14, 13)
+    assert (before_fall.scheduled_at.hour, after_fall.scheduled_at.hour) == (13, 14)
+    assert {
+        item.scheduled_at.astimezone().minute
+        for item in (before_spring, after_spring, before_fall, after_fall)
+    } == {40}
+
+
+def test_missed_run_catches_up_only_inside_twenty_minutes() -> None:
+    schedule = SessionRefreshSchedule()
+
+    assert schedule.due_slot(datetime(2026, 7, 27, 13, 59, tzinfo=UTC)) is not None
+    assert schedule.due_slot(datetime(2026, 7, 27, 14, 1, tzinfo=UTC)) is None
+
+
+def test_retry_backoff_is_bounded() -> None:
+    failed_at = datetime(2026, 7, 27, 14, 0, tzinfo=UTC)
+
+    assert retry_at(failed_at, 1) == failed_at + timedelta(minutes=5)
+    assert retry_at(failed_at, 2) == failed_at + timedelta(minutes=15)
+    assert retry_at(failed_at, 3) == failed_at + timedelta(minutes=30)
+    assert retry_at(failed_at, 99) == failed_at + timedelta(minutes=30)


### PR DESCRIPTION
## Summary
- derive normal and early-close refresh slots from the New York session calendar
- skip weekends/holidays; catch up only within 20 minutes
- coalesce duplicate cron deliveries through durable PostgreSQL slot claims
- enforce 10-minute on-demand cooldown and bounded 5/15/30 retry policy
- expose next scheduled refresh through persisted temporal metadata

## Validation
- `pytest -q`: 2555 passed, 15 skipped
- mypy, Ruff, Lean pre-push, diff check: passed
- migration round trip delegated to Product CI; Docker CLI unavailable locally

## Rollback
Revert this PR. Downgrade 0010 drops only scheduler idempotency claims; latest screening results remain preserved.
