### PR TITLE
S13-05: expose operator-readable strategy fields

### DIFF
--- a/docs/migration/stonk-shared-components.md
+++ b/docs/migration/stonk-shared-components.md
@@ -31,6 +31,8 @@ Plugin SDK.
 | `asa.stonk.options` | `dte_pair_selector` | Select one stable front/back pair from explicit DTE, gap, and target policy |
 | `asa.stonk.options` | `expiration_pair_projection` | Project one exact pair into typed front and back expiration dates |
 | `asa.stonk.options` | `expiration_gap_projection` | Expose actual expiration-gap days and deviation from the manifest target |
+| `asa.stonk.options` | `earnings_event_projection` | Expose earnings date, announcement timing, and canonical days-to-earnings evidence |
+| `asa.stonk.options` | `forward_factor_eligibility_gate` | Expose each Forward Factor hard gate and aggregate eligibility without changing policy |
 | `asa.stonk.options` | `forward_factor` | Calculate raw front IV divided by implied forward IV minus one |
 | `asa.stonk.options` | `implied_forward_volatility` | Derive forward variance and volatility from explicit front/back IV and DTE |
 | `asa.stonk.options` | `option_leg_liquidity` | Test observed quote width, open interest, and volume against explicit thresholds |
@@ -41,7 +43,7 @@ Plugin SDK.
 | `asa.stonk.options` | `skew_momentum_research_decision` | Apply the versioned two-sided skew, volatility-value, momentum-alignment, liquidity, and missing-evidence policy |
 | `asa.stonk.options` | `double_calendar_structure` | Compose canonical put and call calendars as a typed tuple |
 | `asa.stonk.options` | `option_structure_collection_liquidity` | Require coherent quoted liquidity evidence on every selected leg |
-| `asa.stonk.options` | `earnings_calendar_liquidity` | Apply quote/open-interest gates and emit LOW/ADEQUATE/HIGH/UNKNOWN volume evidence |
+| `asa.stonk.options` | `earnings_calendar_liquidity` | Apply quote/open-interest gates and emit volume band plus explicit downgrade reason |
 | `asa.stonk.options` | `option_structure_debit` | Compute mark debit and conservative long-ask/short-bid debit when evidence is complete |
 
 The double calendar is composition of two existing `OptionStructureType.CALENDAR`

--- a/docs/migration/stonk-strategy-manifests.md
+++ b/docs/migration/stonk-strategy-manifests.md
@@ -6,9 +6,9 @@ The source behaviors are pinned to Stonk revision
 
 | Manifest ID | Version | Graph ownership |
 |---|---:|---|
-| `earnings_calendar` | `1.1.0` | confirmed event window, nearest eligible 30-day expiration gap (±5 days), liquidity, coarse volume, calendar debit, score and gated verdict |
+| `earnings_calendar` | `1.2.0` | confirmed event window, readable event and expiration facts, nearest eligible 30-day expiration gap (±5 days), liquidity, coarse volume, calendar debit, score and gated verdict |
 | `skew_momentum` | `2.0.1-research` | two-sided historical skew stretch, fail-closed directional core gates, IV/RV value gates, three-dimensional momentum alignment, delta-selected vertical, liquidity, debit, and verdict |
-| `forward_factor` | `1.2.1` | DTE pair, raw front IV, implied forward volatility, confirmed-earnings exclusion, common-strike liquidity-complete put/call double calendar, and gated verdict |
+| `forward_factor` | `1.3.0` | DTE pair, raw front IV, implied forward volatility, explicit hard gates, confirmed-earnings exclusion, common-strike liquidity-complete put/call double calendar, and gated verdict |
 | `asa.stonk.stock_momentum` | `1.0.0` | deterministic candidate cap, bounded momentum score and verdict |
 
 Every graph uses exact Component versions from `asa.stonk.shared`,

--- a/docs/strategies/stonk-strategy-library.md
+++ b/docs/strategies/stonk-strategy-library.md
@@ -6,8 +6,8 @@ it does not dispatch legacy service code.
 
 | Strategy ID | Version | Component dependencies | Purpose |
 |---|---:|---|---|
-| `earnings_calendar` | `1.1.0` | shared + options | confirmed-event calendar targeting a 30-day gap with liquidity and coarse volume evidence |
-| `forward_factor` | `1.2.1` | shared + options | earnings-excluded, common-strike forward-volatility double-calendar candidate |
+| `earnings_calendar` | `1.2.0` | shared + options | confirmed-event calendar targeting a 30-day gap with readable dates, liquidity, and coarse volume evidence |
+| `forward_factor` | `1.3.0` | shared + options | earnings-excluded, common-strike forward-volatility double-calendar candidate with explicit hard gates |
 | `skew_momentum` | `2.0.1-research` | shared + options | fail-closed two-sided skew/volatility-value vertical with three-dimensional momentum alignment |
 | `asa.stonk.stock_momentum` | `1.0.0` | shared | deterministic equity momentum candidate set |
 

