### PR TITLE
PATCH-012B: select common strikes for Forward Factor

### DIFF
--- a/docs/migration/stonk-strategy-manifests.md
+++ b/docs/migration/stonk-strategy-manifests.md
@@ -8,7 +8,7 @@ The source behaviors are pinned to Stonk revision
 |---|---:|---|
 | `earnings_calendar` | `1.1.0` | confirmed event window, nearest eligible 30-day expiration gap (±5 days), liquidity, coarse volume, calendar debit, score and gated verdict |
 | `skew_momentum` | `2.0.0-research` | two-sided historical skew stretch, IV/RV value gates, three-dimensional momentum alignment, delta-selected vertical, liquidity, debit, and verdict |
-| `forward_factor` | `1.2.0` | DTE pair, raw front IV, implied forward volatility, confirmed-earnings exclusion, liquidity-complete put/call double calendar, and gated verdict |
+| `forward_factor` | `1.2.1` | DTE pair, raw front IV, implied forward volatility, confirmed-earnings exclusion, common-strike liquidity-complete put/call double calendar, and gated verdict |
 | `asa.stonk.stock_momentum` | `1.0.0` | deterministic candidate cap, bounded momentum score and verdict |
 
 Every graph uses exact Component versions from `asa.stonk.shared`,

--- a/docs/strategies/stonk-strategy-library.md
+++ b/docs/strategies/stonk-strategy-library.md
@@ -7,7 +7,7 @@ it does not dispatch legacy service code.
 | Strategy ID | Version | Component dependencies | Purpose |
 |---|---:|---|---|
 | `earnings_calendar` | `1.1.0` | shared + options | confirmed-event calendar targeting a 30-day gap with liquidity and coarse volume evidence |
-| `forward_factor` | `1.2.0` | shared + options | earnings-excluded forward-volatility double-calendar candidate |
+| `forward_factor` | `1.2.1` | shared + options | earnings-excluded, common-strike forward-volatility double-calendar candidate |
 | `skew_momentum` | `2.0.0-research` | shared + options | two-sided skew/volatility-value vertical with three-dimensional momentum alignment |
 | `asa.stonk.stock_momentum` | `1.0.0` | shared | deterministic equity momentum candidate set |
 

--- a/strategies/stonk_components.py
+++ b/strategies/stonk_components.py
@@ -97,16 +97,19 @@ def _definition(
     inputs: tuple[PortDefinition, ...],
     outputs: tuple[PortDefinition, ...],
     parameters: tuple[ParameterDefinition, ...] = (),
+    *,
+    version: str = "1.0.0",
+    algorithm_version: str = "1.0.0",
 ) -> ComponentDefinition:
     return ComponentDefinition(
         namespace,
         name,
-        "1.0.0",
+        version,
         category,
         inputs,
         outputs,
         parameters,
-        algorithm_version="1.0.0",
+        algorithm_version=algorithm_version,
         explanation_template=ManifestObject(
             (("migration_source", "Stonk@5f3fec8"), ("operation", name))
         ),
@@ -858,6 +861,46 @@ class DeltaNearestLeg(BaseComponent):
         return ComponentValues((("contract", TypedValue(OPTION_CONTRACT, selected)),))
 
 
+def _nearest_common_strike_delta(
+    chain: OptionChain,
+    front: date,
+    back: date,
+    option_type: OptionType,
+    target: Decimal,
+) -> OptionContract | None:
+    """Select the nearest front delta only among uniquely constructible calendars."""
+
+    choices = tuple(
+        item
+        for item in chain.find(expiration=front, option_type=option_type)
+        if item.delta is not None
+        and len(
+            chain.find(
+                expiration=front,
+                option_type=option_type,
+                strike=item.strike,
+            )
+        )
+        == 1
+        and len(
+            chain.find(
+                expiration=back,
+                option_type=option_type,
+                strike=item.strike,
+            )
+        )
+        == 1
+    )
+    return min(
+        choices,
+        key=lambda item: (
+            abs(abs(cast(Decimal, item.delta)) - abs(target)),
+            _contract_key(item),
+        ),
+        default=None,
+    )
+
+
 def _same_strike(
     chain: OptionChain,
     expiration: date,
@@ -1339,6 +1382,8 @@ class DoubleCalendarStructure(BaseComponent):
             ParameterDefinition("put_delta_target", D),
             ParameterDefinition("call_delta_target", D),
         ),
+        version="1.0.1",
+        algorithm_version="1.0.1",
     )
 
     def evaluate(self, inputs: ComponentValues, parameters: ComponentValues) -> ComponentValues:
@@ -1347,8 +1392,16 @@ class DoubleCalendarStructure(BaseComponent):
         back = cast(date, _input(inputs, "back_expiration", date))
         put_target = cast(Decimal, _parameter(parameters, "put_delta_target", Decimal))
         call_target = cast(Decimal, _parameter(parameters, "call_delta_target", Decimal))
-        put_front = _nearest_delta(chain.contracts, front, OptionType.PUT, put_target)
-        call_front = _nearest_delta(chain.contracts, front, OptionType.CALL, call_target)
+        put_front = _nearest_common_strike_delta(
+            chain, front, back, OptionType.PUT, put_target
+        )
+        call_front = _nearest_common_strike_delta(
+            chain, front, back, OptionType.CALL, call_target
+        )
+        if put_front is None or call_front is None:
+            return ComponentValues(
+                (("structures", TypedValue(OPTION_STRUCTURE_LIST, ())),)
+            )
         structures = (
             _calendar(chain, front, back, OptionType.PUT, put_front.strike, "put"),
             _calendar(chain, front, back, OptionType.CALL, call_front.strike, "call"),

--- a/strategies/stonk_manifests.py
+++ b/strategies/stonk_manifests.py
@@ -21,10 +21,12 @@ def _node(
     namespace: str,
     component: str,
     parameters: tuple[ParameterSpec, ...] = (),
+    *,
+    component_version: str = "1.0.0",
 ) -> NodeSpec:
     return NodeSpec(
         node_id,
-        ComponentReference(namespace, component, "1.0.0"),
+        ComponentReference(namespace, component, component_version),
         parameters,
     )
 
@@ -360,7 +362,7 @@ SKEW_MOMENTUM_VERTICAL_MANIFEST = StrategyManifest(
 FORWARD_FACTOR_CALENDAR_MANIFEST = StrategyManifest(
     "1.1.0",
     "forward_factor",
-    "1.2.0",
+    "1.2.1",
     ManifestMetadata(
         "Forward Factor Calendar",
         "Raw-front-IV forward factor with confirmed-earnings exclusion and "
@@ -394,6 +396,7 @@ FORWARD_FACTOR_CALENDAR_MANIFEST = StrategyManifest(
                 _parameter("put_delta_target", "Decimal", "-0.35"),
                 _parameter("call_delta_target", "Decimal", "0.35"),
             ),
+            component_version="1.0.1",
         ),
         _node("forward_iv", "asa.stonk.options", "implied_forward_volatility"),
         _node("factor", "asa.stonk.options", "forward_factor"),

--- a/strategies/stonk_plugins.py
+++ b/strategies/stonk_plugins.py
@@ -17,7 +17,7 @@ STONK_OPTIONS_PLUGIN = StrategyPlugin(
     PluginMetadata(
         "asa.stonk.options",
         "stonk_options_components",
-        "2.0.0",
+        "2.0.1",
         "Provider-neutral earnings, expiration, option-leg, and structure primitives.",
     ),
     OPTIONS_STONK_COMPONENTS,

--- a/strategy_runtime/adapters/forward_factor.py
+++ b/strategy_runtime/adapters/forward_factor.py
@@ -39,11 +39,11 @@ from strategy_runtime.result import UniversalScreeningResult, compute_observatio
 
 FORWARD_FACTOR_CONTRACT = StrategyContract(
     strategy_id="forward_factor",
-    version="1.2.0",
+    version="1.2.1",
     category="options_volatility",
     description=(
         "Raw-front-IV forward factor with confirmed-earnings exclusion and "
-        "a liquidity-complete delta-selected double calendar."
+        "a common-strike, liquidity-complete delta-selected double calendar."
     ),
     requirements=(
         DataRequirement(

--- a/tests/screening/test_live_adapters.py
+++ b/tests/screening/test_live_adapters.py
@@ -291,6 +291,34 @@ class CapturingMultiExpirationFixtureProvider(MultiExpirationFixtureProvider):
         return super().fetch(request, budget)
 
 
+class AsymmetricForwardFactorFixtureProvider(MultiExpirationFixtureProvider):
+    """GS/MU-shaped front/back ladders whose nearest front strikes are absent later."""
+
+    def _value(self, subject, address, observed_at, evidence):  # noqa: ANN001
+        value = super()._value(subject, address, observed_at, evidence)
+        if not isinstance(value, OptionChain):
+            return value
+        back_expiration = observed_at.date() + timedelta(days=91)
+        omitted = {
+            (OptionType.PUT, _SPOT - Decimal("10")),
+            (OptionType.CALL, _SPOT + Decimal("5")),
+        }
+        return OptionChain(
+            value.option_chain_id,
+            value.underlying,
+            value.observed_at,
+            tuple(
+                item
+                for item in value.contracts
+                if not (
+                    item.expiration == back_expiration
+                    and (item.option_type, item.strike) in omitted
+                )
+            ),
+            value.evidence,
+        )
+
+
 class UnconfirmedEarningsFixtureProvider(MultiExpirationFixtureProvider):
     def _value(self, subject, address, observed_at, evidence):  # noqa: ANN001
         value = super()._value(subject, address, observed_at, evidence)
@@ -399,6 +427,23 @@ class TestForwardFactorAndEarningsCalendarNeedTwoExpirations:
         )
         assert result.subject_identity == f"symbol:{SYMBOL}"
         assert result.signal_classification == "FAIL"
+
+    def test_forward_factor_asymmetric_ladders_return_normal_outcome(self) -> None:
+        fulfillment, clock = _fulfillment(AsymmetricForwardFactorFixtureProvider)
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+        (result,) = run_screening(
+            TARGET_STRATEGY_REGISTRY,
+            adapters,
+            clock,
+            strategy_ids=("forward_factor",),
+        )
+
+        assert result.outcome_status in (
+            ScreeningOutcomeStatus.PASS,
+            ScreeningOutcomeStatus.NO_SIGNAL,
+        )
+        assert result.subject_identity == f"symbol:{SYMBOL}"
+        assert result.failure_detail is None
 
     def test_unconfirmed_earnings_does_not_trigger_exclusion(self) -> None:
         fulfillment, clock = _fulfillment(UnconfirmedEarningsFixtureProvider)

--- a/tests/strategies/test_stonk_components.py
+++ b/tests/strategies/test_stonk_components.py
@@ -65,10 +65,12 @@ from strategies.stonk_components import (
     OPTION_COLLECTION,
     OPTION_CONTRACT,
     OPTION_STRUCTURE,
+    OPTION_STRUCTURE_LIST,
     OPTION_TYPE,
     SECURITY_COLLECTION,
     B,
     D,
+    OptionStructureCollectionLiquidity,
 )
 from strategies.type_system import ComponentValues, StrategyTypeReference, TypedValue
 
@@ -143,6 +145,18 @@ def chain() -> OptionChain:
     return OptionChain("chain-1", security(), NOW, contracts, EVIDENCE)
 
 
+def asymmetric_double_calendar_chain() -> OptionChain:
+    contracts = (
+        contract("front-call-105", FRONT, "105", OptionType.CALL, "0.55", "2"),
+        contract("front-call-110", FRONT, "110", OptionType.CALL, "0.45", "1"),
+        contract("back-call-110", BACK, "110", OptionType.CALL, "0.48", "2"),
+        contract("front-put-95", FRONT, "95", OptionType.PUT, "-0.30", "2"),
+        contract("front-put-90", FRONT, "90", OptionType.PUT, "-0.40", "1"),
+        contract("back-put-90", BACK, "90", OptionType.PUT, "-0.43", "2"),
+    )
+    return OptionChain("asymmetric-chain", security(), NOW, contracts, EVIDENCE)
+
+
 def earnings_event(*, confirmed: bool = True) -> EarningsEvent:
     return EarningsEvent(
         "event-1",
@@ -160,13 +174,17 @@ def earnings_event(*, confirmed: bool = True) -> EarningsEvent:
 def test_plugins_register_all_components_statically_and_deterministically() -> None:
     registry = build_plugin_registry((), STONK_STRATEGY_PLUGINS)
     expected = {
-        (component.definition.namespace, component.definition.name)
+        (
+            component.definition.namespace,
+            component.definition.name,
+            component.definition.version,
+        )
         for plugin in STONK_STRATEGY_PLUGINS
         for component in plugin.components
     }
     assert len(expected) == 25
-    for namespace, name in expected:
-        assert registry.resolve(ComponentReference(namespace, name, "1.0.0"))
+    for namespace, name, version in expected:
+        assert registry.resolve(ComponentReference(namespace, name, version))
     assert (
         registry.identity
         == build_plugin_registry((), tuple(reversed(STONK_STRATEGY_PLUGINS))).identity
@@ -175,9 +193,9 @@ def test_plugins_register_all_components_statically_and_deterministically() -> N
         "52b919f7ea1a628d4b4a43056e59e37fb4f1ede111d85a122dc1c83f9cc1a598"
     )
     assert STONK_STRATEGY_PLUGINS[0].metadata.version == "1.2.0"
-    assert STONK_STRATEGY_PLUGINS[1].metadata.version == "2.0.0"
+    assert STONK_STRATEGY_PLUGINS[1].metadata.version == "2.0.1"
     assert STONK_STRATEGY_PLUGINS[1].plugin_id == (
-        "09220ea9fce99914437438914a652dbba578ceee83d61954934dde760e0cb998"
+        "f1346d9bb415a06ae62e6849a42af5a60bf3a4798587a0f81f64d55a8fca0536"
     )
 
 
@@ -498,6 +516,70 @@ def test_calendar_vertical_double_calendar_and_debit_are_replay_stable() -> None
     assert isinstance(double, tuple)
     assert len(double) == 2
     assert all(isinstance(item, OptionStructure) for item in double)
+
+
+def test_double_calendar_selects_nearest_delta_from_common_strikes() -> None:
+    structures = (
+        DoubleCalendarStructure()
+        .evaluate(
+            values(
+                chain=(OPTION_CHAIN, asymmetric_double_calendar_chain()),
+                front_expiration=(DATE, FRONT),
+                back_expiration=(DATE, BACK),
+            ),
+            values(
+                put_delta_target=(D, Decimal("-0.30")),
+                call_delta_target=(D, Decimal("0.55")),
+            ),
+        )
+        .get("structures")
+        .value
+    )
+
+    assert isinstance(structures, tuple)
+    assert tuple(
+        {leg.contract.strike for leg in structure.legs} for structure in structures
+    ) == ({Decimal("90")}, {Decimal("110")})
+
+
+def test_double_calendar_without_common_strike_is_empty_and_ineligible() -> None:
+    asymmetric = asymmetric_double_calendar_chain()
+    no_common_put = replace(
+        asymmetric,
+        contracts=tuple(
+            item
+            for item in asymmetric.contracts
+            if not (item.expiration == BACK and item.option_type is OptionType.PUT)
+        ),
+    )
+    structures = (
+        DoubleCalendarStructure()
+        .evaluate(
+            values(
+                chain=(OPTION_CHAIN, no_common_put),
+                front_expiration=(DATE, FRONT),
+                back_expiration=(DATE, BACK),
+            ),
+            values(
+                put_delta_target=(D, Decimal("-0.30")),
+                call_delta_target=(D, Decimal("0.55")),
+            ),
+        )
+        .get("structures")
+        .value
+    )
+
+    assert structures == ()
+    assert (
+        OptionStructureCollectionLiquidity()
+        .evaluate(
+            values(structures=(OPTION_STRUCTURE_LIST, structures)),
+            ComponentValues(()),
+        )
+        .get("acceptable")
+        .value
+        is False
+    )
 
 
 def test_components_fail_closed_on_missing_matches_and_invalid_parameters() -> None:

--- a/tests/strategies/test_stonk_manifests.py
+++ b/tests/strategies/test_stonk_manifests.py
@@ -76,17 +76,17 @@ def test_four_manifest_catalog_is_canonical_serializable_and_identity_pinned() -
     expected = {
         "earnings_calendar": "a165405844d32da747950e2bbd088849bf375b839b79557cb859e6daf51fdd9e",
         "skew_momentum": "47f0686f74f7687ce09e3f8c13ac5c3c032ff957fab8c801c59443b660ae4028",
-        "forward_factor": "afeec769ff76c5ae7bf78279c9770b4bbc0ad9956f5bef23c3d27ca8c0de0b1f",
+        "forward_factor": "c7f2b6bc3a46a8182464b098f3b703261cde89d11bf9b9ae0bd85cd56e349bf4",
         "asa.stonk.stock_momentum": (
             "456a84aa09ca73c65c32490ebaa270beb5b85db273e9d0c10d987f434e13047d"
         ),
     }
     graph_ids = {
-        "earnings_calendar": "d6e3ef8beaecb79ae1593d5e3fc727e7268f65ae3f5dce30e0bf4f0083d61ec6",
-        "skew_momentum": "7a50328bbfcb8fe5cce355c36651b3bffb9bab6bff4c3907220480b9722be628",
-        "forward_factor": "7470c8acd6788128c80b8890a4f107e7475dba9c65442e1433a308547021dd5e",
+        "earnings_calendar": "c81ed69e3cab866c0f5af1487514e291755975ac490c085f611e08e261c01e22",
+        "skew_momentum": "7722239ef2338c8a210c2f6ad338882e060f217257a88595fe5ba5e97097b9b5",
+        "forward_factor": "239ec2db5f7b34ec1ecc00f0c1e201498ee8c3e8351ccbbaee4ae7e3a489b678",
         "asa.stonk.stock_momentum": (
-            "b271f594470d17175fd0126baa137faa71b44680ff7eb46274ea18553518a16c"
+            "610044e8bce050be3b1433a6fd73a3c20c04e77b27b9b1d063052d0567a3dbcf"
         ),
     }
     component_registry = registry()
@@ -364,6 +364,55 @@ def test_forward_factor_manifest_requires_source_iv_and_builds_double_calendar()
     rejected = execute_strategy_graph(graph, rejected_context)
     assert rejected.outputs.get("eligible").value is False
     assert rejected.outputs.get("verdict").value == "FAIL"
+
+
+def test_forward_factor_without_common_put_strike_returns_fail_not_exception() -> None:
+    option_chain, expirations = _forward_chain()
+    option_chain = replace(
+        option_chain,
+        contracts=tuple(
+            item
+            for item in option_chain.contracts
+            if not (
+                item.expiration == expirations.cycles[1].expiration_date
+                and item.option_type is OptionType.PUT
+            )
+        ),
+    )
+    execution_context = context(
+        **{
+            "expiration_select.expirations": (EXPIRATION_COLLECTION, expirations),
+            "double_calendar.chain": (OPTION_CHAIN, option_chain),
+            "forward_iv.front_iv": (D, Decimal("0.48")),
+            "forward_iv.back_iv": (
+                D,
+                Decimal("0.4548992562461861547567860943472296"),
+            ),
+            "forward_iv.front_dte": (
+                StrategyTypeReference("Integer", "1.0.0"),
+                60,
+            ),
+            "forward_iv.back_dte": (
+                StrategyTypeReference("Integer", "1.0.0"),
+                90,
+            ),
+            "factor.front_iv": (D, Decimal("0.48")),
+            "eligibility.left": (
+                StrategyTypeReference("Boolean", "1.0.0"),
+                True,
+            ),
+        }
+    )
+
+    result = execute_strategy_graph(
+        compile_strategy_graph(FORWARD_FACTOR_CALENDAR_MANIFEST, registry()),
+        execution_context,
+    )
+
+    assert result.outputs.get("structures").value == ()
+    assert result.outputs.get("liquidity_acceptable").value is False
+    assert result.outputs.get("eligible").value is False
+    assert result.outputs.get("verdict").value == "FAIL"
 
 
 def test_stock_momentum_manifest_stops_before_portfolio_policy() -> None:

--- a/tests/strategies/test_strategy_library.py
+++ b/tests/strategies/test_strategy_library.py
@@ -28,7 +28,7 @@ def test_library_is_complete_ordered_and_identity_pinned() -> None:
         == StrategyLibrary(tuple(reversed(STONK_STRATEGY_MANIFESTS))).identity
     )
     assert STONK_STRATEGY_LIBRARY.identity == (
-        "3b0c3c391880899728dc46bacbf6277913e64dab88973843fa9929ae298575b0"
+        "9da93cd3358f46803181faed62b9a1e0f2c81282473b29924d65ee317bceacfb"
     )
 
 


### PR DESCRIPTION
## Summary

- fixes the recurring Forward Factor graph failure when the nearest front-expiration delta strike is absent from the back expiration;
- selects put and call strikes independently from the uniquely constructible common-strike set;
- returns an empty typed structure collection when either side is unavailable, allowing existing liquidity and eligibility gates to produce a truthful `FAIL`;
- versions the component at `1.0.1`, Forward Factor at `1.2.1`, and the options plugin at `2.0.1`.

Relates to #244 and #250.

## Scope integrity

- no symbol-specific behavior;
- no screening orchestration changes;
- no broad `GraphExecutionError` catch;
- no threshold or Forward Factor math changes;
- no provider awareness or payload changes.

## Root-cause confirmation

The new asymmetric-ladder regression failed before the fix at `_same_strike`: the front-only nearest put strike did not exist at the back expiration. This confirms the handoff's common-strike diagnosis.

## Validation

- `pytest -q`: **2629 passed, 17 skipped**
- changed-file Ruff: **passed**
- `mypy asa`: **passed (41 source files)**
- Lean entrypoint check: **passed**
- Lean frozen-governance integrity: **passed**
- `git diff --check`: **passed**

Repository-wide Ruff currently reports 495 pre-existing findings outside this patch; every changed Python file passes Ruff.

## Production verification

Not performed. This worker has no merge or deployment authority. After Founder merge/deployment, GS and MU require two scheduled production cycles with normal outcomes, plus the existing 82-pair health/readiness/refresh-integrity checks.

## Final verdict

`COMPLETE_AWAITING_PRODUCTION`
