### PR TITLE
UNI-001: expand production screening universe to 30 symbols

### DIFF
--- a/screening/__init__.py
+++ b/screening/__init__.py
@@ -15,6 +15,7 @@ from screening.errors import (
 )
 from screening.live_acquisition import (
     APPROVED_LIVE_UNIVERSE,
+    EARNINGS_CALENDAR_UNIVERSE,
     acquire_capability,
     build_capability_registry,
     build_fulfillment_service,
@@ -33,6 +34,7 @@ from screening.runner import StrategyAdapter, StrategyAdapterError, run_screenin
 
 __all__ = [
     "APPROVED_LIVE_UNIVERSE",
+    "EARNINGS_CALENDAR_UNIVERSE",
     "TARGET_STRATEGY_ADAPTERS",
     "TARGET_STRATEGY_REGISTRY",
     "Clock",

--- a/screening/live_acquisition.py
+++ b/screening/live_acquisition.py
@@ -69,10 +69,60 @@ def enabled_provider_configs(config: MarketDataConfig) -> tuple[ProviderConfig, 
     return tuple(item for item in config.providers if item.enabled)
 
 
-APPROVED_LIVE_UNIVERSE = ("AAPL", "MSFT", "NVDA", "AMD", "SPY", "QQQ")
-"""The SPRINT-007 Founder-approved live validation_universe. Both
-screening/cli.py's --live flag and asa/'s POST .../refresh endpoint bound
-live acquisition to this same set -- neither widens it independently."""
+APPROVED_LIVE_UNIVERSE = (
+    # Mega-cap single names -- deep, liquid options chains (SPRINT-007's
+    # original bar, unchanged by this expansion).
+    "AAPL", "MSFT", "NVDA", "AMD", "GOOGL", "AMZN", "META", "TSLA", "AVGO", "NFLX",
+    # Financials
+    "JPM", "BAC", "GS",
+    # Healthcare
+    "UNH", "LLY",
+    # Industrials / consumer
+    "HD", "WMT", "DIS",
+    # Energy
+    "XOM", "CVX",
+    # Semis
+    "INTC", "MU",
+    # Major index / sector ETFs
+    "SPY", "QQQ", "IWM", "DIA", "XLF", "XLE", "XLK", "GLD",
+)
+"""SPRINT-011/UNI-001: expanded from the SPRINT-007 six-symbol
+validation_universe (AAPL, MSFT, NVDA, AMD, SPY, QQQ) to 30 symbols, per
+Founder-authorized SPRINT-011 (docs/sprints/SPRINT-011.yaml). Selection
+criteria unchanged from SPRINT-007/PROD-001 and from
+project/reports/SPRINT-008D-REFRESH-UNIVERSE-EXPANSION.md's own recorded
+trigger conditions: deep, liquid, optionable single-name or index/sector
+ETF options markets only, diversified across sectors, no thin or illiquid
+chains that would degrade forward_factor/skew_momentum's strike/expiration
+selection regardless of code correctness. That report explicitly deferred
+expansion pending real production usage data and Founder re-approval;
+SPRINT-011 is that re-approval and that data (SPRINT-010's own production
+evidence, project/reports/SPRINT-010.md).
+
+Both screening/cli.py's --live flag and asa/'s POST .../refresh endpoint
+bound live acquisition to this same set -- neither widens it
+independently. A future change must widen this one tuple, not add a
+second copy anywhere.
+
+Excluded from consideration: meme/low-float names, thinly-traded
+small-caps, and any single name without a consistently deep multi-
+expiration chain -- PROD-001's original liquidity bar, applied
+identically to every candidate added here, not loosened for this
+expansion. Rollback: revert this tuple to the prior six-symbol value
+(git revert of the commit that introduced this expansion); no other file
+needs to change, since every caller reads this one constant directly.
+"""
+
+EARNINGS_CALENDAR_UNIVERSE = tuple(
+    symbol
+    for symbol in APPROVED_LIVE_UNIVERSE
+    if symbol not in {"SPY", "QQQ", "IWM", "DIA", "XLF", "XLE", "XLK", "GLD"}
+)
+"""SPRINT-011/UNI-001: the single-name subset of APPROVED_LIVE_UNIVERSE
+eligible for earnings_calendar -- ETFs have no earnings events and were
+never eligible. Derived from APPROVED_LIVE_UNIVERSE by exclusion (not a
+second maintained list) so it can never drift out of sync as that tuple
+changes."""
 
 _FIXTURE_PROVIDER_ID = "deterministic_fixture"
 

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -11,6 +11,7 @@ from asa.scheduled_screening import (
     run_scheduled_refresh,
 )
 from market_data.transport import ReadOnlyHttpResponse
+from screening import APPROVED_LIVE_UNIVERSE
 from tests.asa.fakes import InMemoryLatestResultRepository
 from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
 
@@ -56,10 +57,16 @@ def _tradier_refresh_responses(expiration: str) -> list[ReadOnlyHttpResponse]:
 
 
 def test_production_universe_is_forward_factor_and_skew_momentum_only() -> None:
+    # SPRINT-011/UNI-001 expanded APPROVED_LIVE_UNIVERSE; the pair count here
+    # derives from it rather than a hardcoded literal so this assertion
+    # doesn't silently drift out of sync (matching PROD-005's own established
+    # single-source-of-truth rationale). earnings_calendar's own addition to
+    # the scheduler is UNI-002's job, not this one.
     signal_ids = {signal_id for signal_id, _symbol in PRODUCTION_SCREENING_UNIVERSE}
     assert signal_ids == {"forward_factor", "skew_momentum"}
-    assert len(PRODUCTION_SCREENING_UNIVERSE) == 12
-    assert len(set(PRODUCTION_SCREENING_UNIVERSE)) == 12  # no duplicate pairs
+    expected = 2 * len(APPROVED_LIVE_UNIVERSE)
+    assert len(PRODUCTION_SCREENING_UNIVERSE) == expected
+    assert len(set(PRODUCTION_SCREENING_UNIVERSE)) == expected  # no duplicate pairs
 
 
 def test_no_enabled_provider_raises(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/screening/test_cli.py
+++ b/tests/screening/test_cli.py
@@ -159,7 +159,10 @@ class TestLive:
 
     def test_fixture_only_universe_symbol_rejected_with_live_flag(self, capsys, monkeypatch) -> None:
         _clear_provider_env(monkeypatch)
-        exit_code = main(["--live", "--universe", "TSLA", "--as-of", AS_OF])
+        # GME is deliberately excluded from APPROVED_LIVE_UNIVERSE (SPRINT-011/
+        # UNI-001's own liquidity bar) -- a stable negative case, unlike TSLA
+        # which SPRINT-011 added to the approved set.
+        exit_code = main(["--live", "--universe", "GME", "--as-of", AS_OF])
         assert exit_code == 2
         assert "unsupported universe" in capsys.readouterr().err
 

--- a/tests/screening/test_live_acquisition.py
+++ b/tests/screening/test_live_acquisition.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 import pytest
+
 from domain import (
     CanonicalInstrumentIdentity,
     EvidenceKind,
@@ -26,6 +27,8 @@ from market_data import (
 )
 from market_data.fixture import fixture_provider_registration
 from screening.live_acquisition import (
+    APPROVED_LIVE_UNIVERSE,
+    EARNINGS_CALENDAR_UNIVERSE,
     acquire_capability,
     build_capability_registry,
     build_fulfillment_service,
@@ -211,3 +214,19 @@ class TestBuildFulfillmentServiceAndAcquireCapability:
         )
         assert first.status == second.status
         assert first.selected_provider == second.selected_provider
+
+
+class TestApprovedLiveUniverse:
+    def test_size_is_within_sprint_011_target_range(self) -> None:
+        assert 25 <= len(APPROVED_LIVE_UNIVERSE) <= 50
+
+    def test_no_duplicate_symbols(self) -> None:
+        assert len(set(APPROVED_LIVE_UNIVERSE)) == len(APPROVED_LIVE_UNIVERSE)
+
+    def test_earnings_calendar_universe_is_a_proper_subset(self) -> None:
+        assert set(EARNINGS_CALENDAR_UNIVERSE) <= set(APPROVED_LIVE_UNIVERSE)
+        assert len(EARNINGS_CALENDAR_UNIVERSE) < len(APPROVED_LIVE_UNIVERSE)
+
+    def test_earnings_calendar_universe_excludes_known_ETFs(self) -> None:
+        etfs = {"SPY", "QQQ", "IWM", "DIA", "XLF", "XLE", "XLK", "GLD"}
+        assert set(EARNINGS_CALENDAR_UNIVERSE).isdisjoint(etfs)


### PR DESCRIPTION
Expands \`APPROVED_LIVE_UNIVERSE\` 6→30 symbols (diversified mega-caps + 8 major ETFs), same liquidity bar as original SPRINT-007 approval. Adds \`EARNINGS_CALENDAR_UNIVERSE\` (single-name subset, ETFs excluded). Per-pair request budget confirmed unaffected (built fresh per pair, 100/provider headroom, unchanged by symbol count).

Verified live against production: forward_factor/SPY, skew_momentum/SPY both non-missing. earnings_calendar/AAPL still \`missing_data\` on a distinct failure mode (expiration-pair selection) -- filed #236, not blocking (other earnings-eligible symbols in the set).

Fixed two tests whose assumptions the expansion itself invalidated (TSLA now approved; hardcoded pair count).

Full suite: 1915 passed, 14 skipped, zero regressions.

Ref docs/sprints/SPRINT-011.yaml, UNI-001. Issue: #236 (unrelated pre-existing defect, filed not fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)