### PR TITLE
UNI-002: activate expanded scheduled screening

### DIFF
--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -48,7 +48,7 @@ from asa.integrations.universal_screening_postgres import PostgresLatestResultRe
 from market_data import load_market_data_config_from_environment
 from market_data.live_transport import build_live_transport
 from market_data.session_schedule import SessionRefreshSchedule
-from screening import APPROVED_LIVE_UNIVERSE
+from screening import APPROVED_LIVE_UNIVERSE, EARNINGS_CALENDAR_UNIVERSE
 from screening.live_acquisition import live_only_config
 from strategy_runtime.adapters import build_migrated_strategy_registry
 from strategy_runtime.lifecycle import RecommendedAction
@@ -59,19 +59,23 @@ from strategy_runtime.market_data_planning import (
 from strategy_runtime.persistence import LatestResultRepository, ObservationHistoryRepository
 from strategy_runtime.service import record_opportunity_observation, refresh
 
-# The initial production screening universe
-# (project/reports/SPRINT-008D-SCREENING-UNIVERSE.md, PROD-001): the two
-# signals whose data requirements are met entirely by Tradier, across the
-# full APPROVED_LIVE_UNIVERSE -- referenced directly, not copied, so this
-# tuple can never silently drift out of sync with the one bound
-# asa/api/screening_routes.py and screening/cli.py's own --live flag both
-# already enforce (PROD-005 confirmed this explicitly). earnings_calendar
-# is deliberately excluded pending PROD-004's own provider validation.
+# The production screening universe (project/reports/SPRINT-008D-SCREENING-
+# UNIVERSE.md, PROD-001; expanded SPRINT-011/UNI-001-UNI-002): all three
+# migrated strategies now run in scheduled production. forward_factor and
+# skew_momentum, whose data requirements are met entirely by Tradier, run
+# across the full APPROVED_LIVE_UNIVERSE; earnings_calendar, which needs an
+# earnings event, runs only across EARNINGS_CALENDAR_UNIVERSE (the
+# single-name subset -- ETFs have no earnings). Both source tuples are
+# referenced directly, never copied, so this can't silently drift out of
+# sync with the same bound asa/api/screening_routes.py and screening/cli.py's
+# own --live flag already enforce (PROD-005 confirmed this pattern
+# explicitly; SPRINT-010's REL-001 fixed earnings_calendar's own live
+# acquisition, the reason it was excluded here before).
 PRODUCTION_SCREENING_UNIVERSE: tuple[tuple[str, str], ...] = tuple(
     (signal_id, symbol)
     for signal_id in ("forward_factor", "skew_momentum")
     for symbol in APPROVED_LIVE_UNIVERSE
-)
+) + tuple(("earnings_calendar", symbol) for symbol in EARNINGS_CALENDAR_UNIVERSE)
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -198,6 +202,10 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     outcomes = run_scheduled_refresh(enforce_schedule=True)
     failures = [item for item in outcomes if item.error is not None]
+    outcome_counts: dict[str, int] = {}
+    for item in outcomes:
+        key = "infrastructure_failure" if item.error is not None else (item.outcome or "unknown")
+        outcome_counts[key] = outcome_counts.get(key, 0) + 1
 
     if not args.json:
         print(f"SCHEDULED SCREENING RUN -- {len(outcomes)} pairs")
@@ -209,12 +217,19 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"  {item.signal_id:<18} {item.symbol:<6} {item.outcome} "
                     f"(requests={item.request_count})"
                 )
+        print(f"  outcome counts: {outcome_counts}")
 
     print(
         json.dumps(
             {
                 "total": len(outcomes),
                 "failed": len(failures),
+                # Sanitized outcome-distribution counts only (no symbols, no
+                # request bodies) -- SPRINT-011/UNI-002's own safe
+                # operational diagnostic, distinguishing legitimate
+                # no_signal/pass outcomes from real infrastructure failures
+                # at a glance, without exposing anything secret.
+                "outcome_counts": outcome_counts,
                 "results": [
                     {
                         "signal_id": item.signal_id,

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -11,7 +11,7 @@ from asa.scheduled_screening import (
     run_scheduled_refresh,
 )
 from market_data.transport import ReadOnlyHttpResponse
-from screening import APPROVED_LIVE_UNIVERSE
+from screening import APPROVED_LIVE_UNIVERSE, EARNINGS_CALENDAR_UNIVERSE
 from tests.asa.fakes import InMemoryLatestResultRepository
 from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
 
@@ -56,17 +56,28 @@ def _tradier_refresh_responses(expiration: str) -> list[ReadOnlyHttpResponse]:
     ]
 
 
-def test_production_universe_is_forward_factor_and_skew_momentum_only() -> None:
-    # SPRINT-011/UNI-001 expanded APPROVED_LIVE_UNIVERSE; the pair count here
-    # derives from it rather than a hardcoded literal so this assertion
-    # doesn't silently drift out of sync (matching PROD-005's own established
-    # single-source-of-truth rationale). earnings_calendar's own addition to
-    # the scheduler is UNI-002's job, not this one.
+def test_production_universe_covers_all_three_migrated_strategies() -> None:
+    # SPRINT-011/UNI-002: earnings_calendar joins forward_factor/skew_momentum
+    # in the scheduled universe now that REL-001 (SPRINT-010) fixed its live
+    # acquisition. Counts derive from the source tuples, not a hardcoded
+    # literal, so this can't silently drift (PROD-005's own established
+    # single-source-of-truth rationale).
     signal_ids = {signal_id for signal_id, _symbol in PRODUCTION_SCREENING_UNIVERSE}
-    assert signal_ids == {"forward_factor", "skew_momentum"}
-    expected = 2 * len(APPROVED_LIVE_UNIVERSE)
+    assert signal_ids == {"forward_factor", "skew_momentum", "earnings_calendar"}
+    expected = 2 * len(APPROVED_LIVE_UNIVERSE) + len(EARNINGS_CALENDAR_UNIVERSE)
     assert len(PRODUCTION_SCREENING_UNIVERSE) == expected
     assert len(set(PRODUCTION_SCREENING_UNIVERSE)) == expected  # no duplicate pairs
+
+
+def test_earnings_calendar_pairs_use_the_single_name_subset_only() -> None:
+    etfs = {"SPY", "QQQ", "IWM", "DIA", "XLF", "XLE", "XLK", "GLD"}
+    earnings_symbols = {
+        symbol
+        for signal_id, symbol in PRODUCTION_SCREENING_UNIVERSE
+        if signal_id == "earnings_calendar"
+    }
+    assert earnings_symbols == set(EARNINGS_CALENDAR_UNIVERSE)
+    assert earnings_symbols.isdisjoint(etfs)
 
 
 def test_no_enabled_provider_raises(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Wires earnings_calendar + expanded universe into \`PRODUCTION_SCREENING_UNIVERSE\` (all 3 strategies now scheduled: forward_factor/skew_momentum × full 30-symbol universe, earnings_calendar × single-name subset). 5-window market-day cadence already existed (SPRINT-010/TEMP-005), confirmed matching by inspection + existing test, untouched. Duplicate coalescing + per-pair isolation already in place, untouched. Added sanitized outcome-distribution counts to the scheduled run's JSON diagnostic.

Full suite: 1916 passed, 14 skipped, zero regressions.

Ref docs/sprints/SPRINT-011.yaml, UNI-002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)