### PR TITLE
PATCH-012C: fail closed without directional skew evidence

### DIFF
--- a/docs/contracts/skew-momentum-evidence.md
+++ b/docs/contracts/skew-momentum-evidence.md
@@ -40,7 +40,7 @@ members. Strategy adapters must not choose peer universes or sector members.
 
 ## Research policy v2
 
-The canonical manifest pins `2.0.0-research`. Historical stretch uses a
+The canonical manifest pins `2.0.1-research`. Historical stretch uses a
 60-observation z-score window with at least 40 valid observations and requires
 `z <= -2.0`. The ATM leg must be fair or cheap to realized volatility
 (`ATM IV - RV <= 0`); the wing must be rich to both realized volatility and
@@ -53,7 +53,8 @@ dimension has equal weight. Bullish alignment is respectively `> 0`, `>= 0.70`,
 and `> 0`; bearish alignment is `< 0`, `<= 0.30`, and `< 0`. Two of three
 dimensions are required for PASS.
 
-Core-gate failure is FAIL. Passing core gates with conflicting or incomplete
+Core-gate failure or absence of any explicitly true directional core gate is
+FAIL. Passing core gates with conflicting or incomplete
 momentum is WATCH. If both directional branches qualify, the result is WATCH.
 Missing evidence is UNKNOWN and never replaced by a proxy. Unsupported ETFs and
 missing-sector subjects therefore keep sector-relative evidence UNKNOWN.

--- a/docs/migration/stonk-strategy-manifests.md
+++ b/docs/migration/stonk-strategy-manifests.md
@@ -7,7 +7,7 @@ The source behaviors are pinned to Stonk revision
 | Manifest ID | Version | Graph ownership |
 |---|---:|---|
 | `earnings_calendar` | `1.1.0` | confirmed event window, nearest eligible 30-day expiration gap (±5 days), liquidity, coarse volume, calendar debit, score and gated verdict |
-| `skew_momentum` | `2.0.0-research` | two-sided historical skew stretch, IV/RV value gates, three-dimensional momentum alignment, delta-selected vertical, liquidity, debit, and verdict |
+| `skew_momentum` | `2.0.1-research` | two-sided historical skew stretch, fail-closed directional core gates, IV/RV value gates, three-dimensional momentum alignment, delta-selected vertical, liquidity, debit, and verdict |
 | `forward_factor` | `1.2.1` | DTE pair, raw front IV, implied forward volatility, confirmed-earnings exclusion, common-strike liquidity-complete put/call double calendar, and gated verdict |
 | `asa.stonk.stock_momentum` | `1.0.0` | deterministic candidate cap, bounded momentum score and verdict |
 

--- a/docs/strategies/stonk-strategy-library.md
+++ b/docs/strategies/stonk-strategy-library.md
@@ -8,7 +8,7 @@ it does not dispatch legacy service code.
 |---|---:|---|---|
 | `earnings_calendar` | `1.1.0` | shared + options | confirmed-event calendar targeting a 30-day gap with liquidity and coarse volume evidence |
 | `forward_factor` | `1.2.1` | shared + options | earnings-excluded, common-strike forward-volatility double-calendar candidate |
-| `skew_momentum` | `2.0.0-research` | shared + options | two-sided skew/volatility-value vertical with three-dimensional momentum alignment |
+| `skew_momentum` | `2.0.1-research` | shared + options | fail-closed two-sided skew/volatility-value vertical with three-dimensional momentum alignment |
 | `asa.stonk.stock_momentum` | `1.0.0` | shared | deterministic equity momentum candidate set |
 
 ## Use

--- a/strategies/stonk_components.py
+++ b/strategies/stonk_components.py
@@ -1099,6 +1099,8 @@ class SkewMomentumResearchDecision(BaseComponent):
             ParameterDefinition("minimum_open_interest", INTEGER),
             ParameterDefinition("minimum_volume", INTEGER),
         ),
+        version="1.0.1",
+        algorithm_version="1.0.1",
     )
 
     def evaluate(self, inputs: ComponentValues, parameters: ComponentValues) -> ComponentValues:
@@ -1300,7 +1302,10 @@ class SkewMomentumResearchDecision(BaseComponent):
                 else "WATCH"
             )
         else:
