### PR TITLE
CLOSE-002: replace hardcoded skew_momentum/earnings_calendar scores with real live signals

### DIFF
--- a/.github/workflows/validate-architecture.yml
+++ b/.github/workflows/validate-architecture.yml
@@ -20,6 +20,8 @@ on:
       - 'domain/**'
       - 'market_data/**'
       - 'strategy_runtime/**'
+      - 'screening/**'
+      - 'analytics/**'
       - 'asa/**'
       - 'docs/providers/**'
       - 'architecture/**'
@@ -38,6 +40,8 @@ on:
       - 'tests/portfolio/**'
       - 'tests/execution_planning/**'
       - 'tests/strategy_runtime/**'
+      - 'tests/screening/**'
+      - 'tests/analytics/**'
   workflow_dispatch:
 
 jobs:
@@ -74,6 +78,8 @@ jobs:
           tests/portfolio
           tests/execution_planning
           tests/strategy_runtime
+          tests/screening
+          tests/analytics
           -v
 
       - name: Check generated provider documentation drift

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -31,6 +31,12 @@ from analytics.forward_factor import (
     compute_days_to_expiration,
     compute_option_implied_volatility,
 )
+from analytics.realized_volatility import (
+    InsufficientPriceHistoryError,
+    compute_log_returns,
+    compute_realized_volatility,
+    compute_trailing_return,
+)
 from analytics.registry import AnalyticsFeatureDefinition, AnalyticsRegistry
 
 __all__ = [
@@ -44,12 +50,16 @@ __all__ = [
     "DuplicateFeatureRegistrationError",
     "ExpirationCandidate",
     "FeatureComputation",
+    "InsufficientPriceHistoryError",
     "MissingImpliedVolatilityError",
     "NoMatchingContractError",
     "UnknownFeatureIdError",
     "compute_days_to_expiration",
     "compute_feature",
+    "compute_log_returns",
     "compute_option_implied_volatility",
+    "compute_realized_volatility",
+    "compute_trailing_return",
     "select_atm_strike",
     "select_earnings_relative_expiration_pair",
     "select_expiration_pair",

--- a/analytics/engine.py
+++ b/analytics/engine.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from decimal import Decimal
 
-from domain import EvidenceReference
 from analytics.clock import Clock
 from analytics.features import DerivedFeatureResult
 from analytics.registry import AnalyticsFeatureDefinition
+from domain import EvidenceReference
 
 # A feature computation is a pure function of its named inputs to one
 # Decimal value. Different features take wildly different inputs (implied

--- a/analytics/forward_factor.py
+++ b/analytics/forward_factor.py
@@ -22,10 +22,10 @@ from datetime import date
 from decimal import Decimal
 from typing import cast
 
-from domain import MarketCapability, OptionChain, OptionType
 from analytics.engine import FeatureComputation
 from analytics.errors import MissingImpliedVolatilityError, NoMatchingContractError
 from analytics.registry import AnalyticsFeatureDefinition, AnalyticsRegistry
+from domain import MarketCapability, OptionChain, OptionType
 
 DAYS_TO_EXPIRATION_FEATURE_ID = "days_to_expiration"
 OPTION_IMPLIED_VOLATILITY_FEATURE_ID = "option_implied_volatility"

--- a/analytics/realized_volatility.py
+++ b/analytics/realized_volatility.py
@@ -1,0 +1,58 @@
+"""Realized volatility and price momentum from a historical close series
+(SPRINT-011-CLOSEOUT/CLOSE-002).
+
+Pure functions over an already-acquired, already-canonical close-price
+series (domain.OHLCVBar.close) -- no acquisition, no provider knowledge,
+matching this package's own established convention (analytics/
+forward_factor.py's identical shape). Used by screening/live_adapters.py
+to replace hardcoded score inputs (screening/context_builders.py's
+build_skew_momentum_context()/build_earnings_calendar_context(), until
+this ticket both silently disconnected from any live market data --
+see project/reports/SPRINT-011.md) with real, symbol-specific signals.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from decimal import Decimal
+
+_TRADING_DAYS_PER_YEAR = Decimal(252)
+
+
+class InsufficientPriceHistoryError(ValueError):
+    """Fewer than two closes were supplied; no return is computable."""
+
+
+def compute_log_returns(closes: Sequence[Decimal]) -> tuple[Decimal, ...]:
+    if len(closes) < 2:
+        raise InsufficientPriceHistoryError("at least two closes are required")
+    if any(value <= 0 for value in closes):
+        raise InsufficientPriceHistoryError("closes must be strictly positive")
+    return tuple((closes[i] / closes[i - 1]).ln() for i in range(1, len(closes)))
+
+
+def compute_realized_volatility(closes: Sequence[Decimal]) -> Decimal:
+    """Annualized realized volatility: stdev of daily log returns * sqrt(252),
+    the standard, well-known estimator this codebase has no prior
+    implementation of (grepped before writing this, per root_cause_policy's
+    own do_not_repeat_repository_history_already_available rule) -- not
+    ported from anywhere, since there is nowhere to port it from.
+    """
+    returns = compute_log_returns(closes)
+    mean = sum(returns, Decimal(0)) / len(returns)
+    variance = sum(((value - mean) ** 2 for value in returns), Decimal(0)) / len(returns)
+    return variance.sqrt() * _TRADING_DAYS_PER_YEAR.sqrt()
+
+
+def compute_trailing_return(closes: Sequence[Decimal]) -> Decimal:
+    """Simple time-series momentum: total return from the oldest to the
+    newest close in the supplied window (Volatility Vibes, "How to Spot
+    10x Vertical Spreads BEFORE They Take Off", 17:10 "Gaining a
+    Directional Edge From Momentum" -- time series momentum is "whether a
+    stock's recent return is positive or negative").
+    """
+    if len(closes) < 2:
+        raise InsufficientPriceHistoryError("at least two closes are required")
+    if closes[0] <= 0:
+        raise InsufficientPriceHistoryError("closes must be strictly positive")
+    return (closes[-1] - closes[0]) / closes[0]

--- a/analytics/registry.py
+++ b/analytics/registry.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from domain import MarketCapability
 from analytics.errors import DuplicateFeatureRegistrationError, UnknownFeatureIdError
+from domain import MarketCapability
 
 
 def _normalized_text(value: str, owner: str, field_name: str) -> None:

--- a/screening/adapters.py
+++ b/screening/adapters.py
@@ -112,7 +112,17 @@ def run_earnings_calendar(
     event = fixtures.earnings_calendar_event()
     chain = fixtures.earnings_calendar_chain()
     context = build_earnings_calendar_context(
-        chain, event, front, back, fixtures.AS_OF_DATE, target_strike=Decimal("100")
+        chain,
+        event,
+        front,
+        back,
+        fixtures.AS_OF_DATE,
+        target_strike=Decimal("100"),
+        # Deterministic, offline-only fixture values -- this dry-run path
+        # never touches live market data, so there is no real richness
+        # signal to compute. Unrelated to the live adapter's own real,
+        # symbol-specific score_values (screening/live_adapters.py).
+        score_values=(Decimal("80"), Decimal("60")),
     )
     graph = compile_strategy_graph(EARNINGS_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
     result = execute_strategy_graph(graph, context)
@@ -130,7 +140,13 @@ def run_skew_momentum(
 ) -> ScreeningResult:
     chain = fixtures.skew_momentum_chain()
     context = build_skew_momentum_context(
-        chain, fixtures.SKEW_EXPIRATION, strike=Decimal("100"), option_type=OptionType.CALL
+        chain,
+        fixtures.SKEW_EXPIRATION,
+        strike=Decimal("100"),
+        option_type=OptionType.CALL,
+        # Deterministic, offline-only fixture values -- see
+        # run_earnings_calendar's own identical note above.
+        score_values=(Decimal("80"), Decimal("70")),
     )
     graph = compile_strategy_graph(SKEW_MOMENTUM_VERTICAL_MANIFEST, _COMPONENT_REGISTRY)
     result = execute_strategy_graph(graph, context)

--- a/screening/context_builders.py
+++ b/screening/context_builders.py
@@ -3,10 +3,17 @@
 Constructs each target strategy's frozen manifest execution context from
 canonical market data. Forward Factor's builder uses analytics/ for the
 implied-forward-volatility inputs SPRINT-006 found missing (ANALYTICS-002)
-instead of any hardcoded external constant; Earnings Calendar and Skew
-Momentum need no derived analytics, so their builders just isolate the
-context-construction logic previously inline in screening/adapters.py into
-separately testable functions.
+instead of any hardcoded external constant.
+
+Earnings Calendar and Skew Momentum's own score.values inputs were
+hardcoded constants from this ticket's original authorship until
+SPRINT-011-CLOSEOUT/CLOSE-002 found them: identical for every symbol,
+completely disconnected from vertical/calendar/debit's own real computed
+outputs, silently making every live PASS/WATCH verdict from either
+strategy meaningless. Both builders now take score_values as a required
+keyword argument -- real, symbol-specific, live-data-derived signals the
+caller (screening/live_adapters.py) computes, never invented here. See
+project/reports/SPRINT-011.md for the full defect writeup.
 
 Adapters only: no strategy modification, no provider import. Every builder
 here takes already-canonical domain objects and produces a ComponentValues
@@ -24,7 +31,6 @@ from analytics.expiration_selection import ExpirationCandidate, select_expiratio
 from analytics.forward_factor import compute_days_to_expiration, compute_option_implied_volatility
 from domain import EarningsEvent, ExpirationCollection, ExpirationCycle, OptionChain, OptionType
 from strategies.stonk_components import (
-    D,
     DATE,
     DECIMAL_LIST,
     EARNINGS_EVENT,
@@ -32,6 +38,7 @@ from strategies.stonk_components import (
     EXPIRATION_CYCLE,
     OPTION_CHAIN,
     OPTION_CONTRACT,
+    D,
 )
 from strategies.type_system import ComponentValues, StrategyTypeReference, TypedValue
 
@@ -132,7 +139,17 @@ def build_earnings_calendar_context(
     as_of: date,
     *,
     target_strike: Decimal,
+    score_values: tuple[Decimal, Decimal],
 ) -> ComponentValues:
+    """score_values -- SPRINT-011-CLOSEOUT/CLOSE-002: (term_structure_richness,
+    iv_realized_vol_richness), both real, symbol-specific, live-data-derived
+    signals the caller computes inline (screening/live_adapters.py's
+    build_live_earnings_calendar_adapter, using _richness_score()) -- this
+    function no longer hardcodes (80, 60) regardless of symbol. Weights
+    (3, 1) remain a genuine strategy parameter, same status as
+    verdict_classifier's own pass_threshold/watch_threshold literals, not
+    market data -- unchanged by this fix.
+    """
     return _context(
         **{
             "event_window.event": (EARNINGS_EVENT, event),
@@ -145,7 +162,7 @@ def build_earnings_calendar_context(
             "expiration_select.event": (EARNINGS_EVENT, event),
             "calendar.chain": (OPTION_CHAIN, chain),
             "calendar.target_strike": (D, target_strike),
-            "score.values": (DECIMAL_LIST, (Decimal("80"), Decimal("60"))),
+            "score.values": (DECIMAL_LIST, score_values),
             "score.weights": (DECIMAL_LIST, (Decimal("3"), Decimal("1"))),
         }
     )
@@ -157,14 +174,24 @@ def build_skew_momentum_context(
     *,
     strike: Decimal,
     option_type: OptionType = OptionType.CALL,
+    score_values: tuple[Decimal, Decimal],
 ) -> ComponentValues:
+    """score_values -- SPRINT-011-CLOSEOUT/CLOSE-002: (skew_richness,
+    momentum_richness), both real, symbol-specific, live-data-derived
+    signals the caller computes inline (screening/live_adapters.py's
+    build_live_skew_momentum_adapter, using _richness_score()) -- this
+    function no longer hardcodes (80, 70) regardless of symbol. Weights
+    (2, 1) remain a genuine strategy parameter (skew is the primary edge,
+    momentum an enhancer, per Volatility Vibes' own framing), not market
+    data -- unchanged by this fix.
+    """
     (contract,) = chain.find(expiration=expiration, strike=strike, option_type=option_type)
     return _context(
         **{
             "vertical.chain": (OPTION_CHAIN, chain),
             "vertical.expiration": (DATE, expiration),
             "liquidity.contract": (OPTION_CONTRACT, contract),
-            "score.values": (DECIMAL_LIST, (Decimal("80"), Decimal("70"))),
+            "score.values": (DECIMAL_LIST, score_values),
             "score.weights": (DECIMAL_LIST, (Decimal("2"), Decimal("1"))),
         }
     )

--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -31,16 +31,19 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from typing import cast
 
 from analytics.expiration_selection import (
     ExpirationCandidate,
     rank_expiration_pairs,
     select_earnings_relative_expiration_pair,
 )
+from analytics.realized_volatility import compute_realized_volatility, compute_trailing_return
 from domain import (
     DomainInvariantError,
     EarningsEvent,
     MarketCapability,
+    OHLCVBar,
     OptionChain,
     OptionType,
     Quote,
@@ -67,6 +70,7 @@ from screening.live_context import (
     classify_domain_invariant_error,
     combine_option_chains,
     select_atm_strike_at_expiration,
+    select_nearest_delta_contract,
 )
 from screening.registry import ScreeningStrategyDefinition
 from screening.results import ScreeningOutcomeStatus, ScreeningResult
@@ -236,6 +240,78 @@ def _spot_price(quote: Quote) -> Decimal:
     )
 
 
+# SPRINT-011-CLOSEOUT/CLOSE-002: real, live-data-derived score inputs for
+# Earnings Calendar and Skew Momentum, replacing what were unconditional
+# hardcoded constants (identical for every symbol) since this ticket's
+# original authorship. See project/reports/SPRINT-011.md for the full
+# defect writeup and cited sources for each strategy's own thesis.
+_HISTORICAL_LOOKBACK_DAYS = 45  # calendar days -- ~30 trading days
+# Centers a richness score at 50 (neutral); a 1/3 (0.33) vol-point or
+# return gap saturates it to 0 or 100. A deliberate, documented, linear
+# approximation -- not the exact z-score-against-own-history system either
+# cited video describes (that needs a persisted historical skew/IV-term
+# time series this codebase does not have yet); reusing IV-vs-realized-
+# volatility and price momentum instead, both computable from data this
+# system already acquires live.
+_RICHNESS_SCALE = Decimal("300")
+
+
+def _richness_score(raw_gap: Decimal) -> Decimal:
+    return max(Decimal(0), min(Decimal(100), Decimal(50) + raw_gap * _RICHNESS_SCALE))
+
+
+def _acquire_daily_closes(
+    fulfillment: CapabilityFulfillmentService, symbol: str, now: datetime
+) -> tuple[Decimal, ...]:
+    """Oldest-first daily close series over a fixed lookback window, for
+    realized-volatility and momentum computation. Unlike every other
+    capability this module acquires, a historical-bars request fulfils as
+    *one MarketObservation per day* (market_data/tradier.py's own
+    _normalize()) -- this reads every observation, not just the first, and
+    skips the single-observation freshness/usability gate _acquire_or_raise
+    applies elsewhere: "freshness" for a completed prior trading day's
+    close is not the same concept as for a live quote or chain.
+    """
+    lookback_start = now - timedelta(days=_HISTORICAL_LOOKBACK_DAYS)
+    subject = build_capability_subject(
+        symbol,
+        MarketCapability.HISTORICAL_BARS_V1,
+        now,
+        effective_start=lookback_start,
+        effective_end=now,
+        required_fields=("close",),
+    )
+    try:
+        result = acquire_capability(
+            fulfillment,
+            MarketCapability.HISTORICAL_BARS_V1,
+            subject,
+            effective_start=lookback_start,
+            effective_end=now,
+            required_fields=("close",),
+            maximum_age_seconds=int(timedelta(days=_HISTORICAL_LOOKBACK_DAYS + 1).total_seconds()),
+        )
+    except DomainInvariantError as exc:
+        raise StrategyAdapterError(
+            ScreeningOutcomeStatus.MISSING_DATA,
+            classify_domain_invariant_error(exc, MarketCapability.HISTORICAL_BARS_V1, symbol),
+        ) from exc
+    if result.status is FulfillmentStatus.FAILED or not result.observations:
+        raise StrategyAdapterError(
+            ScreeningOutcomeStatus.MISSING_DATA,
+            f"a valid request for live {MarketCapability.HISTORICAL_BARS_V1.value} for "
+            f"{symbol} could not be completed or normalized",
+        )
+    ordered = sorted(result.observations, key=lambda item: item.effective_time)
+    closes = tuple(cast(OHLCVBar, item.value).close for item in ordered)
+    if len(closes) < 2:
+        raise StrategyAdapterError(
+            ScreeningOutcomeStatus.MISSING_DATA,
+            f"fewer than two historical daily closes available for {symbol}",
+        )
+    return closes
+
+
 def build_live_forward_factor_adapter(
     symbol: str,
     fulfillment: CapabilityFulfillmentService,
@@ -382,8 +458,44 @@ def build_live_earnings_calendar_adapter(
         target_strike = select_atm_strike_at_expiration(
             chain, front_cycle.expiration_date, spot_price, OptionType.CALL
         )
+        back_strike = select_atm_strike_at_expiration(
+            chain, back_cycle.expiration_date, spot_price, OptionType.CALL
+        )
+        (front_contract,) = chain.find(
+            expiration=front_cycle.expiration_date, strike=target_strike, option_type=OptionType.CALL
+        )
+        (back_contract,) = chain.find(
+            expiration=back_cycle.expiration_date, strike=back_strike, option_type=OptionType.CALL
+        )
+        if front_contract.implied_volatility is None or back_contract.implied_volatility is None:
+            raise StrategyAdapterError(
+                ScreeningOutcomeStatus.MISSING_DATA,
+                f"front or back at-the-money contract for {symbol} has no implied_volatility",
+            )
+        # Term-structure richness (Karl Domm, "This Option Strategy Turned
+        # $10k Into $1 Million In One Year", ~06:45): the single strongest
+        # predictor in that video's own 72,500-event study was a steep
+        # negative term-structure slope, i.e. front-month IV meaningfully
+        # richer than the ~45-day-out expiration -- approximated here as
+        # this strategy's own already-selected front/back ATM IVs, not a
+        # separately-fetched fixed 45-day point (this system selects
+        # front/back via its own earnings-relative DTE policy, not a fixed
+        # calendar pin).
+        term_richness = _richness_score(front_contract.implied_volatility - back_contract.implied_volatility)
+        closes = _acquire_daily_closes(fulfillment, symbol, now)
+        realized_vol = compute_realized_volatility(closes)
+        # iv30/rv30-style richness (same source, ~09:40): front-month IV
+        # priced above what has actually realized -- the second predictor
+        # that video's own decile analysis found correlated with returns.
+        iv_rv_richness = _richness_score(front_contract.implied_volatility - realized_vol)
         context = build_earnings_calendar_context(
-            chain, event, front_cycle, back_cycle, as_of, target_strike=target_strike  # type: ignore[arg-type]
+            chain,
+            event,  # type: ignore[arg-type]
+            front_cycle,
+            back_cycle,
+            as_of,
+            target_strike=target_strike,
+            score_values=(term_richness, iv_rv_richness),
         )
         graph = compile_strategy_graph(EARNINGS_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
         result = execute_strategy_graph(graph, context)
@@ -444,8 +556,39 @@ def build_live_skew_momentum_adapter(
         strike = select_atm_strike_at_expiration(
             chain, nearest.expiration_date, spot_price, OptionType.CALL  # type: ignore[arg-type]
         )
+        (atm_contract,) = chain.find(  # type: ignore[attr-defined]
+            expiration=nearest.expiration_date, strike=strike, option_type=OptionType.CALL
+        )
+        wing_contract = select_nearest_delta_contract(
+            chain,  # type: ignore[arg-type]
+            nearest.expiration_date,
+            OptionType.CALL,
+            Decimal("0.25"),
+            exclude_strike=strike,
+        )
+        if atm_contract.implied_volatility is None or wing_contract.implied_volatility is None:
+            raise StrategyAdapterError(
+                ScreeningOutcomeStatus.MISSING_DATA,
+                f"at-the-money or 25-delta wing contract for {symbol} has no implied_volatility",
+            )
+        # Skew richness (Volatility Vibes, "How to Spot 10x Vertical
+        # Spreads BEFORE They Take Off", ~05:53): call skew = (ATM_IV -
+        # 25-delta_IV) / ATM_IV; a more negative value means the wing
+        # trades richer than the near-the-money leg. Inverted here (wing
+        # minus ATM, not normalized) so a positive richness score means
+        # "the wing we'd sell is rich" -- the sign the vertical's own
+        # long-ATM/short-wing structure (strategies/stonk_manifests.py's
+        # own frozen 0.50/0.25 delta targets, unchanged by this fix) is
+        # built to exploit.
+        skew_richness = _richness_score(wing_contract.implied_volatility - atm_contract.implied_volatility)
+        closes = _acquire_daily_closes(fulfillment, symbol, now)
+        momentum_richness = _richness_score(compute_trailing_return(closes))
         context = build_skew_momentum_context(
-            chain, nearest.expiration_date, strike=strike, option_type=OptionType.CALL  # type: ignore[arg-type]
+            chain,  # type: ignore[arg-type]
+            nearest.expiration_date,
+            strike=strike,
+            option_type=OptionType.CALL,
+            score_values=(skew_richness, momentum_richness),
         )
         graph = compile_strategy_graph(SKEW_MOMENTUM_VERTICAL_MANIFEST, _COMPONENT_REGISTRY)
         result = execute_strategy_graph(graph, context)

--- a/screening/live_context.py
+++ b/screening/live_context.py
@@ -87,6 +87,42 @@ def select_atm_strike_at_expiration(
     return select_atm_strike(strikes, spot_price)
 
 
+class NoContractNearDeltaError(ValueError):
+    """No contract with a populated delta exists at the given expiration."""
+
+
+def select_nearest_delta_contract(
+    chain: OptionChain,
+    expiration: date,
+    option_type: OptionType,
+    target_delta: Decimal,
+    *,
+    exclude_strike: Decimal | None = None,
+) -> OptionContract:
+    """SPRINT-011-CLOSEOUT/CLOSE-002: a screening-layer-owned delta lookup,
+    used only to measure a real, live skew/richness signal for scoring --
+    a fresh, small, public implementation, not a reach into
+    strategies/stonk_components.py's own private _nearest_delta (this
+    module's own docstring already established why screening/ cannot do
+    that: no queryable API, would reach into private internals). The
+    execution graph's own leg selection (strategies/stonk_manifests.py's
+    frozen VerticalStructure node) is completely unmodified by this --
+    this function only informs the score context supplied alongside it,
+    never the structure itself.
+    """
+    candidates = tuple(
+        contract
+        for contract in chain.find(expiration=expiration, option_type=option_type)
+        if contract.delta is not None and contract.strike != exclude_strike
+    )
+    if not candidates:
+        raise NoContractNearDeltaError(
+            f"no {option_type.value} contract with a populated delta at expiration "
+            f"{expiration.isoformat()}"
+        )
+    return min(candidates, key=lambda item: abs(abs(item.delta) - abs(target_delta)))  # type: ignore[arg-type]
+
+
 def _is_monthly_expiration(expiration: date) -> bool:
     """Third Friday of the month -- the standard monthly options cycle."""
     return expiration.weekday() == 4 and 15 <= expiration.day <= 21

--- a/tests/analytics/test_forward_factor_manifest_integration.py
+++ b/tests/analytics/test_forward_factor_manifest_integration.py
@@ -42,7 +42,7 @@ from strategies import (
     execute_strategy_graph,
 )
 from strategies.plugins import build_plugin_registry
-from strategies.stonk_components import D, EXPIRATION_COLLECTION, OPTION_CHAIN
+from strategies.stonk_components import EXPIRATION_COLLECTION, OPTION_CHAIN, D
 from strategies.type_system import ComponentValues, StrategyTypeReference, TypedValue
 
 AS_OF = date(2026, 7, 22)

--- a/tests/analytics/test_realized_volatility.py
+++ b/tests/analytics/test_realized_volatility.py
@@ -1,0 +1,67 @@
+"""SPRINT-011-CLOSEOUT/CLOSE-002: realized volatility and price momentum."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from analytics.realized_volatility import (
+    InsufficientPriceHistoryError,
+    compute_log_returns,
+    compute_realized_volatility,
+    compute_trailing_return,
+)
+
+
+class TestComputeLogReturns:
+    def test_two_closes_produce_one_return(self) -> None:
+        returns = compute_log_returns((Decimal("100"), Decimal("110")))
+        assert len(returns) == 1
+        assert returns[0] > Decimal(0)  # price rose
+
+    def test_flat_series_produces_zero_returns(self) -> None:
+        returns = compute_log_returns((Decimal("100"), Decimal("100"), Decimal("100")))
+        assert all(value == Decimal(0) for value in returns)
+
+    def test_fewer_than_two_closes_raises(self) -> None:
+        with pytest.raises(InsufficientPriceHistoryError):
+            compute_log_returns((Decimal("100"),))
+
+    def test_non_positive_close_raises(self) -> None:
+        with pytest.raises(InsufficientPriceHistoryError):
+            compute_log_returns((Decimal("100"), Decimal("0")))
+
+
+class TestComputeRealizedVolatility:
+    def test_flat_series_has_zero_volatility(self) -> None:
+        closes = tuple(Decimal("100") for _ in range(20))
+        assert compute_realized_volatility(closes) == Decimal(0)
+
+    def test_more_volatile_series_scores_higher(self) -> None:
+        calm = (Decimal("100"), Decimal("101"), Decimal("100"), Decimal("101"), Decimal("100"))
+        wild = (Decimal("100"), Decimal("130"), Decimal("90"), Decimal("140"), Decimal("80"))
+        assert compute_realized_volatility(wild) > compute_realized_volatility(calm)
+
+    def test_result_is_non_negative(self) -> None:
+        closes = (Decimal("100"), Decimal("95"), Decimal("105"), Decimal("98"))
+        assert compute_realized_volatility(closes) >= Decimal(0)
+
+
+class TestComputeTrailingReturn:
+    def test_positive_when_price_rose(self) -> None:
+        assert compute_trailing_return((Decimal("100"), Decimal("120"))) == Decimal("0.2")
+
+    def test_negative_when_price_fell(self) -> None:
+        assert compute_trailing_return((Decimal("100"), Decimal("80"))) == Decimal("-0.2")
+
+    def test_zero_when_flat(self) -> None:
+        assert compute_trailing_return((Decimal("100"), Decimal("100"), Decimal("100"))) == Decimal(0)
+
+    def test_only_endpoints_matter_not_the_path(self) -> None:
+        volatile_path = (Decimal("100"), Decimal("200"), Decimal("10"), Decimal("110"))
+        assert compute_trailing_return(volatile_path) == Decimal("0.1")
+
+    def test_fewer_than_two_closes_raises(self) -> None:
+        with pytest.raises(InsufficientPriceHistoryError):
+            compute_trailing_return((Decimal("100"),))

--- a/tests/screening/test_context_builders.py
+++ b/tests/screening/test_context_builders.py
@@ -45,19 +45,31 @@ class TestBuildEarningsCalendarContext:
         event = fixtures.earnings_calendar_event()
         chain = fixtures.earnings_calendar_chain()
         context = build_earnings_calendar_context(
-            chain, event, front, back, fixtures.AS_OF_DATE, target_strike=Decimal("100")
+            chain,
+            event,
+            front,
+            back,
+            fixtures.AS_OF_DATE,
+            target_strike=Decimal("100"),
+            score_values=(Decimal("80"), Decimal("60")),
         )
         values = dict(context.entries)
         assert values["calendar.target_strike"].value == Decimal("100")
         assert values["event_window.event"].value is event
+        assert values["score.values"].value == (Decimal("80"), Decimal("60"))
 
 
 class TestBuildSkewMomentumContext:
     def test_builds_a_context(self) -> None:
         chain = fixtures.skew_momentum_chain()
         context = build_skew_momentum_context(
-            chain, fixtures.SKEW_EXPIRATION, strike=Decimal("100"), option_type=OptionType.CALL
+            chain,
+            fixtures.SKEW_EXPIRATION,
+            strike=Decimal("100"),
+            option_type=OptionType.CALL,
+            score_values=(Decimal("80"), Decimal("70")),
         )
         values = dict(context.entries)
         assert values["vertical.expiration"].value == fixtures.SKEW_EXPIRATION
         assert values["liquidity.contract"].value.strike == Decimal("100")
+        assert values["score.values"].value == (Decimal("80"), Decimal("70"))

--- a/tests/screening/test_live_adapters.py
+++ b/tests/screening/test_live_adapters.py
@@ -116,6 +116,82 @@ _EXPIRATIONS_DAYS_OUT_AND_IV = (
 )
 
 
+def _synthetic_daily_bars_fetch_result(provider, request):  # noqa: ANN001
+    """SPRINT-011-CLOSEOUT/CLOSE-002: a HISTORICAL_BARS_V1 request fulfils
+    as one MarketObservation per day (matching market_data/tradier.py's
+    own real shape) -- DeterministicFixtureProvider.fetch() returns
+    exactly one observation per request regardless of capability, not
+    enough for realized-volatility/momentum computation. Shared by every
+    fixture provider in this module that needs to serve a real,
+    non-constant close series instead of the base provider's single fixed
+    bar.
+    """
+    received_at = provider._dependencies.clock.now().astimezone(UTC)  # noqa: SLF001
+    reference = provider._request_reference(request)  # noqa: SLF001
+    response = ProviderResponseMetadata(
+        provider.provider_id,
+        reference,
+        received_at,
+        "fixture",
+        provider._scenario.latency_milliseconds,  # noqa: SLF001
+        0,
+        (("network_requests", "0"),),
+    )
+    attempt = ProviderAttemptMetadata(provider.provider_id, request.capability, 1, 1, response)
+    (subject,) = request.subjects
+    instrument = subject.canonical_instrument
+    observations = []
+    for day_offset in range(29, -1, -1):
+        observed_at = received_at - timedelta(days=day_offset)
+        # Deterministic drift + oscillation, never a flat series, so
+        # realized volatility and trailing momentum are both genuinely
+        # non-zero.
+        close = Decimal("200") + Decimal(day_offset % 5) + Decimal(str((29 - day_offset) * 0.15))
+        bar = OHLCVBar(
+            instrument,
+            86400,
+            observed_at - timedelta(days=1),
+            observed_at,
+            close - Decimal("2"),
+            close + Decimal("2"),
+            close - Decimal("3"),
+            close,
+            Decimal("50000000"),
+        )
+        evidence = (EvidenceReference(EvidenceKind.OBSERVATION, f"fixture-bars-{day_offset}"),)
+        identity = market_observation_identity(
+            provider.provider_id, request.capability, subject, observed_at, bar, "v1"
+        )
+        age_seconds = day_offset * 86400
+        observations.append(
+            MarketObservation(
+                identity,
+                request.capability,
+                subject,
+                observed_at,
+                received_at,
+                bar,
+                "v1",
+                ProviderProvenance(provider.provider_id, reference, evidence),
+                FreshnessMetadata(
+                    received_at,
+                    observed_at,
+                    request.maximum_age_seconds,
+                    age_seconds,
+                    FreshnessStatus.FRESH
+                    if age_seconds <= request.maximum_age_seconds
+                    else FreshnessStatus.STALE,
+                ),
+                CompletenessMetadata(
+                    subject.request_context.required_fields,
+                    subject.request_context.required_fields,
+                    (),
+                ),
+            )
+        )
+    return ProviderFetchResult(tuple(observations), None, (attempt,))
+
+
 class MultiExpirationFixtureProvider(DeterministicFixtureProvider):
     """deterministic_fixture with a four-expiration, multi-strike option
     chain -- still zero network, still fully deterministic, only the
@@ -196,6 +272,14 @@ class MultiExpirationFixtureProvider(DeterministicFixtureProvider):
         return OptionChain(
             f"fixture:{address}:multi-expiration", security, observed_at, contracts, evidence
         )
+
+    def fetch(self, request, budget):  # noqa: ANN001
+        # SPRINT-011-CLOSEOUT/CLOSE-002: see _synthetic_daily_bars_fetch_result's
+        # own docstring. Every other capability still goes through the
+        # real base implementation.
+        if request.capability is not MarketCapability.HISTORICAL_BARS_V1:
+            return super().fetch(request, budget)
+        return _synthetic_daily_bars_fetch_result(self, request)
 
 
 class CapturingMultiExpirationFixtureProvider(MultiExpirationFixtureProvider):
@@ -398,6 +482,8 @@ class TradierShapedMultiExpirationProvider(DeterministicFixtureProvider):
                 return self._expirations_response(request)
             if "contracts" in request.required_fields:
                 return self._chain_response_for_one_expiration(request)
+        if request.capability is MarketCapability.HISTORICAL_BARS_V1:
+            return _synthetic_daily_bars_fetch_result(self, request)
         return super().fetch(request, budget)
 
     def _attempt(self, request, reference, received_at):  # noqa: ANN001

--- a/tests/screening/test_live_context_delta_selection.py
+++ b/tests/screening/test_live_context_delta_selection.py
@@ -1,0 +1,145 @@
+"""SPRINT-011-CLOSEOUT/CLOSE-002: select_nearest_delta_contract() -- a
+screening-layer-owned delta lookup used only to measure a real skew
+signal for scoring, decoupled from strategies/stonk_components.py's own
+private _nearest_delta (see screening/live_context.py's own module
+docstring for why screening/ cannot reach into strategies/'s internals).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from domain import (
+    CanonicalInstrumentIdentity,
+    EvidenceKind,
+    EvidenceReference,
+    Instrument,
+    InstrumentKind,
+    OptionChain,
+    OptionContract,
+    OptionType,
+    Security,
+    SecurityAssetType,
+)
+from screening.live_context import NoContractNearDeltaError, select_nearest_delta_contract
+
+NOW = datetime(2026, 7, 22, 16, 0, tzinfo=UTC)
+EXPIRATION = NOW.date()
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "test"),)
+INSTRUMENT = Instrument(
+    CanonicalInstrumentIdentity("figi", "BBG000B9XRY4"), InstrumentKind.EQUITY, "AAPL", "USD"
+)
+SECURITY = Security(INSTRUMENT, "AAPL", SecurityAssetType.EQUITY, "XNAS")
+
+
+def _contract(strike: Decimal, delta: Decimal, option_type: OptionType = OptionType.CALL) -> OptionContract:
+    return OptionContract(
+        CanonicalInstrumentIdentity("fixture-option", f"AAPL-{strike}-{option_type.value}"),
+        SECURITY,
+        EXPIRATION,
+        strike,
+        option_type,
+        Decimal("4.90"),
+        Decimal("5.10"),
+        Decimal("5.00"),
+        1000,
+        5000,
+        delta,
+        Decimal("0.03"),
+        Decimal("-0.10"),
+        Decimal("0.20"),
+        Decimal("0.01"),
+        Decimal("0.30"),
+        NOW,
+        EVIDENCE,
+    )
+
+
+def _chain(contracts: tuple[OptionContract, ...]) -> OptionChain:
+    return OptionChain("fixture:delta-selection", SECURITY, NOW, contracts, EVIDENCE)
+
+
+class TestSelectNearestDeltaContract:
+    def test_selects_the_contract_closest_to_the_target_delta(self) -> None:
+        chain = _chain(
+            (
+                _contract(Decimal("95"), Decimal("0.60")),
+                _contract(Decimal("100"), Decimal("0.50")),
+                _contract(Decimal("105"), Decimal("0.25")),
+                _contract(Decimal("110"), Decimal("0.10")),
+            )
+        )
+        selected = select_nearest_delta_contract(chain, EXPIRATION, OptionType.CALL, Decimal("0.25"))
+        assert selected.strike == Decimal("105")
+
+    def test_excludes_the_given_strike(self) -> None:
+        chain = _chain(
+            (
+                _contract(Decimal("100"), Decimal("0.26")),
+                _contract(Decimal("105"), Decimal("0.20")),
+            )
+        )
+        # Without exclusion the 100-strike (delta 0.26) is nearer to 0.25;
+        # excluding it must fall through to the next-nearest candidate.
+        selected = select_nearest_delta_contract(
+            chain, EXPIRATION, OptionType.CALL, Decimal("0.25"), exclude_strike=Decimal("100")
+        )
+        assert selected.strike == Decimal("105")
+
+    def test_ignores_contracts_with_no_delta(self) -> None:
+        chain = _chain((_contract(Decimal("100"), Decimal("0.50")),))
+        no_delta = OptionContract(
+            CanonicalInstrumentIdentity("fixture-option", "AAPL-105-call"),
+            SECURITY,
+            EXPIRATION,
+            Decimal("105"),
+            OptionType.CALL,
+            Decimal("4.90"),
+            Decimal("5.10"),
+            Decimal("5.00"),
+            1000,
+            5000,
+            None,
+            Decimal("0.03"),
+            Decimal("-0.10"),
+            Decimal("0.20"),
+            Decimal("0.01"),
+            Decimal("0.30"),
+            NOW,
+            EVIDENCE,
+        )
+        chain_with_gap = OptionChain(
+            "fixture:delta-selection", SECURITY, NOW, chain.contracts + (no_delta,), EVIDENCE
+        )
+        selected = select_nearest_delta_contract(
+            chain_with_gap, EXPIRATION, OptionType.CALL, Decimal("0.25")
+        )
+        assert selected.strike == Decimal("100")  # the only candidate with a populated delta
+
+    def test_raises_when_no_candidate_has_a_delta(self) -> None:
+        no_delta = OptionContract(
+            CanonicalInstrumentIdentity("fixture-option", "AAPL-100-call"),
+            SECURITY,
+            EXPIRATION,
+            Decimal("100"),
+            OptionType.CALL,
+            Decimal("4.90"),
+            Decimal("5.10"),
+            Decimal("5.00"),
+            1000,
+            5000,
+            None,
+            Decimal("0.03"),
+            Decimal("-0.10"),
+            Decimal("0.20"),
+            Decimal("0.01"),
+            Decimal("0.30"),
+            NOW,
+            EVIDENCE,
+        )
+        with pytest.raises(NoContractNearDeltaError):
+            select_nearest_delta_contract(
+                _chain((no_delta,)), EXPIRATION, OptionType.CALL, Decimal("0.25")
+            )


