### PR TITLE
S13-02a: durable attempt contract, normalized outcomes, cycle/pair identity

### DIFF
--- a/market_data/attempts.py
+++ b/market_data/attempts.py
@@ -1,0 +1,169 @@
+"""Durable, provider-neutral acquisition attempt records (SPRINT-013 S13-02).
+
+market_data owns the attempt contract and the normalized outcome vocabulary.
+Persistence, cycle/pair identity, and query surfaces are owned elsewhere
+(asa/integrations, screening, asa/market_data_ops respectively) -- this
+module only defines the shape and the pure projection from an already-
+computed CapabilityFulfillmentResult.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from domain import MarketCapability
+from domain.values import DomainInvariantError, require_tz_aware
+from market_data.fulfillment import CapabilityFulfillmentResult, FulfillmentStatus
+from market_data.providers import ProviderErrorCode
+
+
+class AcquisitionOutcome(str, Enum):
+    """SPRINT-013 S13-02's closed, provider-neutral outcome vocabulary."""
+
+    SUCCESS = "success"
+    UPSTREAM_RATE_LIMITED = "upstream_rate_limited"
+    LOCAL_QUOTA_EXHAUSTED = "local_quota_exhausted"
+    EMPTY_PAYLOAD = "empty_payload"
+    NO_MATCHING_DATA = "no_matching_data"
+    STALE_DATA = "stale_data"
+    INCOMPLETE_DATA = "incomplete_data"
+    MALFORMED_PAYLOAD = "malformed_payload"
+    ENTITLEMENT_UNAVAILABLE = "entitlement_unavailable"
+    TRANSPORT_FAILURE = "transport_failure"
+    FALLBACK_EXHAUSTED = "fallback_exhausted"
+
+
+# Closed fold from the wider 17-value ProviderErrorCode vocabulary onto
+# S13-02's 11-value normalized outcome list. Several source codes share a
+# bucket by design; see project/reports/SPRINT-013-S13-02-notes.md for the
+# per-code rationale on the ambiguous folds (auth/entitlement grouped
+# together, and the internal-defect-shaped codes folded into
+# transport_failure since none of the 11 buckets fit them precisely).
+_OUTCOME_BY_ERROR_CODE: dict[ProviderErrorCode, AcquisitionOutcome] = {
+    ProviderErrorCode.RATE_LIMITED: AcquisitionOutcome.UPSTREAM_RATE_LIMITED,
+    ProviderErrorCode.QUOTA_EXHAUSTED: AcquisitionOutcome.LOCAL_QUOTA_EXHAUSTED,
+    ProviderErrorCode.EMPTY_PAYLOAD: AcquisitionOutcome.EMPTY_PAYLOAD,
+    ProviderErrorCode.NO_DATA: AcquisitionOutcome.NO_MATCHING_DATA,
+    ProviderErrorCode.UNSUPPORTED_CAPABILITY: AcquisitionOutcome.NO_MATCHING_DATA,
+    ProviderErrorCode.UNSUPPORTED_SYMBOL: AcquisitionOutcome.NO_MATCHING_DATA,
+    ProviderErrorCode.STALE_DATA: AcquisitionOutcome.STALE_DATA,
+    ProviderErrorCode.INCOMPLETE_DATA: AcquisitionOutcome.INCOMPLETE_DATA,
+    ProviderErrorCode.SCHEMA_MISMATCH: AcquisitionOutcome.MALFORMED_PAYLOAD,
+    ProviderErrorCode.ENTITLEMENT_MISSING: AcquisitionOutcome.ENTITLEMENT_UNAVAILABLE,
+    ProviderErrorCode.AUTHORIZATION_FAILED: AcquisitionOutcome.ENTITLEMENT_UNAVAILABLE,
+    ProviderErrorCode.AUTHENTICATION_FAILED: AcquisitionOutcome.ENTITLEMENT_UNAVAILABLE,
+    ProviderErrorCode.TIMEOUT: AcquisitionOutcome.TRANSPORT_FAILURE,
+    ProviderErrorCode.PROVIDER_UNAVAILABLE: AcquisitionOutcome.TRANSPORT_FAILURE,
+    ProviderErrorCode.TRANSPORT_ERROR: AcquisitionOutcome.TRANSPORT_FAILURE,
+    ProviderErrorCode.CONFIGURATION_ERROR: AcquisitionOutcome.TRANSPORT_FAILURE,
+    ProviderErrorCode.INVALID_REQUEST: AcquisitionOutcome.TRANSPORT_FAILURE,
+    ProviderErrorCode.UNKNOWN_PROVIDER_ERROR: AcquisitionOutcome.TRANSPORT_FAILURE,
+}
+
+
+def normalize_acquisition_outcome(error_code: ProviderErrorCode | None) -> AcquisitionOutcome:
+    """Fold a single attempt's provider error code onto the closed S13-02
+    outcome vocabulary. ``None`` (no error) always means the attempt
+    succeeded. ``FALLBACK_EXHAUSTED`` is never returned here -- it is a
+    pair-evaluation-level signal, see ``summary_outcome_for``.
+    """
+    if error_code is None:
+        return AcquisitionOutcome.SUCCESS
+    return _OUTCOME_BY_ERROR_CODE[error_code]
+
+
+def summary_outcome_for(result: CapabilityFulfillmentResult) -> AcquisitionOutcome:
+    """The pair-evaluation-level acquisition outcome for one capability
+    request: SUCCESS if any candidate was fulfilled (whether the primary
+    provider or a fallback), FALLBACK_EXHAUSTED if every candidate failed.
+
+    Individual attempt rows already carry ``fulfillment_status``
+    (FULFILLED/DEGRADED/FAILED), which distinguishes a primary-provider
+    success from a fallback-provider success; this function is the
+    fallback_success_and_failure_are_distinct signal at the request level.
+    """
+    if result.status is FulfillmentStatus.FAILED:
+        return AcquisitionOutcome.FALLBACK_EXHAUSTED
+    return AcquisitionOutcome.SUCCESS
+
+
+@dataclass(frozen=True, slots=True)
+class AcquisitionAttemptRecord:
+    """One durable, append-only record of a single provider fulfillment
+    attempt within one pair evaluation of one screening cycle.
+
+    Carries only safe, generic evidence -- no raw payloads, headers, or
+    credentials. ``safe_summary`` is the existing sanitized
+    NormalizedProviderError.safe_summary; nothing provider-internal is
+    added here.
+    """
+
+    screening_cycle_id: str
+    pair_evaluation_id: str
+    sequence: int
+    capability: MarketCapability
+    provider_id: str
+    priority: int
+    fulfillment_status: FulfillmentStatus
+    outcome: AcquisitionOutcome
+    retryable: bool
+    safe_summary: str | None
+    recorded_at: datetime
+
+    def __post_init__(self) -> None:
+        for name in ("screening_cycle_id", "pair_evaluation_id", "provider_id"):
+            value = getattr(self, name)
+            if not value or value != value.strip():
+                raise DomainInvariantError(f"AcquisitionAttemptRecord.{name} must be normalized")
+        if type(self.sequence) is not int or self.sequence < 0:
+            raise DomainInvariantError("AcquisitionAttemptRecord.sequence must be non-negative")
+        if type(self.priority) is not int or self.priority < 1:
+            raise DomainInvariantError("AcquisitionAttemptRecord.priority must be positive")
+        require_tz_aware(self.recorded_at, "AcquisitionAttemptRecord", "recorded_at")
+        if self.outcome is AcquisitionOutcome.SUCCESS and self.safe_summary is not None:
+            raise DomainInvariantError(
+                "AcquisitionAttemptRecord success attempts must not carry a safe_summary"
+            )
+        if self.outcome is not AcquisitionOutcome.SUCCESS and self.safe_summary is None:
+            raise DomainInvariantError(
+                "AcquisitionAttemptRecord failed attempts require a safe_summary"
+            )
+
+
+def attempt_records_for(
+    result: CapabilityFulfillmentResult,
+    *,
+    screening_cycle_id: str,
+    pair_evaluation_id: str,
+    recorded_at: datetime,
+    sequence_offset: int = 0,
+) -> tuple[AcquisitionAttemptRecord, ...]:
+    """Project one CapabilityFulfillmentResult's attempt evidence into
+    durable, append-only attempt records, deterministically ordered by
+    attempt sequence within the pair evaluation (matching
+    ``result.attempts`` order, which ``CapabilityFulfillmentService``
+    already produces deterministically).
+    """
+    records: list[AcquisitionAttemptRecord] = []
+    for offset, attempt in enumerate(result.attempts):
+        outcome = normalize_acquisition_outcome(
+            attempt.error.code if attempt.error is not None else None
+        )
+        records.append(
+            AcquisitionAttemptRecord(
+                screening_cycle_id=screening_cycle_id,
+                pair_evaluation_id=pair_evaluation_id,
+                sequence=sequence_offset + offset,
+                capability=result.request.capability,
+                provider_id=attempt.provider_id,
+                priority=attempt.priority,
+                fulfillment_status=result.status,
+                outcome=outcome,
+                retryable=attempt.error.retryable if attempt.error is not None else False,
+                safe_summary=attempt.error.safe_summary if attempt.error is not None else None,
+                recorded_at=recorded_at,
+            )
+        )
+    return tuple(records)