-            verdict = "WATCH"
+            # Missing or mixed-negative core evidence cannot support a
+            # directional signal. UNKNOWN remains visible in the gate outputs,
+            # but it is never positive evidence for WATCH.
+            verdict = "FAIL"
 
         return ComponentValues(
             (

--- a/strategies/stonk_manifests.py
+++ b/strategies/stonk_manifests.py
@@ -207,7 +207,7 @@ EARNINGS_CALENDAR_MANIFEST = StrategyManifest(
 SKEW_MOMENTUM_VERTICAL_MANIFEST = StrategyManifest(
     "1.1.0",
     "skew_momentum",
-    "2.0.0-research",
+    "2.0.1-research",
     ManifestMetadata(
         "Skew Momentum v2 Research",
         "Two-sided skew, volatility-value, and three-dimension momentum policy.",
@@ -234,6 +234,7 @@ SKEW_MOMENTUM_VERTICAL_MANIFEST = StrategyManifest(
                 _parameter("minimum_open_interest", "Integer", 50),
                 _parameter("minimum_volume", "Integer", 10),
             ),
+            component_version="1.0.1",
         ),
     ),
     (),

--- a/strategies/stonk_plugins.py
+++ b/strategies/stonk_plugins.py
@@ -17,7 +17,7 @@ STONK_OPTIONS_PLUGIN = StrategyPlugin(
     PluginMetadata(
         "asa.stonk.options",
         "stonk_options_components",
-        "2.0.1",
+        "2.0.2",
         "Provider-neutral earnings, expiration, option-leg, and structure primitives.",
     ),
     OPTIONS_STONK_COMPONENTS,

--- a/strategy_runtime/adapters/skew_momentum_vertical.py
+++ b/strategy_runtime/adapters/skew_momentum_vertical.py
@@ -40,7 +40,7 @@ from strategy_runtime.result import UniversalScreeningResult, compute_observatio
 
 SKEW_MOMENTUM_VERTICAL_CONTRACT = StrategyContract(
     strategy_id="skew_momentum",
-    version="2.0.0-research",
+    version="2.0.1-research",
     category="options_momentum",
     description=(
         "Two-sided skew and volatility-value gates with three-dimension momentum alignment."

--- a/tests/fixtures/ui-screening-result.json
+++ b/tests/fixtures/ui-screening-result.json
@@ -1,6 +1,6 @@
 {
   "signal_id": "skew_momentum",
-  "signal_version": "2.0.0-research",
+  "signal_version": "2.0.1-research",
   "symbol": "AAPL",
   "outcome": "watch",
   "evaluation_state": "pass",
@@ -41,7 +41,7 @@
   "direction": "BULLISH",
   "structure": "vertical",
   "reason_codes": ["momentum_incomplete"],
-  "assumptions": ["research policy 2.0.0-research"],
+  "assumptions": ["research policy 2.0.1-research"],
   "updated_at": "2026-07-29T13:45:00Z",
   "age_seconds": 120,
   "observed_at": "2026-07-29T13:40:00Z",

--- a/tests/strategies/test_stonk_components.py
+++ b/tests/strategies/test_stonk_components.py
@@ -193,9 +193,9 @@ def test_plugins_register_all_components_statically_and_deterministically() -> N
         "52b919f7ea1a628d4b4a43056e59e37fb4f1ede111d85a122dc1c83f9cc1a598"
     )
     assert STONK_STRATEGY_PLUGINS[0].metadata.version == "1.2.0"
-    assert STONK_STRATEGY_PLUGINS[1].metadata.version == "2.0.1"
+    assert STONK_STRATEGY_PLUGINS[1].metadata.version == "2.0.2"
     assert STONK_STRATEGY_PLUGINS[1].plugin_id == (
-        "f1346d9bb415a06ae62e6849a42af5a60bf3a4798587a0f81f64d55a8fca0536"
+        "311b6ff79cdfc302571eb6e6e44ff33415565ad21e43c4dec7550c94978778c9"
     )
 
 

--- a/tests/strategies/test_stonk_manifests.py
+++ b/tests/strategies/test_stonk_manifests.py
@@ -75,18 +75,18 @@ def test_four_manifest_catalog_is_canonical_serializable_and_identity_pinned() -
     )
     expected = {
         "earnings_calendar": "a165405844d32da747950e2bbd088849bf375b839b79557cb859e6daf51fdd9e",
-        "skew_momentum": "47f0686f74f7687ce09e3f8c13ac5c3c032ff957fab8c801c59443b660ae4028",
+        "skew_momentum": "64fed57c5a281dde0a1e071714e4379abc7f901aada4a26d5d97372d366cfdbf",
         "forward_factor": "c7f2b6bc3a46a8182464b098f3b703261cde89d11bf9b9ae0bd85cd56e349bf4",
         "asa.stonk.stock_momentum": (
             "456a84aa09ca73c65c32490ebaa270beb5b85db273e9d0c10d987f434e13047d"
         ),
     }
     graph_ids = {
-        "earnings_calendar": "c81ed69e3cab866c0f5af1487514e291755975ac490c085f611e08e261c01e22",
-        "skew_momentum": "7722239ef2338c8a210c2f6ad338882e060f217257a88595fe5ba5e97097b9b5",
-        "forward_factor": "239ec2db5f7b34ec1ecc00f0c1e201498ee8c3e8351ccbbaee4ae7e3a489b678",
+        "earnings_calendar": "b81f305fc9fcfc644328447ae60c20e8b50f9e67c822ea18f070c9148a27aab4",
+        "skew_momentum": "8a67a57212765d28550778144d90260082c4bd02d494ffd3a82623e27cf6ace7",
+        "forward_factor": "cbf3d7b7f32f77155b888c90434b85a172335d7ef5957295f022ca28fd36549f",
         "asa.stonk.stock_momentum": (
-            "610044e8bce050be3b1433a6fd73a3c20c04e77b27b9b1d063052d0567a3dbcf"
+            "511a906f3f36685d4bef88bdd796c200c576e16bdf95736eb8d0134db4f0cf7c"
         ),
     }
     component_registry = registry()
@@ -262,7 +262,7 @@ def test_skew_research_policy_boundaries_and_unknown_evidence() -> None:
     assert _execute_skew_policy(call_atm_iv_minus_rv=Decimal("0")).get("verdict").value == "PASS"
     assert (
         _execute_skew_policy(historical_valid_observations=39).get("verdict").value
-        == "WATCH"
+        == "FAIL"
     )
     assert _execute_skew_policy(comparison_peer_count=4).get("verdict").value == "WATCH"
     assert (
@@ -290,6 +290,36 @@ def test_skew_research_policy_boundaries_and_unknown_evidence() -> None:
         _execute_skew_policy(call_wing_iv_minus_rv=Decimal("0")).get("verdict").value
         == "FAIL"
     )
+
+
+def test_skew_research_policy_requires_one_true_directional_core_gate() -> None:
+    bullish_false_bearish_unknown = _execute_skew_policy(
+        call_atm_iv_minus_rv=Decimal("0.01"),
+        put_atm_iv_minus_rv=Decimal("0"),
+        put_skew_zscore=None,
+    )
+    assert bullish_false_bearish_unknown.get("bullish_core_gate").value is False
+    assert bullish_false_bearish_unknown.get("bearish_core_gate").value is None
+    assert bullish_false_bearish_unknown.get("direction").value == "UNKNOWN"
+    assert bullish_false_bearish_unknown.get("verdict").value == "FAIL"
+
+    both_unknown = _execute_skew_policy(
+        call_skew_zscore=None,
+        put_skew_zscore=None,
+        put_atm_iv_minus_rv=Decimal("0"),
+    )
+    assert both_unknown.get("bullish_core_gate").value is None
+    assert both_unknown.get("bearish_core_gate").value is None
+    assert both_unknown.get("verdict").value == "FAIL"
+
+    qualifying_incomplete = _execute_skew_policy(comparison_peer_count=4)
+    assert qualifying_incomplete.get("bullish_core_gate").value is True
+    assert qualifying_incomplete.get("verdict").value == "WATCH"
+
+    illiquid = _execute_skew_policy(call_wing_iv_minus_rv=Decimal("0"))
+    assert illiquid.get("bullish_core_gate").value is False
+    assert illiquid.get("liquidity_acceptable").value is False
+    assert illiquid.get("verdict").value == "FAIL"
 
 
 def _forward_chain() -> tuple[OptionChain, ExpirationCollection]:

--- a/tests/strategies/test_strategy_library.py
+++ b/tests/strategies/test_strategy_library.py
@@ -28,7 +28,7 @@ def test_library_is_complete_ordered_and_identity_pinned() -> None:
         == StrategyLibrary(tuple(reversed(STONK_STRATEGY_MANIFESTS))).identity
     )
     assert STONK_STRATEGY_LIBRARY.identity == (
-        "9da93cd3358f46803181faed62b9a1e0f2c81282473b29924d65ee317bceacfb"
+        "9570359adb400ba0cd3f322d85e77d32278274ebe37109de9688f0721ab8b7e8"
     )
 
 


### PR DESCRIPTION
## Ticket

S13-01 / PATCH-012C — fail-closed Skew Momentum verdicts. Tracks #261.

## Root cause

`SkewMomentumResearchDecision.evaluate()` emitted `WATCH` from its final fallback whenever neither directional core gate was explicitly true. That converted `False/UNKNOWN` and `UNKNOWN/UNKNOWN` evidence into a signal-level WATCH.

## Change

- require at least one explicitly true directional core gate for ordinary directional WATCH/PASS
- preserve UNKNOWN in gate outputs without treating it as positive evidence
- preserve approved both-branches conflict WATCH
- preserve hard liquidity failure as FAIL
- bump decision component/algorithm, plugin, manifest, runtime-contract, and strategy versions
- repin deterministic manifest, graph, plugin, and strategy-library identities

No thresholds changed.

## Exclusions

No provider, API projection, frontend logic, symbol branches, execution behavior, persistence, or brokerage changes.

## Tests

- full pytest: **2635 passed, 17 skipped**
- focused strategy/architecture/live-adapter/UI suite: **51 passed**
- changed-file Ruff: passed
- mypy `asa`: passed
- Lean entrypoint + frozen-governance integrity: passed
- `git diff --check`: passed

Repository-wide mypy outside required `asa` scope still has 12 pre-existing errors in `strategies/calculations.py`, `strategies/registry.py`, and `strategies/__init__.py`; this PR adds none.

## Rollback

Revert commit `7e5aeba`; no schema or data migration exists.

## Deployment verification

After Founder merge/deploy, inspect scheduled Skew Momentum rows and prove no WATCH has both directional core gates non-true. Zero PASS remains acceptable.

## Authority

Draft only. No merge or deployment until SPRINT-013 delegation activation reaches `main` or Founder merges directly.