### PR DESCRIPTION
CLOSE-002 set out to validate skew_momentum's 30/30 identical-score result. Root cause: \`build_skew_momentum_context()\` fed the score node two hardcoded constants -- \`(80,70)\` weighted \`(2,1)\` = 76.666... regardless of symbol. Checking the other strategies (Founder's explicit ask) found \`earnings_calendar\` has the identical pattern (\`(80,60)\` weighted \`(3,1)\` = 75.0). \`forward_factor\` is clean.

Founder supplied real thesis sources for each strategy (not invented here):
- skew_momentum: [Volatility Vibes video](https://youtube.com/watch?v=6I5a3QQX4y0) -- skew richness (ATM vs 25-delta wing IV) + time-series momentum
- earnings_calendar: [Karl Domm video](https://youtu.be/oW6MHjzxHpU) -- term-structure slope (front vs back IV) + IV-vs-realized-volatility, the two strongest predictors from a 72,500-event study

Both now compute real, live, symbol-specific signals: new \`analytics/realized_volatility.py\` (realized vol + momentum from historical bars, a capability this codebase already supported per-provider but no strategy had used), \`screening/live_context.py::select_nearest_delta_contract()\` (fresh screening-owned delta lookup, doesn't touch the frozen execution graph), wired through \`screening/live_adapters.py\`. Weights preserved as genuine strategy parameters (not market data). Dry-run/fixture path unchanged (still deterministic, explicitly labeled, unrelated fix).

**Near-miss avoided while investigating CLOSE-001 separately (already merged, PR #240):** an earlier attempt to surface real exception detail put raw text into the persisted/public result; two existing regression tests caught it before merge. Unrelated to this PR but same session, worth noting for context.

Full suite: 1937 passed (16 new tests), 14 skipped, zero regressions. Ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)