### PR TITLE
SPRINT-012 WS2: establish named derived facts

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -11,6 +11,24 @@ from __future__ import annotations
 
 from analytics.atm_selection import select_atm_strike
 from analytics.clock import Clock
+from analytics.derived_facts import (
+    DERIVED_FACT_DEFINITIONS,
+    DERIVED_FACT_REGISTRY,
+    compute_bid_ask_spread_ratio,
+    compute_days_to_earnings,
+    compute_earnings_inside_trade_window,
+    compute_expiration_gap_days,
+    compute_expiration_gap_distance,
+    compute_forward_factor,
+    compute_historical_percentile,
+    compute_historical_zscore,
+    compute_implied_forward_volatility,
+    compute_iv_realized_spread,
+    compute_momentum_dimensions,
+    compute_normalized_skew,
+    compute_open_interest_quality,
+    compute_option_volume_band,
+)
 from analytics.engine import FeatureComputation, compute_feature
 from analytics.errors import (
     AnalyticsError,
@@ -24,7 +42,12 @@ from analytics.expiration_selection import (
     select_earnings_relative_expiration_pair,
     select_expiration_pair,
 )
-from analytics.features import DerivedFeatureResult
+from analytics.features import (
+    DerivedFact,
+    DerivedFactQualityStatus,
+    DerivedFactSet,
+    DerivedFactValue,
+)
 from analytics.forward_factor import (
     FORWARD_FACTOR_ANALYTICS_COMPUTATIONS,
     FORWARD_FACTOR_ANALYTICS_REGISTRY,
@@ -46,7 +69,12 @@ __all__ = [
     "AnalyticsFeatureDefinition",
     "AnalyticsRegistry",
     "Clock",
-    "DerivedFeatureResult",
+    "DerivedFact",
+    "DERIVED_FACT_DEFINITIONS",
+    "DERIVED_FACT_REGISTRY",
+    "DerivedFactQualityStatus",
+    "DerivedFactSet",
+    "DerivedFactValue",
     "DuplicateFeatureRegistrationError",
     "ExpirationCandidate",
     "FeatureComputation",
@@ -55,11 +83,25 @@ __all__ = [
     "NoMatchingContractError",
     "UnknownFeatureIdError",
     "compute_days_to_expiration",
+    "compute_days_to_earnings",
+    "compute_earnings_inside_trade_window",
+    "compute_expiration_gap_days",
+    "compute_expiration_gap_distance",
     "compute_feature",
+    "compute_forward_factor",
+    "compute_historical_percentile",
+    "compute_historical_zscore",
+    "compute_implied_forward_volatility",
+    "compute_iv_realized_spread",
     "compute_log_returns",
     "compute_option_implied_volatility",
+    "compute_option_volume_band",
+    "compute_open_interest_quality",
     "compute_realized_volatility",
     "compute_trailing_return",
+    "compute_bid_ask_spread_ratio",
+    "compute_momentum_dimensions",
+    "compute_normalized_skew",
     "select_atm_strike",
     "select_earnings_relative_expiration_pair",
     "select_expiration_pair",

--- a/analytics/derived_facts.py
+++ b/analytics/derived_facts.py
@@ -1,0 +1,261 @@
+"""Canonical reusable financial calculations for SPRINT-012."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+from decimal import ROUND_HALF_EVEN, Context, Decimal, localcontext
+
+from analytics.registry import AnalyticsFeatureDefinition, AnalyticsRegistry
+from domain import MarketCapability
+
+DERIVED_FACT_DECIMAL_CONTEXT = Context(prec=34, rounding=ROUND_HALF_EVEN)
+
+REALIZED_VOLATILITY = "realized_volatility"
+IMPLIED_FORWARD_VOLATILITY = "implied_forward_volatility"
+FORWARD_FACTOR = "forward_factor"
+DAYS_TO_EARNINGS = "days_to_earnings"
+EARNINGS_INSIDE_TRADE_WINDOW = "earnings_inside_trade_window"
+EXPIRATION_GAP_DAYS = "expiration_gap_days"
+EXPIRATION_GAP_DISTANCE = "expiration_gap_distance_from_target"
+NORMALIZED_CALL_SKEW = "normalized_call_skew"
+NORMALIZED_PUT_SKEW = "normalized_put_skew"
+SKEW_HISTORICAL_PERCENTILE = "skew_historical_percentile"
+SKEW_HISTORICAL_ZSCORE = "skew_historical_zscore"
+ATM_IV_VS_REALIZED = "atm_iv_vs_realized_volatility"
+CALL_WING_IV_VS_REALIZED = "call_wing_iv_vs_realized_volatility"
+PUT_WING_IV_VS_REALIZED = "put_wing_iv_vs_realized_volatility"
+NAMED_MOMENTUM_DIMENSIONS = "named_momentum_dimensions"
+OPTION_VOLUME_BAND = "option_volume_band"
+SPREAD_QUALITY = "spread_quality"
+OPEN_INTEREST_QUALITY = "open_interest_quality"
+
+
+def compute_implied_forward_volatility(
+    front_iv: Decimal,
+    back_iv: Decimal,
+    front_dte: int,
+    back_dte: int,
+) -> Decimal:
+    """Forward volatility implied between two expirations."""
+
+    if min(front_iv, back_iv) <= 0:
+        raise ValueError("implied volatilities must be positive")
+    if front_dte <= 0 or back_dte <= front_dte:
+        raise ValueError("DTE values must be positive and strictly increasing")
+    with localcontext(DERIVED_FACT_DECIMAL_CONTEXT):
+        variance = (back_iv**2 * Decimal(back_dte) - front_iv**2 * Decimal(front_dte)) / Decimal(
+            back_dte - front_dte
+        )
+        if variance <= 0:
+            raise ValueError("forward variance must be positive")
+        return variance.sqrt()
+
+
+def compute_forward_factor(front_iv: Decimal, implied_forward_volatility: Decimal) -> Decimal:
+    if implied_forward_volatility <= 0:
+        raise ValueError("implied forward volatility must be positive")
+    with localcontext(DERIVED_FACT_DECIMAL_CONTEXT):
+        return front_iv / implied_forward_volatility - Decimal(1)
+
+
+def compute_days_to_earnings(as_of: date, earnings_date: date) -> int:
+    return (earnings_date - as_of).days
+
+
+def compute_earnings_inside_trade_window(
+    earnings_date: date, front_expiration: date, back_expiration: date
+) -> bool:
+    if back_expiration <= front_expiration:
+        raise ValueError("back expiration must follow front expiration")
+    return front_expiration < earnings_date <= back_expiration
+
+
+def compute_expiration_gap_days(front_expiration: date, back_expiration: date) -> int:
+    gap = (back_expiration - front_expiration).days
+    if gap <= 0:
+        raise ValueError("back expiration must follow front expiration")
+    return gap
+
+
+def compute_expiration_gap_distance(
+    front_expiration: date, back_expiration: date, target_days: int
+) -> int:
+    if target_days < 0:
+        raise ValueError("target_days must be non-negative")
+    return abs(compute_expiration_gap_days(front_expiration, back_expiration) - target_days)
+
+
+def compute_normalized_skew(atm_iv: Decimal, wing_iv: Decimal) -> Decimal:
+    if atm_iv <= 0 or wing_iv < 0:
+        raise ValueError("implied volatilities must be valid")
+    return (wing_iv - atm_iv) / atm_iv
+
+
+def compute_historical_percentile(current: Decimal, history: Sequence[Decimal]) -> Decimal:
+    if not history:
+        raise ValueError("history cannot be empty")
+    less_or_equal = sum(1 for value in history if value <= current)
+    return Decimal(less_or_equal) / Decimal(len(history))
+
+
+def compute_historical_zscore(current: Decimal, history: Sequence[Decimal]) -> Decimal:
+    if len(history) < 2:
+        raise ValueError("at least two historical values are required")
+    with localcontext(DERIVED_FACT_DECIMAL_CONTEXT):
+        mean = sum(history, Decimal(0)) / Decimal(len(history))
+        variance = sum(((value - mean) ** 2 for value in history), Decimal(0)) / Decimal(
+            len(history)
+        )
+        if variance == 0:
+            raise ValueError("historical variance must be positive")
+        return (current - mean) / variance.sqrt()
+
+
+def compute_iv_realized_spread(
+    implied_volatility: Decimal, realized_volatility: Decimal
+) -> Decimal:
+    if min(implied_volatility, realized_volatility) < 0:
+        raise ValueError("volatilities must be non-negative")
+    return implied_volatility - realized_volatility
+
+
+def compute_bid_ask_spread_ratio(bid: Decimal | None, ask: Decimal | None) -> Decimal:
+    if bid is None or ask is None or bid < 0 or ask < bid:
+        raise ValueError("valid ordered bid and ask are required")
+    midpoint = (bid + ask) / Decimal(2)
+    if midpoint <= 0:
+        raise ValueError("bid/ask midpoint must be positive")
+    return (ask - bid) / midpoint
+
+
+def compute_option_volume_band(volume: int | None) -> int:
+    """Raw coarse order-of-magnitude band; interpretation belongs to strategy."""
+
+    if volume is None:
+        return 0
+    if volume < 0:
+        raise ValueError("volume must be non-negative")
+    if volume == 0:
+        return 0
+    return len(str(volume))
+
+
+def compute_open_interest_quality(open_interest: int | None) -> int:
+    """Canonical raw open interest; thresholds belong to strategy policy."""
+
+    if open_interest is None:
+        return 0
+    if open_interest < 0:
+        raise ValueError("open_interest must be non-negative")
+    return open_interest
+
+
+def compute_momentum_dimensions(
+    closes: Sequence[Decimal],
+) -> tuple[Decimal, Decimal]:
+    from analytics.realized_volatility import (
+        compute_realized_volatility,
+        compute_trailing_return,
+    )
+
+    return compute_trailing_return(closes), compute_realized_volatility(closes)
+
+
+def _definition(
+    feature_id: str,
+    description: str,
+    *capabilities: MarketCapability,
+) -> AnalyticsFeatureDefinition:
+    return AnalyticsFeatureDefinition(feature_id, "1.0.0", description, tuple(capabilities))
+
+
+DERIVED_FACT_DEFINITIONS = (
+    _definition(
+        REALIZED_VOLATILITY,
+        "Annualized population volatility of canonical daily log returns.",
+        MarketCapability.HISTORICAL_BARS_V1,
+    ),
+    _definition(
+        IMPLIED_FORWARD_VOLATILITY,
+        "Forward volatility implied by two canonical expiration IVs.",
+        MarketCapability.OPTION_CHAIN_V1,
+    ),
+    _definition(
+        FORWARD_FACTOR,
+        "Front implied volatility divided by implied forward volatility minus one.",
+        MarketCapability.OPTION_CHAIN_V1,
+    ),
+    _definition(
+        DAYS_TO_EARNINGS,
+        "Calendar days from effective date to confirmed earnings.",
+        MarketCapability.EARNINGS_CALENDAR_V1,
+    ),
+    _definition(
+        EARNINGS_INSIDE_TRADE_WINDOW,
+        "Whether earnings occurs after front and through back expiration.",
+        MarketCapability.EARNINGS_CALENDAR_V1,
+        MarketCapability.OPTION_CHAIN_V1,
+    ),
+    _definition(
+        EXPIRATION_GAP_DAYS,
+        "Calendar-day distance between selected expirations.",
+        MarketCapability.OPTION_CHAIN_V1,
+    ),
+    _definition(
+        EXPIRATION_GAP_DISTANCE,
+        "Absolute distance between actual and target expiration gap.",
+        MarketCapability.OPTION_CHAIN_V1,
+    ),
+    *(
+        _definition(
+            identifier,
+            "Provider-neutral normalized option skew.",
+            MarketCapability.OPTION_CHAIN_V1,
+        )
+        for identifier in (NORMALIZED_CALL_SKEW, NORMALIZED_PUT_SKEW)
+    ),
+    *(
+        _definition(
+            identifier,
+            "Historical location of normalized skew.",
+            MarketCapability.OPTION_CHAIN_V1,
+        )
+        for identifier in (
+            SKEW_HISTORICAL_PERCENTILE,
+            SKEW_HISTORICAL_ZSCORE,
+        )
+    ),
+    *(
+        _definition(
+            identifier,
+            "Implied volatility minus realized volatility.",
+            MarketCapability.OPTION_CHAIN_V1,
+            MarketCapability.HISTORICAL_BARS_V1,
+        )
+        for identifier in (
+            ATM_IV_VS_REALIZED,
+            CALL_WING_IV_VS_REALIZED,
+            PUT_WING_IV_VS_REALIZED,
+        )
+    ),
+    _definition(
+        NAMED_MOMENTUM_DIMENSIONS,
+        "Trailing return and realized volatility over canonical closes.",
+        MarketCapability.HISTORICAL_BARS_V1,
+    ),
+    *(
+        _definition(
+            identifier,
+            "Raw option-liquidity dimension without strategy thresholds.",
+            MarketCapability.OPTION_CHAIN_V1,
+        )
+        for identifier in (
+            OPTION_VOLUME_BAND,
+            SPREAD_QUALITY,
+            OPEN_INTEREST_QUALITY,
+        )
+    ),
+)
+
+DERIVED_FACT_REGISTRY = AnalyticsRegistry(DERIVED_FACT_DEFINITIONS)

--- a/analytics/engine.py
+++ b/analytics/engine.py
@@ -1,29 +1,19 @@
-"""Deterministic derived-feature computation engine (ANALYTICS-001).
-
-Invokes one registered feature's pure computation function against
-already-canonical input values (never fetched here -- acquisition is
-explicitly out of scope, per this sprint's must_not_duplicate_market_data
-_acquisition invariant) and wraps the result in the canonical
-DerivedFeatureResult envelope. Implements no financial formula itself.
-"""
+"""Deterministic Derived Fact computation engine."""
 
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from decimal import Decimal
 
 from analytics.clock import Clock
-from analytics.features import DerivedFeatureResult
+from analytics.features import (
+    DerivedFact,
+    DerivedFactQualityStatus,
+    DerivedFactValue,
+)
 from analytics.registry import AnalyticsFeatureDefinition
 from domain import EvidenceReference
 
-# A feature computation is a pure function of its named inputs to one
-# Decimal value. Different features take wildly different inputs (implied
-# volatility needs price/strike/spot/rate/time; DTE needs two dates; a
-# moving average needs a price series) -- a uniform Mapping[str, object]
-# signature keeps the engine itself generic while each computation stays
-# free to validate and interpret its own inputs.
-FeatureComputation = Callable[[Mapping[str, object]], Decimal]
+FeatureComputation = Callable[[Mapping[str, object]], DerivedFactValue]
 
 
 def compute_feature(
@@ -31,33 +21,19 @@ def compute_feature(
     computation: FeatureComputation,
     inputs: Mapping[str, object],
     *,
-    subject_identity: str,
     clock: Clock,
-    parameters: tuple[tuple[str, str], ...] = (),
-    input_provenance: tuple[EvidenceReference, ...] = (),
-) -> DerivedFeatureResult:
-    """Execute one registered feature's computation and wrap it canonically.
+    unit: str,
+    input_evidence: tuple[EvidenceReference, ...] = (),
+    quality_status: DerivedFactQualityStatus = DerivedFactQualityStatus.VALID,
+) -> DerivedFact:
+    """Compute one registered fact without acquisition, policy, or isolation."""
 
-    ``inputs`` drives the actual computation and may hold any object a
-    computation needs (canonical domain values included). ``parameters`` is
-    a separate, caller-curated, already-normalized record of the simple
-    scalar inputs worth keeping for explainability (e.g. an as-of date or an
-    expiration) -- deliberately not auto-derived from ``inputs`` by
-    stringifying every value, since a canonical domain object's repr is
-    neither normalized text nor a meaningful record on its own.
-
-    Raises whatever the computation itself raises for invalid or
-    insufficient input -- this engine performs no isolation of its own;
-    unlike a screening strategy run, a feature computation is a synchronous
-    helper call within a larger, already-isolated caller.
-    """
-    value = computation(inputs)
-    return DerivedFeatureResult(
-        definition.feature_id,
-        definition.feature_version,
-        subject_identity,
-        clock.now(),
-        value,
-        parameters,
-        input_provenance,
+    return DerivedFact(
+        derived_fact_id=definition.feature_id,
+        value=computation(inputs),
+        unit=unit,
+        formula_version=definition.feature_version,
+        effective_time=clock.now(),
+        input_evidence=input_evidence,
+        quality_status=quality_status,
     )

--- a/analytics/features.py
+++ b/analytics/features.py
@@ -1,20 +1,26 @@
-"""Canonical derived-feature result contract (ANALYTICS-001).
-
-One immutable, canonically serializable output of one registered analytics
-feature computation. Every field here is deliberately generic -- this
-module implements no financial formula itself (implied volatility, DTE,
-RSI, ...); it only defines the shape every such computation's result must
-take, so any future feature is reusable through the same contract.
-"""
+"""Immutable, typed, provenance-bearing Derived Fact contracts."""
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
+from enum import StrEnum
 
 from domain import EvidenceReference
 from domain.values import require_tz_aware
+
+DerivedFactValue = Decimal | int | bool | date | tuple[Decimal, ...]
+
+
+class DerivedFactQualityStatus(StrEnum):
+    """Data quality only; never a strategy verdict."""
+
+    VALID = "valid"
+    DEGRADED = "degraded"
+    INSUFFICIENT = "insufficient"
 
 
 def _normalized_text(value: str, owner: str, field_name: str) -> None:
@@ -22,35 +28,94 @@ def _normalized_text(value: str, owner: str, field_name: str) -> None:
         raise ValueError(f"{owner}.{field_name} must be non-empty normalized text")
 
 
+def _value_data(value: DerivedFactValue) -> object:
+    if isinstance(value, Decimal):
+        return {"type": "decimal", "value": str(value)}
+    if isinstance(value, datetime):
+        return {"type": "datetime", "value": value.isoformat()}
+    if isinstance(value, date):
+        return {"type": "date", "value": value.isoformat()}
+    if isinstance(value, tuple):
+        return {"type": "decimal_tuple", "value": [str(item) for item in value]}
+    if isinstance(value, bool):
+        return {"type": "boolean", "value": value}
+    return {"type": "integer", "value": value}
+
+
 @dataclass(frozen=True, slots=True)
-class DerivedFeatureResult:
-    """One immutable, canonically serializable derived-feature computation.
+class DerivedFact:
+    """One deterministic point-in-time calculation over canonical evidence."""
 
-    ``parameters`` records the exact named inputs the computation used
-    (already-normalized string values only, never a raw object) so the
-    result stays explainable and reproducible without needing to keep the
-    original canonical market-data objects around.
-    """
-
-    feature_id: str
-    feature_version: str
-    subject_identity: str
-    as_of: datetime
-    value: Decimal
-    parameters: tuple[tuple[str, str], ...]
-    input_provenance: tuple[EvidenceReference, ...]
+    derived_fact_id: str
+    value: DerivedFactValue
+    unit: str
+    formula_version: str
+    effective_time: datetime
+    input_evidence: tuple[EvidenceReference, ...]
+    quality_status: DerivedFactQualityStatus
 
     def __post_init__(self) -> None:
-        for name in ("feature_id", "feature_version", "subject_identity"):
-            _normalized_text(getattr(self, name), "DerivedFeatureResult", name)
-        require_tz_aware(self.as_of, "DerivedFeatureResult", "as_of")
-        parameter_names = tuple(name for name, _ in self.parameters)
-        if len(set(parameter_names)) != len(parameter_names):
-            raise ValueError("DerivedFeatureResult.parameters keys must be unique")
-        for name, param_value in self.parameters:
-            if not name or name != name.strip():
-                raise ValueError("DerivedFeatureResult.parameters keys must be normalized text")
-            if param_value != param_value.strip():
-                raise ValueError(
-                    "DerivedFeatureResult.parameters values must be normalized text"
+        for name in ("derived_fact_id", "unit", "formula_version"):
+            _normalized_text(getattr(self, name), "DerivedFact", name)
+        require_tz_aware(self.effective_time, "DerivedFact", "effective_time")
+        if len(set(self.input_evidence)) != len(self.input_evidence):
+            raise ValueError("DerivedFact.input_evidence must be unique")
+        object.__setattr__(
+            self,
+            "input_evidence",
+            tuple(
+                sorted(
+                    self.input_evidence,
+                    key=lambda item: (
+                        item.kind.value,
+                        item.referenced_id,
+                        item.version or 0,
+                    ),
                 )
+            ),
+        )
+
+    @property
+    def identity(self) -> str:
+        payload = {
+            "namespace": "asa.derived_fact",
+            "version": "v1",
+            "derived_fact_id": self.derived_fact_id,
+            "value": _value_data(self.value),
+            "unit": self.unit,
+            "formula_version": self.formula_version,
+            "effective_time": self.effective_time.isoformat(),
+            "input_evidence": [
+                {
+                    "kind": item.kind.value,
+                    "referenced_id": item.referenced_id,
+                    "version": item.version,
+                }
+                for item in self.input_evidence
+            ],
+            "quality_status": self.quality_status.value,
+        }
+        encoded = json.dumps(
+            payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode()
+        return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class DerivedFactSet:
+    """Named facts with deterministic ordering and lookup."""
+
+    facts: tuple[DerivedFact, ...]
+
+    def __post_init__(self) -> None:
+        ordered = tuple(sorted(self.facts, key=lambda item: item.derived_fact_id))
+        identifiers = tuple(item.derived_fact_id for item in ordered)
+        if len(identifiers) != len(set(identifiers)):
+            raise ValueError("DerivedFactSet fact IDs must be unique")
+        object.__setattr__(self, "facts", ordered)
+
+    def get(self, derived_fact_id: str) -> DerivedFact:
+        for fact in self.facts:
+            if fact.derived_fact_id == derived_fact_id:
+                return fact
+        raise KeyError(derived_fact_id)

--- a/docs/contracts/derived-fact.md
+++ b/docs/contracts/derived-fact.md
@@ -1,0 +1,38 @@
+# Derived Fact Contract
+
+Status: Proposed — Founder merge required
+
+A Derived Fact is an immutable, provider-neutral, point-in-time calculation
+over canonical evidence. It is reusable financial knowledge, not strategy
+judgment.
+
+Required fields:
+
+- `derived_fact_id`: stable semantic name;
+- `value`: typed immutable value;
+- `unit`: explicit interpretation of the value;
+- `formula_version`: pinned calculation semantics;
+- `effective_time`: timezone-aware semantic effective time;
+- `input_evidence`: exact canonical evidence consumed;
+- `quality_status`: `valid`, `degraded`, or `insufficient`.
+
+Identity is a SHA-256 content hash over all fields plus the
+`asa.derived_fact`/`v1` namespace. Execution timestamps, provider payloads,
+strategy thresholds, weights, scores, and verdicts are excluded.
+
+`DerivedFactSet` sorts by ID, rejects duplicate names, and provides named
+lookup. Positional feature tuples are not a public contract.
+
+## Ownership
+
+`analytics/` owns ephemeral calculations. `indicators/` owns persisted,
+cross-run derived indicators. A formula must have exactly one owner.
+
+Strategies may consume Derived Facts and interpret them using versioned
+manifest policy. Screening may orchestrate calculation but may not implement
+financial formulas or reinterpret strategy decisions.
+
+The initial registry contains realized volatility, implied forward volatility,
+forward factor, earnings timing, expiration-gap measurements, normalized call
+and put skew, historical skew location, IV-versus-realized spreads, momentum
+dimensions, and raw option-liquidity dimensions.

--- a/screening/adapters.py
+++ b/screening/adapters.py
@@ -125,8 +125,9 @@ def run_earnings_calendar(
         # Deterministic, offline-only fixture values -- this dry-run path
         # never touches live market data, so there is no real richness
         # signal to compute. Unrelated to the live adapter's own real,
-        # symbol-specific score_values (screening/live_adapters.py).
-        score_values=(Decimal("80"), Decimal("60")),
+        # symbol-specific named score inputs (screening/live_adapters.py).
+        term_structure_richness=Decimal("80"),
+        iv_realized_volatility_richness=Decimal("60"),
     )
     graph = compile_strategy_graph(EARNINGS_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
     result = execute_strategy_graph(graph, context)
@@ -150,7 +151,8 @@ def run_skew_momentum(
         option_type=OptionType.CALL,
         # Deterministic, offline-only fixture values -- see
         # run_earnings_calendar's own identical note above.
-        score_values=(Decimal("80"), Decimal("70")),
+        normalized_skew_richness=Decimal("80"),
+        momentum_richness=Decimal("70"),
     )
     graph = compile_strategy_graph(SKEW_MOMENTUM_VERTICAL_MANIFEST, _COMPONENT_REGISTRY)
     result = execute_strategy_graph(graph, context)

--- a/screening/context_builders.py
+++ b/screening/context_builders.py
@@ -5,15 +5,10 @@ canonical market data. Forward Factor's builder uses analytics/ for the
 implied-forward-volatility inputs SPRINT-006 found missing (ANALYTICS-002)
 instead of any hardcoded external constant.
 
-Earnings Calendar and Skew Momentum's own score.values inputs were
-hardcoded constants from this ticket's original authorship until
-SPRINT-011-CLOSEOUT/CLOSE-002 found them: identical for every symbol,
-completely disconnected from vertical/calendar/debit's own real computed
-outputs, silently making every live PASS/WATCH verdict from either
-strategy meaningless. Both builders now take score_values as a required
-keyword argument -- real, symbol-specific, live-data-derived signals the
-caller (screening/live_adapters.py) computes, never invented here. See
-project/reports/SPRINT-011.md for the full defect writeup.
+Earnings Calendar and Skew Momentum's scoring inputs were hardcoded constants
+until SPRINT-011-CLOSEOUT/CLOSE-002 found them. SPRINT-012 replaces their
+positional tuple API with explicit named inputs. Strategy-owned normalization
+is invoked by orchestration; screening contains no financial formula.
 
 Adapters only: no strategy modification, no provider import. Every builder
 here takes already-canonical domain objects and produces a ComponentValues
@@ -153,16 +148,13 @@ def build_earnings_calendar_context(
     as_of: date,
     *,
     target_strike: Decimal,
-    score_values: tuple[Decimal, Decimal],
+    term_structure_richness: Decimal,
+    iv_realized_volatility_richness: Decimal,
 ) -> ComponentValues:
-    """score_values -- SPRINT-011-CLOSEOUT/CLOSE-002: (term_structure_richness,
-    iv_realized_vol_richness), both real, symbol-specific, live-data-derived
-    signals the caller computes inline (screening/live_adapters.py's
-    build_live_earnings_calendar_adapter, using _richness_score()) -- this
-    function no longer hardcodes (80, 60) regardless of symbol. Weights
-    (3, 1) remain a genuine strategy parameter, same status as
-    verdict_classifier's own pass_threshold/watch_threshold literals, not
-    market data -- unchanged by this fix.
+    """Build from named strategy score inputs, never a positional feature tuple.
+
+    Weights (3, 1) remain the existing strategy policy pending WS4 migration
+    into the manifest.
     """
     return _context(
         **{
@@ -176,7 +168,10 @@ def build_earnings_calendar_context(
             "expiration_select.event": (EARNINGS_EVENT, event),
             "calendar.chain": (OPTION_CHAIN, chain),
             "calendar.target_strike": (D, target_strike),
-            "score.values": (DECIMAL_LIST, score_values),
+            "score.values": (
+                DECIMAL_LIST,
+                (term_structure_richness, iv_realized_volatility_richness),
+            ),
             "score.weights": (DECIMAL_LIST, (Decimal("3"), Decimal("1"))),
         }
     )
@@ -188,16 +183,13 @@ def build_skew_momentum_context(
     *,
     strike: Decimal,
     option_type: OptionType = OptionType.CALL,
-    score_values: tuple[Decimal, Decimal],
+    normalized_skew_richness: Decimal,
+    momentum_richness: Decimal,
 ) -> ComponentValues:
-    """score_values -- SPRINT-011-CLOSEOUT/CLOSE-002: (skew_richness,
-    momentum_richness), both real, symbol-specific, live-data-derived
-    signals the caller computes inline (screening/live_adapters.py's
-    build_live_skew_momentum_adapter, using _richness_score()) -- this
-    function no longer hardcodes (80, 70) regardless of symbol. Weights
-    (2, 1) remain a genuine strategy parameter (skew is the primary edge,
-    momentum an enhancer, per Volatility Vibes' own framing), not market
-    data -- unchanged by this fix.
+    """Build from named strategy score inputs, never a positional feature tuple.
+
+    Weights (2, 1) remain the existing strategy policy pending WS5 migration
+    into the manifest.
     """
     (contract,) = chain.find(expiration=expiration, strike=strike, option_type=option_type)
     return _context(
@@ -205,7 +197,10 @@ def build_skew_momentum_context(
             "vertical.chain": (OPTION_CHAIN, chain),
             "vertical.expiration": (DATE, expiration),
             "liquidity.contract": (OPTION_CONTRACT, contract),
-            "score.values": (DECIMAL_LIST, score_values),
+            "score.values": (
+                DECIMAL_LIST,
+                (normalized_skew_richness, momentum_richness),
+            ),
             "score.weights": (DECIMAL_LIST, (Decimal("2"), Decimal("1"))),
         }
     )

--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -33,6 +33,10 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import cast
 
+from analytics.derived_facts import (
+    compute_iv_realized_spread,
+    compute_normalized_skew,
+)
 from analytics.expiration_selection import (
     ExpirationCandidate,
     rank_expiration_pairs,
@@ -85,6 +89,7 @@ from strategies import (
     execute_strategy_graph,
 )
 from strategies.plugins import build_plugin_registry
+from strategies.scoring import normalize_richness
 
 _COMPONENT_REGISTRY = build_plugin_registry(CORE_COMPONENTS, STONK_STRATEGY_PLUGINS)
 _NON_FAIL_VERDICTS = frozenset({"PASS", "WATCH"})
@@ -192,9 +197,7 @@ def _acquire_or_raise(
             detail += f" at expiration {expiration.isoformat()}"
         raise StrategyAdapterError(ScreeningOutcomeStatus.MISSING_DATA, detail)
     observation = result.observations[0]
-    market_is_open = (
-        UsEquitySessionCalendar().status_at(now) is MarketSessionStatus.OPEN
-    )
+    market_is_open = UsEquitySessionCalendar().status_at(now) is MarketSessionStatus.OPEN
     usability = evaluate_temporal_usability(
         observation.freshness,
         freshness_requirement,
@@ -222,7 +225,11 @@ def _acquire_combined_chain(
     unique_expirations = tuple(dict.fromkeys(expirations))
     chains = tuple(
         _acquire_or_raise(
-            fulfillment, symbol, MarketCapability.OPTION_CHAIN_V1, now, ("contracts",),
+            fulfillment,
+            symbol,
+            MarketCapability.OPTION_CHAIN_V1,
+            now,
+            ("contracts",),
             expiration=expiration,
         )
         for expiration in unique_expirations
@@ -246,18 +253,6 @@ def _spot_price(quote: Quote) -> Decimal:
 # original authorship. See project/reports/SPRINT-011.md for the full
 # defect writeup and cited sources for each strategy's own thesis.
 _HISTORICAL_LOOKBACK_DAYS = 45  # calendar days -- ~30 trading days
-# Centers a richness score at 50 (neutral); a 1/3 (0.33) vol-point or
-# return gap saturates it to 0 or 100. A deliberate, documented, linear
-# approximation -- not the exact z-score-against-own-history system either
-# cited video describes (that needs a persisted historical skew/IV-term
-# time series this codebase does not have yet); reusing IV-vs-realized-
-# volatility and price momentum instead, both computable from data this
-# system already acquires live.
-_RICHNESS_SCALE = Decimal("300")
-
-
-def _richness_score(raw_gap: Decimal) -> Decimal:
-    return max(Decimal(0), min(Decimal(100), Decimal(50) + raw_gap * _RICHNESS_SCALE))
 
 
 def _acquire_daily_closes(
@@ -318,9 +313,7 @@ def build_live_forward_factor_adapter(
     *,
     freshness_requirement: FreshnessRequirement = DEFAULT_FRESHNESS_REQUIREMENT,
 ) -> StrategyAdapter:
-    def _run(
-        definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
-    ) -> ScreeningResult:
+    def _run(definition: ScreeningStrategyDefinition, clock: Clock, run_id: str) -> ScreeningResult:
         now = clock.now()
         as_of = now.date()
         quote = _acquire_or_raise(
@@ -408,9 +401,7 @@ def build_live_earnings_calendar_adapter(
     *,
     freshness_requirement: FreshnessRequirement = DEFAULT_FRESHNESS_REQUIREMENT,
 ) -> StrategyAdapter:
-    def _run(
-        definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
-    ) -> ScreeningResult:
+    def _run(definition: ScreeningStrategyDefinition, clock: Clock, run_id: str) -> ScreeningResult:
         now = clock.now()
         as_of = now.date()
         event = _acquire_or_raise(
@@ -494,7 +485,7 @@ def build_live_earnings_calendar_adapter(
         # separately-fetched fixed 45-day point (this system selects
         # front/back via its own earnings-relative DTE policy, not a fixed
         # calendar pin).
-        term_richness = _richness_score(
+        term_richness = normalize_richness(
             front_contract.implied_volatility - back_contract.implied_volatility
         )
         closes = _acquire_daily_closes(fulfillment, symbol, now)
@@ -502,7 +493,9 @@ def build_live_earnings_calendar_adapter(
         # iv30/rv30-style richness (same source, ~09:40): front-month IV
         # priced above what has actually realized -- the second predictor
         # that video's own decile analysis found correlated with returns.
-        iv_rv_richness = _richness_score(front_contract.implied_volatility - realized_vol)
+        iv_rv_richness = normalize_richness(
+            compute_iv_realized_spread(front_contract.implied_volatility, realized_vol)
+        )
         context = build_earnings_calendar_context(
             chain,
             event,  # type: ignore[arg-type]
@@ -510,7 +503,8 @@ def build_live_earnings_calendar_adapter(
             back_cycle,
             as_of,
             target_strike=target_strike,
-            score_values=(term_richness, iv_rv_richness),
+            term_structure_richness=term_richness,
+            iv_realized_volatility_richness=iv_rv_richness,
         )
         graph = compile_strategy_graph(EARNINGS_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
         result = execute_strategy_graph(graph, context)
@@ -533,9 +527,7 @@ def build_live_skew_momentum_adapter(
     *,
     freshness_requirement: FreshnessRequirement = DEFAULT_FRESHNESS_REQUIREMENT,
 ) -> StrategyAdapter:
-    def _run(
-        definition: ScreeningStrategyDefinition, clock: Clock, run_id: str
-    ) -> ScreeningResult:
+    def _run(definition: ScreeningStrategyDefinition, clock: Clock, run_id: str) -> ScreeningResult:
         now = clock.now()
         as_of = now.date()
         quote = _acquire_or_raise(
@@ -560,22 +552,28 @@ def build_live_skew_momentum_adapter(
         # upcoming expiration ("front month") is the simplest, standard,
         # non-editorial default absent any other established policy.
         nearest = min(future_expirations, key=lambda cycle: cycle.expiration_date)
-        chain = _acquire_or_raise(
-            fulfillment,
-            symbol,
-            MarketCapability.OPTION_CHAIN_V1,
-            now,
-            ("contracts",),
-            expiration=nearest.expiration_date,
+        chain = cast(
+            OptionChain,
+            _acquire_or_raise(
+                fulfillment,
+                symbol,
+                MarketCapability.OPTION_CHAIN_V1,
+                now,
+                ("contracts",),
+                expiration=nearest.expiration_date,
+            ),
         )
         strike = select_atm_strike_at_expiration(
-            chain, nearest.expiration_date, spot_price, OptionType.CALL  # type: ignore[arg-type]
+            chain,
+            nearest.expiration_date,
+            spot_price,
+            OptionType.CALL,
         )
-        (atm_contract,) = chain.find(  # type: ignore[attr-defined]
+        (atm_contract,) = chain.find(
             expiration=nearest.expiration_date, strike=strike, option_type=OptionType.CALL
         )
         wing_contract = select_nearest_delta_contract(
-            chain,  # type: ignore[arg-type]
+            chain,
             nearest.expiration_date,
             OptionType.CALL,
             Decimal("0.25"),
@@ -595,17 +593,21 @@ def build_live_skew_momentum_adapter(
         # long-ATM/short-wing structure (strategies/stonk_manifests.py's
         # own frozen 0.50/0.25 delta targets, unchanged by this fix) is
         # built to exploit.
-        skew_richness = _richness_score(
-            wing_contract.implied_volatility - atm_contract.implied_volatility
+        skew_richness = normalize_richness(
+            compute_normalized_skew(
+                atm_contract.implied_volatility,
+                wing_contract.implied_volatility,
+            )
         )
         closes = _acquire_daily_closes(fulfillment, symbol, now)
-        momentum_richness = _richness_score(compute_trailing_return(closes))
+        momentum_richness = normalize_richness(compute_trailing_return(closes))
         context = build_skew_momentum_context(
-            chain,  # type: ignore[arg-type]
+            chain,
             nearest.expiration_date,
             strike=strike,
             option_type=OptionType.CALL,
-            score_values=(skew_richness, momentum_richness),
+            normalized_skew_richness=skew_richness,
+            momentum_richness=momentum_richness,
         )
         graph = compile_strategy_graph(SKEW_MOMENTUM_VERTICAL_MANIFEST, _COMPONENT_REGISTRY)
         result = execute_strategy_graph(graph, context)
@@ -616,7 +618,7 @@ def build_live_skew_momentum_adapter(
             symbol,
             result.outputs.get("verdict").value,
             result.outputs.get("score").value,
-            chain.evidence,  # type: ignore[attr-defined]
+            chain.evidence,
         )
 
     return _run

--- a/strategies/scoring.py
+++ b/strategies/scoring.py
@@ -1,0 +1,20 @@
+"""Explicit strategy-owned score transforms preserved during SPRINT-012."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+
+def normalize_richness(
+    raw_value: Decimal,
+    *,
+    center: Decimal = Decimal(50),
+    scale: Decimal = Decimal(300),
+    floor: Decimal = Decimal(0),
+    ceiling: Decimal = Decimal(100),
+) -> Decimal:
+    """Apply the existing version-1 bounded linear richness policy."""
+
+    if scale <= 0 or floor > ceiling or not floor <= center <= ceiling:
+        raise ValueError("richness normalization policy is invalid")
+    return max(floor, min(ceiling, center + raw_value * scale))

--- a/strategies/stonk_components.py
+++ b/strategies/stonk_components.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 
 import hashlib
 from datetime import date
-from decimal import Context, Decimal, ROUND_HALF_EVEN, localcontext
+from decimal import ROUND_HALF_EVEN, Context, Decimal, localcontext
 from typing import cast
 
+from analytics.derived_facts import (
+    compute_forward_factor,
+    compute_implied_forward_volatility,
+)
 from domain import (
     AnnouncementTime,
     EarningsEvent,
@@ -507,11 +511,13 @@ class ForwardFactor(BaseComponent):
     def evaluate(self, inputs: ComponentValues, parameters: ComponentValues) -> ComponentValues:
         front = cast(Decimal, _input(inputs, "front_ex_earnings_iv", Decimal))
         forward = cast(Decimal, _input(inputs, "implied_forward_iv", Decimal))
-        if front < 0 or forward <= 0:
+        try:
+            factor = compute_forward_factor(front, forward)
+        except ValueError as exc:
             raise ComponentContractError(
                 "forward factor requires non-negative front IV and positive forward IV"
-            )
-        return ComponentValues((("factor", TypedValue(D, front / forward - Decimal(1))),))
+            ) from exc
+        return ComponentValues((("factor", TypedValue(D, factor)),))
 
 
 class ImpliedForwardVolatility(BaseComponent):
@@ -538,14 +544,15 @@ class ImpliedForwardVolatility(BaseComponent):
         back_dte = cast(int, _input(inputs, "back_dte", int))
         if not (Decimal(0) < front_iv <= Decimal(5)) or not (Decimal(0) < back_iv <= Decimal(5)):
             raise ComponentContractError("IV inputs must be annualized decimal ratios")
-        if front_dte < 1 or back_dte <= front_dte:
-            raise ComponentContractError("back DTE must be greater than positive front DTE")
-        with localcontext(FINANCIAL_DECIMAL_CONTEXT):
-            numerator = back_iv * back_iv * back_dte - front_iv * front_iv * front_dte
-            variance = numerator / Decimal(back_dte - front_dte)
-            if variance <= 0:
-                raise ComponentContractError("implied forward variance must be positive")
-            forward_iv = variance.sqrt()
+        try:
+            with localcontext(FINANCIAL_DECIMAL_CONTEXT):
+                forward_iv = compute_implied_forward_volatility(
+                    front_iv, back_iv, front_dte, back_dte
+                )
+        except ValueError as exc:
+            raise ComponentContractError(
+                "back DTE and implied forward variance must be valid"
+            ) from exc
         return ComponentValues((("implied_forward_iv", TypedValue(D, forward_iv)),))
 
 

--- a/tests/analytics/test_derived_facts.py
+++ b/tests/analytics/test_derived_facts.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from analytics.derived_facts import (
+    DERIVED_FACT_REGISTRY,
+    compute_bid_ask_spread_ratio,
+    compute_days_to_earnings,
+    compute_earnings_inside_trade_window,
+    compute_expiration_gap_days,
+    compute_expiration_gap_distance,
+    compute_forward_factor,
+    compute_historical_percentile,
+    compute_historical_zscore,
+    compute_implied_forward_volatility,
+    compute_iv_realized_spread,
+    compute_momentum_dimensions,
+    compute_normalized_skew,
+    compute_open_interest_quality,
+    compute_option_volume_band,
+)
+
+
+def test_forward_variance_and_factor_independent_vector() -> None:
+    forward = compute_implied_forward_volatility(Decimal("0.40"), Decimal("0.35"), 30, 60)
+    assert forward == Decimal("0.2915475947422650235437076438772792")
+    assert compute_forward_factor(Decimal("0.40"), forward) == (
+        Decimal("0.371988681140070699029212441775431")
+    )
+
+
+def test_earnings_and_expiration_temporal_facts() -> None:
+    as_of = date(2026, 7, 1)
+    front = date(2026, 7, 18)
+    earnings = date(2026, 7, 21)
+    back = date(2026, 8, 22)
+    assert compute_days_to_earnings(as_of, earnings) == 20
+    assert compute_earnings_inside_trade_window(earnings, front, back)
+    assert compute_expiration_gap_days(front, back) == 35
+    assert compute_expiration_gap_distance(front, back, 30) == 5
+
+
+def test_normalized_skew_and_iv_realized_spread() -> None:
+    assert compute_normalized_skew(Decimal("0.20"), Decimal("0.25")) == Decimal("0.25")
+    assert compute_iv_realized_spread(Decimal("0.30"), Decimal("0.18")) == Decimal("0.12")
+    history = (Decimal("-0.2"), Decimal("0"), Decimal("0.1"))
+    assert compute_historical_percentile(Decimal("0"), history) == (Decimal(2) / Decimal(3))
+    assert compute_historical_zscore(Decimal("0.1"), history) > 0
+
+
+def test_raw_liquidity_dimensions_do_not_embed_strategy_thresholds() -> None:
+    assert compute_bid_ask_spread_ratio(Decimal("0.90"), Decimal("1.10")) == Decimal("0.2")
+    assert compute_option_volume_band(999) == 3
+    assert compute_option_volume_band(None) == 0
+    assert compute_open_interest_quality(1250) == 1250
+
+
+def test_named_momentum_dimensions_are_replay_stable() -> None:
+    closes = (Decimal("100"), Decimal("101"), Decimal("103"))
+    first = compute_momentum_dimensions(closes)
+    assert first == compute_momentum_dimensions(closes)
+    assert first[0] == Decimal("0.03")
+
+
+def test_initial_registry_is_closed_versioned_and_complete() -> None:
+    assert len(DERIVED_FACT_REGISTRY.registered_ids()) == 18
+    assert DERIVED_FACT_REGISTRY.get("forward_factor").feature_version == "1.0.0"
+
+
+@pytest.mark.parametrize(
+    ("call", "message"),
+    [
+        (
+            lambda: compute_implied_forward_volatility(Decimal("0.5"), Decimal("0.2"), 30, 31),
+            "variance",
+        ),
+        (
+            lambda: compute_expiration_gap_days(date(2026, 8, 1), date(2026, 7, 1)),
+            "back expiration",
+        ),
+        (
+            lambda: compute_bid_ask_spread_ratio(Decimal("2"), Decimal("1")),
+            "bid and ask",
+        ),
+    ],
+)
+def test_invalid_inputs_fail_closed(call: object, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        call()  # type: ignore[operator]

--- a/tests/analytics/test_engine.py
+++ b/tests/analytics/test_engine.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 import pytest
 
 from analytics.engine import compute_feature
+from analytics.features import DerivedFactQualityStatus
 from analytics.registry import AnalyticsFeatureDefinition
 from domain import EvidenceKind, EvidenceReference, MarketCapability
 
@@ -17,77 +18,49 @@ EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "analytics:test-evidence
 
 @dataclass(frozen=True)
 class FixedClock:
-    fixed_at: datetime = AS_OF
-
     def now(self) -> datetime:
-        return self.fixed_at
+        return AS_OF
 
 
 def _double(inputs: Mapping[str, object]) -> Decimal:
-    """A synthetic, deliberately non-financial computation -- ANALYTICS-001
-    proves the framework's mechanics, not any real formula (that's
-    ANALYTICS-002's job).
-    """
     return Decimal(str(inputs["value"])) * 2
 
 
 def _raises(inputs: Mapping[str, object]) -> Decimal:
-    raise ValueError("insufficient input for this synthetic computation")
+    raise ValueError("insufficient input")
 
 
-_DEFINITION = AnalyticsFeatureDefinition(
-    "synthetic_double", "1.0.0", "Doubles a value; test-only.", (MarketCapability.OPTION_CHAIN_V1,)
+DEFINITION = AnalyticsFeatureDefinition(
+    "synthetic_double",
+    "1.0.0",
+    "Doubles a value; test-only.",
+    (MarketCapability.OPTION_CHAIN_V1,),
 )
 
 
-class TestComputeFeature:
-    def test_wraps_the_computation_result_canonically(self) -> None:
-        result = compute_feature(
-            _DEFINITION,
-            _double,
-            {"value": "21"},
-            subject_identity="figi:BBG000B9XRY4",
-            clock=FixedClock(),
-            parameters=(("value", "21"),),
-            input_provenance=EVIDENCE,
-        )
-        assert result.feature_id == "synthetic_double"
-        assert result.feature_version == "1.0.0"
-        assert result.value == Decimal("42")
-        assert result.as_of == AS_OF
-        assert result.parameters == (("value", "21"),)
-        assert result.input_provenance == EVIDENCE
+def test_engine_wraps_named_computation_with_provenance() -> None:
+    result = compute_feature(
+        DEFINITION,
+        _double,
+        {"value": "21"},
+        clock=FixedClock(),
+        unit="ratio",
+        input_evidence=EVIDENCE,
+    )
+    assert result.derived_fact_id == "synthetic_double"
+    assert result.formula_version == "1.0.0"
+    assert result.value == Decimal("42")
+    assert result.effective_time == AS_OF
+    assert result.quality_status is DerivedFactQualityStatus.VALID
+    assert result.input_evidence == EVIDENCE
 
-    def test_defaults_are_empty(self) -> None:
-        result = compute_feature(
-            _DEFINITION,
-            _double,
-            {"value": "1"},
-            subject_identity="figi:BBG000B9XRY4",
-            clock=FixedClock(),
-        )
-        assert result.parameters == ()
-        assert result.input_provenance == ()
 
-    def test_computation_exceptions_propagate_uncaught(self) -> None:
-        """The engine performs no isolation -- unlike a screening strategy
-        run, a feature computation is a synchronous helper call within a
-        larger, already-isolated caller.
-        """
-        with pytest.raises(ValueError, match="insufficient input"):
-            compute_feature(
-                _DEFINITION,
-                _raises,
-                {},
-                subject_identity="figi:BBG000B9XRY4",
-                clock=FixedClock(),
-            )
+def test_computation_exceptions_propagate() -> None:
+    with pytest.raises(ValueError, match="insufficient input"):
+        compute_feature(DEFINITION, _raises, {}, clock=FixedClock(), unit="ratio")
 
-    def test_is_deterministic_for_identical_inputs_and_clock(self) -> None:
-        first = compute_feature(
-            _DEFINITION, _double, {"value": "5"}, subject_identity="figi:x", clock=FixedClock()
-        )
-        second = compute_feature(
-            _DEFINITION, _double, {"value": "5"}, subject_identity="figi:x", clock=FixedClock()
-        )
-        assert first == second
+
+def test_identical_inputs_and_clock_replay_identically() -> None:
+    first = compute_feature(DEFINITION, _double, {"value": "5"}, clock=FixedClock(), unit="ratio")
+    second = compute_feature(DEFINITION, _double, {"value": "5"}, clock=FixedClock(), unit="ratio")
+    assert first == second

--- a/tests/analytics/test_features.py
+++ b/tests/analytics/test_features.py
@@ -5,59 +5,68 @@ from decimal import Decimal
 
 import pytest
 
-from analytics.features import DerivedFeatureResult
+from analytics.features import (
+    DerivedFact,
+    DerivedFactQualityStatus,
+    DerivedFactSet,
+)
 from domain import EvidenceKind, EvidenceReference
 
 AS_OF = datetime(2026, 7, 22, 16, 0, tzinfo=UTC)
 EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "analytics:test-evidence"),)
 
 
-def _result(**overrides: object) -> DerivedFeatureResult:
+def _fact(**overrides: object) -> DerivedFact:
     fields: dict[str, object] = {
-        "feature_id": "days_to_expiration",
-        "feature_version": "1.0.0",
-        "subject_identity": "figi:BBG000B9XRY4",
-        "as_of": AS_OF,
-        "value": Decimal("16"),
-        "parameters": (("expiration", "2026-08-07"),),
-        "input_provenance": EVIDENCE,
+        "derived_fact_id": "days_to_expiration",
+        "value": 16,
+        "unit": "calendar_days",
+        "formula_version": "1.0.0",
+        "effective_time": AS_OF,
+        "input_evidence": EVIDENCE,
+        "quality_status": DerivedFactQualityStatus.VALID,
     }
     fields.update(overrides)
-    return DerivedFeatureResult(**fields)  # type: ignore[arg-type]
+    return DerivedFact(**fields)  # type: ignore[arg-type]
 
 
-class TestDerivedFeatureResultInvariants:
-    def test_valid_result_constructs(self) -> None:
-        result = _result()
-        assert result.value == Decimal("16")
+def test_fact_is_immutable_deterministic_and_complete() -> None:
+    fact = _fact()
+    assert fact.value == 16
+    assert fact.identity == _fact().identity
+    with pytest.raises(AttributeError):
+        fact.value = 17  # type: ignore[misc]
 
-    @pytest.mark.parametrize(
-        "field", ["feature_id", "feature_version", "subject_identity"]
-    )
-    def test_empty_identity_field_rejected(self, field: str) -> None:
-        with pytest.raises(ValueError, match="normalized text"):
-            _result(**{field: ""})
 
-    def test_naive_as_of_rejected(self) -> None:
-        with pytest.raises(ValueError):
-            _result(as_of=datetime(2026, 7, 22, 16, 0))
+@pytest.mark.parametrize("field", ["derived_fact_id", "unit", "formula_version"])
+def test_empty_semantic_field_is_rejected(field: str) -> None:
+    with pytest.raises(ValueError, match="normalized text"):
+        _fact(**{field: ""})
 
-    def test_duplicate_parameter_keys_rejected(self) -> None:
-        with pytest.raises(ValueError, match="unique"):
-            _result(parameters=(("expiration", "2026-08-07"), ("expiration", "2026-09-18")))
 
-    def test_unnormalized_parameter_key_rejected(self) -> None:
-        with pytest.raises(ValueError, match="normalized text"):
-            _result(parameters=((" expiration ", "2026-08-07"),))
+def test_naive_effective_time_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        _fact(effective_time=datetime(2026, 7, 22, 16, 0))
 
-    def test_unnormalized_parameter_value_rejected(self) -> None:
-        with pytest.raises(ValueError, match="normalized text"):
-            _result(parameters=(("expiration", " 2026-08-07 "),))
 
-    def test_empty_parameters_is_allowed(self) -> None:
-        result = _result(parameters=())
-        assert result.parameters == ()
+def test_duplicate_evidence_is_rejected() -> None:
+    with pytest.raises(ValueError, match="unique"):
+        _fact(input_evidence=EVIDENCE + EVIDENCE)
 
-    def test_empty_provenance_is_allowed(self) -> None:
-        result = _result(input_provenance=())
-        assert result.input_provenance == ()
+
+def test_evidence_order_does_not_change_identity() -> None:
+    other = EvidenceReference(EvidenceKind.OBSERVATION, "analytics:other")
+    first = _fact(input_evidence=EVIDENCE + (other,))
+    second = _fact(input_evidence=(other,) + EVIDENCE)
+    assert first.input_evidence == second.input_evidence
+    assert first.identity == second.identity
+
+
+def test_fact_set_is_ordered_named_and_unique() -> None:
+    later = _fact(derived_fact_id="z", value=Decimal("2"))
+    earlier = _fact(derived_fact_id="a", value=Decimal("1"))
+    facts = DerivedFactSet((later, earlier))
+    assert tuple(item.derived_fact_id for item in facts.facts) == ("a", "z")
+    assert facts.get("z") is later
+    with pytest.raises(ValueError, match="unique"):
+        DerivedFactSet((earlier, earlier))

--- a/tests/architecture/test_strategy_boundaries.py
+++ b/tests/architecture/test_strategy_boundaries.py
@@ -41,11 +41,18 @@ def _strategy_files() -> list[Path]:
 
 
 class TestStrategyImportScope:
-    """strategies/ imports only strategies, indicators, facts, reconciliation, domain."""
+    """Strategies consume derived facts, indicators, facts, and domain contracts."""
 
     @pytest.mark.parametrize("py_file", _strategy_files())
     def test_only_permitted_roots(self, py_file):
-        permitted = {"strategies", "indicators", "facts", "reconciliation", "domain"} | STDLIB_ALLOWED
+        permitted = {
+            "strategies",
+            "analytics",
+            "indicators",
+            "facts",
+            "reconciliation",
+            "domain",
+        } | STDLIB_ALLOWED
         imported = _imported_roots(py_file)
         assert imported <= permitted, (
             f"{py_file.name} imports outside {permitted}: {imported - permitted}"

--- a/tests/architecture/test_strategy_integrity_semantics.py
+++ b/tests/architecture/test_strategy_integrity_semantics.py
@@ -35,7 +35,6 @@ KNOWN_SCREENING_SEMANTIC_DEBT = frozenset(
     {
         "_outcome_status_for_verdict",
         "_spot_price",
-        "_richness_score",
     }
 )
 

--- a/tests/screening/test_context_builders.py
+++ b/tests/screening/test_context_builders.py
@@ -99,7 +99,8 @@ class TestBuildEarningsCalendarContext:
             back,
             fixtures.AS_OF_DATE,
             target_strike=Decimal("100"),
-            score_values=(Decimal("80"), Decimal("60")),
+            term_structure_richness=Decimal("80"),
+            iv_realized_volatility_richness=Decimal("60"),
         )
         values = dict(context.entries)
         assert values["calendar.target_strike"].value == Decimal("100")
@@ -115,7 +116,8 @@ class TestBuildSkewMomentumContext:
             fixtures.SKEW_EXPIRATION,
             strike=Decimal("100"),
             option_type=OptionType.CALL,
-            score_values=(Decimal("80"), Decimal("70")),
+            normalized_skew_richness=Decimal("80"),
+            momentum_richness=Decimal("70"),
         )
         values = dict(context.entries)
         assert values["vertical.expiration"].value == fixtures.SKEW_EXPIRATION


### PR DESCRIPTION
## Summary

Implements WS2 of #250: one immutable, typed, formula-versioned, provenance-bearing Derived Fact contract plus a closed registry of the 18 initial reusable quantities. Removes the positional score-values API and relocates reusable forward math from strategy components to analytics.

## Founder review required

This PR introduces the public DerivedFact contract and its quality vocabulary (`valid`, `degraded`, `insufficient`). It must not merge without Founder review. WS3 is paused pending approval.

## Contract

Each fact records derived_fact_id, typed value, unit, formula_version, semantic effective_time, exact input evidence, quality_status, and deterministic content identity. DerivedFactSet provides canonical ordering and named lookup.

## Ownership

- analytics owns reusable calculations and their versions.
- strategies own bounded richness normalization.
- screening invokes these owners but contains no richness, skew, IV-spread, or forward formula.
- indicators remain the durable cross-run layer.

The registry covers realized volatility, implied forward volatility, forward factor, earnings timing, expiration-gap facts, call/put skew, historical skew location, IV-versus-realized spreads, momentum dimensions, and option liquidity dimensions.

## Validation

- pytest: 2,607 passed, 17 skipped
- targeted derived-fact/architecture suite: 179 passed
- Ruff: pass
- mypy: 55 source files pass
- Lean entrypoint, integrity, validator, pre-push: pass
- git diff --check: pass

## Safety

No provider calls, persistence schema, broker behavior, deployment behavior, thresholds, verdicts, or live configuration changed. No merge or deployment performed.