### PR TITLE
CLOSE-001: log full exception detail at screening's generic catch-all

### DIFF
--- a/screening/runner.py
+++ b/screening/runner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from collections.abc import Callable, Mapping
 from datetime import datetime
 
@@ -18,6 +19,8 @@ from screening.clock import Clock
 from screening.errors import UnknownScreeningStrategyIdError
 from screening.registry import ScreeningRegistry, ScreeningStrategyDefinition
 from screening.results import ScreeningOutcomeStatus, ScreeningResult, bounded_failure_detail
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class StrategyAdapterError(Exception):
@@ -124,6 +127,16 @@ def _run_one(
     except StrategyAdapterError as error:
         return _adapter_error_result(run_id, definition, as_of, error)
     except Exception as exc:  # noqa: BLE001 -- deliberate per-strategy isolation boundary
+        # Persisted/API-facing detail stays class-name-only (test_runner.py::
+        # test_strategy_exception asserts raw exception text is never
+        # leaked into a publicly-served result) -- full detail goes only to
+        # this operator-only log line, never into the ScreeningResult
+        # itself (SPRINT-011-CLOSEOUT/CLOSE-001).
+        _LOGGER.warning(
+            "strategy adapter raised an unhandled exception",
+            extra={"strategy_id": definition.strategy_id},
+            exc_info=True,
+        )
         return _exception_result(
             run_id, definition, as_of, f"{type(exc).__name__}: unhandled adapter exception"
         )

--- a/tests/architecture/test_screening_boundaries.py
+++ b/tests/architecture/test_screening_boundaries.py
@@ -23,8 +23,16 @@ FORBIDDEN_INFRASTRUCTURE_MODULES = {
 
 STDLIB_ALLOWED = {
     "__future__", "abc", "argparse", "collections", "dataclasses", "datetime", "decimal", "enum",
-    "hashlib", "json", "re", "sys", "typing",
+    "hashlib", "json", "logging", "re", "sys", "typing",
 }
+# "logging" added (SPRINT-011-CLOSEOUT/CLOSE-001): pure stdlib, no network/
+# disk/process side channel FORBIDDEN_INFRASTRUCTURE_MODULES above already
+# guards against -- this module's own docstring's actual concern is a
+# dependency on providers/market_data internals/infrastructure, not
+# observability. screening/runner.py needs it to log full (operator-only,
+# never persisted or API-exposed) exception detail at its own generic
+# except-Exception boundary, matching asa/scheduled_screening.py's own
+# existing use of the same pattern.
 
 
 def _imported_roots(py_file: Path) -> set[str]:


### PR DESCRIPTION
Diagnostic-only fix enabling real root-cause work on the 6 forward_factor \`strategy_exception\` symbols (GS, LLY, MU, NFLX, XLE, XLK): adds an operator-only warning log with \`exc_info=True\` at \`screening/runner.py::_run_one\`'s generic catch-all. Persisted/API-facing result is unchanged (still class-name-only -- \`test_strategy_exception\` proves it).

**Near-miss caught before merge**: an earlier version put \`str(exc)\` directly into the persisted result instead. Two existing regression tests (\`test_strategy_exception\`, \`test_no_credential_or_internal_exception_detail_leaks_beyond_the_type_name\`) exist specifically to prevent that -- caught it, reverted, went with logging instead.

Required adding \`logging\` to \`test_screening_boundaries.py\`'s \`STDLIB_ALLOWED\` (pure stdlib, not in \`FORBIDDEN_INFRASTRUCTURE_MODULES\`, same pattern \`asa/scheduled_screening.py\` already uses).

Full suite: 1916 passed, 14 skipped, zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)