### PR TITLE
PATCH-011B: fix refresh starvation and 45-day freshness skew

### DIFF
--- a/asa/integrations/universal_screening_postgres.py
+++ b/asa/integrations/universal_screening_postgres.py
@@ -76,12 +76,14 @@ class PostgresLatestResultRepository:
                                 EXCLUDED.source_observed_at,
                                 EXCLUDED.observed_at
                             ),
+                            EXCLUDED.observed_at,
                             EXCLUDED.observation_id
                         ) >= (
                             COALESCE(
                                 universal_screening_state.source_observed_at,
                                 universal_screening_state.observed_at
                             ),
+                            universal_screening_state.observed_at,
                             universal_screening_state.observation_id
                         )
                 """),

--- a/strategy_runtime/persistence.py
+++ b/strategy_runtime/persistence.py
@@ -141,10 +141,10 @@ class LatestResultRepository(Protocol):
     """Stores only the latest UniversalSignalRow per (signal_id,
     symbol). upsert() advances that row only when the candidate's source
     observation ordering key is not older; late arrivals never regress
-    latest state. Same-time candidates use observation identity as the
-    deterministic tie-breaker. It never accumulates history
-    (ObservationHistoryRepository's own job). A symbol a given run never
-    touches is never removed by that run.
+    latest state. Same-source candidates are ordered by evaluation time,
+    then observation identity as the final deterministic tie-breaker. It
+    never accumulates history (ObservationHistoryRepository's own job). A
+    symbol a given run never touches is never removed by that run.
     """
 
     def upsert(self, row: UniversalSignalRow) -> None: ...
@@ -156,12 +156,20 @@ class LatestResultRepository(Protocol):
     def get_one(self, signal_id: str, symbol: str) -> UniversalSignalRow | None: ...
 
 
-def latest_ordering_key(row: UniversalSignalRow) -> tuple[datetime, str]:
-    """Canonical monotonic order: source time, then stable observation identity."""
+def latest_ordering_key(row: UniversalSignalRow) -> tuple[datetime, datetime, str]:
+    """Canonical monotonic order: source time, evaluation time, stable identity.
+
+    The former two-part key used a SHA-derived observation identity as the
+    second element. SHA lexical order is deterministic but not chronological,
+    so a later scheduled evaluation using unchanged source data could be
+    rejected and leave its refresh metadata stuck on an older slot. Evaluation
+    time is the truthful same-source ordering dimension; identity remains only
+    the final idempotent tie-breaker.
+    """
     source_time = (
         row.temporal.observed_at if row.temporal is not None else row.observed_at
     )
-    return source_time, row.observation_id
+    return source_time, row.observed_at, row.observation_id
 
 
 def should_replace_latest(

--- a/strategy_runtime/service.py
+++ b/strategy_runtime/service.py
@@ -28,7 +28,7 @@ from collections.abc import Mapping
 from dataclasses import replace
 from datetime import UTC, datetime
 
-from domain import FreshnessStatus, MarketObservation
+from domain import FreshnessStatus, MarketCapability, MarketObservation
 from market_data import CapabilityFulfillmentService
 from market_data.session_calendar import NEW_YORK, UsEquitySessionCalendar
 from market_data.session_schedule import SessionRefreshSchedule
@@ -67,6 +67,43 @@ _USABILITY_PRIORITY = {
 }
 
 
+def _current_temporal_observations(
+    observations: tuple[MarketObservation, ...],
+) -> tuple[MarketObservation, ...]:
+    """Return the current effective evidence for temporal classification.
+
+    A historical-bars capability intentionally contributes a time series. Its
+    oldest bar defines analytical coverage, not the freshness of the current
+    result. Treating every bar as a peer current input made a 45-day lookback
+    appear as roughly 45 days of age and cross-input skew. Keep the latest bar
+    per subject/provider as the current evidence point while retaining every
+    observation for acquisition timing and strategy computation elsewhere.
+    Point-in-time capabilities remain unchanged.
+    """
+    point_in_time: list[MarketObservation] = []
+    latest_historical: dict[tuple[str, str], MarketObservation] = {}
+    for observation in observations:
+        if observation.capability is not MarketCapability.HISTORICAL_BARS_V1:
+            point_in_time.append(observation)
+            continue
+        key = (
+            observation.subject.subject_identity,
+            observation.provenance.provider_id,
+        )
+        existing = latest_historical.get(key)
+        if existing is None or (
+            observation.effective_time,
+            observation.observation_id,
+        ) > (
+            existing.effective_time,
+            existing.observation_id,
+        ):
+            latest_historical[key] = observation
+    return tuple(point_in_time) + tuple(
+        latest_historical[key] for key in sorted(latest_historical)
+    )
+
+
 def _temporal_metadata(
     registry: StrategyRegistry[UniversalScreeningResult],
     strategy_id: str,
@@ -82,7 +119,10 @@ def _temporal_metadata(
     )
     if not observations:
         return None
-    effective_times = tuple(item.effective_time.astimezone(UTC) for item in observations)
+    current_observations = _current_temporal_observations(observations)
+    effective_times = tuple(
+        item.effective_time.astimezone(UTC) for item in current_observations
+    )
     recorded_times = tuple(item.recorded_time.astimezone(UTC) for item in observations)
     observed = max(effective_times)
     received = max(recorded_times)
@@ -101,11 +141,11 @@ def _temporal_metadata(
             requirement,
             market_is_open=session_status.value == "open",
         )
-        for item in observations
+        for item in current_observations
     )
     usability = max(decisions, key=lambda item: _USABILITY_PRIORITY[item.status])
     freshness = max(
-        (item.freshness.status for item in observations),
+        (item.freshness.status for item in current_observations),
         key=lambda item: _FRESHNESS_PRIORITY[item],
     )
     previous_observed = (

--- a/tests/strategy_runtime/test_refresh_integrity_regressions.py
+++ b/tests/strategy_runtime/test_refresh_integrity_regressions.py
@@ -1,0 +1,161 @@
+"""Regression coverage for SPRINT-011 refresh-integrity defects #246/#247."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from types import SimpleNamespace
+from typing import cast
+
+from domain import FreshnessStatus, MarketCapability, MarketObservation
+from market_data.temporal import DEFAULT_FRESHNESS_REQUIREMENT
+from strategy_runtime.persistence import UniversalSignalRow, should_replace_latest
+from strategy_runtime.result import (
+    EvaluationState,
+    ResultTemporalMetadata,
+    RowType,
+    UniversalScreeningResult,
+)
+from strategy_runtime.service import _temporal_metadata
+
+EVALUATED = datetime(2026, 7, 27, 18, 0, tzinfo=UTC)
+
+
+def _temporal(*, source: datetime, evaluated: datetime) -> ResultTemporalMetadata:
+    return ResultTemporalMetadata(
+        observed_at=source,
+        received_at=evaluated,
+        evaluated_at=evaluated,
+        persisted_at=evaluated,
+        market_session_date=date(2026, 7, 27),
+        market_session_status="open",
+        age_seconds=max(0, int((evaluated - source).total_seconds())),
+        last_refresh_attempt_at=evaluated,
+        last_successful_refresh_at=evaluated,
+        next_refresh_at=evaluated + timedelta(hours=1),
+        data_advanced_on_last_refresh=True,
+        freshness_status="live",
+        usability_status="usable",
+        usability_reason="observation is current",
+        warning_codes=(),
+        acquisition_started_at=evaluated,
+        acquisition_completed_at=evaluated,
+        input_time_skew_seconds=0,
+    )
+
+
+def _row(
+    *, observation_id: str, source: datetime, evaluated: datetime
+) -> UniversalSignalRow:
+    return UniversalSignalRow.from_result(
+        UniversalScreeningResult(
+            strategy_id="alpha",
+            strategy_version="1.0.0",
+            symbol="AAPL",
+            observation_id=observation_id,
+            opportunity_id=None,
+            row_type=RowType.RESULT,
+            verdict="pass",
+            evaluation_state=EvaluationState.PASS,
+            lifecycle_stage=None,
+            recommendation_state=None,
+            data_quality="fresh",
+            metrics={},
+            economics={},
+            blockers=(),
+            warnings=(),
+            provenance=(),
+            observed_at=evaluated,
+            temporal=_temporal(source=source, evaluated=evaluated),
+        )
+    )
+
+
+def test_later_same_source_evaluation_wins_even_with_lower_hash_identity() -> None:
+    source = EVALUATED - timedelta(minutes=1)
+    existing = _row(observation_id="zzz", source=source, evaluated=EVALUATED)
+    later = _row(
+        observation_id="aaa",
+        source=source,
+        evaluated=EVALUATED + timedelta(hours=1),
+    )
+
+    assert should_replace_latest(existing, later) is True
+    assert should_replace_latest(later, existing) is False
+
+
+def test_later_evaluation_cannot_regress_an_older_source_observation() -> None:
+    existing = _row(
+        observation_id="aaa",
+        source=EVALUATED,
+        evaluated=EVALUATED,
+    )
+    older_source = _row(
+        observation_id="zzz",
+        source=EVALUATED - timedelta(days=1),
+        evaluated=EVALUATED + timedelta(hours=1),
+    )
+
+    assert should_replace_latest(existing, older_source) is False
+
+
+def _observation(
+    *, capability: MarketCapability, effective_time: datetime, observation_id: str
+) -> MarketObservation:
+    freshness = SimpleNamespace(
+        status=FreshnessStatus.FRESH,
+        age_seconds=max(0, int((EVALUATED - effective_time).total_seconds())),
+    )
+    return cast(
+        MarketObservation,
+        SimpleNamespace(
+            capability=capability,
+            effective_time=effective_time,
+            recorded_time=EVALUATED,
+            observation_id=observation_id,
+            freshness=freshness,
+            subject=SimpleNamespace(subject_identity="AAPL"),
+            provenance=SimpleNamespace(provider_id="fixture"),
+        ),
+    )
+
+
+def test_historical_coverage_does_not_become_current_age_or_input_skew() -> None:
+    oldest_bar = _observation(
+        capability=MarketCapability.HISTORICAL_BARS_V1,
+        effective_time=EVALUATED - timedelta(days=45),
+        observation_id="oldest-bar",
+    )
+    latest_bar = _observation(
+        capability=MarketCapability.HISTORICAL_BARS_V1,
+        effective_time=EVALUATED - timedelta(minutes=5),
+        observation_id="latest-bar",
+    )
+    quote = _observation(
+        capability=MarketCapability.REAL_TIME_QUOTE_V1,
+        effective_time=EVALUATED - timedelta(seconds=2),
+        observation_id="quote",
+    )
+    fulfillment = SimpleNamespace(
+        completed_results=(
+            SimpleNamespace(observations=(oldest_bar, latest_bar, quote)),
+        )
+    )
+    registry = SimpleNamespace(
+        contract_for=lambda _strategy_id: SimpleNamespace(
+            freshness_requirement=DEFAULT_FRESHNESS_REQUIREMENT
+        )
+    )
+
+    temporal = _temporal_metadata(
+        registry,
+        "alpha",
+        EVALUATED,
+        fulfillment,
+        previous=None,
+    )
+
+    assert temporal is not None
+    assert temporal.age_seconds == 300
+    assert temporal.input_time_skew_seconds == 298
+    assert temporal.freshness_status == "live"
+    assert temporal.usability_status == "usable"


### PR DESCRIPTION
## Objective

Resolve SPRINT-011 close blockers #246 and #247 at their shared persistence/temporal boundaries.

## Root cause

### #246 — apparent scheduler starvation

The scheduled runner already iterates every configured pair and isolates each failure. The actual loss occurs at latest-state persistence when a later evaluation uses the same source-observation timestamp as the stored result.

The monotonic key was `(source_observed_at, observation_id)`. `observation_id` is SHA-derived, so lexical order is deterministic but not chronological. A later scheduled evaluation with unchanged source data could therefore have a lower hash and be rejected by both the in-memory and PostgreSQL repositories. Because the whole incoming row was rejected, `last_refresh_attempt_at`, `next_refresh_at`, and the newer evaluation were left stuck on the prior cycle. This creates the appearance that pairs were never attempted and explains why a subset becomes persistently stuck across cycles.

Fix: order by `(source_observed_at, evaluated_at, observation_id)`, using the result's `observed_at` as evaluation time. Older source observations still cannot regress latest state; later evaluations of the same source now advance deterministically.

### #247 — ~45-day age/skew while live/usable

`strategy_runtime.service._temporal_metadata()` flattened every market observation and computed:

- `age_seconds` from the oldest effective time
- `input_time_skew_seconds` from oldest-to-newest effective time
- freshness/usability from provider freshness classifications

After PR #241 added a 45-day historical-bars series, the oldest analytical bar was treated as a peer current input. The intentional lookback window therefore appeared as ~45 days of age and input skew, while the provider's current-evidence freshness could still report `live`/`usable`.

Fix: historical bars now contribute only their latest bar per subject/provider to current temporal classification. The full series remains available to strategy computation and acquisition timing; its coverage length no longer contaminates current-input age or skew.

## Changes

- add evaluation time to the canonical latest-state ordering key
- align the PostgreSQL `ON CONFLICT` ordering tuple with the runtime helper
- select latest historical evidence for freshness/age/skew calculations
- add regressions for:
  - later same-source evaluations with lexically lower observation IDs
  - older source data remaining unable to regress latest state
  - current quote + 45-day history producing current age/skew rather than a 45-day constant

## Scope and limitations

This PR fixes the confirmed root causes for #246/#247. It does not add a separate refresh-attempt ledger or operator endpoint; those remain useful observability follow-ups, but are not required to correct the current persisted-state and freshness defects.

## Validation

CI required. Local repository execution is unavailable in this environment, so the PR should not merge unless the full test, type, lint, architecture, and PostgreSQL checks pass.

Closes #246
Closes #247