### PR TITLE
S13-06: expose deployment identity in API and UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ POSTGRES_USER=asa
 POSTGRES_PASSWORD=asa
 ASA_DATABASE_URL=postgresql+psycopg://asa:asa@localhost:5432/asa
 ASA_ENVIRONMENT=development
+ASA_APPLICATION_VERSION=0.1.0
+# ASA_RELEASE_SHA is injected by the deployment environment; omit when unavailable.
+# ASA_RELEASE_SHA=
 ASA_QUOTE_PROVIDER=deterministic_fake
 ASA_BROKER_PORTFOLIO_PROVIDER=deterministic_fake_broker
 ASA_FRESH_FOR_SECONDS=300

--- a/asa/api/models.py
+++ b/asa/api/models.py
@@ -58,6 +58,12 @@ class HealthResponse(BaseModel):
     status: str
 
 
+class BuildIdentityResponse(BaseModel):
+    application_version: str
+    api_version: str
+    release_sha: str | None
+
+
 class StartRunRequest(BaseModel):
     requested_at: datetime
     release_sha: str = Field(min_length=1, max_length=64)

--- a/asa/api/routes.py
+++ b/asa/api/routes.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException, Request, status
 
 from asa.api.models import (
+    BuildIdentityResponse,
     HealthResponse,
     IngestQuotesRequest,
     IngestQuotesResponse,
@@ -28,12 +29,23 @@ def build_router(
     portfolio_runner: RunPortfolioIntelligence,
     portfolio_query: PublishedPortfolioQuery,
     run_query: RunQueryService,
+    application_version: str,
+    api_version: str,
+    release_sha: str | None,
 ) -> APIRouter:
     router = APIRouter(prefix="/api/v1")
 
     @router.get("/health", response_model=HealthResponse)
     def health() -> HealthResponse:
         return HealthResponse(status="ok")
+
+    @router.get("/version", response_model=BuildIdentityResponse)
+    def version() -> BuildIdentityResponse:
+        return BuildIdentityResponse(
+            application_version=application_version,
+            api_version=api_version,
+            release_sha=release_sha,
+        )
 
     @router.get("/readiness", response_model=HealthResponse)
     def readiness() -> HealthResponse:

--- a/asa/bootstrap.py
+++ b/asa/bootstrap.py
@@ -40,6 +40,8 @@ from strategy_runtime.adapters import (
 )
 from strategy_runtime.persistence import LatestResultRepository, ObservationHistoryRepository
 
+API_VERSION = "v1"
+
 
 @dataclass(frozen=True)
 class DependencyOverrides:
@@ -91,7 +93,7 @@ def build_application(
     )
     run_query = RunQueryService(run_repository)
 
-    app = FastAPI(title="ASA Market Quote API", version="1.0.0")
+    app = FastAPI(title="ASA Market Quote API", version=settings.application_version)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=[origin.strip() for origin in settings.cors_origins.split(",")],
@@ -106,6 +108,9 @@ def build_application(
             portfolio_runner=portfolio_runner,
             portfolio_query=portfolio_query,
             run_query=run_query,
+            application_version=settings.application_version,
+            api_version=API_VERSION,
+            release_sha=settings.release_sha,
         )
     )
     app.include_router(
@@ -142,7 +147,7 @@ def build_application(
             # confirm which contract it's talking to. Future versions get
             # their own /api/v2 prefix (URL-path versioning, matching the
             # existing /api/v1 convention) rather than a header switch.
-            response.headers["API-Version"] = "v1"
+            response.headers["API-Version"] = API_VERSION
             return response
         finally:
             request_id_context.reset(token)

--- a/asa/config.py
+++ b/asa/config.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("DATABASE_URL", "ASA_DATABASE_URL"),
     )
     environment: str = "development"
+    application_version: str = Field(default="0.1.0", min_length=1, max_length=64)
+    release_sha: str | None = Field(default=None, min_length=1, max_length=64)
     quote_provider: str = "deterministic_fake"
     broker_portfolio_provider: str = "deterministic_fake_broker"
     robinhood_username: SecretStr | None = None
@@ -36,6 +38,14 @@ class Settings(BaseSettings):
         le=65535,
         validation_alias=AliasChoices("PORT", "ASA_PORT"),
     )