--- a/market_data/attempts.py
+++ b/market_data/attempts.py
@@ -97,7 +97,11 @@ class AcquisitionAttemptRecord:
     Carries only safe, generic evidence -- no raw payloads, headers, or
     credentials. ``safe_summary`` is the existing sanitized
     NormalizedProviderError.safe_summary; nothing provider-internal is
-    added here.
+    added here. The outcome fold is diagnostically lossless: ``outcome``
+    is the aggregate S13-02 bucket (useful for reporting/summaries), and
+    ``diagnostic_code`` is always the original, still-safe ProviderErrorCode
+    it was folded from -- root-cause analysis never has to guess which of
+    several folded codes actually happened.
     """
 
     screening_cycle_id: str
@@ -108,6 +112,7 @@ class AcquisitionAttemptRecord:
     priority: int
     fulfillment_status: FulfillmentStatus
     outcome: AcquisitionOutcome
+    diagnostic_code: ProviderErrorCode | None
     retryable: bool
     safe_summary: str | None
     recorded_at: datetime
@@ -122,14 +127,24 @@ class AcquisitionAttemptRecord:
         if type(self.priority) is not int or self.priority < 1:
             raise DomainInvariantError("AcquisitionAttemptRecord.priority must be positive")
         require_tz_aware(self.recorded_at, "AcquisitionAttemptRecord", "recorded_at")
-        if self.outcome is AcquisitionOutcome.SUCCESS and self.safe_summary is not None:
-            raise DomainInvariantError(
-                "AcquisitionAttemptRecord success attempts must not carry a safe_summary"
-            )
-        if self.outcome is not AcquisitionOutcome.SUCCESS and self.safe_summary is None:
-            raise DomainInvariantError(
-                "AcquisitionAttemptRecord failed attempts require a safe_summary"
-            )
+        if self.outcome is AcquisitionOutcome.SUCCESS:
+            if self.safe_summary is not None or self.diagnostic_code is not None:
+                raise DomainInvariantError(
+                    "AcquisitionAttemptRecord success attempts must not carry "
+                    "a safe_summary or diagnostic_code"
+                )
+        else:
+            if self.safe_summary is None or self.diagnostic_code is None:
+                raise DomainInvariantError(
+                    "AcquisitionAttemptRecord failed attempts require both a "
+                    "safe_summary and a diagnostic_code -- the normalized outcome "
+                    "fold must stay diagnostically lossless"
+                )
+            if normalize_acquisition_outcome(self.diagnostic_code) is not self.outcome:
+                raise DomainInvariantError(
+                    "AcquisitionAttemptRecord.diagnostic_code must fold onto "
+                    "the record's own outcome"
+                )
 
 
 def attempt_records_for(
@@ -148,9 +163,8 @@ def attempt_records_for(
     """
     records: list[AcquisitionAttemptRecord] = []
     for offset, attempt in enumerate(result.attempts):