--- a/screening/context_builders.py
+++ b/screening/context_builders.py
@@ -75,6 +75,7 @@ def build_forward_factor_context(
     front_strike: Decimal,
     back_strike: Decimal,
     earnings_eligible: bool,
+    confirmed_earnings_date: date | None = None,
     option_type: OptionType = OptionType.CALL,
 ) -> ComponentValues:
     """front_strike/back_strike -- SPRINT-011-CLOSEOUT/CLOSE-001: previously
@@ -136,7 +137,11 @@ def build_forward_factor_context(
             "forward_iv.front_dte": (_INTEGER, int(front_dte)),
             "forward_iv.back_dte": (_INTEGER, int(back_dte)),
             "factor.front_iv": (D, front_iv),
-            "eligibility.left": (B, earnings_eligible),
+            "eligibility.earnings_eligible": (B, earnings_eligible),
+            "eligibility.confirmed_earnings_date": (
+                StrategyTypeReference("Optional", "1.0.0", (DATE,)),
+                confirmed_earnings_date,
+            ),
         }
     )
 
@@ -160,6 +165,8 @@ def build_earnings_calendar_context(
     return _context(
         **{
             "event_window.event": (EARNINGS_EVENT, event),
+            "event_projection.event": (EARNINGS_EVENT, event),
+            "event_projection.as_of": (DATE, as_of),
             "event_window.front": (EXPIRATION_CYCLE, front),
             "event_window.back": (EXPIRATION_CYCLE, back),
             "expiration_select.expirations": (

--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -444,6 +444,11 @@ def build_live_forward_factor_adapter(
             front_strike=front_strike,
             back_strike=back_strike,
             earnings_eligible=earnings_eligible,
+            confirmed_earnings_date=(
+                earnings_event.earnings_date
+                if earnings_event is not None and earnings_event.confirmed
+                else None
+            ),
             option_type=OptionType.CALL,
         )
         graph = compile_strategy_graph(FORWARD_FACTOR_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)

--- a/strategies/stonk_components.py
+++ b/strategies/stonk_components.py
@@ -13,6 +13,7 @@ from decimal import ROUND_HALF_EVEN, Context, Decimal, localcontext
 from typing import cast
 
 from analytics.derived_facts import (
+    compute_days_to_earnings,
     compute_expiration_gap_days,
     compute_expiration_gap_distance,
     compute_forward_factor,
@@ -68,6 +69,18 @@ VOLUME_BAND = StrategyTypeReference(
     "1.0.0",
     qualifiers=ManifestObject((("values", ("LOW", "ADEQUATE", "HIGH", "UNKNOWN")),)),
 )
+ANNOUNCEMENT_TIMING = StrategyTypeReference(
+    "Enum",
+    "1.0.0",
+    qualifiers=ManifestObject((("values", tuple(item.value for item in AnnouncementTime)),)),
+)
+VOLUME_DOWNGRADE_REASON = StrategyTypeReference(
+    "Enum",
+    "1.0.0",
+    qualifiers=ManifestObject(
+        (("values", ("NONE", "UNKNOWN_VOLUME", "BELOW_MINIMUM_VOLUME_BAND")),)
+    ),
+)
 SECURITY_COLLECTION = StrategyTypeReference("SecurityCollection", "1.0.0")
 OPTION_CONTRACT = StrategyTypeReference("OptionContract", "1.0.0")
 OPTION_COLLECTION = StrategyTypeReference("OptionCollection", "1.0.0")
@@ -79,6 +92,7 @@ OPTION_STRUCTURE = StrategyTypeReference("OptionStructure", "1.0.0")
 OPTION_STRUCTURE_LIST = StrategyTypeReference("List", "1.0.0", (OPTION_STRUCTURE,))
 OPTIONAL_DECIMAL = StrategyTypeReference("Optional", "1.0.0", (D,))
 OPTIONAL_BOOLEAN = StrategyTypeReference("Optional", "1.0.0", (B,))
+OPTIONAL_DATE = StrategyTypeReference("Optional", "1.0.0", (DATE,))
 OPTIONAL_OPTION_STRUCTURE = StrategyTypeReference("Optional", "1.0.0", (OPTION_STRUCTURE,))
 SKEW_DIRECTION = StrategyTypeReference(
     "Enum",
@@ -431,6 +445,79 @@ class EarningsEventWindow(BaseComponent):
             and (event.confirmed or not require_confirmed)
         )
         return ComponentValues((("eligible", TypedValue(B, eligible)),))
+
+
+class EarningsEventProjection(BaseComponent):
+    """Expose event facts and canonical days-to-event derived evidence."""
+
+    __slots__ = ()
+    definition = _definition(
+        "asa.stonk.options",
+        "earnings_event_projection",
+        ComponentCategory.TRANSFORM,
+        (PortDefinition("event", EARNINGS_EVENT), PortDefinition("as_of", DATE)),
+        (
+            PortDefinition("earnings_date", DATE),
+            PortDefinition("days_to_earnings", INTEGER),
+            PortDefinition("announcement_timing", ANNOUNCEMENT_TIMING),
+        ),
+    )
+
+    def evaluate(self, inputs: ComponentValues, parameters: ComponentValues) -> ComponentValues:
+        event = cast(EarningsEvent, _input(inputs, "event", EarningsEvent))
+        as_of = cast(date, _input(inputs, "as_of", date))
+        return ComponentValues(
+            (
+                (
+                    "announcement_timing",
+                    TypedValue(ANNOUNCEMENT_TIMING, event.announcement_time.value),
+                ),
+                (
+                    "days_to_earnings",
+                    TypedValue(INTEGER, compute_days_to_earnings(as_of, event.earnings_date)),
+                ),
+                ("earnings_date", TypedValue(DATE, event.earnings_date)),
+            )
+        )
+
+
+class ForwardFactorEligibilityGate(BaseComponent):
+    """Expose each hard gate while preserving existing aggregate eligibility."""
+
+    __slots__ = ()
+    definition = _definition(
+        "asa.stonk.options",
+        "forward_factor_eligibility_gate",
+        ComponentCategory.PREDICATE,
+        (
+            PortDefinition("earnings_eligible", B),
+            PortDefinition("structures", OPTION_STRUCTURE_LIST),
+            PortDefinition("liquidity_acceptable", B),
+            PortDefinition("confirmed_earnings_date", OPTIONAL_DATE),
+        ),
+        (
+            PortDefinition("earnings_exclusion_gate", B),
+            PortDefinition("structure_constructible_gate", B),
+            PortDefinition("liquidity_gate", B),
+            PortDefinition("eligible", B),
+            PortDefinition("confirmed_earnings_date", OPTIONAL_DATE),
+        ),
+    )
+
+    def evaluate(self, inputs: ComponentValues, parameters: ComponentValues) -> ComponentValues:
+        earnings_gate = cast(bool, inputs.get("earnings_eligible").value)
+        structures = cast(tuple[OptionStructure, ...], inputs.get("structures").value)
+        liquidity_gate = cast(bool, inputs.get("liquidity_acceptable").value)
+        structure_gate = bool(structures)
+        return ComponentValues(
+            (
+                ("confirmed_earnings_date", inputs.get("confirmed_earnings_date")),
+                ("earnings_exclusion_gate", TypedValue(B, earnings_gate)),
+                ("eligible", TypedValue(B, earnings_gate and structure_gate and liquidity_gate)),
+                ("liquidity_gate", TypedValue(B, liquidity_gate)),
+                ("structure_constructible_gate", TypedValue(B, structure_gate)),
+            )
+        )
 
 
 class ExpirationPairSelector(BaseComponent):
@@ -1458,8 +1545,11 @@ class EarningsCalendarLiquidity(BaseComponent):
             PortDefinition("acceptable", B),
             PortDefinition("volume_band", VOLUME_BAND),
             PortDefinition("volume_supplement_strong", B),
+            PortDefinition("volume_downgrade_reason", VOLUME_DOWNGRADE_REASON),
         ),
         (ParameterDefinition("minimum_volume_band", VOLUME_BAND),),
+        version="1.1.0",
+        algorithm_version="1.1.0",
     )
 
     def evaluate(self, inputs: ComponentValues, parameters: ComponentValues) -> ComponentValues:
@@ -1496,11 +1586,19 @@ class EarningsCalendarLiquidity(BaseComponent):
             else "HIGH"
         )
         supplement_strong = band_rank[volume_band] >= band_rank[minimum_band]
+        downgrade_reason = (
+            "NONE"
+            if supplement_strong
+            else "UNKNOWN_VOLUME"
+            if volume_band == "UNKNOWN"
+            else "BELOW_MINIMUM_VOLUME_BAND"
+        )
         return ComponentValues(
             (
                 ("acceptable", TypedValue(B, acceptable)),
                 ("volume_band", TypedValue(VOLUME_BAND, volume_band)),
                 ("volume_supplement_strong", TypedValue(B, supplement_strong)),
+                ("volume_downgrade_reason", TypedValue(VOLUME_DOWNGRADE_REASON, downgrade_reason)),
             )
         )
 
@@ -1570,6 +1668,8 @@ SHARED_STONK_COMPONENTS: tuple[BaseComponent, ...] = (
 
 OPTIONS_STONK_COMPONENTS: tuple[BaseComponent, ...] = (
     EarningsEventWindow(),
+    EarningsEventProjection(),
+    ForwardFactorEligibilityGate(),
     ExpirationPairSelector(),
     DtePairSelector(),
     ExpirationPairProjection(),

--- a/strategies/stonk_manifests.py
+++ b/strategies/stonk_manifests.py
@@ -52,7 +52,7 @@ def _output(
 EARNINGS_CALENDAR_MANIFEST = StrategyManifest(
     "1.1.0",
     "earnings_calendar",
-    "1.1.0",
+    "1.2.0",
     ManifestMetadata(
         "Earnings Calendar Spread",
         "Confirmed earnings calendar targeting a 30-day expiration gap with liquidity evidence.",
@@ -67,6 +67,7 @@ EARNINGS_CALENDAR_MANIFEST = StrategyManifest(
             "earnings_event_window",
             (_parameter("require_confirmed", "Boolean", True),),
         ),
+        _node("event_projection", "asa.stonk.options", "earnings_event_projection"),
         _node(
             "expiration_select",
             "asa.stonk.options",
@@ -99,6 +100,7 @@ EARNINGS_CALENDAR_MANIFEST = StrategyManifest(
             "asa.stonk.options",
             "earnings_calendar_liquidity",
             (_parameter("minimum_volume_band", "Enum", "ADEQUATE"),),
+            component_version="1.1.0",
         ),
         _node("event_gap_eligibility", "asa.core", "boolean_and"),
         _node("eligibility", "asa.core", "boolean_and"),
@@ -149,10 +151,21 @@ EARNINGS_CALENDAR_MANIFEST = StrategyManifest(
         ),
     ),
     (
+        _output("earnings_date", "event_projection", "earnings_date", "fact"),
+        _output(
+            "days_to_earnings",
+            "event_projection",
+            "days_to_earnings",
+            "derived_fact",
+            "days_to_earnings",
+        ),
+        _output("announcement_timing", "event_projection", "announcement_timing", "fact"),
         _output("earnings_eligible", "event_window", "eligible", "gate"),
         _output("eligible", "eligibility", "result", "gate"),
         _output("gap_eligible", "expiration_select", "gap_eligible", "gate"),
         _output("selected_expirations", "expiration_select", "selected", "fact"),
+        _output("selected_front_expiration", "pair", "front_expiration", "fact"),
+        _output("selected_back_expiration", "pair", "back_expiration", "fact"),
         _output(
             "actual_gap_days",
             "gap",
@@ -181,6 +194,12 @@ EARNINGS_CALENDAR_MANIFEST = StrategyManifest(
             "liquidity",
             "volume_supplement_strong",
             "gate",
+        ),
+        _output(
+            "volume_downgrade_reason",
+            "liquidity",
+            "volume_downgrade_reason",
+            "fact",
         ),
         _output("mid_debit", "debit", "mid_debit", "fact"),
         _output("conservative_debit", "debit", "conservative_debit", "fact"),
@@ -363,7 +382,7 @@ SKEW_MOMENTUM_VERTICAL_MANIFEST = StrategyManifest(
 FORWARD_FACTOR_CALENDAR_MANIFEST = StrategyManifest(
     "1.1.0",
     "forward_factor",
-    "1.2.1",
+    "1.3.0",
     ManifestMetadata(
         "Forward Factor Calendar",
         "Raw-front-IV forward factor with confirmed-earnings exclusion and "
@@ -406,7 +425,7 @@ FORWARD_FACTOR_CALENDAR_MANIFEST = StrategyManifest(
             "asa.stonk.options",
             "option_structure_collection_liquidity",
         ),
-        _node("eligibility", "asa.core", "boolean_and"),
+        _node("eligibility", "asa.stonk.options", "forward_factor_eligibility_gate"),
         _node(
             "verdict",
             "asa.stonk.shared",
@@ -424,16 +443,33 @@ FORWARD_FACTOR_CALENDAR_MANIFEST = StrategyManifest(
         EdgeSpec("pair", "back_expiration", "double_calendar", "back_expiration"),
         EdgeSpec("forward_iv", "implied_forward_iv", "factor", "implied_forward_iv"),
         EdgeSpec("double_calendar", "structures", "liquidity", "structures"),
-        EdgeSpec("liquidity", "acceptable", "eligibility", "right"),
+        EdgeSpec("double_calendar", "structures", "eligibility", "structures"),
+        EdgeSpec("liquidity", "acceptable", "eligibility", "liquidity_acceptable"),
         EdgeSpec("factor", "factor", "verdict", "score"),
         EdgeSpec("verdict", "verdict", "gated_verdict", "verdict"),
-        EdgeSpec("eligibility", "result", "gated_verdict", "eligible"),
+        EdgeSpec("eligibility", "eligible", "gated_verdict", "eligible"),
     ),
     (
         _output("selected_expirations", "expiration_select", "selected", "fact"),
+        _output("selected_front_expiration", "pair", "front_expiration", "fact"),
+        _output("selected_back_expiration", "pair", "back_expiration", "fact"),
         _output("structures", "double_calendar", "structures", "structure"),
+        _output("earnings_exclusion_gate", "eligibility", "earnings_exclusion_gate", "gate"),
+        _output(
+            "structure_constructible_gate",
+            "eligibility",
+            "structure_constructible_gate",
+            "gate",
+        ),
+        _output("liquidity_gate", "eligibility", "liquidity_gate", "gate"),
         _output("liquidity_acceptable", "liquidity", "acceptable", "gate"),
-        _output("eligible", "eligibility", "result", "gate"),
+        _output("eligible", "eligibility", "eligible", "gate"),
+        _output(
+            "confirmed_earnings_date_when_relevant",
+            "eligibility",
+            "confirmed_earnings_date",
+            "fact",
+        ),
         _output("front_iv", "factor", "front_iv", "fact"),
         _output(
             "implied_forward_volatility",

--- a/strategies/stonk_plugins.py
+++ b/strategies/stonk_plugins.py
@@ -17,7 +17,7 @@ STONK_OPTIONS_PLUGIN = StrategyPlugin(
     PluginMetadata(
         "asa.stonk.options",
         "stonk_options_components",
-        "2.0.2",
+        "2.1.0",
         "Provider-neutral earnings, expiration, option-leg, and structure primitives.",
     ),
     OPTIONS_STONK_COMPONENTS,

--- a/strategy_runtime/adapters/earnings_calendar.py
+++ b/strategy_runtime/adapters/earnings_calendar.py
@@ -65,7 +65,7 @@ from strategy_runtime.result import UniversalScreeningResult, compute_observatio
 
 EARNINGS_CALENDAR_CONTRACT = StrategyContract(
     strategy_id="earnings_calendar",
-    version="1.1.0",
+    version="1.2.0",
     category="options_earnings",
     description=(
         "Confirmed earnings calendar targeting a 30-day expiration gap with liquidity evidence."

--- a/strategy_runtime/adapters/forward_factor.py
+++ b/strategy_runtime/adapters/forward_factor.py
@@ -39,7 +39,7 @@ from strategy_runtime.result import UniversalScreeningResult, compute_observatio
 
 FORWARD_FACTOR_CONTRACT = StrategyContract(
     strategy_id="forward_factor",
-    version="1.2.1",
+    version="1.3.0",
     category="options_volatility",
     description=(
         "Raw-front-IV forward factor with confirmed-earnings exclusion and "

--- a/tests/analytics/test_forward_factor_manifest_integration.py
+++ b/tests/analytics/test_forward_factor_manifest_integration.py
@@ -42,7 +42,7 @@ from strategies import (
     execute_strategy_graph,
 )
 from strategies.plugins import build_plugin_registry
-from strategies.stonk_components import EXPIRATION_COLLECTION, OPTION_CHAIN, D
+from strategies.stonk_components import DATE, EXPIRATION_COLLECTION, OPTION_CHAIN, D
 from strategies.type_system import ComponentValues, StrategyTypeReference, TypedValue
 
 AS_OF = date(2026, 7, 22)
@@ -173,8 +173,12 @@ def test_analytics_outputs_feed_the_real_manifest_with_zero_additional_math() ->
             ),
             ("factor.front_iv", TypedValue(D, front_iv)),
             (
-                "eligibility.left",
+                "eligibility.earnings_eligible",
                 TypedValue(StrategyTypeReference("Boolean", "1.0.0"), True),
+            ),
+            (
+                "eligibility.confirmed_earnings_date",
+                TypedValue(StrategyTypeReference("Optional", "1.0.0", (DATE,)), None),
             ),
         )
     )

--- a/tests/screening/test_adapters.py
+++ b/tests/screening/test_adapters.py
@@ -40,7 +40,15 @@ class TestForwardFactorAdapter:
         assert result.strategy_native_score > Decimal("0")
         assert result.explanation is not None
         assert dict(result.explanation.formula_versions)["forward_factor"] == "1.0.0"
-        assert dict(result.explanation.gate_results)["eligible"] is True
+        gates = dict(result.explanation.gate_results)
+        assert gates["eligible"] is True
+        assert gates["earnings_exclusion_gate"] is True
+        assert gates["structure_constructible_gate"] is True
+        assert gates["liquidity_gate"] is True
+        facts = dict(result.explanation.canonical_facts)
+        assert facts["selected_front_expiration"] == "2026-09-21"
+        assert facts["selected_back_expiration"] == "2026-10-21"
+        assert facts["confirmed_earnings_date_when_relevant"] is None
 
     def test_is_deterministic(self) -> None:
         first = run_forward_factor(_definition("forward_factor"), FixedClock(), "run-1")
@@ -59,6 +67,14 @@ class TestEarningsCalendarAdapter:
         assert dict(result.explanation.named_derived_facts)["actual_gap_days"] == 30
         assert dict(result.explanation.formula_versions)["actual_gap_days"] == "1.0.0"
         assert dict(result.explanation.gate_results)["liquidity_acceptable"] is True
+        facts = dict(result.explanation.canonical_facts)
+        derived = dict(result.explanation.named_derived_facts)
+        assert facts["earnings_date"] == "2026-08-05"
+        assert facts["announcement_timing"] == "after_close"
+        assert facts["selected_front_expiration"] == "2026-07-31"
+        assert facts["selected_back_expiration"] == "2026-08-30"
+        assert facts["volume_downgrade_reason"] == "NONE"
+        assert derived["days_to_earnings"] == 14
 
     def test_is_deterministic(self) -> None:
         first = run_earnings_calendar(_definition("earnings_calendar"), FixedClock(), "run-1")

--- a/tests/screening/test_context_builders.py
+++ b/tests/screening/test_context_builders.py
@@ -33,7 +33,8 @@ class TestBuildForwardFactorContext:
         assert values["forward_iv.front_dte"].value == 61
         assert values["forward_iv.back_dte"].value == 91
         assert values["factor.front_iv"].value == Decimal("0.48")
-        assert values["eligibility.left"].value is True
+        assert values["eligibility.earnings_eligible"].value is True
+        assert values["eligibility.confirmed_earnings_date"].value is None
 
     def test_raises_when_no_pair_satisfies_the_dte_policy(self) -> None:
         chain = fixtures.forward_factor_chain()

--- a/tests/strategies/test_stonk_components.py
+++ b/tests/strategies/test_stonk_components.py
@@ -182,7 +182,7 @@ def test_plugins_register_all_components_statically_and_deterministically() -> N
         for plugin in STONK_STRATEGY_PLUGINS
         for component in plugin.components
     }
-    assert len(expected) == 25
+    assert len(expected) == 27
     for namespace, name, version in expected:
         assert registry.resolve(ComponentReference(namespace, name, version))
     assert (
@@ -193,9 +193,9 @@ def test_plugins_register_all_components_statically_and_deterministically() -> N
         "52b919f7ea1a628d4b4a43056e59e37fb4f1ede111d85a122dc1c83f9cc1a598"
     )
     assert STONK_STRATEGY_PLUGINS[0].metadata.version == "1.2.0"
-    assert STONK_STRATEGY_PLUGINS[1].metadata.version == "2.0.2"
+    assert STONK_STRATEGY_PLUGINS[1].metadata.version == "2.1.0"
     assert STONK_STRATEGY_PLUGINS[1].plugin_id == (
-        "311b6ff79cdfc302571eb6e6e44ff33415565ad21e43c4dec7550c94978778c9"
+        "f8fc6379b6ac6e6cdf3526a95f51a316b3e8488e7305d7899dcedf4ad50fb420"
     )
 
 

--- a/tests/strategies/test_stonk_manifests.py
+++ b/tests/strategies/test_stonk_manifests.py
@@ -74,19 +74,19 @@ def test_four_manifest_catalog_is_canonical_serializable_and_identity_pinned() -
         "asa.stonk.stock_momentum",
     )
     expected = {
-        "earnings_calendar": "a165405844d32da747950e2bbd088849bf375b839b79557cb859e6daf51fdd9e",
+        "earnings_calendar": "b8a635c5bcb17511b774539731c6b7ca916c581eb5aaa80629de6c1dc4149208",
         "skew_momentum": "64fed57c5a281dde0a1e071714e4379abc7f901aada4a26d5d97372d366cfdbf",
-        "forward_factor": "c7f2b6bc3a46a8182464b098f3b703261cde89d11bf9b9ae0bd85cd56e349bf4",
+        "forward_factor": "c1fd2ba652daf76d395f3db00d668d6b7fc9fdca94a1fa602646e2b65a8e14cd",
         "asa.stonk.stock_momentum": (
             "456a84aa09ca73c65c32490ebaa270beb5b85db273e9d0c10d987f434e13047d"
         ),
     }
     graph_ids = {
-        "earnings_calendar": "b81f305fc9fcfc644328447ae60c20e8b50f9e67c822ea18f070c9148a27aab4",
-        "skew_momentum": "8a67a57212765d28550778144d90260082c4bd02d494ffd3a82623e27cf6ace7",
-        "forward_factor": "cbf3d7b7f32f77155b888c90434b85a172335d7ef5957295f022ca28fd36549f",
+        "earnings_calendar": "47d7867153dc1717e0e1ddefb7b5aaf466fab380c9fb64a0f603237f00953bc6",
+        "skew_momentum": "7a671af384867ec1a0bab2c87fd2fc08032b889949bd82bc7334e357d862c6e9",
+        "forward_factor": "26e65fe346ac30d48f7060cd225d15c7a205c6db08ae71caa977cee4c1dcc91f",
         "asa.stonk.stock_momentum": (
-            "511a906f3f36685d4bef88bdd796c200c576e16bdf95736eb8d0134db4f0cf7c"
+            "10871d17a6aa79e8c7ec9654d71359fc050bc84eb9ca5d2df5d322dfb5e7f3fd"
         ),
     }
     component_registry = registry()
@@ -105,6 +105,8 @@ def test_earnings_calendar_manifest_executes_and_replays() -> None:
     execution_context = context(
         **{
             "event_window.event": (EARNINGS_EVENT, earnings_event()),
+            "event_projection.event": (EARNINGS_EVENT, earnings_event()),
+            "event_projection.as_of": (DATE, AS_OF),
             "event_window.front": (EXPIRATION_CYCLE, front),
             "event_window.back": (EXPIRATION_CYCLE, back),
             "expiration_select.expirations": (
@@ -128,6 +130,14 @@ def test_earnings_calendar_manifest_executes_and_replays() -> None:
     assert first.outputs.get("gap_eligible").value is True
     assert first.outputs.get("liquidity_acceptable").value is True
     assert first.outputs.get("option_volume_band").value == "HIGH"
+    assert first.outputs.get("volume_downgrade_reason").value == "NONE"
+    assert first.outputs.get("earnings_date").value == earnings_event().earnings_date
+    assert first.outputs.get("days_to_earnings").value == (
+        earnings_event().earnings_date - AS_OF
+    ).days
+    assert first.outputs.get("announcement_timing").value == "after_close"
+    assert first.outputs.get("selected_front_expiration").value == FRONT
+    assert first.outputs.get("selected_back_expiration").value == BACK
     assert first.outputs.get("score").value == Decimal("75")
     assert first.outputs.get("verdict").value == "PASS"
     assert first.outputs.get("structure").value.identity
@@ -147,6 +157,7 @@ def test_earnings_calendar_manifest_executes_and_replays() -> None:
     )
     weak = execute_strategy_graph(graph, weak_context)
     assert weak.outputs.get("option_volume_band").value == "LOW"
+    assert weak.outputs.get("volume_downgrade_reason").value == "BELOW_MINIMUM_VOLUME_BAND"
     assert weak.outputs.get("verdict").value == "WATCH"
 
     illiquid_chain = replace(
@@ -363,9 +374,13 @@ def test_forward_factor_manifest_requires_source_iv_and_builds_double_calendar()
                 90,
             ),
             "factor.front_iv": (D, Decimal("0.48")),
-            "eligibility.left": (
+            "eligibility.earnings_eligible": (
                 StrategyTypeReference("Boolean", "1.0.0"),
                 True,
+            ),
+            "eligibility.confirmed_earnings_date": (
+                StrategyTypeReference("Optional", "1.0.0", (DATE,)),
+                None,
             ),
         }
     )
@@ -377,16 +392,28 @@ def test_forward_factor_manifest_requires_source_iv_and_builds_double_calendar()
     assert result.outputs.get("verdict").value == "PASS"
     assert result.outputs.get("eligible").value is True
     assert result.outputs.get("liquidity_acceptable").value is True
+    assert result.outputs.get("earnings_exclusion_gate").value is True
+    assert result.outputs.get("structure_constructible_gate").value is True
+    assert result.outputs.get("liquidity_gate").value is True
+    assert result.outputs.get("selected_front_expiration").value == (
+        expirations.cycles[0].expiration_date
+    )
+    assert result.outputs.get("selected_back_expiration").value == (
+        expirations.cycles[1].expiration_date
+    )
+    assert result.outputs.get("confirmed_earnings_date_when_relevant").value is None
     assert result.outputs.get("front_iv").value == Decimal("0.48")
     assert len(result.outputs.get("structures").value) == 2
 
     rejected_context = ComponentValues(
         tuple(
-            (name, value) for name, value in execution_context.entries if name != "eligibility.left"
+            (name, value)
+            for name, value in execution_context.entries
+            if name != "eligibility.earnings_eligible"
         )
         + (
             (
-                "eligibility.left",
+                "eligibility.earnings_eligible",
                 TypedValue(StrategyTypeReference("Boolean", "1.0.0"), False),
             ),
         )
@@ -427,9 +454,13 @@ def test_forward_factor_without_common_put_strike_returns_fail_not_exception() -
                 90,
             ),
             "factor.front_iv": (D, Decimal("0.48")),
-            "eligibility.left": (
+            "eligibility.earnings_eligible": (
                 StrategyTypeReference("Boolean", "1.0.0"),
                 True,
+            ),
+            "eligibility.confirmed_earnings_date": (
+                StrategyTypeReference("Optional", "1.0.0", (DATE,)),
+                None,
             ),
         }
     )
@@ -441,6 +472,8 @@ def test_forward_factor_without_common_put_strike_returns_fail_not_exception() -
 
     assert result.outputs.get("structures").value == ()
     assert result.outputs.get("liquidity_acceptable").value is False
+    assert result.outputs.get("structure_constructible_gate").value is False
+    assert result.outputs.get("liquidity_gate").value is False
     assert result.outputs.get("eligible").value is False
     assert result.outputs.get("verdict").value == "FAIL"
 

--- a/tests/strategies/test_stonk_production_validation.py
+++ b/tests/strategies/test_stonk_production_validation.py
@@ -31,6 +31,7 @@ from strategies import (
 from strategies.component_registry import ComponentRegistry
 from strategies.plugins import build_plugin_registry
 from strategies.stonk_components import (
+    DATE,
     DECIMAL_LIST,
     EARNINGS_EVENT,
     EXPIRATION_COLLECTION,
@@ -67,6 +68,8 @@ def _execution_context(manifest: StrategyManifest) -> ComponentValues:
         return context(
             **{
                 "event_window.event": (EARNINGS_EVENT, earnings_event()),
+                "event_projection.event": (EARNINGS_EVENT, earnings_event()),
+                "event_projection.as_of": (DATE, AS_OF),
                 "event_window.front": (EXPIRATION_CYCLE, front),
                 "event_window.back": (EXPIRATION_CYCLE, back),
                 "expiration_select.expirations": (
@@ -146,9 +149,13 @@ def _execution_context(manifest: StrategyManifest) -> ComponentValues:
                 "forward_iv.front_dte": (INTEGER, 60),
                 "forward_iv.back_dte": (INTEGER, 90),
                 "factor.front_iv": (D, Decimal("0.48")),
-                "eligibility.left": (
+                "eligibility.earnings_eligible": (
                     StrategyTypeReference("Boolean", "1.0.0"),
                     True,
+                ),
+                "eligibility.confirmed_earnings_date": (
+                    StrategyTypeReference("Optional", "1.0.0", (DATE,)),
+                    None,
                 ),
             }
         )

--- a/tests/strategies/test_strategy_library.py
+++ b/tests/strategies/test_strategy_library.py
@@ -28,7 +28,7 @@ def test_library_is_complete_ordered_and_identity_pinned() -> None:
         == StrategyLibrary(tuple(reversed(STONK_STRATEGY_MANIFESTS))).identity
     )
     assert STONK_STRATEGY_LIBRARY.identity == (
-        "9570359adb400ba0cd3f322d85e77d32278274ebe37109de9688f0721ab8b7e8"
+        "ae8abc2ff974116504d0d796761cc9655627d49420bc81191d20233dbf3a4ca3"
     )
 
 


### PR DESCRIPTION
## Ticket

S13-05 — Operator-readable strategy fields

## Summary

- projects Forward Factor hard gates, selected expirations, and relevant confirmed earnings date from manifest-owned outputs
- projects Earnings Calendar event date/countdown/timing, selected expirations, gap evidence, volume band, and explicit downgrade reason
- keeps generic explanation, API, and UI projection unchanged; no strategy-ID branches
- advances affected manifest, component, plugin, and strategy contract versions and repins deterministic identities

## Root cause

Canonical evidence and decisions already existed, but manifests exposed aggregate eligibility and collection identities instead of individual operator fields. Generic API therefore had nothing truthful to project.

## Architecture

- canonical facts -> derived facts -> strategy gates remains intact
- `days_to_earnings` uses registered analytics formula
- hard gates and downgrade reason remain strategy-owned
- no frontend/API calculations or provider policy

## Validation

- full pytest: 2638 passed, 17 skipped
- focused graph/projection tests: 52 passed
- Ruff changed files: passed
- Lean entrypoint and governance integrity: passed
- `git diff --check`: passed
- scoped mypy reports 12 pre-existing errors in untouched `strategies/calculations.py`, `strategies/registry.py`, and `strategies/__init__.py`; no new changed-file diagnostic

## Explicit exclusions

- no thresholds changed
- no strategy-specific API/UI branches
- no acquisition, persistence, provider, or deployment behavior

## Authority

SPRINT-013 delegation active via GOV-013 / Amendment 013. Auto-merge authorized after required gates pass.