+
+    @field_validator("application_version", "release_sha", mode="before")
+    @classmethod
+    def normalize_build_identity(cls, value: object) -> object:
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
 
     @field_validator("database_url")
     @classmethod

--- a/asa/ui/static/api-client.js
+++ b/asa/ui/static/api-client.js
@@ -41,6 +41,7 @@ async function requestJson(path, protectedRoute = true) {
 export const api = Object.freeze({
   health: () => requestJson("/api/v1/health", false),
   readiness: () => requestJson("/api/v1/readiness", false),
+  version: () => requestJson("/api/v1/version", false),
   capabilities: () => requestJson("/api/v1/capabilities"),
   results: () => requestJson("/api/v1/screening?limit=500&offset=0"),
   result: (signalId, symbol) =>

--- a/asa/ui/static/app.js
+++ b/asa/ui/static/app.js
@@ -41,9 +41,13 @@ async function loadPersistedState() {
   state.loading = true;
   state.error = null;
   render();
-  const infrastructure = await Promise.allSettled([api.health(), api.readiness()]);
+  const infrastructure = await Promise.allSettled([api.health(), api.readiness(), api.version()]);
   if (infrastructure[0].status === "fulfilled") state.health = infrastructure[0].value.data;
   if (infrastructure[1].status === "fulfilled") state.readiness = infrastructure[1].value.data;
+  if (infrastructure[2].status === "fulfilled") {
+    state.buildIdentity = infrastructure[2].value.data;
+    state.apiVersion = infrastructure[2].value.data.api_version;
+  }
   if (!hasToken()) {
     state.loading = false;
     render();

--- a/asa/ui/static/render.js
+++ b/asa/ui/static/render.js
@@ -97,7 +97,9 @@ function shellHeader(model, handlers) {
   const readiness = model.readiness?.status || (model.readiness ? "ready" : "unknown");
   status.append(badge(`health:${health}`, health === "ok" ? "pass" : "unknown"));
   status.append(badge(`readiness:${readiness}`, readiness === "ready" ? "pass" : "unknown"));
+  status.append(badge(`app:${model.buildIdentity?.application_version || "unavailable"}`, "raw"));
   status.append(badge(`api:${model.apiVersion || "unavailable"}`, "raw"));
+  status.append(badge(`revision:${model.buildIdentity?.release_sha || "unavailable"}`, "raw"));
   header.append(status);
 
   const nav = element("nav", "primary-nav");
@@ -331,6 +333,8 @@ function healthView(model) {
     ["Health endpoint", JSON.stringify(model.health || "Unavailable")],
     ["Readiness endpoint", JSON.stringify(model.readiness || "Unavailable")],
     ["API contract", model.apiVersion || "Revision unavailable"],
+    ["Application version", model.buildIdentity?.application_version || "Unavailable"],
+    ["Release revision", model.buildIdentity?.release_sha || "Unavailable"],
     ["Persisted rows", String(model.results.length)],
     ["Earliest evaluated", model.evaluatedRange.earliest],
     ["Latest evaluated", model.evaluatedRange.latest],

--- a/asa/ui/static/state.js
+++ b/asa/ui/static/state.js
@@ -1,6 +1,7 @@
 export const state = {
   health: null,
   readiness: null,
+  buildIdentity: null,
   capabilities: null,
   results: [],
   apiVersion: null,

--- a/tests/asa/test_composition.py
+++ b/tests/asa/test_composition.py
@@ -55,6 +55,31 @@ def test_api_version_header_is_present_on_every_response() -> None:
     assert response.headers["API-Version"] == "v1"
 
 
+def test_public_version_endpoint_reports_configured_build_identity() -> None:
+    app = build_application(
+        Settings(application_version="2.4.1", release_sha="abc123def"),
+        DependencyOverrides(repository=InMemoryObservationRepository()),
+    )
+
+    response = TestClient(app).get("/api/v1/version")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "application_version": "2.4.1",
+        "api_version": "v1",
+        "release_sha": "abc123def",
+    }
+
+
+def test_public_version_endpoint_discloses_unavailable_release_explicitly() -> None:
+    app = build_application(
+        Settings(),
+        DependencyOverrides(repository=InMemoryObservationRepository()),
+    )
+
+    assert TestClient(app).get("/api/v1/version").json()["release_sha"] is None
+
+
 def test_agent_api_token_setting_reaches_the_authorizer() -> None:
     app = build_application(
         Settings(agent_api_token=SecretStr("agent-token")),

--- a/tests/asa/test_config.py
+++ b/tests/asa/test_config.py
@@ -108,6 +108,17 @@ def test_railway_port_is_loaded(monkeypatch: pytest.MonkeyPatch) -> None:
     assert Settings(_env_file=None).port == 9123
 
 
+def test_build_identity_strips_configuration_whitespace() -> None:
+    settings = Settings(
+        _env_file=None,
+        application_version=" 2.4.1 ",
+        release_sha=" abc123 ",
+    )
+
+    assert settings.application_version == "2.4.1"
+    assert settings.release_sha == "abc123"
+
+
 def test_robinhood_provider_is_selected_from_railway_variables(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/ui-tests/ui.test.js
+++ b/ui-tests/ui.test.js
@@ -39,6 +39,7 @@ function model(overrides = {}) {
     health: { status: "ok" },
     readiness: { status: "ready" },
     apiVersion: "v1",
+    buildIdentity: { application_version: "0.1.0", api_version: "v1", release_sha: "abc123" },
     results: [fixture],
     visible: [fixture],
     detail: null,
@@ -74,6 +75,17 @@ test("shared public fixture renders exact audit identity, decision, evidence, an
   assert.match(text, /comparison universe incomplete/);
   assert.match(text, /2026-07-29T13:44:00Z/);
   assert.match(text, /observation:fixture:001/);
+});
+
+test("runtime strip renders exact configured build identity and explicit unavailable revision", () => {
+  const root = document.createElement("div");
+  renderApp(root, model(), noOpHandlers);
+  assert.match(root.querySelector(".runtime-strip").textContent, /app:0\.1\.0/);
+  assert.match(root.querySelector(".runtime-strip").textContent, /api:v1/);
+  assert.match(root.querySelector(".runtime-strip").textContent, /revision:abc123/);
+
+  renderApp(root, model({ buildIdentity: { application_version: "0.1.0", api_version: "v1", release_sha: null } }), noOpHandlers);
+  assert.match(root.querySelector(".runtime-strip").textContent, /revision:unavailable/);
 });
 
 test("verdict, evaluation state, outcome, UNKNOWN, failures, and stale states stay distinct", () => {


### PR DESCRIPTION
## Ticket

S13-06 — Deployment identity and UI trust strip

## Summary

- adds public read-only `GET /api/v1/version`
- reports configured application version, API version, and optional release SHA
- renders exact values in UI runtime strip and reports `unavailable` when release SHA is absent
- documents deployment configuration using provider-neutral `ASA_RELEASE_SHA`

## Root cause

API version existed only as a response header learned after protected API calls. Application version and deployed source revision had no public contract, so operators could not verify which build served the UI.

## Safety

- no database, provider, strategy, scheduling, or brokerage calls
- no cycle identity invented
- no Railway-specific runtime branch
- no secrets exposed; release SHA is explicit non-secret configuration

## Validation

- `pytest`: 2638 passed, 17 skipped
- targeted backend: 22 passed
- UI tests: 7 passed
- mypy `asa`: passed
- Ruff changed files: passed
- UI syntax lint: passed
- Lean entrypoint and governance integrity: passed
- `git diff --check`: passed

Repo-wide Ruff still reports 491 pre-existing findings outside this patch; changed-file lint is clean.

## Authority

SPRINT-013 delegation active via GOV-013 / Amendment 013. Auto-merge authorized after required gates pass.
