### PR TITLE
PATCH-011C refresh integrity hardening for issues 246 and 247

### DIFF
--- a/tests/asa/test_universal_screening_service_postgres_integration.py
+++ b/tests/asa/test_universal_screening_service_postgres_integration.py
@@ -12,7 +12,7 @@ raw-SQL/JSON-serialization layer, not just that each works in isolation.
 from __future__ import annotations
 
 import os
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 import pytest
 from alembic import command
@@ -23,6 +23,13 @@ from asa.integrations.universal_screening_postgres import PostgresLatestResultRe
 from market_data.config import load_market_data_config
 from strategy_runtime.adapters import build_migrated_strategy_registry
 from strategy_runtime.market_data_planning import build_shared_market_data_access
+from strategy_runtime.persistence import UniversalSignalRow, should_replace_latest
+from strategy_runtime.result import (
+    EvaluationState,
+    ResultTemporalMetadata,
+    RowType,
+    UniversalScreeningResult,
+)
 from strategy_runtime.service import get_state, refresh
 
 pytestmark = [
@@ -141,3 +148,101 @@ def test_get_state_never_triggers_a_provider_request(
     first = get_state(repository, strategy_id=STRATEGY_ID)
     second = get_state(repository, strategy_id=STRATEGY_ID)
     assert first == second
+
+
+def _temporal(*, source: datetime, evaluated: datetime) -> ResultTemporalMetadata:
+    return ResultTemporalMetadata(
+        observed_at=source,
+        received_at=evaluated,
+        evaluated_at=evaluated,
+        persisted_at=evaluated,
+        market_session_date=date(2026, 7, 27),
+        market_session_status="open",
+        age_seconds=max(0, int((evaluated - source).total_seconds())),
+        last_refresh_attempt_at=evaluated,
+        last_successful_refresh_at=evaluated,
+        next_refresh_at=evaluated + timedelta(hours=1),
+        data_advanced_on_last_refresh=True,
+        freshness_status="live",
+        usability_status="usable",
+        usability_reason="observation is current",
+        warning_codes=(),
+        acquisition_started_at=evaluated,
+        acquisition_completed_at=evaluated,
+        input_time_skew_seconds=0,
+    )
+
+
+def _signal_row(
+    *, observation_id: str, source: datetime, evaluated: datetime
+) -> UniversalSignalRow:
+    return UniversalSignalRow.from_result(
+        UniversalScreeningResult(
+            strategy_id=STRATEGY_ID,
+            strategy_version="1.0.0",
+            symbol=SYMBOL,
+            observation_id=observation_id,
+            opportunity_id=None,
+            row_type=RowType.RESULT,
+            verdict="pass",
+            evaluation_state=EvaluationState.PASS,
+            lifecycle_stage=None,
+            recommendation_state=None,
+            data_quality="fresh",
+            metrics={},
+            economics={},
+            blockers=(),
+            warnings=(),
+            provenance=(),
+            observed_at=evaluated,
+            temporal=_temporal(source=source, evaluated=evaluated),
+        )
+    )
+
+
+def test_postgres_write_guard_matches_the_in_memory_should_replace_latest_decision(
+    repository: PostgresLatestResultRepository,
+) -> None:
+    # PATCH-011C: proves asa/integrations/universal_screening_postgres.py's
+    # own ON CONFLICT ... WHERE ordering-tuple comparison makes the exact
+    # same replace/reject decision as strategy_runtime.persistence.
+    # should_replace_latest() for the specific scenario #246 was about --
+    # a later evaluation of the *same* source observation whose
+    # observation_id happens to be lexically lower than the one already
+    # stored. Both must agree; a real Postgres upsert exercising the
+    # tests/strategy_runtime/test_refresh_integrity_regressions.py::
+    # test_later_same_source_evaluation_wins_even_with_lower_hash_identity
+    # scenario against the real ON CONFLICT clause, not the in-memory fake.
+    same_source = datetime(2026, 7, 27, 18, 0, tzinfo=UTC)
+    existing = _signal_row(observation_id="zzz", source=same_source, evaluated=same_source)
+    later_lower_hash = _signal_row(
+        observation_id="aaa", source=same_source, evaluated=same_source + timedelta(hours=1)
+    )
+    # in-memory helper's own verdict
+    assert should_replace_latest(existing, later_lower_hash) is True
+
+    repository.upsert(existing)
+    repository.upsert(later_lower_hash)
+
+    stored = repository.get_one(STRATEGY_ID, SYMBOL)
+    assert stored is not None
+    # the later evaluation won, matching the in-memory verdict
+    assert stored.observation_id == "aaa"
+
+
+def test_postgres_write_guard_rejects_an_older_source_even_with_a_higher_hash(
+    repository: PostgresLatestResultRepository,
+) -> None:
+    same_evaluated = datetime(2026, 7, 27, 18, 0, tzinfo=UTC)
+    existing = _signal_row(observation_id="aaa", source=same_evaluated, evaluated=same_evaluated)
+    older_source_higher_hash = _signal_row(
+        observation_id="zzz", source=same_evaluated - timedelta(days=1), evaluated=same_evaluated
+    )
+    assert should_replace_latest(existing, older_source_higher_hash) is False
+
+    repository.upsert(existing)
+    repository.upsert(older_source_higher_hash)
+
+    stored = repository.get_one(STRATEGY_ID, SYMBOL)
+    assert stored is not None
+    assert stored.observation_id == "aaa"  # older source never regressed the stored row

--- a/tests/strategy_runtime/test_refresh_integrity_regressions.py
+++ b/tests/strategy_runtime/test_refresh_integrity_regressions.py
@@ -99,10 +99,16 @@ def test_later_evaluation_cannot_regress_an_older_source_observation() -> None:
 
 
 def _observation(
-    *, capability: MarketCapability, effective_time: datetime, observation_id: str
+    *,
+    capability: MarketCapability,
+    effective_time: datetime,
+    observation_id: str,
+    status: FreshnessStatus = FreshnessStatus.FRESH,
+    subject_id: str = "AAPL",
+    provider_id: str = "fixture",
 ) -> MarketObservation:
     freshness = SimpleNamespace(
-        status=FreshnessStatus.FRESH,
+        status=status,
         age_seconds=max(0, int((EVALUATED - effective_time).total_seconds())),
     )
     return cast(
@@ -113,9 +119,17 @@ def _observation(
             recorded_time=EVALUATED,
             observation_id=observation_id,
             freshness=freshness,
-            subject=SimpleNamespace(subject_identity="AAPL"),
-            provenance=SimpleNamespace(provider_id="fixture"),
+            subject=SimpleNamespace(subject_identity=subject_id),
+            provenance=SimpleNamespace(provider_id=provider_id),
         ),
+    )
+
+
+def _registry() -> SimpleNamespace:
+    return SimpleNamespace(
+        contract_for=lambda _strategy_id: SimpleNamespace(
+            freshness_requirement=DEFAULT_FRESHNESS_REQUIREMENT
+        )
     )
 
 
@@ -159,3 +173,109 @@ def test_historical_coverage_does_not_become_current_age_or_input_skew() -> None
     assert temporal.input_time_skew_seconds == 298
     assert temporal.freshness_status == "live"
     assert temporal.usability_status == "usable"
+
+
+def test_exact_duplicate_candidate_is_idempotent() -> None:
+    # PATCH-011C: an identical (source, evaluated, observation_id) tuple is
+    # not a "later arrival" -- but should_replace_latest's own >= comparison
+    # (strategy_runtime/persistence.py) must still treat it as replaceable
+    # (a harmless overwrite with identical values), not silently rejected.
+    # A future >-only comparison would break the scheduler's own re-run-the-
+    # same-slot idempotency guarantee (asa/scheduled_screening.py's claim
+    # repository already prevents duplicate *slot* execution; this is the
+    # separate, lower-level guarantee that a duplicate *write* of the same
+    # observation is never treated as a regression).
+    row = _row(observation_id="aaa", source=EVALUATED, evaluated=EVALUATED)
+    duplicate = _row(observation_id="aaa", source=EVALUATED, evaluated=EVALUATED)
+
+    assert should_replace_latest(row, duplicate) is True
+
+
+def test_stale_latest_historical_bar_is_not_masked_as_live() -> None:
+    # PATCH-011C: filtering historical bars down to the latest-per-group
+    # (#247's own fix) must never suppress genuine staleness -- if even the
+    # *latest* available bar is itself classified stale by the provider's
+    # own freshness metadata, the aggregate result must say so, not report
+    # "live" merely because the 45-day-old peer bars were filtered out.
+    stale_latest_bar = _observation(
+        capability=MarketCapability.HISTORICAL_BARS_V1,
+        effective_time=EVALUATED - timedelta(days=3),
+        observation_id="stale-latest-bar",
+        status=FreshnessStatus.STALE,
+    )
+    quote = _observation(
+        capability=MarketCapability.REAL_TIME_QUOTE_V1,
+        effective_time=EVALUATED - timedelta(seconds=2),
+        observation_id="quote",
+    )
+    fulfillment = SimpleNamespace(
+        completed_results=(SimpleNamespace(observations=(stale_latest_bar, quote)),)
+    )
+
+    temporal = _temporal_metadata(_registry(), "alpha", EVALUATED, fulfillment, previous=None)
+
+    assert temporal is not None
+    assert temporal.freshness_status == "stale"
+
+
+def test_each_subject_provider_group_keeps_its_own_latest_bar() -> None:
+    # PATCH-011C: _current_temporal_observations groups historical bars by
+    # (subject_identity, provider_id) before picking the latest per group --
+    # a strategy pulling historical bars for more than one subject or from
+    # more than one provider must not have one series' latest bar crowd out
+    # another's, and must not silently collapse to a single global "latest".
+    aapl_old = _observation(
+        capability=MarketCapability.HISTORICAL_BARS_V1,
+        effective_time=EVALUATED - timedelta(days=10),
+        observation_id="aapl-old",
+        subject_id="AAPL",
+    )
+    aapl_recent = _observation(
+        capability=MarketCapability.HISTORICAL_BARS_V1,
+        effective_time=EVALUATED - timedelta(minutes=5),
+        observation_id="aapl-recent",
+        subject_id="AAPL",
+    )
+    msft_recent = _observation(
+        capability=MarketCapability.HISTORICAL_BARS_V1,
+        effective_time=EVALUATED - timedelta(minutes=10),
+        observation_id="msft-recent",
+        subject_id="MSFT",
+    )
+    fulfillment = SimpleNamespace(
+        completed_results=(
+            SimpleNamespace(observations=(aapl_old, aapl_recent, msft_recent)),
+        )
+    )
+
+    temporal = _temporal_metadata(_registry(), "alpha", EVALUATED, fulfillment, previous=None)
+
+    assert temporal is not None
+    # Oldest surviving effective_time is MSFT's own latest bar (10 minutes
+    # back), not AAPL's stale 10-day-old bar -- proving the AAPL group's own
+    # old bar was dropped in favor of its own latest, independently of MSFT.
+    assert temporal.age_seconds == 600
+    assert temporal.input_time_skew_seconds == 300  # 10m - 5m between the two surviving bars
+
+
+def test_effective_times_stay_utc_normalized_across_timezone_input() -> None:
+    # PATCH-011C: a non-UTC-but-tz-aware effective_time must normalize
+    # identically to its UTC equivalent -- age/skew must not silently
+    # double-count or drop a timezone offset.
+    from datetime import timezone
+
+    minus_five = timezone(timedelta(hours=-5))
+    quote_in_est = _observation(
+        capability=MarketCapability.REAL_TIME_QUOTE_V1,
+        effective_time=(EVALUATED - timedelta(seconds=2)).astimezone(minus_five),
+        observation_id="quote-est",
+    )
+    fulfillment = SimpleNamespace(
+        completed_results=(SimpleNamespace(observations=(quote_in_est,)),)
+    )
+
+    temporal = _temporal_metadata(_registry(), "alpha", EVALUATED, fulfillment, previous=None)
+
+    assert temporal is not None
+    assert temporal.age_seconds == 2
+    assert temporal.observed_at.utcoffset() == timedelta(0)


### PR DESCRIPTION
## Independently confirmed root cause

Traced both fixes end to end before touching anything, per this packet's own "do not assume the prior patch is complete merely because it merged" instruction.

**#246**: `strategy_runtime/persistence.py::latest_ordering_key()` returns `(source_time, row.observed_at, row.observation_id)` -- `source_time` from `row.temporal.observed_at` (market data's own effective time), `row.observed_at` as the evaluation-time proxy (`refresh()` already passes `UniversalScreeningResult.observed_at` into `_temporal_metadata()` as its own `evaluated_at` param -- same moment, two field names), `observation_id` as final tie-break. `asa/integrations/universal_screening_postgres.py`'s `ON CONFLICT ... WHERE` uses the identical 3-tuple. Confirmed correct, matches this packet's own `preferred_fix_shape.canonical_tuple` exactly.

**#247**: `strategy_runtime/service.py::_current_temporal_observations()` groups `HISTORICAL_BARS_V1` observations by `(subject_identity, provider_id)` and keeps only the latest bar per group for age/skew/freshness/usability, while `recorded_times` still uses the full unfiltered set for acquisition timing. Confirmed correct.

## What was actually missing

PR #248's own regression file covered 3 of this packet's own 8-case `minimum_test_matrix`. Implementation was correct everywhere traced, but 5 required cases were asserted nowhere: `exact_duplicate_is_idempotent`, `Postgres_matches_runtime_helper`, `stale_latest_history_bar`, `multiple_subject_or_provider_series`, `timezone_normalization`.

**Added all five. Every one passed against the existing, unmodified implementation on the first run** -- proving (not assuming) the fix is correct across the full required matrix. **Zero production files touched by this patch -- test-only.**

## Exact files changed

- `tests/strategy_runtime/test_refresh_integrity_regressions.py` (+4 tests)
- `tests/asa/test_universal_screening_service_postgres_integration.py` (+2 tests, exercising `PostgresLatestResultRepository.upsert()` directly against the real `ON CONFLICT` clause for the exact #246 scenario)

## Why the fix is minimal

No behavior changed -- this only adds the test evidence the packet's own acceptance criteria required. A failing new case would have identified a real gap needing a code change; none did.

## Invariants preserved

All of `required_invariants.latest_state` and `.temporal` verified true by the new tests -- see commit message for the full list.

## Validation (packet's own required commands)

- `ruff check asa tests/asa`: clean
- `ruff check strategy_runtime tests/strategy_runtime`: clean (only pre-accepted UP042/046/047 pattern, pre-existing)
- `mypy asa`: 41 files, no issues
- `pytest tests/asa`: 135 passed, 15 skipped
- `pytest tests/strategy_runtime`: 169 passed
- `tools/pos/validate.py` doesn't exist at that path (repo's own README references the same stale path) -- ran the real entrypoint `tools/pos/lean/validate.py`: 4 schema-parse checks pass; `--all-fixtures` intentionally exercises invalid fixtures and reports their expected failures, which is correct validator behavior, not a regression
- Full suite: **1945 passed, 16 skipped, zero regressions**
- `tests/architecture`: 438 passed
- Alembic round-trip: not applicable, no schema change

## Rollback plan

Revert this commit -- test-only, no production behavior/schema/data affected either way.

## Production verification plan

Per this packet's own `production_pending` criteria: observe two consecutive due cycles, confirm all 82 pairs advance `last_refresh_attempt_at`, no pair has overdue `next_refresh_at` without a current attempt, no unexplained ~45-day age/skew, health/readiness stay 200. **Not performed by this worker** -- explicitly deferred, per this packet's own forbidden actions (no merge, no deploy) and `close_rule` (issues stay open until Manager/Founder confirms production evidence).

## Issues #244 and #245

Not touched, not referenced by any change in this patch -- explicitly out of scope per this packet.

---

**This PR is intentionally not merged.** Per `worker_role.authority.forbidden`, merge and deploy are outside this worker's authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)