### PR TITLE
CLOSE-001: fix forward_factor NoMatchingContractError (front/back strike reuse)

### DIFF
--- a/screening/adapters.py
+++ b/screening/adapters.py
@@ -92,7 +92,11 @@ def run_forward_factor(
     chain = fixtures.forward_factor_chain()
     expirations = fixtures.forward_factor_expirations()
     context = build_forward_factor_context(
-        chain, expirations.cycles, fixtures.AS_OF_DATE, strike=Decimal("105")
+        chain,
+        expirations.cycles,
+        fixtures.AS_OF_DATE,
+        front_strike=Decimal("105"),
+        back_strike=Decimal("105"),
     )
     graph = compile_strategy_graph(FORWARD_FACTOR_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
     result = execute_strategy_graph(graph, context)

--- a/screening/context_builders.py
+++ b/screening/context_builders.py
@@ -78,9 +78,23 @@ def build_forward_factor_context(
     available_expirations: tuple[ExpirationCycle, ...],
     as_of: date,
     *,
-    strike: Decimal,
+    front_strike: Decimal,
+    back_strike: Decimal,
     option_type: OptionType = OptionType.CALL,
 ) -> ComponentValues:
+    """front_strike/back_strike -- SPRINT-011-CLOSEOUT/CLOSE-001: previously
+    one shared `strike` was looked up at the front expiration only and
+    reused verbatim for the back expiration's own IV lookup. Real chains
+    frequently list a different strike ladder at the back (longer-dated)
+    expiration than the front, especially for wide-strike-increment names
+    (GS, NFLX confirmed in production) -- reusing the front's strike at
+    the back expiration then raised NoMatchingContractError whenever that
+    exact strike wasn't also listed there. The actual traded structure
+    (double_calendar.chain, below) is unaffected -- it selects its own
+    strikes internally via delta targeting; this only fixes the two IV
+    values compute_option_implied_volatility looks up for the
+    implied-forward-volatility inputs.
+    """
     candidates = tuple(
         ExpirationCandidate(cycle.expiration_date, cycle.days_to_expiration)
         for cycle in available_expirations
@@ -104,7 +118,7 @@ def build_forward_factor_context(
         {
             "chain": chain,
             "expiration": front.expiration_date,
-            "strike": strike,
+            "strike": front_strike,
             "option_type": option_type,
         }
     )
@@ -112,7 +126,7 @@ def build_forward_factor_context(
         {
             "chain": chain,
             "expiration": back.expiration_date,
-            "strike": strike,
+            "strike": back_strike,
             "option_type": option_type,
         }
     )

--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -365,8 +365,14 @@ def build_live_forward_factor_adapter(
                 f"attempted {', '.join(attempted)}",
             )
         front, back = selected
-        strike = select_atm_strike_at_expiration(
+        # SPRINT-011-CLOSEOUT/CLOSE-001: selected independently per
+        # expiration, not one shared strike reused at both -- see
+        # build_forward_factor_context's own docstring for why.
+        front_strike = select_atm_strike_at_expiration(
             chain, front.expiration_date, spot_price, OptionType.CALL
+        )
+        back_strike = select_atm_strike_at_expiration(
+            chain, back.expiration_date, spot_price, OptionType.CALL
         )
         selected_expirations = tuple(
             cycle
@@ -374,7 +380,12 @@ def build_live_forward_factor_adapter(
             if cycle.expiration_date in {front.expiration_date, back.expiration_date}
         )
         context = build_forward_factor_context(
-            chain, selected_expirations, as_of, strike=strike, option_type=OptionType.CALL
+            chain,
+            selected_expirations,
+            as_of,
+            front_strike=front_strike,
+            back_strike=back_strike,
+            option_type=OptionType.CALL,
         )
         graph = compile_strategy_graph(FORWARD_FACTOR_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
         result = execute_strategy_graph(graph, context)
@@ -462,7 +473,9 @@ def build_live_earnings_calendar_adapter(
             chain, back_cycle.expiration_date, spot_price, OptionType.CALL
         )
         (front_contract,) = chain.find(
-            expiration=front_cycle.expiration_date, strike=target_strike, option_type=OptionType.CALL
+            expiration=front_cycle.expiration_date,
+            strike=target_strike,
+            option_type=OptionType.CALL,
         )
         (back_contract,) = chain.find(
             expiration=back_cycle.expiration_date, strike=back_strike, option_type=OptionType.CALL
@@ -481,7 +494,9 @@ def build_live_earnings_calendar_adapter(
         # separately-fetched fixed 45-day point (this system selects
         # front/back via its own earnings-relative DTE policy, not a fixed
         # calendar pin).
-        term_richness = _richness_score(front_contract.implied_volatility - back_contract.implied_volatility)
+        term_richness = _richness_score(
+            front_contract.implied_volatility - back_contract.implied_volatility
+        )
         closes = _acquire_daily_closes(fulfillment, symbol, now)
         realized_vol = compute_realized_volatility(closes)
         # iv30/rv30-style richness (same source, ~09:40): front-month IV
@@ -580,7 +595,9 @@ def build_live_skew_momentum_adapter(
         # long-ATM/short-wing structure (strategies/stonk_manifests.py's
         # own frozen 0.50/0.25 delta targets, unchanged by this fix) is
         # built to exploit.
-        skew_richness = _richness_score(wing_contract.implied_volatility - atm_contract.implied_volatility)
+        skew_richness = _richness_score(
+            wing_contract.implied_volatility - atm_contract.implied_volatility
+        )
         closes = _acquire_daily_closes(fulfillment, symbol, now)
         momentum_richness = _richness_score(compute_trailing_return(closes))
         context = build_skew_momentum_context(

--- a/tests/analytics/test_realized_volatility.py
+++ b/tests/analytics/test_realized_volatility.py
@@ -56,7 +56,8 @@ class TestComputeTrailingReturn:
         assert compute_trailing_return((Decimal("100"), Decimal("80"))) == Decimal("-0.2")
 
     def test_zero_when_flat(self) -> None:
-        assert compute_trailing_return((Decimal("100"), Decimal("100"), Decimal("100"))) == Decimal(0)
+        flat = (Decimal("100"), Decimal("100"), Decimal("100"))
+        assert compute_trailing_return(flat) == Decimal(0)
 
     def test_only_endpoints_matter_not_the_path(self) -> None:
         volatile_path = (Decimal("100"), Decimal("200"), Decimal("10"), Decimal("110"))

--- a/tests/screening/test_context_builders.py
+++ b/tests/screening/test_context_builders.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 import pytest
 
-from domain import ExpirationCycle, OptionType
+from domain import ExpirationCycle, OptionChain, OptionType
 from screening import fixtures
 from screening.context_builders import (
     NoValidExpirationPairError,
@@ -20,7 +20,11 @@ class TestBuildForwardFactorContext:
         chain = fixtures.forward_factor_chain()
         expirations = fixtures.forward_factor_expirations()
         context = build_forward_factor_context(
-            chain, expirations.cycles, fixtures.AS_OF_DATE, strike=Decimal("105")
+            chain,
+            expirations.cycles,
+            fixtures.AS_OF_DATE,
+            front_strike=Decimal("105"),
+            back_strike=Decimal("105"),
         )
         values = dict(context.entries)
         assert values["forward_iv.front_iv"].value == Decimal("0.48")
@@ -36,7 +40,51 @@ class TestBuildForwardFactorContext:
             ExpirationCycle(near_expiration, 5, True, False, fixtures.AS_OF_DATE, fixtures.EVIDENCE),
         )
         with pytest.raises(NoValidExpirationPairError):
-            build_forward_factor_context(chain, too_short, fixtures.AS_OF_DATE, strike=Decimal("105"))
+            build_forward_factor_context(
+                chain,
+                too_short,
+                fixtures.AS_OF_DATE,
+                front_strike=Decimal("105"),
+                back_strike=Decimal("105"),
+            )
+
+    def test_looks_up_front_and_back_iv_at_their_own_distinct_strikes(self) -> None:
+        # SPRINT-011-CLOSEOUT/CLOSE-001 regression: production NoMatchingContractError
+        # for GS/NFLX -- the front expiration's ATM strike was reused verbatim to look
+        # up the back expiration's IV too, and real back-month chains often don't list
+        # the exact same strike as the front month. This chain has strike 105 at the
+        # front expiration only and strike 110 at the back expiration only, proving
+        # front_strike/back_strike are each looked up independently, not conflated.
+        front_only_contract = fixtures.fixture_contract(
+            "ff-front-only", fixtures.FORWARD_FRONT_EXPIRATION, "105", OptionType.CALL, "0.35", "2"
+        )
+        back_only_contract = fixtures.fixture_contract(
+            "ff-back-only",
+            fixtures.FORWARD_BACK_EXPIRATION,
+            "110",
+            OptionType.CALL,
+            "0.38",
+            "3",
+            implied_volatility="0.40",
+        )
+        chain = OptionChain(
+            "mismatched-strike-ladder",
+            fixtures.fixture_security(),
+            fixtures.OBSERVED_AT,
+            (front_only_contract, back_only_contract),
+            fixtures.EVIDENCE,
+        )
+        expirations = fixtures.forward_factor_expirations()
+        context = build_forward_factor_context(
+            chain,
+            expirations.cycles,
+            fixtures.AS_OF_DATE,
+            front_strike=Decimal("105"),
+            back_strike=Decimal("110"),
+        )
+        values = dict(context.entries)
+        assert values["forward_iv.front_iv"].value == Decimal("0.30")  # fixture_contract default
+        assert values["forward_iv.back_iv"].value == Decimal("0.40")
 
 
 class TestBuildEarningsCalendarContext:

--- a/tests/screening/test_live_context_delta_selection.py
+++ b/tests/screening/test_live_context_delta_selection.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 
 import pytest
+
 from domain import (
     CanonicalInstrumentIdentity,
     EvidenceKind,
@@ -34,7 +35,9 @@ INSTRUMENT = Instrument(
 SECURITY = Security(INSTRUMENT, "AAPL", SecurityAssetType.EQUITY, "XNAS")
 
 
-def _contract(strike: Decimal, delta: Decimal, option_type: OptionType = OptionType.CALL) -> OptionContract:
+def _contract(
+    strike: Decimal, delta: Decimal, option_type: OptionType = OptionType.CALL
+) -> OptionContract:
     return OptionContract(
         CanonicalInstrumentIdentity("fixture-option", f"AAPL-{strike}-{option_type.value}"),
         SECURITY,
@@ -71,7 +74,9 @@ class TestSelectNearestDeltaContract:
                 _contract(Decimal("110"), Decimal("0.10")),
             )
         )
-        selected = select_nearest_delta_contract(chain, EXPIRATION, OptionType.CALL, Decimal("0.25"))
+        selected = select_nearest_delta_contract(
+            chain, EXPIRATION, OptionType.CALL, Decimal("0.25")
+        )
         assert selected.strike == Decimal("105")
 
     def test_excludes_the_given_strike(self) -> None:


### PR DESCRIPTION
Root cause of the 6 forward_factor \`strategy_exception\` symbols found via CLOSE-001's own diagnostic logging (PR #240, confirmed firing in production for GS/LLY/NFLX/XLE/XLK after redeploy).

\`build_live_forward_factor_adapter()\` selected the ATM strike once, at the **front** expiration only, then reused that exact strike to look up the **back** expiration's IV too. Real chains often list a different strike ladder at the back expiration -- confirmed for GS/NFLX (both wide-strike-increment names) -- so the lookup at back came back empty and raised \`NoMatchingContractError\`.

Fix mirrors CLOSE-002's own front/back-IV pattern for earnings_calendar: \`build_forward_factor_context()\` now takes \`front_strike\`/\`back_strike\` as two separate required args, each selected independently. The actual traded structure is unaffected -- it selects its own strikes internally via delta targeting; this only fixes the IV lookup.

**\`GraphExecutionError\` (LLY, XLE, XLK) is a separate, not-yet-diagnosed failure** -- likely a numerical edge case in the forward-variance blending formula for these symbols. Chasing it further needs real exception detail, but the traceback isn't reaching Railway's log capture (filed #242, unrelated logging-infra gap).

Added a regression test proving front/back strikes are looked up independently (a chain with strike 105 only at front, 110 only at back, would have raised \`NoMatchingContractError\` under the old shared-strike behavior).

Full suite: 1938 passed, 14 skipped, zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)