### PR TITLE
SPRINT-012 WS5: add canonical Skew Momentum evidence

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -15,6 +15,7 @@ from analytics.derived_facts import (
     DERIVED_FACT_DEFINITIONS,
     DERIVED_FACT_REGISTRY,
     compute_bid_ask_spread_ratio,
+    compute_cross_sectional_momentum,
     compute_days_to_earnings,
     compute_earnings_inside_trade_window,
     compute_expiration_gap_days,
@@ -29,6 +30,8 @@ from analytics.derived_facts import (
     compute_normalized_skew,
     compute_open_interest_quality,
     compute_option_volume_band,
+    compute_sector_relative_momentum,
+    compute_skew_stretch_distributions,
 )
 from analytics.engine import FeatureComputation, compute_feature
 from analytics.errors import (
@@ -84,6 +87,7 @@ __all__ = [
     "NoMatchingContractError",
     "UnknownFeatureIdError",
     "compute_days_to_expiration",
+    "compute_cross_sectional_momentum",
     "compute_days_to_earnings",
     "compute_earnings_inside_trade_window",
     "compute_expiration_gap_days",
@@ -99,6 +103,8 @@ __all__ = [
     "compute_option_volume_band",
     "compute_open_interest_quality",
     "compute_realized_volatility",
+    "compute_sector_relative_momentum",
+    "compute_skew_stretch_distributions",
     "compute_trailing_return",
     "compute_bid_ask_spread_ratio",
     "compute_momentum_dimensions",

--- a/analytics/derived_facts.py
+++ b/analytics/derived_facts.py
@@ -7,7 +7,12 @@ from datetime import date
 from decimal import ROUND_HALF_EVEN, Context, Decimal, localcontext
 
 from analytics.registry import AnalyticsFeatureDefinition, AnalyticsRegistry
-from domain import MarketCapability
+from domain import (
+    ComparisonUniverseReturns,
+    HistoricalSkewObservations,
+    MarketCapability,
+    SectorReferenceReturns,
+)
 
 DERIVED_FACT_DECIMAL_CONTEXT = Context(prec=34, rounding=ROUND_HALF_EVEN)
 
@@ -27,6 +32,8 @@ ATM_IV_VS_REALIZED = "atm_iv_vs_realized_volatility"
 CALL_WING_IV_VS_REALIZED = "call_wing_iv_vs_realized_volatility"
 PUT_WING_IV_VS_REALIZED = "put_wing_iv_vs_realized_volatility"
 NAMED_MOMENTUM_DIMENSIONS = "named_momentum_dimensions"
+CROSS_SECTIONAL_MOMENTUM = "cross_sectional_momentum"
+SECTOR_RELATIVE_MOMENTUM = "sector_relative_momentum"
 OPTION_VOLUME_BAND = "option_volume_band"
 SPREAD_QUALITY = "spread_quality"
 OPEN_INTEREST_QUALITY = "open_interest_quality"
@@ -123,6 +130,46 @@ def compute_historical_zscore(current: Decimal, history: Sequence[Decimal]) -> D
         if variance == 0:
             raise ValueError("historical variance must be positive")
         return (current - mean) / variance.sqrt()
+
+
+def compute_skew_stretch_distributions(
+    current_call_skew: Decimal,
+    current_put_skew: Decimal,
+    history: HistoricalSkewObservations,
+) -> tuple[Decimal, Decimal, Decimal, Decimal]:
+    """Return call/put percentile and z-score without choosing strategy policy."""
+
+    call_history = tuple(item.call_skew for item in history.observations)
+    put_history = tuple(item.put_skew for item in history.observations)
+    return (
+        compute_historical_percentile(current_call_skew, call_history),
+        compute_historical_zscore(current_call_skew, call_history),
+        compute_historical_percentile(current_put_skew, put_history),
+        compute_historical_zscore(current_put_skew, put_history),
+    )
+
+
+def compute_cross_sectional_momentum(
+    subject_return: Decimal,
+    comparison_returns: ComparisonUniverseReturns,
+) -> Decimal:
+    """Exact empirical percentile against an explicitly supplied universe."""
+
+    return compute_historical_percentile(
+        subject_return,
+        tuple(item.return_value for item in comparison_returns.returns),
+    )
+
+
+def compute_sector_relative_momentum(
+    subject_return: Decimal,
+    sector_returns: SectorReferenceReturns,
+) -> Decimal:
+    """Subject return minus the equally weighted explicit sector reference."""
+
+    values = tuple(item.return_value for item in sector_returns.returns)
+    with localcontext(DERIVED_FACT_DECIMAL_CONTEXT):
+        return subject_return - sum(values, Decimal(0)) / Decimal(len(values))
 
 
 def compute_iv_realized_spread(
@@ -225,6 +272,16 @@ DERIVED_FACT_DEFINITIONS = (
         EXPIRATION_GAP_DISTANCE,
         "Absolute distance between actual and target expiration gap.",
         MarketCapability.OPTION_CHAIN_V1,
+    ),
+    _definition(
+        CROSS_SECTIONAL_MOMENTUM,
+        "Subject return empirical percentile within an explicit comparison universe.",
+        MarketCapability.HISTORICAL_BARS_V1,
+    ),
+    _definition(
+        SECTOR_RELATIVE_MOMENTUM,
+        "Subject return minus an explicit equally weighted sector reference.",
+        MarketCapability.HISTORICAL_BARS_V1,
     ),
     *(
         _definition(

--- a/docs/contracts/skew-momentum-evidence.md
+++ b/docs/contracts/skew-momentum-evidence.md
@@ -1,0 +1,54 @@
+# Skew Momentum canonical evidence
+
+WS5 consumes provider-neutral evidence. Provider payloads, universe selection,
+lookback selection, and verdict policy are not part of these contracts.
+
+## Canonical inputs
+
+- `HistoricalSkewObservation` records normalized call and put skew for one
+  canonical instrument at one effective time with evidence references.
+- `HistoricalSkewObservations` is a deterministic, single-instrument series.
+  The caller supplies the approved lookback; the contract does not choose one.
+- `CanonicalReturnObservation` records one exact return, its period, effective
+  time, canonical instrument, and evidence.
+- `ComparisonUniverseReturns` contains an explicit, same-period comparison
+  universe. It never infers peers from symbols.
+- `SectorReferenceReturns` contains explicit same-period sector members and a
+  normalized sector identifier. It never infers sector membership.
+
+All contracts are frozen, immutable, provider-neutral, deterministically
+ordered, and provenance-bearing.
+
+## Policy-free derived facts
+
+- historical call and put skew percentile;
+- historical call and put skew z-score;
+- cross-sectional return percentile;
+- sector-relative return versus the equally weighted supplied reference.
+
+Both historical-stretch methods are calculated so the Founder can select the
+binding strategy method after reviewing distributions. Neither method is a
+PASS/WATCH/FAIL decision.
+
+Capability declarations remain provider-neutral:
+
+- skew history derives from `option_chain_v1`;
+- comparison and sector returns derive from `historical_bars_v1`.
+
+The orchestration layer must supply already-selected histories and comparison
+members. Strategy adapters must not choose lookbacks, peer universes, sector
+members, thresholds, or weights.
+
+## Deterministic distribution vectors
+
+The regression fixture deliberately contains four skew observations:
+
+| Quantity | Current | Distribution result |
+|---|---:|---:|
+| call skew | 0.18 | percentile 0.75; z-score 0.9838699100999074664200364142417615 |
+| put skew | 0.18 | percentile 0.25; z-score -0.8049844718999242907073025207432594 |
+| subject return | 0.05 | cross-sectional percentile 0.6666… |
+| subject return | 0.07 | sector-relative return 0.02 |
+
+These vectors validate direction and reproducibility only. They do not
+establish strategy thresholds.

--- a/domain/__init__.py
+++ b/domain/__init__.py
@@ -9,10 +9,10 @@ Depends on nothing but itself and the standard library.
 
 from domain.canonical_fact import CanonicalFact
 from domain.execution import (
+    ExecutionPlan,
     ExecutionPlanningEvent,
     ExecutionPlanningEventType,
     ExecutionPlanningLifecycle,
-    ExecutionPlan,
     ExecutionSummary,
     PlannedOrder,
     PlannedOrderSide,
@@ -72,8 +72,8 @@ from domain.market_data import (
     MarketObservation,
     NormalizedProviderErrorMetadata,
     OHLCVBar,
-    ProviderErrorKind,
     ProviderAddressProjection,
+    ProviderErrorKind,
     ProviderProvenance,
     Quote,
     TradingCalendarEvent,
@@ -84,24 +84,24 @@ from domain.market_data import (
     serialize_market_data,
 )
 from domain.observation import Observation
-from domain.opportunity import Opportunity, RecommendationState
 from domain.operational import (
     CanonicalInstrumentIdentity,
-    InstrumentValuation,
     Instrument,
     InstrumentKind,
+    InstrumentValuation,
     MonetaryAmount,
     Portfolio,
     PortfolioEvaluationRequest,
     PortfolioSnapshot,
-    PositionDirection,
     Position,
+    PositionDirection,
     ProposedPosition,
     RiskPolicy,
     RiskPolicyScope,
     RiskPolicyType,
     SectorClassification,
 )
+from domain.opportunity import Opportunity, RecommendationState
 from domain.outcome_metrics import ExpectedOutcomeMetrics
 from domain.provenance import Provenance, ProviderDisagreement
 from domain.provider import Provider
@@ -117,16 +117,27 @@ from domain.simulation import (
     SimulationTraceEvent,
     SimulationTraceEventType,
 )
+from domain.strategy_evidence import (
+    CanonicalReturnObservation,
+    ComparisonUniverseReturns,
+    HistoricalSkewObservation,
+    HistoricalSkewObservations,
+    SectorReferenceReturns,
+)
 from domain.values import DomainInvariantError, is_normalized_value
 
 __all__ = [
     "CanonicalFact",
+    "CanonicalReturnObservation",
     "CanonicalInstrumentIdentity",
     "Confidence",
+    "ComparisonUniverseReturns",
     "DomainInvariantError",
     "is_normalized_value",
     "EvidenceKind",
     "EvidenceReference",
+    "HistoricalSkewObservation",
+    "HistoricalSkewObservations",
     "ExpectedOutcomeMetrics",
     "ExecutionPlanningEvent",
     "ExecutionPlanningEventType",
@@ -218,6 +229,7 @@ __all__ = [
     "SimulationTraceEvent",
     "SimulationTraceEventType",
     "SectorClassification",
+    "SectorReferenceReturns",
     "TimeInForce",
     "VolatilityEvidence",
     "deserialize_financial_contract",

--- a/domain/strategy_evidence.py
+++ b/domain/strategy_evidence.py
@@ -1,0 +1,119 @@
+"""Provider-neutral canonical evidence required by multi-subject strategies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from domain.operational import CanonicalInstrumentIdentity
+from domain.references import EvidenceReference
+from domain.values import require_finite_decimal, require_tz_aware
+
+
+def _evidence(
+    values: tuple[EvidenceReference, ...], owner: str
+) -> tuple[EvidenceReference, ...]:
+    if not values or len(values) != len(set(values)):
+        raise ValueError(f"{owner}.evidence must be non-empty and unique")
+    return tuple(
+        sorted(values, key=lambda item: (item.kind.value, item.referenced_id, item.version or 0))
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class HistoricalSkewObservation:
+    """One canonical call/put skew observation at a semantic effective time."""
+
+    instrument: CanonicalInstrumentIdentity
+    call_skew: Decimal
+    put_skew: Decimal
+    effective_time: datetime
+    evidence: tuple[EvidenceReference, ...]
+
+    def __post_init__(self) -> None:
+        require_finite_decimal(self.call_skew, "HistoricalSkewObservation", "call_skew")
+        require_finite_decimal(self.put_skew, "HistoricalSkewObservation", "put_skew")
+        require_tz_aware(self.effective_time, "HistoricalSkewObservation", "effective_time")
+        object.__setattr__(
+            self, "evidence", _evidence(self.evidence, "HistoricalSkewObservation")
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HistoricalSkewObservations:
+    """Deterministically ordered history; lookback selection is external policy."""
+
+    observations: tuple[HistoricalSkewObservation, ...]
+
+    def __post_init__(self) -> None:
+        if not self.observations:
+            raise ValueError("HistoricalSkewObservations cannot be empty")
+        instruments = {item.instrument for item in self.observations}
+        if len(instruments) != 1:
+            raise ValueError("HistoricalSkewObservations must describe one instrument")
+        ordered = tuple(sorted(self.observations, key=lambda item: item.effective_time))
+        if len({item.effective_time for item in ordered}) != len(ordered):
+            raise ValueError("HistoricalSkewObservations effective times must be unique")
+        object.__setattr__(self, "observations", ordered)
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalReturnObservation:
+    """One exact return supplied by canonical bars, without universe policy."""
+
+    instrument: CanonicalInstrumentIdentity
+    return_value: Decimal
+    period_start: datetime
+    period_end: datetime
+    effective_time: datetime
+    evidence: tuple[EvidenceReference, ...]
+
+    def __post_init__(self) -> None:
+        require_finite_decimal(self.return_value, "CanonicalReturnObservation", "return_value")
+        for field_name in ("period_start", "period_end", "effective_time"):
+            require_tz_aware(
+                getattr(self, field_name), "CanonicalReturnObservation", field_name
+            )
+        if self.period_end <= self.period_start or self.effective_time < self.period_end:
+            raise ValueError("CanonicalReturnObservation temporal range is invalid")
+        object.__setattr__(
+            self, "evidence", _evidence(self.evidence, "CanonicalReturnObservation")
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ComparisonUniverseReturns:
+    """Returns for an explicitly supplied comparison universe."""
+
+    returns: tuple[CanonicalReturnObservation, ...]
+
+    def __post_init__(self) -> None:
+        if not self.returns:
+            raise ValueError("ComparisonUniverseReturns cannot be empty")
+        ordered = tuple(
+            sorted(
+                self.returns,
+                key=lambda item: (item.instrument.scheme, item.instrument.value),
+            )
+        )
+        if len({item.instrument for item in ordered}) != len(ordered):
+            raise ValueError("ComparisonUniverseReturns instruments must be unique")
+        periods = {(item.period_start, item.period_end) for item in ordered}
+        if len(periods) != 1:
+            raise ValueError("ComparisonUniverseReturns must share one return period")
+        object.__setattr__(self, "returns", ordered)
+
+
+@dataclass(frozen=True, slots=True)
+class SectorReferenceReturns:
+    """Explicit sector reference members; sector membership is not inferred."""
+
+    sector_id: str
+    returns: tuple[CanonicalReturnObservation, ...]
+
+    def __post_init__(self) -> None:
+        if not self.sector_id or self.sector_id != self.sector_id.strip():
+            raise ValueError("SectorReferenceReturns.sector_id must be normalized")
+        normalized = ComparisonUniverseReturns(self.returns)
+        object.__setattr__(self, "returns", normalized.returns)

--- a/tests/analytics/test_derived_facts.py
+++ b/tests/analytics/test_derived_facts.py
@@ -67,7 +67,7 @@ def test_named_momentum_dimensions_are_replay_stable() -> None:
 
 
 def test_initial_registry_is_closed_versioned_and_complete() -> None:
-    assert len(DERIVED_FACT_REGISTRY.registered_ids()) == 19
+    assert len(DERIVED_FACT_REGISTRY.registered_ids()) == 21
     assert DERIVED_FACT_REGISTRY.get("forward_factor").feature_version == "1.0.0"
 
 

--- a/tests/analytics/test_skew_momentum_evidence.py
+++ b/tests/analytics/test_skew_momentum_evidence.py
@@ -1,0 +1,84 @@
+"""WS5 policy-free skew and momentum distribution vectors."""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from analytics import (
+    DERIVED_FACT_REGISTRY,
+    compute_cross_sectional_momentum,
+    compute_sector_relative_momentum,
+    compute_skew_stretch_distributions,
+)
+from domain import MarketCapability
+from domain import (
+    CanonicalInstrumentIdentity,
+    CanonicalReturnObservation,
+    ComparisonUniverseReturns,
+    EvidenceKind,
+    EvidenceReference,
+    HistoricalSkewObservation,
+    HistoricalSkewObservations,
+    SectorReferenceReturns,
+)
+
+T0 = datetime(2026, 1, 2, tzinfo=UTC)
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "distribution-input"),)
+INSTRUMENT = CanonicalInstrumentIdentity("figi", "figi-AAPL")
+
+
+def _return(symbol: str, value: str) -> CanonicalReturnObservation:
+    return CanonicalReturnObservation(
+        CanonicalInstrumentIdentity("figi", f"figi-{symbol}"),
+        Decimal(value),
+        T0,
+        T0 + timedelta(days=20),
+        T0 + timedelta(days=20),
+        EVIDENCE,
+    )
+
+
+def test_skew_distribution_exposes_both_methods_without_selecting_policy() -> None:
+    history = HistoricalSkewObservations(
+        tuple(
+            HistoricalSkewObservation(
+                INSTRUMENT,
+                Decimal(call),
+                Decimal(put),
+                T0 + timedelta(days=index),
+                EVIDENCE,
+            )
+            for index, (call, put) in enumerate(
+                (("0.05", "0.30"), ("0.10", "0.25"), ("0.15", "0.20"), ("0.20", "0.15"))
+            )
+        )
+    )
+    call_percentile, call_zscore, put_percentile, put_zscore = (
+        compute_skew_stretch_distributions(Decimal("0.18"), Decimal("0.18"), history)
+    )
+    assert call_percentile == Decimal("0.75")
+    assert call_zscore > 0
+    assert put_percentile == Decimal("0.25")
+    assert put_zscore < 0
+
+
+def test_comparison_and_sector_distributions_are_deterministic() -> None:
+    universe = ComparisonUniverseReturns(
+        (_return("MSFT", "0.02"), _return("NVDA", "0.08"), _return("GOOG", "0.04"))
+    )
+    sector = SectorReferenceReturns(
+        "technology",
+        (_return("MSFT", "0.02"), _return("NVDA", "0.08")),
+    )
+    assert compute_cross_sectional_momentum(Decimal("0.05"), universe) == Decimal(2) / Decimal(3)
+    assert compute_sector_relative_momentum(Decimal("0.07"), sector) == Decimal("0.02")
+
+
+def test_new_derived_facts_declare_complete_provider_neutral_capabilities() -> None:
+    for identifier in ("cross_sectional_momentum", "sector_relative_momentum"):
+        assert DERIVED_FACT_REGISTRY.get(identifier).required_capabilities == (
+            MarketCapability.HISTORICAL_BARS_V1,
+        )
+    for identifier in ("skew_historical_percentile", "skew_historical_zscore"):
+        assert DERIVED_FACT_REGISTRY.get(identifier).required_capabilities == (
+            MarketCapability.OPTION_CHAIN_V1,
+        )

--- a/tests/domain/test_strategy_evidence.py
+++ b/tests/domain/test_strategy_evidence.py
@@ -1,0 +1,73 @@
+"""WS5 provider-neutral canonical strategy-evidence contracts."""
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from domain import (
+    CanonicalInstrumentIdentity,
+    CanonicalReturnObservation,
+    ComparisonUniverseReturns,
+    EvidenceKind,
+    EvidenceReference,
+    HistoricalSkewObservation,
+    HistoricalSkewObservations,
+    SectorReferenceReturns,
+)
+
+T0 = datetime(2026, 1, 2, tzinfo=UTC)
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "canonical-input"),)
+
+
+def _instrument(symbol: str) -> CanonicalInstrumentIdentity:
+    return CanonicalInstrumentIdentity("figi", f"figi-{symbol}")
+
+
+def _return(symbol: str, value: str) -> CanonicalReturnObservation:
+    return CanonicalReturnObservation(
+        _instrument(symbol),
+        Decimal(value),
+        T0,
+        T0 + timedelta(days=20),
+        T0 + timedelta(days=20),
+        EVIDENCE,
+    )
+
+
+def test_historical_skew_is_immutable_ordered_and_single_instrument() -> None:
+    later = HistoricalSkewObservation(
+        _instrument("AAPL"), Decimal("0.20"), Decimal("0.30"), T0, EVIDENCE
+    )
+    earlier = HistoricalSkewObservation(
+        _instrument("AAPL"),
+        Decimal("0.10"),
+        Decimal("0.15"),
+        T0 - timedelta(days=1),
+        EVIDENCE,
+    )
+    history = HistoricalSkewObservations((later, earlier))
+    assert history.observations == (earlier, later)
+    with pytest.raises(FrozenInstanceError):
+        later.call_skew = Decimal("0")  # type: ignore[misc]
+    with pytest.raises(ValueError, match="one instrument"):
+        HistoricalSkewObservations(
+            (
+                earlier,
+                HistoricalSkewObservation(
+                    _instrument("MSFT"), Decimal("0.1"), Decimal("0.2"), T0, EVIDENCE
+                ),
+            )
+        )
+
+
+def test_return_collections_preserve_explicit_membership_and_period() -> None:
+    universe = ComparisonUniverseReturns((_return("MSFT", "0.02"), _return("AAPL", "0.04")))
+    assert tuple(item.instrument.value for item in universe.returns) == (
+        "figi-AAPL",
+        "figi-MSFT",
+    )
+    sector = SectorReferenceReturns("technology", universe.returns)
+    assert sector.sector_id == "technology"
+    assert sector.returns == universe.returns


### PR DESCRIPTION
## Summary

Implements the Founder-authorized safe evidence and derived-fact foundation for full-fidelity Skew Momentum v2. It does not select thresholds, weights, lookbacks, or verdict policy.

- add immutable provider-neutral historical skew observations
- add explicit comparison-universe and sector-reference return contracts
- preserve canonical instrument identity, effective times, periods, and evidence provenance
- add policy-free call/put percentile and z-score distributions
- add cross-sectional return percentile and sector-relative return calculations
- declare option-chain and historical-bars capabilities on the owning derived facts
- document deterministic distribution vectors and the remaining policy boundary

## Architecture

Binding flow remains canonical facts → derived facts → strategy policy. Contracts never infer symbols, peers, sectors, lookbacks, or provider addresses. No acquisition policy was added to adapters.

This PR is deliberately contract/derived-fact only. WS5 strategy graph and live acquisition stay blocked until the Founder approves the remaining policy packet.

## Distribution evidence

Deterministic fixtures prove both historical methods without selecting one:

- current call skew 0.18 → percentile 0.75; z-score 0.9838699100999074664200364142417615
- current put skew 0.18 → percentile 0.25; z-score -0.8049844718999242907073025207432594
- subject return 0.05 → cross-sectional percentile 2/3
- subject return 0.07 → sector-relative return 0.02

These are regression vectors, not empirical production distributions and not a basis for thresholds.

## Validation

- full pytest: 2617 passed, 17 skipped
- changed-file Ruff: passed
- targeted mypy: passed
- Lean pre-push: all five checks passed
- git diff check: passed

## Safety

- no provider or live API calls
- no strategy thresholds, weights, or verdict changes
- no adapter-owned acquisition policy
- no persistence/schema changes
- no merge or deployment performed

Founder review is required because this adds public canonical evidence contracts.