### PR TITLE
S13-08: modularity audit; dedupe option-leg liquidity gate

### DIFF
--- a/project/reports/SPRINT-013-S13-08-audit.md
+++ b/project/reports/SPRINT-013-S13-08-audit.md
@@ -1,0 +1,50 @@
+# SPRINT-013 S13-08 — Strategy Modularity and Core-Ownership Audit
+
+Scope: `strategies/`, `strategy_runtime/`, `screening/`, `analytics/`, `market_data/`, `asa/` (API projection). Inventory of significant operations, not a line-by-line sweep, per ticket scope.
+
+## Legacy system disambiguation
+
+`strategies/reference_strategy.py`, `strategies/registry.py` (`DEFAULT_REGISTRY`), and the `moving_average_crossover`/`breakout`/`momentum` demo strategies are **dead in the live path** — zero references from `screening/`, `asa/`, or `strategy_runtime/`; only referenced by `tests/architecture/test_strategy_boundaries.py` and `tests/strategies/*`. The live production path is `asa/` API routes → `strategy_runtime.service` → `strategy_runtime/adapters/*` → `screening.adapters.TARGET_STRATEGY_REGISTRY` + `screening.live_adapters`, backed by `strategies/stonk_manifests.py` and `strategies/stonk_components.py`. `tests/architecture/test_strategy_boundaries.py` only guards the dead demo path and does not cover the live strategy files at all — a coverage gap, not a defect, noted for S13-08 follow-up architecture-test work.
+
+## Findings
+
+| # | Location | Behavior | Classification | Action taken |
+|---|---|---|---|---|
+| 1 | `screening/live_adapters.py:110-117`, `screening/context_builders.py:44-53` vs `strategies/stonk_manifests.py` | Earnings Calendar / Forward Factor DTE-selection policy values are duplicated (deliberately, per an existing code comment) between `screening` and the frozen manifest parameters. | REMOVE_DUPLICATE, but the fix requires a queryable manifest-parameter accessor that does not exist today | **Not fixed.** Design decision needed (new manifest read API) — recorded as blocker below, not attempted as a bounded PR. |
+| 2 | `screening/live_adapters.py` (`LIVE_ADAPTER_FACTORIES`, the three `build_live_*_adapter` functions) | The nominally-generic `screening/` layer contains three complete strategy-specific acquisition/threshold/gate implementations keyed by strategy-id string literals, including hardcoded strategy-specific constants (e.g. `MAX_FORWARD_FACTOR_PAIR_ATTEMPTS`, a 20-session return window, a specific richness-formula citation). | UNKNOWN_REQUIRES_ARCHITECT_OR_FOUNDER | **Not fixed.** This is the sprint's largest structural finding — splitting generic acquisition mechanics (belongs in `screening`/`market_data`) from strategy-specific selection thresholds (belongs in each strategy's manifest/adapter) is a multi-file design decision, not a bounded move. Recorded as blocker below. |
+| 3 | `screening/live_adapters.py:663-676` | Skew Momentum's 25-delta option "wing" selection target is a hardcoded magic number with no declared owner — it is distinct from the vertical-structure delta targets that *are* manifest parameters. | UNKNOWN_REQUIRES_ARCHITECT_OR_FOUNDER | **Not fixed.** Needs a new manifest parameter slot; folded into finding #2's remediation rather than a standalone patch, since both live in the same file/decision. |
+| 4 | `strategies/stonk_components.py` — `SkewMomentumResearchDecision.evaluate()` inline multi-leg liquidity check vs `OptionLegLiquidity.evaluate()` | Identical quote-width/open-interest/volume gate math implemented twice: once as the reusable `OptionLegLiquidity` component, once inlined per-leg inside the Skew Momentum decision component. Violates "one owner per gate_primitive." | REMOVE_DUPLICATE | **Fixed.** Extracted to a shared pure helper `_contract_liquid()`; both components now call it. Behavior is bit-identical (same boolean expression, same short-circuiting) — no output or `algorithm_version` change. See PR below. |
+| 5 | `strategies/stonk_components.py` — `SkewMomentumResearchDecision.evaluate()` overall | Bullish/bearish core gates, momentum alignment, direction, verdict — all parameterized via `ParameterDefinition`s, no provider/DB/network/cache access. | KEEP_STRATEGY_POLICY | No action — correctly owned. |
+| 6 | `strategies/scoring.py` (`normalize_richness`) | Generic-looking bounded linear transform, imported by `screening/live_adapters.py`. Initially flagged by reconnaissance as misplaced (candidate `MOVE_CORE_ANALYTICS`). | KEEP_STRATEGY_POLICY (verified) | **No action — reconnaissance finding rejected on verification.** [SPRINT-012-PREFLIGHT.md](SPRINT-012-PREFLIGHT.md) explicitly records this as a deliberate SPRINT-012 decision to keep richness normalization as strategy/manifest-owned policy, not core analytics. Moving it would reverse a recorded prior architecture decision without Founder/architect sign-off. The real smell — `screening` importing from `strategies` at all — is a symptom of finding #2 and should be resolved together with it, not in isolation. |
+| 7 | `analytics/forward_factor.py` | Strategy-named filename, but contents (`compute_days_to_expiration`, `compute_option_implied_volatility`) are genuinely generic, capability-scoped facts, registered in `analytics/registry.py`. | Confirmed correctly placed | No action. |
+| 8 | `strategy_runtime/adapters/_screening_bridge.py` | Single shared, strategy-neutral `ScreeningResult → UniversalScreeningResult` translator, no strategy-ID branching. | Confirmed correctly placed | No action. |
+| 9 | `strategy_runtime/adapters/__init__.py`, `asa/scheduled_screening.py` | Strategy-id literals appear only as static composition-root wiring/config, not conditional branching inside generic logic. | Confirmed correctly placed | No action. |
+| 10 | `market_data/budget.py`, `market_data/fulfillment.py` | Never imported from `strategies/` (verified: zero `market_data` imports under `strategies/`). | Confirmed clean | No action. |
+| 11 | `strategy_runtime/adapters/{skew_momentum_vertical,forward_factor,earnings_calendar}.py` | Thin translation-only glue; no provider/DB/budget/cache objects leak into strategy-facing code. | Confirmed correctly placed | No action. |
+
+## Blockers raised (Founder/architect decision required)
+
+**Exact blocked action:** splitting `screening/live_adapters.py`'s per-strategy acquisition/threshold logic (findings #1, #2, #3) into (a) generic reusable acquisition mechanics owned by `screening`/`market_data`, and (b) strategy-specific selection thresholds owned by each strategy's manifest/adapter, including adding a queryable manifest-parameter read API that does not exist today.
+
+**Confirmed root cause:** `screening/live_adapters.py` was built as a single per-strategy implementation file during earlier sprints, before the S13-08 modularity rule existed; it now holds a mix of genuinely generic acquisition orchestration and strategy-specific policy (DTE windows, richness formula selection, the 25-delta skew wing target) with no boundary between them.
+
+**Why current authority/tools cannot resolve it:** this is a multi-file architectural split affecting three live production strategies simultaneously (Skew Momentum, Forward Factor, Earnings Calendar) and requires designing a new manifest-parameter accessor contract. Per `blocker_policy` and the S13-08 acceptance criteria, "broad refactor is not used as a substitute for evidence" — this is exactly the kind of change the ticket says must not be attempted speculatively.
+
+**Options:**
+- (a) Design a manifest-parameter read API now, then split `live_adapters.py` into generic + per-strategy-adapter-owned files, one bounded PR per strategy (3 PRs) plus one shared-mechanics PR. Highest correctness, highest effort/risk to 3 live strategies at once.
+- (b) Leave `live_adapters.py` as-is for this sprint, track as a named architecture debt item (new issue), and constrain S13-08 to the findings that were safely bounded (#4, done). Lowest risk, defers the structural fix.
+- (c) Split only the lowest-risk piece first (e.g. just the DTE-policy duplication in finding #1, once a minimal manifest read accessor exists) and leave the acquisition/threshold split for a dedicated future sprint.
+
+**Recommended option:** (c) — resolves the clearest duplicate-ownership violation (#1) without touching the higher-risk acquisition/threshold logic (#2, #3), and can be scoped as its own bounded ticket once a manifest read API is designed.
+
+**Smallest Founder action required:** decide whether to (i) accept option (c) and authorize a follow-up ticket to design the manifest-parameter read API, (ii) accept option (b) and have this tracked as a standing architecture-debt issue instead of sprint scope, or (iii) authorize the full split under option (a).
+
+**Work continuing in parallel:** S13-08's safely-bounded finding (#4) is fixed in this same PR; sprint execution continues to S13-02 without waiting on this blocker, per `blocker_policy.forbidden: stopping_unrelated_unblocked_work`.
+
+## Acceptance status
+
+- Concise audit matrix recorded: yes (this document).
+- Every remaining strategy operation justified as policy or composition: yes, per findings #5–#11.
+- Verified shared logic moved to correct core layer: finding #4 moved (dedup within `strategies/`, no cross-layer move was needed for this one).
+- No duplicate calculation/persistence path remains in touched scope: true for finding #4; findings #1–#3 remain open pending the blocker above.
+- Broad refactor not used as a substitute for evidence: confirmed — findings #1–#3 were deliberately *not* fixed speculatively.

--- a/strategies/stonk_components.py
+++ b/strategies/stonk_components.py
@@ -826,6 +826,31 @@ class ImpliedForwardVolatility(BaseComponent):
         return ComponentValues((("implied_forward_iv", TypedValue(D, forward_iv)),))
 
 
+def _contract_liquid(
+    contract: OptionContract,
+    maximum_spread: Decimal,
+    minimum_oi: int,
+    minimum_volume: int,
+) -> bool:
+    """Shared quote-width/open-interest/volume gate for a single leg contract."""
+
+    if (
+        contract.bid is None
+        or contract.ask is None
+        or contract.mark is None
+        or contract.mark <= 0
+        or contract.open_interest is None
+        or contract.volume is None
+    ):
+        return False
+    spread = (contract.ask - contract.bid) / contract.mark
+    return (
+        spread <= maximum_spread
+        and contract.open_interest >= minimum_oi
+        and contract.volume >= minimum_volume
+    )
+
+
 class OptionLegLiquidity(BaseComponent):
     """Evaluate quote width, open interest, and volume without deriving a mark."""
 
@@ -850,21 +875,7 @@ class OptionLegLiquidity(BaseComponent):
         minimum_volume = cast(int, _parameter(parameters, "minimum_volume", int))
         if maximum_spread < 0 or minimum_oi < 0 or minimum_volume < 0:
             raise ComponentContractError("liquidity thresholds cannot be negative")
-        liquid = False
-        if (
-            contract.bid is not None
-            and contract.ask is not None
-            and contract.mark is not None
-            and contract.mark > 0
-            and contract.open_interest is not None
-            and contract.volume is not None
-        ):
-            spread = (contract.ask - contract.bid) / contract.mark
-            liquid = (
-                spread <= maximum_spread
-                and contract.open_interest >= minimum_oi
-                and contract.volume >= minimum_volume
-            )
+        liquid = _contract_liquid(contract, maximum_spread, minimum_oi, minimum_volume)
         return ComponentValues((("liquid", TypedValue(B, liquid)),))
 
 
@@ -1327,16 +1338,7 @@ class SkewMomentumResearchDecision(BaseComponent):
         liquidity_acceptable = False
         if structure is not None:
             liquidity_acceptable = all(
-                leg.contract.bid is not None
-                and leg.contract.ask is not None
-                and leg.contract.mark is not None
-                and leg.contract.mark > 0
-                and (leg.contract.ask - leg.contract.bid) / leg.contract.mark
-                <= maximum_spread
-                and leg.contract.open_interest is not None
-                and leg.contract.open_interest >= minimum_oi
-                and leg.contract.volume is not None
-                and leg.contract.volume >= minimum_volume
+                _contract_liquid(leg.contract, maximum_spread, minimum_oi, minimum_volume)
                 for leg in structure.legs
             )
         mid_debit: Decimal | None = None


### PR DESCRIPTION
## Summary

SPRINT-013 S13-08 (strategy modularity / core-ownership audit), the mandatory
first workstream in v1.1's execution_order.

- Full audit matrix: [project/reports/SPRINT-013-S13-08-audit.md](../blob/s13-08-audit-and-liquidity-dedup/project/reports/SPRINT-013-S13-08-audit.md)
- Confirms the live production path (`strategy_runtime/adapters/*` +
  `strategies/stonk_manifests.py` + `strategies/stonk_components.py`) is
  correctly bounded to strategy policy/composition, with two exceptions.

## Fixed in this PR

`SkewMomentumResearchDecision.evaluate()` reimplemented `OptionLegLiquidity`'s
quote-width/open-interest/volume gate inline per leg instead of reusing the
already-registered component — a "one owner per gate_primitive" violation.
Extracted to a shared `_contract_liquid()` helper; both call sites now use
it. Output is bit-identical for identical inputs (same boolean expression,
same short-circuiting) — no `algorithm_version` change, no behavior change.

## Found, not fixed — recorded as a blocker

`screening/live_adapters.py` mixes generic acquisition orchestration with
strategy-specific thresholds (DTE policy duplicated from the manifests, an
unowned 25-delta skew "wing" target, strategy-id-keyed factory functions).
Splitting this touches three live strategies at once and needs a new
manifest-parameter read API — out of this ticket's bounded-PR scope per its
own rule against speculative broad refactors. Full detail, options, and
recommendation are in the audit report's "Blockers raised" section.

## Rejected reconnaissance finding

`strategies/scoring.py`'s `normalize_richness` looked like misplaced generic
math on first pass, but `project/reports/SPRINT-012-PREFLIGHT.md` records it
as a deliberate SPRINT-012 decision to keep richness normalization
strategy-owned. Left as-is rather than reversing a recorded architecture
decision without sign-off.

## Validation

- `tests/strategies/test_stonk_components.py`,
  `tests/strategies/test_stonk_manifests.py`,
  `tests/screening/test_adapters.py`: pass (targeted, changed-behavior scope).
- Full `validate-architecture.yml` scope (architecture, domain, observation,
  providers, reconciliation, facts, indicators, strategies, guardrails,
  ranking, position_proposals, portfolio, execution_planning,
  strategy_runtime, screening, analytics): **1660 passed, 0 failed.**
- `ruff check strategies/stonk_components.py`: clean.
- `git diff --check`: clean.
- Secret scan: no repo tool exists (noted as a gap, out of this ticket's
  scope); manually reviewed diff — pure boolean-logic refactor, no
  credentials/config/payloads touched.
- `mypy_asa_passes`: not applicable to this file (`strategies.*` is
  `follow_imports = "skip"` in `pyproject.toml`'s mypy config); local mypy
  run was also blocked by an unrelated environment gap (Python 3.14 on this
  machine vs the project's `<3.13` pin, so `pydantic` isn't installable
  here) — noted for transparency, not a finding against this PR.
- `governance_integrity` / `lean_entrypoint` gates: not applicable (no
  `governance/`, `project/roles/`, or `tools/pos/` files touched).

## Self-review

- Facts/derived-facts/strategy-policy boundaries preserved.
- No threshold or provider-priority change.
- Deterministic outputs and `algorithm_version` accounting preserved.
- Constitution and frozen governance unchanged.

## Sprint continuity

Per SPRINT-013 v1.1 `execution_order.mandatory_sequence`, S13-02 is next.