-        outcome = normalize_acquisition_outcome(
-            attempt.error.code if attempt.error is not None else None
-        )
+        error_code = attempt.error.code if attempt.error is not None else None
+        outcome = normalize_acquisition_outcome(error_code)
         records.append(
             AcquisitionAttemptRecord(
                 screening_cycle_id=screening_cycle_id,
@@ -161,6 +175,7 @@ def attempt_records_for(
                 priority=attempt.priority,
                 fulfillment_status=result.status,
                 outcome=outcome,
+                diagnostic_code=error_code,
                 retryable=attempt.error.retryable if attempt.error is not None else False,
                 safe_summary=attempt.error.safe_summary if attempt.error is not None else None,
                 recorded_at=recorded_at,

--- a/project/reports/SPRINT-013-S13-02-notes.md
+++ b/project/reports/SPRINT-013-S13-02-notes.md
@@ -1,0 +1,11 @@
+# SPRINT-013 S13-02 — Outcome Vocabulary Fold Notes
+
+`market_data/attempts.py`'s `AcquisitionOutcome` is the 11-value closed vocabulary the sprint defines. The existing `ProviderErrorCode` has 17 values, so 3 groupings are not 1-to-1. Recorded here for review, not silently decided:
+
+| Existing codes | Folded to | Rationale |
+|---|---|---|
+| `ENTITLEMENT_MISSING`, `AUTHORIZATION_FAILED`, `AUTHENTICATION_FAILED` | `entitlement_unavailable` | All three mean "we lack valid credentialed access to this capability from this provider" — distinct from a transient network problem. |
+| `TIMEOUT`, `PROVIDER_UNAVAILABLE`, `TRANSPORT_ERROR`, `CONFIGURATION_ERROR`, `INVALID_REQUEST`, `UNKNOWN_PROVIDER_ERROR` | `transport_failure` | The first three are literal transport-shaped failures. The last three (config/invalid-request/unknown) don't cleanly fit any of the 11 buckets — they're internal-defect-shaped, not data-availability-shaped — and are folded here as the closest available bucket ("we could not successfully complete a request/response cycle with this provider"), rather than adding a 12th value outside the ticket's defined vocabulary. If this masks a real distinction operators need (e.g. `CONFIGURATION_ERROR` should page differently than a genuine timeout), flag it and we'll add a dedicated bucket in a follow-up rather than silently living with the fold. |
+| `UNSUPPORTED_CAPABILITY`, `UNSUPPORTED_SYMBOL` | `no_matching_data` | Both mean "this provider has no data offering matching the request," which is exactly what `no_matching_data` already means for `NO_DATA`. |
+
+`fallback_exhausted` is never returned by the per-attempt mapping (`normalize_acquisition_outcome`) — no single attempt's own error code means "every candidate was exhausted." It's a pair-evaluation-level signal, computed by `summary_outcome_for(result)`: `FALLBACK_EXHAUSTED` when `CapabilityFulfillmentResult.status is FulfillmentStatus.FAILED`, `SUCCESS` otherwise. `fulfillment_status` (FULFILLED/DEGRADED/FAILED) is persisted on every attempt record, which is what actually satisfies `fallback_success_and_failure_are_distinct` — DEGRADED means a fallback candidate succeeded, FAILED means fallback was exhausted.

--- a/project/reports/SPRINT-013-S13-02-notes.md
+++ b/project/reports/SPRINT-013-S13-02-notes.md
@@ -9,3 +9,16 @@
 | `UNSUPPORTED_CAPABILITY`, `UNSUPPORTED_SYMBOL` | `no_matching_data` | Both mean "this provider has no data offering matching the request," which is exactly what `no_matching_data` already means for `NO_DATA`. |
 
 `fallback_exhausted` is never returned by the per-attempt mapping (`normalize_acquisition_outcome`) — no single attempt's own error code means "every candidate was exhausted." It's a pair-evaluation-level signal, computed by `summary_outcome_for(result)`: `FALLBACK_EXHAUSTED` when `CapabilityFulfillmentResult.status is FulfillmentStatus.FAILED`, `SUCCESS` otherwise. `fulfillment_status` (FULFILLED/DEGRADED/FAILED) is persisted on every attempt record, which is what actually satisfies `fallback_success_and_failure_are_distinct` — DEGRADED means a fallback candidate succeeded, FAILED means fallback was exhausted.
+
+## Diagnostic losslessness (Founder review, added after initial draft)
+
+The aggregate `AcquisitionOutcome` fold above is useful for reporting and dashboards, but folding e.g. `TIMEOUT`/`PROVIDER_UNAVAILABLE`/`TRANSPORT_ERROR`/`CONFIGURATION_ERROR`/`INVALID_REQUEST`/`UNKNOWN_PROVIDER_ERROR` all onto `transport_failure` would erase the specific cause needed for root-cause analysis if that were the only thing persisted. `AcquisitionAttemptRecord` therefore always carries both: `outcome` (the aggregate bucket) and `diagnostic_code` (the original `ProviderErrorCode` it was folded from — still a safe, closed, generic enum, not raw exception text). A record's `__post_init__` enforces that `diagnostic_code` is present iff `outcome is not SUCCESS`, and that it actually folds onto the record's own `outcome` (can't attach a mismatched pair). Nothing is lost; the aggregate is additive, not a replacement.
+
+## Cycle identity (Founder review, added after initial draft)
+
+The original draft derived `screening_cycle_id` from raw wall-clock time alone. Replaced with a deterministic hash of a canonical `(invocation_type, slot_id, scope_id)` tuple:
+- `slot_id`: for scheduled runs, the existing `ScheduledRefreshSlot.slot_id` (`market_data/session_schedule.py`) — itself already a deterministic hash of `(session_date, ordinal, scheduled_at)`. For manual/on-demand runs with no schedule slot, `manual_invocation_slot_id(now)` substitutes a UTC-normalized-then-hashed timestamp — never used alone, always as one component of the tuple.
+- `scope_id`: `scope_identity(universe)`, an order-independent hash of the (strategy_id, subject) pairs the cycle covers.
+- `invocation_type`: caller-supplied (e.g. `"scheduled"` vs `"manual"`), so two overlapping invocations of different kinds over the same slot/scope can never collide.
+
+Same tuple always yields the same `cycle_id` — reprocessing the same due slot (e.g. after a claim-repository retry) is therefore idempotent at the cycle level, which is a deliberate property, not an accident. `pair_evaluation_id` stays a readable composite of `cycle_id:strategy_id:subject_identity` (not hashed) for operator/query readability; `:` is rejected in every component so two distinct pairs can never collide onto the same composite string.

--- a/screening/cycle_identity.py
+++ b/screening/cycle_identity.py
@@ -1,0 +1,34 @@
+"""Screening-cycle and pair-evaluation identity (SPRINT-013 S13-02).
+
+screening owns minting this identity; it does not own persistence (that is
+asa/integrations), the attempt contract (market_data), or query surfaces
+(asa/market_data_ops). A cycle spans one scheduled-refresh invocation across
+every (signal_id, symbol) pair; a pair evaluation is one (signal_id, symbol)
+iteration within that cycle.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from domain.values import require_tz_aware
+
+
+def new_screening_cycle_id(now: datetime) -> str:
+    """Identity for one scheduled-refresh invocation, derived from its
+    caller-supplied start time rather than uuid/random -- screening/'s own
+    architecture boundary (SCREEN-002, test_screening_boundaries.py)
+    forbids non-deterministic sources so cycles stay replayable.
+    """
+    require_tz_aware(now, "new_screening_cycle_id", "now")
+    return f"cycle_{now.strftime('%Y%m%dT%H%M%S%f')}Z"
+
+
+def pair_evaluation_id(screening_cycle_id: str, signal_id: str, symbol: str) -> str:
+    """Deterministic identity for one (signal_id, symbol) evaluation within
+    a cycle -- a pure composite key, already unique per cycle (each pair is
+    evaluated at most once per cycle) and reproducible for tests/replay.
+    """
+    if not screening_cycle_id or not signal_id or not symbol:
+        raise ValueError("pair_evaluation_id requires non-empty cycle, signal, and symbol")
+    return f"{screening_cycle_id}:{signal_id}:{symbol}"

--- a/screening/cycle_identity.py
+++ b/screening/cycle_identity.py
@@ -3,32 +3,81 @@
 screening owns minting this identity; it does not own persistence (that is
 asa/integrations), the attempt contract (market_data), or query surfaces
 (asa/market_data_ops). A cycle spans one scheduled-refresh invocation across
-every (signal_id, symbol) pair; a pair evaluation is one (signal_id, symbol)
-iteration within that cycle.
+every (strategy_id, subject) pair; a pair evaluation is one
+(strategy_id, subject) iteration within that cycle.
+
+Cycle identity is never derived from raw wall-clock time alone -- it is a
+deterministic hash of a canonical (invocation_type, slot_id, scope_id)
+tuple, so re-processing the same due schedule slot (e.g. after a retry)
+yields the identical cycle_id (idempotent at the cycle level), and
+overlapping invocations of different kinds (e.g. a scheduled run and a
+concurrent manual run) can never collide, because invocation_type is part
+of the hashed tuple.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
+import hashlib
+from datetime import UTC, datetime
 
 from domain.values import require_tz_aware
 
 
-def new_screening_cycle_id(now: datetime) -> str:
-    """Identity for one scheduled-refresh invocation, derived from its
-    caller-supplied start time rather than uuid/random -- screening/'s own
-    architecture boundary (SCREEN-002, test_screening_boundaries.py)
-    forbids non-deterministic sources so cycles stay replayable.
-    """
-    require_tz_aware(now, "new_screening_cycle_id", "now")
-    return f"cycle_{now.strftime('%Y%m%dT%H%M%S%f')}Z"
+def _require_normalized(value: str, owner: str, field_name: str) -> None:
+    if not value or value != value.strip():
+        raise ValueError(f"{owner} requires a non-empty normalized {field_name}")
+    if ":" in value:
+        raise ValueError(f"{owner} {field_name} must not contain ':' (used as a key separator)")
 
 
-def pair_evaluation_id(screening_cycle_id: str, signal_id: str, symbol: str) -> str:
-    """Deterministic identity for one (signal_id, symbol) evaluation within
-    a cycle -- a pure composite key, already unique per cycle (each pair is
-    evaluated at most once per cycle) and reproducible for tests/replay.
+def scope_identity(universe: tuple[tuple[str, str], ...]) -> str:
+    """Deterministic, order-independent identity for a screening universe
+    (the set of (strategy_id, subject) pairs one cycle covers). Two calls
+    with the same pairs in any order return the same scope id.
     """
-    if not screening_cycle_id or not signal_id or not symbol:
-        raise ValueError("pair_evaluation_id requires non-empty cycle, signal, and symbol")
-    return f"{screening_cycle_id}:{signal_id}:{symbol}"
+    if not universe:
+        raise ValueError("scope_identity requires a non-empty universe")
+    payload = ",".join(sorted(f"{strategy_id}:{subject}" for strategy_id, subject in universe))
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def manual_invocation_slot_id(now: datetime) -> str:
+    """A slot substitute for invocations with no ScheduledRefreshSlot (a
+    manual or on-demand run outside the exchange-calendar schedule).
+    Timezone-normalized to UTC before hashing, so the same instant always
+    yields the same id regardless of the caller's tzinfo representation.
+    Never used alone as a cycle_id -- only as one component of the
+    (invocation_type, slot_id, scope_id) tuple new_screening_cycle_id hashes.
+    """
+    require_tz_aware(now, "manual_invocation_slot_id", "now")
+    normalized = now.astimezone(UTC).isoformat()
+    return f"manual_{hashlib.sha256(normalized.encode()).hexdigest()[:16]}"
+
+
+def new_screening_cycle_id(*, invocation_type: str, slot_id: str, scope_id: str) -> str:
+    """Deterministic identity for one screening cycle, derived from a
+    canonical (invocation_type, slot_id, scope_id) tuple. The same tuple
+    always yields the same cycle_id.
+    """
+    for name, value in (
+        ("invocation_type", invocation_type),
+        ("slot_id", slot_id),
+        ("scope_id", scope_id),
+    ):
+        _require_normalized(value, "new_screening_cycle_id", name)
+    payload = f"{invocation_type}:{slot_id}:{scope_id}"
+    return f"cycle_{hashlib.sha256(payload.encode()).hexdigest()}"
+
+
+def pair_evaluation_id(screening_cycle_id: str, strategy_id: str, subject_identity: str) -> str:
+    """Deterministic identity for one (strategy_id, subject) evaluation
+    within a cycle -- a pure composite key, already unique per cycle (each
+    pair is evaluated at most once per cycle) and reproducible for
+    tests/replay. ``:`` is rejected in the components (not just the cycle
+    id, which is itself a fixed-format hash) so two distinct pairs can
+    never collide onto the same composite string.
+    """
+    _require_normalized(screening_cycle_id, "pair_evaluation_id", "screening_cycle_id")
+    _require_normalized(strategy_id, "pair_evaluation_id", "strategy_id")
+    _require_normalized(subject_identity, "pair_evaluation_id", "subject_identity")
+    return f"{screening_cycle_id}:{strategy_id}:{subject_identity}"

--- a/tests/market_data/test_attempts.py
+++ b/tests/market_data/test_attempts.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from domain.values import DomainInvariantError
+from market_data import FulfillmentStatus, ProviderErrorCode
+from market_data.attempts import (
+    AcquisitionAttemptRecord,
+    AcquisitionOutcome,
+    attempt_records_for,
+    normalize_acquisition_outcome,
+    summary_outcome_for,
+)
+from tests.market_data.test_fulfillment import (
+    CAPABILITY,
+    FixtureScenario,
+    provider,
+    request,
+    service,
+)
+
+RECORDED_AT = datetime(2026, 7, 21, 16, 0, tzinfo=UTC)
+
+
+def test_normalize_acquisition_outcome_success_is_none_error() -> None:
+    assert normalize_acquisition_outcome(None) is AcquisitionOutcome.SUCCESS
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        (ProviderErrorCode.RATE_LIMITED, AcquisitionOutcome.UPSTREAM_RATE_LIMITED),
+        (ProviderErrorCode.QUOTA_EXHAUSTED, AcquisitionOutcome.LOCAL_QUOTA_EXHAUSTED),
+        (ProviderErrorCode.EMPTY_PAYLOAD, AcquisitionOutcome.EMPTY_PAYLOAD),
+        (ProviderErrorCode.NO_DATA, AcquisitionOutcome.NO_MATCHING_DATA),
+        (ProviderErrorCode.UNSUPPORTED_CAPABILITY, AcquisitionOutcome.NO_MATCHING_DATA),
+        (ProviderErrorCode.UNSUPPORTED_SYMBOL, AcquisitionOutcome.NO_MATCHING_DATA),
+        (ProviderErrorCode.STALE_DATA, AcquisitionOutcome.STALE_DATA),
+        (ProviderErrorCode.INCOMPLETE_DATA, AcquisitionOutcome.INCOMPLETE_DATA),
+        (ProviderErrorCode.SCHEMA_MISMATCH, AcquisitionOutcome.MALFORMED_PAYLOAD),
+        (ProviderErrorCode.ENTITLEMENT_MISSING, AcquisitionOutcome.ENTITLEMENT_UNAVAILABLE),
+        (ProviderErrorCode.AUTHORIZATION_FAILED, AcquisitionOutcome.ENTITLEMENT_UNAVAILABLE),
+        (ProviderErrorCode.AUTHENTICATION_FAILED, AcquisitionOutcome.ENTITLEMENT_UNAVAILABLE),
+        (ProviderErrorCode.TIMEOUT, AcquisitionOutcome.TRANSPORT_FAILURE),
+        (ProviderErrorCode.PROVIDER_UNAVAILABLE, AcquisitionOutcome.TRANSPORT_FAILURE),
+        (ProviderErrorCode.TRANSPORT_ERROR, AcquisitionOutcome.TRANSPORT_FAILURE),
+        (ProviderErrorCode.CONFIGURATION_ERROR, AcquisitionOutcome.TRANSPORT_FAILURE),
+        (ProviderErrorCode.INVALID_REQUEST, AcquisitionOutcome.TRANSPORT_FAILURE),
+        (ProviderErrorCode.UNKNOWN_PROVIDER_ERROR, AcquisitionOutcome.TRANSPORT_FAILURE),
+    ],
+)
+def test_normalize_acquisition_outcome_covers_every_provider_error_code(code, expected) -> None:
+    assert normalize_acquisition_outcome(code) is expected
+
+
+def test_every_provider_error_code_is_mapped() -> None:
+    for code in ProviderErrorCode:
+        # Must not raise KeyError -- every code has a bucket.
+        normalize_acquisition_outcome(code)
+
+
+def test_attempt_record_requires_summary_iff_not_success() -> None:
+    with pytest.raises(DomainInvariantError):
+        AcquisitionAttemptRecord(
+            "cycle_1", "cycle_1:s:AAPL", 0, CAPABILITY, "primary", 1,
+            FulfillmentStatus.FULFILLED, AcquisitionOutcome.SUCCESS, False,
+            "unexpected summary", RECORDED_AT,
+        )
+    with pytest.raises(DomainInvariantError):
+        AcquisitionAttemptRecord(
+            "cycle_1", "cycle_1:s:AAPL", 0, CAPABILITY, "primary", 1,
+            FulfillmentStatus.FAILED, AcquisitionOutcome.TRANSPORT_FAILURE, True,
+            None, RECORDED_AT,
+        )
+
+
+def test_attempt_records_for_success_result_is_single_record() -> None:
+    fulfillment, _ = service(provider("primary"))
+    result = fulfillment.fulfill(request())
+    records = attempt_records_for(
+        result,
+        screening_cycle_id="cycle_1",
+        pair_evaluation_id="cycle_1:forward_factor:AAPL",
+        recorded_at=RECORDED_AT,
+    )
+    assert len(records) == 1
+    assert records[0].outcome is AcquisitionOutcome.SUCCESS
+    assert records[0].fulfillment_status is FulfillmentStatus.FULFILLED
+    assert records[0].sequence == 0
+    assert records[0].safe_summary is None
+    assert summary_outcome_for(result) is AcquisitionOutcome.SUCCESS
+
+
+def test_attempt_records_for_degraded_result_preserves_order_and_fallback_success() -> None:
+    primary = provider(
+        "primary", FixtureScenario(failures=((CAPABILITY, ProviderErrorCode.TIMEOUT),))
+    )
+    fulfillment, _ = service(primary, provider("secondary"))
+    result = fulfillment.fulfill(request())
+    records = attempt_records_for(
+        result,
+        screening_cycle_id="cycle_1",
+        pair_evaluation_id="cycle_1:forward_factor:AAPL",
+        recorded_at=RECORDED_AT,
+    )
+    assert len(records) == 2
+    assert [item.sequence for item in records] == [0, 1]
+    assert records[0].provider_id == "primary"
+    assert records[0].outcome is AcquisitionOutcome.TRANSPORT_FAILURE
+    assert records[0].fulfillment_status is FulfillmentStatus.DEGRADED
+    assert records[0].safe_summary is not None
+    assert records[1].provider_id == "secondary"
+    assert records[1].outcome is AcquisitionOutcome.SUCCESS
+    assert records[1].fulfillment_status is FulfillmentStatus.DEGRADED
+    # Fallback succeeded (DEGRADED), distinct from fallback exhausted (FAILED).
+    assert summary_outcome_for(result) is AcquisitionOutcome.SUCCESS
+
+
+def test_attempt_records_for_failed_result_is_fallback_exhausted() -> None:
+    failed = FixtureScenario(failures=((CAPABILITY, ProviderErrorCode.NO_DATA),))
+    fulfillment, _ = service(provider("primary", failed), provider("secondary", failed))
+    result = fulfillment.fulfill(request(), required=False)
+    records = attempt_records_for(
+        result,
+        screening_cycle_id="cycle_1",
+        pair_evaluation_id="cycle_1:forward_factor:AAPL",
+        recorded_at=RECORDED_AT,
+    )
+    assert len(records) == 2
+    assert all(item.fulfillment_status is FulfillmentStatus.FAILED for item in records)
+    assert all(item.outcome is AcquisitionOutcome.NO_MATCHING_DATA for item in records)
+    assert summary_outcome_for(result) is AcquisitionOutcome.FALLBACK_EXHAUSTED
+
+
+def test_attempt_records_for_sequence_offset_continues_across_capabilities() -> None:
+    fulfillment, _ = service(provider("primary"))
+    result = fulfillment.fulfill(request())
+    records = attempt_records_for(
+        result,
+        screening_cycle_id="cycle_1",
+        pair_evaluation_id="cycle_1:forward_factor:AAPL",
+        recorded_at=RECORDED_AT,
+        sequence_offset=3,
+    )
+    assert records[0].sequence == 3

--- a/tests/market_data/test_attempts.py
+++ b/tests/market_data/test_attempts.py
@@ -61,18 +61,40 @@ def test_every_provider_error_code_is_mapped() -> None:
         normalize_acquisition_outcome(code)
 
 
-def test_attempt_record_requires_summary_iff_not_success() -> None:
+def test_attempt_record_requires_summary_and_diagnostic_code_iff_not_success() -> None:
     with pytest.raises(DomainInvariantError):
         AcquisitionAttemptRecord(
             "cycle_1", "cycle_1:s:AAPL", 0, CAPABILITY, "primary", 1,
-            FulfillmentStatus.FULFILLED, AcquisitionOutcome.SUCCESS, False,
+            FulfillmentStatus.FULFILLED, AcquisitionOutcome.SUCCESS, None, False,
             "unexpected summary", RECORDED_AT,
         )
     with pytest.raises(DomainInvariantError):
         AcquisitionAttemptRecord(
             "cycle_1", "cycle_1:s:AAPL", 0, CAPABILITY, "primary", 1,
-            FulfillmentStatus.FAILED, AcquisitionOutcome.TRANSPORT_FAILURE, True,
-            None, RECORDED_AT,
+            FulfillmentStatus.FULFILLED, AcquisitionOutcome.SUCCESS,
+            ProviderErrorCode.TIMEOUT, False, None, RECORDED_AT,
+        )
+    with pytest.raises(DomainInvariantError):
+        AcquisitionAttemptRecord(
+            "cycle_1", "cycle_1:s:AAPL", 0, CAPABILITY, "primary", 1,
+            FulfillmentStatus.FAILED, AcquisitionOutcome.TRANSPORT_FAILURE, None, True,
+            "a summary but no diagnostic code", RECORDED_AT,
+        )
+    with pytest.raises(DomainInvariantError):
+        AcquisitionAttemptRecord(
+            "cycle_1", "cycle_1:s:AAPL", 0, CAPABILITY, "primary", 1,
+            FulfillmentStatus.FAILED, AcquisitionOutcome.TRANSPORT_FAILURE,
+            ProviderErrorCode.TIMEOUT, True, None, RECORDED_AT,
+        )
+
+
+def test_attempt_record_rejects_diagnostic_code_that_does_not_fold_onto_outcome() -> None:
+    with pytest.raises(DomainInvariantError):
+        AcquisitionAttemptRecord(
+            "cycle_1", "cycle_1:s:AAPL", 0, CAPABILITY, "primary", 1,
+            FulfillmentStatus.FAILED, AcquisitionOutcome.TRANSPORT_FAILURE,
+            ProviderErrorCode.NO_DATA,  # folds to NO_MATCHING_DATA, not TRANSPORT_FAILURE
+            True, "mismatched diagnostic code", RECORDED_AT,
         )
 
 
@@ -90,6 +112,7 @@ def test_attempt_records_for_success_result_is_single_record() -> None:
     assert records[0].fulfillment_status is FulfillmentStatus.FULFILLED
     assert records[0].sequence == 0
     assert records[0].safe_summary is None
+    assert records[0].diagnostic_code is None
     assert summary_outcome_for(result) is AcquisitionOutcome.SUCCESS
 
 
@@ -109,10 +132,12 @@ def test_attempt_records_for_degraded_result_preserves_order_and_fallback_succes
     assert [item.sequence for item in records] == [0, 1]
     assert records[0].provider_id == "primary"
     assert records[0].outcome is AcquisitionOutcome.TRANSPORT_FAILURE
+    assert records[0].diagnostic_code is ProviderErrorCode.TIMEOUT
     assert records[0].fulfillment_status is FulfillmentStatus.DEGRADED
     assert records[0].safe_summary is not None
     assert records[1].provider_id == "secondary"
     assert records[1].outcome is AcquisitionOutcome.SUCCESS
+    assert records[1].diagnostic_code is None
     assert records[1].fulfillment_status is FulfillmentStatus.DEGRADED
     # Fallback succeeded (DEGRADED), distinct from fallback exhausted (FAILED).
     assert summary_outcome_for(result) is AcquisitionOutcome.SUCCESS
@@ -131,6 +156,7 @@ def test_attempt_records_for_failed_result_is_fallback_exhausted() -> None:
     assert len(records) == 2
     assert all(item.fulfillment_status is FulfillmentStatus.FAILED for item in records)
     assert all(item.outcome is AcquisitionOutcome.NO_MATCHING_DATA for item in records)
+    assert all(item.diagnostic_code is ProviderErrorCode.NO_DATA for item in records)
     assert summary_outcome_for(result) is AcquisitionOutcome.FALLBACK_EXHAUSTED
 
 

--- a/tests/screening/test_cycle_identity.py
+++ b/tests/screening/test_cycle_identity.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from domain.values import DomainInvariantError
+from screening.cycle_identity import new_screening_cycle_id, pair_evaluation_id
+
+NOW = datetime(2026, 7, 21, 16, 0, 0, 123456, tzinfo=UTC)
+
+
+def test_new_screening_cycle_id_is_deterministic_from_timestamp() -> None:
+    first = new_screening_cycle_id(NOW)
+    second = new_screening_cycle_id(NOW)
+    assert first == second
+    assert first.startswith("cycle_")
+
+
+def test_new_screening_cycle_id_differs_by_timestamp() -> None:
+    other = datetime(2026, 7, 21, 16, 0, 1, 123456, tzinfo=UTC)
+    assert new_screening_cycle_id(NOW) != new_screening_cycle_id(other)
+
+
+def test_new_screening_cycle_id_requires_tz_aware() -> None:
+    with pytest.raises(DomainInvariantError):
+        new_screening_cycle_id(datetime(2026, 7, 21, 16, 0))
+
+
+def test_pair_evaluation_id_is_deterministic() -> None:
+    cycle = new_screening_cycle_id(NOW)
+    first = pair_evaluation_id(cycle, "forward_factor", "AAPL")
+    second = pair_evaluation_id(cycle, "forward_factor", "AAPL")
+    assert first == second
+
+
+def test_pair_evaluation_id_differs_by_signal_and_symbol() -> None:
+    cycle = new_screening_cycle_id(NOW)
+    assert pair_evaluation_id(cycle, "forward_factor", "AAPL") != pair_evaluation_id(
+        cycle, "skew_momentum", "AAPL"
+    )
+    assert pair_evaluation_id(cycle, "forward_factor", "AAPL") != pair_evaluation_id(
+        cycle, "forward_factor", "MSFT"
+    )
+
+
+@pytest.mark.parametrize(
+    "cycle,signal_id,symbol",
+    [("", "forward_factor", "AAPL"), ("cycle_1", "", "AAPL"), ("cycle_1", "forward_factor", "")],
+)
+def test_pair_evaluation_id_rejects_empty_components(cycle, signal_id, symbol) -> None:
+    with pytest.raises(ValueError):
+        pair_evaluation_id(cycle, signal_id, symbol)

--- a/tests/screening/test_cycle_identity.py
+++ b/tests/screening/test_cycle_identity.py
@@ -1,41 +1,151 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 
-from domain.values import DomainInvariantError
-from screening.cycle_identity import new_screening_cycle_id, pair_evaluation_id
+from screening.cycle_identity import (
+    manual_invocation_slot_id,
+    new_screening_cycle_id,
+    pair_evaluation_id,
+    scope_identity,
+)
 
-NOW = datetime(2026, 7, 21, 16, 0, 0, 123456, tzinfo=UTC)
+UNIVERSE = (("forward_factor", "AAPL"), ("skew_momentum", "AAPL"), ("earnings_calendar", "MSFT"))
 
 
-def test_new_screening_cycle_id_is_deterministic_from_timestamp() -> None:
-    first = new_screening_cycle_id(NOW)
-    second = new_screening_cycle_id(NOW)
+# -- scope_identity -----------------------------------------------------
+
+
+def test_scope_identity_is_order_independent() -> None:
+    reversed_universe = tuple(reversed(UNIVERSE))
+    assert scope_identity(UNIVERSE) == scope_identity(reversed_universe)
+
+
+def test_scope_identity_differs_for_different_universes() -> None:
+    smaller = UNIVERSE[:-1]
+    assert scope_identity(UNIVERSE) != scope_identity(smaller)
+
+
+def test_scope_identity_rejects_empty_universe() -> None:
+    with pytest.raises(ValueError):
+        scope_identity(())
+
+
+# -- manual_invocation_slot_id (timezone normalization) ------------------
+
+
+def test_manual_invocation_slot_id_normalizes_timezone_representation() -> None:
+    utc_instant = datetime(2026, 7, 21, 20, 0, tzinfo=UTC)
+    same_instant_other_tz = utc_instant.astimezone(timezone(timedelta(hours=-4)))
+    # Same absolute instant, different tzinfo representation -- the raw
+    # isoformat() strings differ even though the instants are equal, which
+    # is exactly what would leak into the hash without astimezone(UTC)
+    # normalization first.
+    assert utc_instant.isoformat() != same_instant_other_tz.isoformat()
+    assert manual_invocation_slot_id(utc_instant) == manual_invocation_slot_id(
+        same_instant_other_tz
+    )
+
+
+def test_manual_invocation_slot_id_differs_for_different_instants() -> None:
+    first = datetime(2026, 7, 21, 20, 0, tzinfo=UTC)
+    second = datetime(2026, 7, 21, 20, 0, 1, tzinfo=UTC)
+    assert manual_invocation_slot_id(first) != manual_invocation_slot_id(second)
+
+
+def test_manual_invocation_slot_id_requires_tz_aware() -> None:
+    with pytest.raises(ValueError):
+        manual_invocation_slot_id(datetime(2026, 7, 21, 20, 0))
+
+
+# -- new_screening_cycle_id -----------------------------------------------
+
+
+def test_new_screening_cycle_id_is_deterministic_for_the_same_tuple() -> None:
+    scope = scope_identity(UNIVERSE)
+    first = new_screening_cycle_id(invocation_type="scheduled", slot_id="slot_abc", scope_id=scope)
+    second = new_screening_cycle_id(
+        invocation_type="scheduled", slot_id="slot_abc", scope_id=scope
+    )
     assert first == second
     assert first.startswith("cycle_")
 
 
-def test_new_screening_cycle_id_differs_by_timestamp() -> None:
-    other = datetime(2026, 7, 21, 16, 0, 1, 123456, tzinfo=UTC)
-    assert new_screening_cycle_id(NOW) != new_screening_cycle_id(other)
+def test_repeated_slot_reprocessing_is_idempotent_at_the_cycle_level() -> None:
+    """A retried scheduled slot (same slot_id, e.g. after a claim-repository
+    retry) must resolve to the same cycle_id as the original attempt."""
+    scope = scope_identity(UNIVERSE)
+    original = new_screening_cycle_id(
+        invocation_type="scheduled", slot_id="slot_2026-07-21-3", scope_id=scope
+    )
+    retried = new_screening_cycle_id(
+        invocation_type="scheduled", slot_id="slot_2026-07-21-3", scope_id=scope
+    )
+    assert original == retried
 
 
-def test_new_screening_cycle_id_requires_tz_aware() -> None:
-    with pytest.raises(DomainInvariantError):
-        new_screening_cycle_id(datetime(2026, 7, 21, 16, 0))
+def test_overlapping_invocation_types_never_collide() -> None:
+    """A scheduled run and a concurrent manual run over the same slot/scope
+    must never resolve to the same cycle_id."""
+    scope = scope_identity(UNIVERSE)
+    scheduled = new_screening_cycle_id(
+        invocation_type="scheduled", slot_id="slot_shared", scope_id=scope
+    )
+    manual = new_screening_cycle_id(invocation_type="manual", slot_id="slot_shared", scope_id=scope)
+    assert scheduled != manual
+
+
+def test_new_screening_cycle_id_collision_across_distinguishing_components() -> None:
+    scope_a = scope_identity(UNIVERSE)
+    scope_b = scope_identity(UNIVERSE[:-1])
+    base = new_screening_cycle_id(invocation_type="scheduled", slot_id="slot_1", scope_id=scope_a)
+    different_slot = new_screening_cycle_id(
+        invocation_type="scheduled", slot_id="slot_2", scope_id=scope_a
+    )
+    different_scope = new_screening_cycle_id(
+        invocation_type="scheduled", slot_id="slot_1", scope_id=scope_b
+    )
+    different_type = new_screening_cycle_id(
+        invocation_type="manual", slot_id="slot_1", scope_id=scope_a
+    )
+    assert len({base, different_slot, different_scope, different_type}) == 4
+
+
+@pytest.mark.parametrize(
+    "invocation_type,slot_id,scope_id",
+    [("", "slot_1", "scope_1"), ("scheduled", "", "scope_1"), ("scheduled", "slot_1", "")],
+)
+def test_new_screening_cycle_id_rejects_empty_components(
+    invocation_type, slot_id, scope_id
+) -> None:
+    with pytest.raises(ValueError):
+        new_screening_cycle_id(
+            invocation_type=invocation_type, slot_id=slot_id, scope_id=scope_id
+        )
+
+
+def test_new_screening_cycle_id_rejects_colon_in_components() -> None:
+    with pytest.raises(ValueError):
+        new_screening_cycle_id(invocation_type="sched:uled", slot_id="slot_1", scope_id="scope_1")
+
+
+# -- pair_evaluation_id -----------------------------------------------
 
 
 def test_pair_evaluation_id_is_deterministic() -> None:
-    cycle = new_screening_cycle_id(NOW)
+    cycle = new_screening_cycle_id(
+        invocation_type="scheduled", slot_id="slot_1", scope_id=scope_identity(UNIVERSE)
+    )
     first = pair_evaluation_id(cycle, "forward_factor", "AAPL")
     second = pair_evaluation_id(cycle, "forward_factor", "AAPL")
     assert first == second
 
 
-def test_pair_evaluation_id_differs_by_signal_and_symbol() -> None:
-    cycle = new_screening_cycle_id(NOW)
+def test_pair_evaluation_id_differs_by_strategy_and_subject() -> None:
+    cycle = new_screening_cycle_id(
+        invocation_type="scheduled", slot_id="slot_1", scope_id=scope_identity(UNIVERSE)
+    )
     assert pair_evaluation_id(cycle, "forward_factor", "AAPL") != pair_evaluation_id(
         cycle, "skew_momentum", "AAPL"
     )
@@ -45,9 +155,14 @@ def test_pair_evaluation_id_differs_by_signal_and_symbol() -> None:
 
 
 @pytest.mark.parametrize(
-    "cycle,signal_id,symbol",
+    "cycle,strategy_id,subject",
     [("", "forward_factor", "AAPL"), ("cycle_1", "", "AAPL"), ("cycle_1", "forward_factor", "")],
 )
-def test_pair_evaluation_id_rejects_empty_components(cycle, signal_id, symbol) -> None:
+def test_pair_evaluation_id_rejects_empty_components(cycle, strategy_id, subject) -> None:
     with pytest.raises(ValueError):
-        pair_evaluation_id(cycle, signal_id, symbol)
+        pair_evaluation_id(cycle, strategy_id, subject)
+
+
+def test_pair_evaluation_id_rejects_colon_in_components() -> None:
+    with pytest.raises(ValueError):
+        pair_evaluation_id("cycle_1", "forward:factor", "AAPL")


### PR DESCRIPTION
## Summary

First bounded slice of S13-02 (durable acquisition attempts and screening-
cycle identity). Pure contract layer -- no persistence, no migration, no
production wiring yet (that's S13-02b, tracked separately and gated on
explicit Founder authorization at merge time since it carries a Postgres
migration Railway auto-applies on merge to `main`).

- `market_data/attempts.py`: `AcquisitionOutcome` (the sprint's closed
  11-value outcome vocabulary), a documented fold from the existing
  17-value `ProviderErrorCode`, `AcquisitionAttemptRecord`, and
  `attempt_records_for()` / `summary_outcome_for()` to project an existing
  `CapabilityFulfillmentResult` into durable records without changing
  `CapabilityFulfillmentService` itself.
- `screening/cycle_identity.py`: `new_screening_cycle_id()` /
  `pair_evaluation_id()`.

## Founder review addressed (two corrections from the initial draft)

1. **Cycle identity is no longer wall-clock-derived.** `screening_cycle_id`
   is a deterministic hash of `(invocation_type, slot_id, scope_id)`:
   `slot_id` reuses the existing `ScheduledRefreshSlot.slot_id` for
   scheduled runs, or `manual_invocation_slot_id()` (UTC-normalized before
   hashing) for manual runs; `scope_id` is an order-independent hash of the
   universe. Same tuple always yields the same `cycle_id`, so reprocessing
   the same due slot (e.g. after a retry) is idempotent at the cycle level,
   and overlapping invocations of different kinds never collide.
   `pair_evaluation_id(cycle_id, strategy_id, subject_identity)` rejects
   `:` in every component so two distinct pairs can never collide onto the
   same composite string. Added collision, timezone-normalization,
   repeated-slot, and overlapping-invocation tests.
2. **The outcome fold is now diagnostically lossless.**
   `AcquisitionAttemptRecord` carries both `outcome` (the aggregate S13-02
   bucket) and `diagnostic_code` (the original, still-safe
   `ProviderErrorCode` it was folded from). `__post_init__` enforces they
   travel together and that `diagnostic_code` actually folds onto the
   record's own `outcome`.

Full rationale for both in `project/reports/SPRINT-013-S13-02-notes.md`.

## Validation

- Full `validate-architecture.yml` scope (architecture, domain, observation,
  providers, reconciliation, facts, indicators, strategies, guardrails,
  ranking, position_proposals, portfolio, execution_planning,
  strategy_runtime, screening, analytics, market_data): **1886 passed, 1
  skipped, 0 failed.**
- `ruff check` on all new/changed files: clean, except the same
  pre-existing repo-wide `UP042` (str+Enum vs StrEnum) pattern already
  present in `FulfillmentStatus`/`BudgetScope`/`RequestOutcome`/
  `ProviderErrorCode` -- matched for consistency, not introduced by this
  change.
- `git diff --check`: clean.
- Secret scan: no repo tool exists (same gap noted in PR #267); manually
  reviewed -- pure domain/contract code, no credentials/payloads.

## Self-review

- Facts/derived-facts/strategy-policy boundaries preserved (this PR touches
  neither `strategies/` nor `strategy_runtime/`).
- No threshold, verdict, or provider-priority change.
- `UNKNOWN` semantics untouched.
- Constitution and frozen governance unchanged.

## Merge policy

S13-02a is contract-and-identity-only, no schema/deployment impact --
eligible for delegate auto-merge once CI is green, per the active
Amendment 013 delegation.