### PR TITLE
S13-02b: PostgreSQL persistence, migration, and wiring for acquisition attempts

### DIFF
--- a/asa/bootstrap.py
+++ b/asa/bootstrap.py
@@ -29,10 +29,14 @@ from asa.integrations.providers.deterministic_fake_broker import (
 )
 from asa.integrations.providers.robinhood import RobinhoodPortfolioProvider
 from asa.integrations.runs_postgres import PostgresRunPublicationRepository
+from asa.integrations.screening_acquisition_attempts_postgres import (
+    PostgresAcquisitionAttemptRepository,
+)
 from asa.integrations.universal_screening_postgres import PostgresLatestResultRepository
 from asa.logging import configure_logging, request_id_context
 from asa.market_data_ops.routes import build_operations_router
 from asa.ui import mount_ui
+from market_data.attempts import AcquisitionAttemptRepository
 from market_data.live_transport import build_live_transport as build_transport_for_provider
 from strategy_runtime.adapters import (
     build_migrated_signal_catalog,
@@ -53,6 +57,7 @@ class DependencyOverrides:
     market_data_transport_factory: Callable[[str], object] | None = None
     latest_result_repository: LatestResultRepository | None = None
     observation_history_repository: ObservationHistoryRepository | None = None
+    acquisition_attempt_repository: AcquisitionAttemptRepository | None = None
 
 
 def build_application(
@@ -79,6 +84,10 @@ def build_application(
     observation_history_repository = (
         selected.observation_history_repository
         or PostgresObservationHistoryRepository(engine_factory(settings.database_url))
+    )
+    acquisition_attempt_repository = (
+        selected.acquisition_attempt_repository
+        or PostgresAcquisitionAttemptRepository(engine_factory(settings.database_url))
     )
     agent_authorize = build_agent_authorizer(settings.agent_api_token)
     quote_service = MarketQuoteService(
@@ -118,6 +127,7 @@ def build_application(
             settings.operations_token,
             selected.market_data_transport_factory or build_transport_for_provider,
             max_runs_per_hour=None if settings.environment == "development" else 50,
+            acquisition_attempt_repository=acquisition_attempt_repository,
         )
     )
     app.include_router(

--- a/asa/integrations/screening_acquisition_attempts_postgres.py
+++ b/asa/integrations/screening_acquisition_attempts_postgres.py
@@ -1,0 +1,149 @@
+"""PostgreSQL-backed AcquisitionAttemptRepository (SPRINT-013 S13-02).
+
+Raw SQL through sqlalchemy.Engine/text(), no ORM -- matches every other
+asa/integrations repository. Idempotent on (pair_evaluation_id, sequence)
+via ON CONFLICT DO NOTHING, the same pattern
+asa.integrations.refresh_schedule_postgres.PostgresRefreshScheduleClaimRepository
+already uses for its own idempotency key, so record() re-recording the
+exact same attempt is a silent no-op, never a duplicate row and never an
+error -- matching InMemoryAcquisitionAttemptRepository's semantics exactly
+(market_data.attempts.AcquisitionAttemptRepository's own documented
+contract).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Engine, text
+from sqlalchemy.engine import RowMapping
+
+from domain import MarketCapability
+from market_data.attempts import (
+    AcquisitionAttemptRecord,
+    AcquisitionOutcome,
+    AttemptQuery,
+)
+from market_data.fulfillment import FulfillmentStatus
+from market_data.providers import ProviderErrorCode
+
+
+class PostgresAcquisitionAttemptRepository:
+    def __init__(self, engine: Engine) -> None:
+        self._engine = engine
+
+    def record(self, attempts: tuple[AcquisitionAttemptRecord, ...]) -> None:
+        if not attempts:
+            return
+        with self._engine.begin() as connection:
+            for attempt in attempts:
+                connection.execute(
+                    text("""
+                        INSERT INTO screening_acquisition_attempts (
+                            screening_cycle_id, pair_evaluation_id, sequence, capability,
+                            provider_id, priority, fulfillment_status, outcome,
+                            diagnostic_code, retryable, safe_summary, recorded_at
+                        ) VALUES (
+                            :screening_cycle_id, :pair_evaluation_id, :sequence, :capability,
+                            :provider_id, :priority, :fulfillment_status, :outcome,
+                            :diagnostic_code, :retryable, :safe_summary, :recorded_at
+                        )
+                        ON CONFLICT (pair_evaluation_id, sequence) DO NOTHING
+                    """),
+                    _to_params(attempt),
+                )
+
+    def query(self, query: AttemptQuery) -> tuple[AcquisitionAttemptRecord, ...]:
+        where, params = _where_clause(query)
+        params["limit"] = query.limit
+        params["offset"] = query.offset
+        with self._engine.connect() as connection:
+            rows = connection.execute(
+                text(
+                    "SELECT * FROM screening_acquisition_attempts "
+                    f"{where} "
+                    "ORDER BY recorded_at, pair_evaluation_id, sequence "
+                    "LIMIT :limit OFFSET :offset"
+                ),
+                params,
+            ).mappings()
+            return tuple(_to_record(row) for row in rows)
+
+    def summarize(self, query: AttemptQuery) -> dict[AcquisitionOutcome, int]:
+        where, params = _where_clause(query)
+        with self._engine.connect() as connection:
+            rows = connection.execute(
+                text(
+                    "SELECT outcome, COUNT(*) AS attempt_count "
+                    "FROM screening_acquisition_attempts "
+                    f"{where} "
+                    "GROUP BY outcome"
+                ),
+                params,
+            ).mappings()
+            return {AcquisitionOutcome(row["outcome"]): row["attempt_count"] for row in rows}
+
+
+def _where_clause(query: AttemptQuery) -> tuple[str, dict[str, object]]:
+    clauses = []
+    params: dict[str, object] = {}
+    if query.screening_cycle_id is not None:
+        clauses.append("screening_cycle_id = :screening_cycle_id")
+        params["screening_cycle_id"] = query.screening_cycle_id
+    if query.pair_evaluation_id is not None:
+        clauses.append("pair_evaluation_id = :pair_evaluation_id")
+        params["pair_evaluation_id"] = query.pair_evaluation_id
+    if query.provider_id is not None:
+        clauses.append("provider_id = :provider_id")
+        params["provider_id"] = query.provider_id
+    if query.capability is not None:
+        clauses.append("capability = :capability")
+        params["capability"] = query.capability.value
+    if query.outcome is not None:
+        clauses.append("outcome = :outcome")
+        params["outcome"] = query.outcome.value
+    if query.recorded_after is not None:
+        clauses.append("recorded_at >= :recorded_after")
+        params["recorded_after"] = query.recorded_after
+    if query.recorded_before is not None:
+        clauses.append("recorded_at <= :recorded_before")
+        params["recorded_before"] = query.recorded_before
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    return where, params
+
+
+def _to_params(attempt: AcquisitionAttemptRecord) -> dict[str, object]:
+    diagnostic_code = None if attempt.diagnostic_code is None else attempt.diagnostic_code.value
+    return {
+        "screening_cycle_id": attempt.screening_cycle_id,
+        "pair_evaluation_id": attempt.pair_evaluation_id,
+        "sequence": attempt.sequence,
+        "capability": attempt.capability.value,
+        "provider_id": attempt.provider_id,
+        "priority": attempt.priority,
+        "fulfillment_status": attempt.fulfillment_status.value,
+        "outcome": attempt.outcome.value,
+        "diagnostic_code": diagnostic_code,
+        "retryable": attempt.retryable,
+        "safe_summary": attempt.safe_summary,
+        "recorded_at": attempt.recorded_at,
+    }
+
+
+def _to_record(mapping: RowMapping) -> AcquisitionAttemptRecord:
+    return AcquisitionAttemptRecord(
+        screening_cycle_id=mapping["screening_cycle_id"],
+        pair_evaluation_id=mapping["pair_evaluation_id"],
+        sequence=mapping["sequence"],
+        capability=MarketCapability(mapping["capability"]),
+        provider_id=mapping["provider_id"],
+        priority=mapping["priority"],
+        fulfillment_status=FulfillmentStatus(mapping["fulfillment_status"]),
+        outcome=AcquisitionOutcome(mapping["outcome"]),
+        diagnostic_code=(
+            None
+            if mapping["diagnostic_code"] is None
+            else ProviderErrorCode(mapping["diagnostic_code"])
+        ),
+        retryable=mapping["retryable"],
+        safe_summary=mapping["safe_summary"],
+        recorded_at=mapping["recorded_at"],
+    )

--- a/asa/market_data_ops/routes.py
+++ b/asa/market_data_ops/routes.py
@@ -3,15 +3,24 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import UTC, datetime
 
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field, SecretStr
 
 from asa.market_data_ops.auth import OperationsRunLimiter, token_matches
 from asa.market_data_ops.service import ALLOWED_PROVIDER_IDS, run_bounded_validation
+from domain import MarketCapability
+from market_data.attempts import (
+    MAXIMUM_QUERY_LIMIT,
+    AcquisitionAttemptRepository,
+    AcquisitionOutcome,
+    AttemptQuery,
+)
 from market_data.live_transport import build_live_transport as build_transport_for_provider
 
 _NOT_FOUND = HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+_BAD_QUERY = status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 class ValidateRequest(BaseModel):
@@ -45,10 +54,38 @@ class ValidateResponse(BaseModel):
     providers: list[ProviderResultResponse]
 
 
+class AttemptResponse(BaseModel):
+    screening_cycle_id: str
+    pair_evaluation_id: str
+    sequence: int
+    capability: str
+    provider_id: str
+    priority: int
+    fulfillment_status: str
+    outcome: str
+    diagnostic_code: str | None
+    retryable: bool
+    safe_summary: str | None
+    recorded_at: str
+
+
+class AttemptListResponse(BaseModel):
+    attempts: list[AttemptResponse]
+    limit: int
+    offset: int
+    returned_count: int
+
+
+class AttemptSummaryResponse(BaseModel):
+    generated_at: str
+    outcome_counts: dict[str, int]
+
+
 def build_operations_router(
     operations_token: SecretStr | None,
     transport_factory: Callable[[str], object] = build_transport_for_provider,
     max_runs_per_hour: int | None = 50,
+    acquisition_attempt_repository: AcquisitionAttemptRepository | None = None,
 ) -> APIRouter:
     router = APIRouter(prefix="/ops")
     limiter = OperationsRunLimiter(max_runs_per_hour=max_runs_per_hour)
@@ -109,6 +146,111 @@ def build_operations_router(
                 )
                 for provider in outcome.providers
             ],
+        )
+
+    def _build_attempt_query(
+        screening_cycle_id: str | None,
+        pair_evaluation_id: str | None,
+        provider_id: str | None,
+        capability: str | None,
+        outcome_filter: str | None,
+        recorded_after: str | None,
+        recorded_before: str | None,
+        limit: int,
+        offset: int,
+    ) -> AttemptQuery:
+        try:
+            parsed_capability = None if capability is None else MarketCapability(capability)
+            parsed_outcome = (
+                None if outcome_filter is None else AcquisitionOutcome(outcome_filter)
+            )
+            parsed_after = (
+                None if recorded_after is None else datetime.fromisoformat(recorded_after)
+            )
+            parsed_before = (
+                None if recorded_before is None else datetime.fromisoformat(recorded_before)
+            )
+            return AttemptQuery(
+                screening_cycle_id=screening_cycle_id,
+                pair_evaluation_id=pair_evaluation_id,
+                provider_id=provider_id,
+                capability=parsed_capability,
+                outcome=parsed_outcome,
+                recorded_after=parsed_after,
+                recorded_before=parsed_before,
+                limit=limit,
+                offset=offset,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=_BAD_QUERY, detail="invalid query parameters") from exc
+
+    @router.get("/screening/attempts", response_model=AttemptListResponse)
+    def list_attempts(
+        request: Request,
+        screening_cycle_id: str | None = None,
+        pair_evaluation_id: str | None = None,
+        provider_id: str | None = None,
+        capability: str | None = None,
+        outcome: str | None = None,
+        recorded_after: str | None = None,
+        recorded_before: str | None = None,
+        limit: int = Query(default=100, ge=1, le=MAXIMUM_QUERY_LIMIT),
+        offset: int = Query(default=0, ge=0),
+    ) -> AttemptListResponse:
+        _authorize(request)
+        if acquisition_attempt_repository is None:
+            raise _NOT_FOUND
+        parsed = _build_attempt_query(
+            screening_cycle_id, pair_evaluation_id, provider_id, capability, outcome,
+            recorded_after, recorded_before, limit, offset,
+        )
+        results = acquisition_attempt_repository.query(parsed)
+        return AttemptListResponse(
+            attempts=[
+                AttemptResponse(
+                    screening_cycle_id=item.screening_cycle_id,
+                    pair_evaluation_id=item.pair_evaluation_id,
+                    sequence=item.sequence,
+                    capability=item.capability.value,
+                    provider_id=item.provider_id,
+                    priority=item.priority,
+                    fulfillment_status=item.fulfillment_status.value,
+                    outcome=item.outcome.value,
+                    diagnostic_code=(
+                        None if item.diagnostic_code is None else item.diagnostic_code.value
+                    ),
+                    retryable=item.retryable,
+                    safe_summary=item.safe_summary,
+                    recorded_at=item.recorded_at.isoformat(),
+                )
+                for item in results
+            ],
+            limit=parsed.limit,
+            offset=parsed.offset,
+            returned_count=len(results),
+        )
+
+    @router.get("/screening/attempts/summary", response_model=AttemptSummaryResponse)
+    def summarize_attempts(
+        request: Request,
+        screening_cycle_id: str | None = None,
+        pair_evaluation_id: str | None = None,
+        provider_id: str | None = None,
+        capability: str | None = None,
+        recorded_after: str | None = None,
+        recorded_before: str | None = None,
+    ) -> AttemptSummaryResponse:
+        _authorize(request)
+        if acquisition_attempt_repository is None:
+            raise _NOT_FOUND
+        parsed = _build_attempt_query(
+            screening_cycle_id, pair_evaluation_id, provider_id, capability, None,
+            recorded_after, recorded_before, 1, 0,
+        )
+        counts = acquisition_attempt_repository.summarize(parsed)
+        return AttemptSummaryResponse(
+            generated_at=datetime.now(UTC).isoformat(),
+            outcome_counts={key.value: value for key, value in counts.items()},
         )
 
     return router

--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -44,11 +44,23 @@ from asa.integrations.postgres import create_postgres_engine
 from asa.integrations.refresh_schedule_postgres import (
     PostgresRefreshScheduleClaimRepository,
 )
+from asa.integrations.screening_acquisition_attempts_postgres import (
+    PostgresAcquisitionAttemptRepository,
+)
 from asa.integrations.universal_screening_postgres import PostgresLatestResultRepository
 from market_data import load_market_data_config_from_environment
+from market_data.attempts import AcquisitionAttemptRepository, attempt_records_for
 from market_data.live_transport import build_live_transport
 from market_data.session_schedule import SessionRefreshSchedule
 from screening import APPROVED_LIVE_UNIVERSE, EARNINGS_CALENDAR_UNIVERSE
+from screening.cycle_identity import (
+    manual_invocation_slot_id,
+    new_screening_cycle_id,
+    scope_identity,
+)
+from screening.cycle_identity import (
+    pair_evaluation_id as compute_pair_evaluation_id,
+)
 from screening.live_acquisition import live_only_config
 from strategy_runtime.adapters import build_migrated_strategy_registry
 from strategy_runtime.lifecycle import RecommendedAction
@@ -92,6 +104,7 @@ class PairOutcome:
     outcome: str | None
     request_count: int | None
     error: str | None
+    attempts_recorded: bool
 
 
 class RefreshScheduleClaimRepository(Protocol):
@@ -103,6 +116,7 @@ def run_scheduled_refresh(
     *,
     repository: LatestResultRepository | None = None,
     history_repository: ObservationHistoryRepository | None = None,
+    acquisition_attempt_repository: AcquisitionAttemptRepository | None = None,
     transport_factory: Callable[[str], object] = build_live_transport,
     claim_repository: RefreshScheduleClaimRepository | None = None,
     enforce_schedule: bool = False,
@@ -115,13 +129,25 @@ def run_scheduled_refresh(
     asa/api/screening_routes.py already uses, never shared or cached
     across pairs.
 
-    ``repository`` and ``transport_factory`` are injectable (default:
-    the real Postgres repository and the real live transport) so this
-    function is directly testable without a live database or network,
-    the same DependencyOverrides-style pattern asa/bootstrap.py already
-    uses.
+    ``repository``, ``transport_factory``, and ``acquisition_attempt_
+    repository`` are injectable (default: the real Postgres repositories
+    and the real live transport) so this function is directly testable
+    without a live database or network, the same DependencyOverrides-style
+    pattern asa/bootstrap.py already uses.
+
+    One screening_cycle_id is minted once for the whole invocation
+    (SPRINT-013 S13-02) -- deterministically, from (invocation_type,
+    slot_id, scope_id), never from raw wall-clock alone
+    (screening.cycle_identity.new_screening_cycle_id). Each pair gets its
+    own pair_evaluation_id derived from that cycle. Attempt persistence is
+    best-effort per pair: a persistence failure never aborts an otherwise-
+    successful strategy evaluation, but PairOutcome.attempts_recorded is
+    set False so acquisition accounting is never silently reported
+    complete when it wasn't.
     """
     run_at = now or datetime.now(UTC)
+    invocation_type = "manual"
+    slot_id = manual_invocation_slot_id(run_at)
     if enforce_schedule:
         slot = SessionRefreshSchedule().due_slot(run_at)
         if slot is None:
@@ -133,12 +159,18 @@ def run_scheduled_refresh(
         )
         if not resolved_claim_repository.claim(slot.slot_id, run_at):
             return ()
+        invocation_type = "scheduled"
+        slot_id = slot.slot_id
 
     resolved_repository = repository or PostgresLatestResultRepository(
         create_postgres_engine(Settings().database_url)
     )
     resolved_history_repository = history_repository or PostgresObservationHistoryRepository(
         create_postgres_engine(Settings().database_url)
+    )
+    resolved_acquisition_attempt_repository = (
+        acquisition_attempt_repository
+        or PostgresAcquisitionAttemptRepository(create_postgres_engine(Settings().database_url))
     )
     registry = build_migrated_strategy_registry()
     config = live_only_config(load_market_data_config_from_environment())
@@ -148,10 +180,14 @@ def run_scheduled_refresh(
             "provider; none are enabled"
         )
     clock = _SystemClock()
+    screening_cycle_id = new_screening_cycle_id(
+        invocation_type=invocation_type, slot_id=slot_id, scope_id=scope_identity(universe)
+    )
     outcomes: list[PairOutcome] = []
     for signal_id, symbol in universe:
         access = build_shared_market_data_access(config, transport_factory, clock, (symbol,))
         subject_access = access[symbol]
+        pair_id = compute_pair_evaluation_id(screening_cycle_id, signal_id, symbol)
         try:
             result = refresh(
                 registry,
@@ -178,6 +214,31 @@ def run_scheduled_refresh(
                             "opportunity_id": result.opportunity_id,
                         },
                     )
+            attempts_recorded = True
+            try:
+                sequence_offset = 0
+                for fulfillment_result in subject_access.fulfillment.completed_results:
+                    records = attempt_records_for(
+                        fulfillment_result,
+                        screening_cycle_id=screening_cycle_id,
+                        pair_evaluation_id=pair_id,
+                        recorded_at=clock.now(),
+                        sequence_offset=sequence_offset,
+                    )
+                    sequence_offset += len(records)
+                    resolved_acquisition_attempt_repository.record(records)
+            except Exception:
+                attempts_recorded = False
+                _LOGGER.warning(
+                    "scheduled acquisition attempt recording failed -- "
+                    "diagnostics incomplete for this pair",
+                    extra={
+                        "signal_id": signal_id,
+                        "symbol": symbol,
+                        "screening_cycle_id": screening_cycle_id,
+                        "pair_evaluation_id": pair_id,
+                    },
+                )
             outcomes.append(
                 PairOutcome(
                     signal_id,
@@ -185,10 +246,11 @@ def run_scheduled_refresh(
                     result.evaluation_state.value,
                     len(subject_access.budget_manager.accounting),
                     None,
+                    attempts_recorded,
                 )
             )
         except Exception as exc:
-            outcomes.append(PairOutcome(signal_id, symbol, None, None, str(exc)))
+            outcomes.append(PairOutcome(signal_id, symbol, None, None, str(exc), False))
     return tuple(outcomes)
 
 
@@ -202,6 +264,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     outcomes = run_scheduled_refresh(enforce_schedule=True)
     failures = [item for item in outcomes if item.error is not None]
+    incomplete_diagnostics = [item for item in outcomes if not item.attempts_recorded]
     outcome_counts: dict[str, int] = {}
     for item in outcomes:
         key = "infrastructure_failure" if item.error is not None else (item.outcome or "unknown")
@@ -213,17 +276,25 @@ def main(argv: Sequence[str] | None = None) -> int:
             if item.error is not None:
                 print(f"  {item.signal_id:<18} {item.symbol:<6} FAILED: {item.error}")
             else:
+                incomplete = "" if item.attempts_recorded else " [attempt diagnostics incomplete]"
                 print(
                     f"  {item.signal_id:<18} {item.symbol:<6} {item.outcome} "
-                    f"(requests={item.request_count})"
+                    f"(requests={item.request_count}){incomplete}"
                 )
         print(f"  outcome counts: {outcome_counts}")
+        if incomplete_diagnostics:
+            print(f"  attempt diagnostics incomplete for {len(incomplete_diagnostics)} pair(s)")
 
     print(
         json.dumps(
             {
                 "total": len(outcomes),
                 "failed": len(failures),
+                # Never silently report complete acquisition accounting
+                # (SPRINT-013 S13-02): a pair whose attempt persistence
+                # failed is counted here even though its own screening
+                # result may otherwise be a normal, non-failing outcome.
+                "attempt_diagnostics_incomplete": len(incomplete_diagnostics),
                 # Sanitized outcome-distribution counts only (no symbols, no
                 # request bodies) -- SPRINT-011/UNI-002's own safe
                 # operational diagnostic, distinguishing legitimate
@@ -237,6 +308,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "outcome": item.outcome,
                         "request_count": item.request_count,
                         "error": item.error,
+                        "attempts_recorded": item.attempts_recorded,
                     }
                     for item in outcomes
                 ],

--- a/market_data/attempts.py
+++ b/market_data/attempts.py
@@ -12,11 +12,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+from typing import Protocol, runtime_checkable
 
 from domain import MarketCapability
 from domain.values import DomainInvariantError, require_tz_aware
 from market_data.fulfillment import CapabilityFulfillmentResult, FulfillmentStatus
 from market_data.providers import ProviderErrorCode
+
+MAXIMUM_QUERY_LIMIT = 500
 
 
 class AcquisitionOutcome(str, Enum):
@@ -182,3 +185,108 @@ def attempt_records_for(
             )
         )
     return tuple(records)
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptQuery:
+    """Bounded, filtered query for durable attempt records. All filters are
+    optional and combine with AND. ``limit`` is always enforced (capped at
+    MAXIMUM_QUERY_LIMIT) so no caller -- including operations routes -- can
+    request an unbounded result set.
+    """
+
+    screening_cycle_id: str | None = None
+    pair_evaluation_id: str | None = None
+    provider_id: str | None = None
+    capability: MarketCapability | None = None
+    outcome: AcquisitionOutcome | None = None
+    recorded_after: datetime | None = None
+    recorded_before: datetime | None = None
+    limit: int = 100
+    offset: int = 0
+
+    def __post_init__(self) -> None:
+        if type(self.limit) is not int or not 1 <= self.limit <= MAXIMUM_QUERY_LIMIT:
+            raise ValueError(f"AttemptQuery.limit must be in [1, {MAXIMUM_QUERY_LIMIT}]")
+        if type(self.offset) is not int or self.offset < 0:
+            raise ValueError("AttemptQuery.offset must be non-negative")
+        if self.recorded_after is not None:
+            require_tz_aware(self.recorded_after, "AttemptQuery", "recorded_after")
+        if self.recorded_before is not None:
+            require_tz_aware(self.recorded_before, "AttemptQuery", "recorded_before")
+        if (
+            self.recorded_after is not None
+            and self.recorded_before is not None
+            and self.recorded_after > self.recorded_before
+        ):
+            raise ValueError("AttemptQuery.recorded_after must not be after recorded_before")
+
+
+@runtime_checkable
+class AcquisitionAttemptRepository(Protocol):
+    """Append-only durable storage for AcquisitionAttemptRecord. Concrete
+    implementations (in-memory, PostgreSQL) must share identical semantics:
+    idempotent on (pair_evaluation_id, sequence) -- re-recording the exact
+    same attempt is a no-op, never a duplicate row and never an error -- and
+    stable-ordered queries (recorded_at, pair_evaluation_id, sequence).
+    """
+
+    def record(self, attempts: tuple[AcquisitionAttemptRecord, ...]) -> None: ...
+
+    def query(self, query: AttemptQuery) -> tuple[AcquisitionAttemptRecord, ...]: ...
+
+    def summarize(self, query: AttemptQuery) -> dict[AcquisitionOutcome, int]:
+        """Count of matching attempts grouped by outcome. Ignores
+        ``query.limit``/``query.offset`` -- a summary counts every matching
+        row, not one bounded page of them.
+        """
+        ...
+
+
+class InMemoryAcquisitionAttemptRepository:
+    """Reference implementation and test double. Production code may also
+    use this directly for non-Postgres deployments; asa/integrations owns
+    the PostgreSQL-backed implementation with identical semantics.
+    """
+
+    def __init__(self) -> None:
+        self._rows: list[AcquisitionAttemptRecord] = []
+        self._seen: set[tuple[str, int]] = set()
+
+    def record(self, attempts: tuple[AcquisitionAttemptRecord, ...]) -> None:
+        for attempt in attempts:
+            key = (attempt.pair_evaluation_id, attempt.sequence)
+            if key in self._seen:
+                continue
+            self._seen.add(key)
+            self._rows.append(attempt)
+
+    def query(self, query: AttemptQuery) -> tuple[AcquisitionAttemptRecord, ...]:
+        matches = [item for item in self._rows if _matches(item, query)]
+        matches.sort(key=lambda item: (item.recorded_at, item.pair_evaluation_id, item.sequence))
+        return tuple(matches[query.offset : query.offset + query.limit])
+
+    def summarize(self, query: AttemptQuery) -> dict[AcquisitionOutcome, int]:
+        counts: dict[AcquisitionOutcome, int] = {}
+        for item in self._rows:
+            if _matches(item, query):
+                counts[item.outcome] = counts.get(item.outcome, 0) + 1
+        return counts
+
+
+def _matches(item: AcquisitionAttemptRecord, query: AttemptQuery) -> bool:
+    cycle_ok = (
+        query.screening_cycle_id is None or item.screening_cycle_id == query.screening_cycle_id
+    )
+    pair_ok = (
+        query.pair_evaluation_id is None or item.pair_evaluation_id == query.pair_evaluation_id
+    )
+    return (
+        cycle_ok
+        and pair_ok
+        and (query.provider_id is None or item.provider_id == query.provider_id)
+        and (query.capability is None or item.capability is query.capability)
+        and (query.outcome is None or item.outcome is query.outcome)
+        and (query.recorded_after is None or item.recorded_at >= query.recorded_after)
+        and (query.recorded_before is None or item.recorded_at <= query.recorded_before)
+    )

--- a/migrations/versions/0011_screening_acquisition_attempts.py
+++ b/migrations/versions/0011_screening_acquisition_attempts.py
@@ -1,0 +1,77 @@
+"""Create screening_acquisition_attempts -- durable, append-only provider
+acquisition attempt records (SPRINT-013 S13-02).
+
+Additive only, mirrors 0006/0010's own conventions: an auto-incrementing
+surrogate key (this table accumulates one row per provider attempt, not one
+row per pair), indexes on every column S13-02's acceptance requires
+queryable (cycle, pair, provider, capability, outcome, time), and a unique
+constraint on (pair_evaluation_id, sequence) -- the idempotency key
+AcquisitionAttemptRepository implementations rely on so re-recording the
+same attempt (e.g. a caller-level retry of the persistence write itself,
+not a new provider attempt) is a no-op rather than a duplicate row.
+
+Revision ID: 0011
+Revises: 0010
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0011"
+down_revision: str | None = "0010"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "screening_acquisition_attempts"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("screening_cycle_id", sa.String(length=96), nullable=False),
+        sa.Column("pair_evaluation_id", sa.String(length=255), nullable=False),
+        sa.Column("sequence", sa.Integer(), nullable=False),
+        sa.Column("capability", sa.String(length=64), nullable=False),
+        sa.Column("provider_id", sa.String(length=64), nullable=False),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column("fulfillment_status", sa.String(length=32), nullable=False),
+        sa.Column("outcome", sa.String(length=32), nullable=False),
+        sa.Column("diagnostic_code", sa.String(length=64), nullable=True),
+        sa.Column("retryable", sa.Boolean(), nullable=False),
+        sa.Column("safe_summary", sa.String(length=500), nullable=True),
+        sa.Column("recorded_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint(
+            "pair_evaluation_id", "sequence", name="uq_screening_acquisition_attempts_pair_sequence"
+        ),
+    )
+    op.create_index(
+        "ix_screening_acquisition_attempts_cycle", _TABLE, ["screening_cycle_id"]
+    )
+    op.create_index(
+        "ix_screening_acquisition_attempts_pair", _TABLE, ["pair_evaluation_id"]
+    )
+    op.create_index(
+        "ix_screening_acquisition_attempts_provider", _TABLE, ["provider_id"]
+    )
+    op.create_index(
+        "ix_screening_acquisition_attempts_capability", _TABLE, ["capability"]
+    )
+    op.create_index(
+        "ix_screening_acquisition_attempts_outcome", _TABLE, ["outcome"]
+    )
+    op.create_index(
+        "ix_screening_acquisition_attempts_recorded_at", _TABLE, ["recorded_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_screening_acquisition_attempts_recorded_at", table_name=_TABLE)
+    op.drop_index("ix_screening_acquisition_attempts_outcome", table_name=_TABLE)
+    op.drop_index("ix_screening_acquisition_attempts_capability", table_name=_TABLE)
+    op.drop_index("ix_screening_acquisition_attempts_provider", table_name=_TABLE)
+    op.drop_index("ix_screening_acquisition_attempts_pair", table_name=_TABLE)
+    op.drop_index("ix_screening_acquisition_attempts_cycle", table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -10,6 +10,7 @@ from asa.scheduled_screening import (
     PRODUCTION_SCREENING_UNIVERSE,
     run_scheduled_refresh,
 )
+from market_data.attempts import AttemptQuery, InMemoryAcquisitionAttemptRepository
 from market_data.transport import ReadOnlyHttpResponse
 from screening import APPROVED_LIVE_UNIVERSE, EARNINGS_CALENDAR_UNIVERSE
 from tests.asa.fakes import InMemoryLatestResultRepository
@@ -207,3 +208,114 @@ def test_duplicate_cron_delivery_executes_slot_once(
     assert len(first) == 1
     assert duplicate == ()
     assert len(claims.claimed) == 1
+
+
+# -- SPRINT-013 S13-02: acquisition attempt recording -----------------------
+
+
+def test_attempts_are_recorded_under_one_shared_cycle_id_for_every_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    repository = InMemoryLatestResultRepository()
+    attempt_repository = InMemoryAcquisitionAttemptRepository()
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+    universe = (("skew_momentum", "AAPL"), ("skew_momentum", "MSFT"))
+
+    outcomes = run_scheduled_refresh(
+        universe,
+        repository=repository,
+        acquisition_attempt_repository=attempt_repository,
+        transport_factory=lambda _provider_id: ScriptedTransport(
+            _tradier_refresh_responses(expiration)
+        ),
+    )
+
+    assert all(item.attempts_recorded for item in outcomes)
+    recorded = attempt_repository.query(AttemptQuery(limit=100))
+    assert recorded  # at least one provider attempt was actually persisted
+    cycle_ids = {item.screening_cycle_id for item in recorded}
+    assert len(cycle_ids) == 1  # one cycle spans the whole invocation
+    pair_ids = {item.pair_evaluation_id for item in recorded}
+    cycle_id = next(iter(cycle_ids))
+    assert pair_ids <= {
+        f"{cycle_id}:skew_momentum:AAPL",
+        f"{cycle_id}:skew_momentum:MSFT",
+    }
+
+
+def test_manual_invocation_uses_a_different_cycle_id_each_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+    universe = (("skew_momentum", "AAPL"),)
+    first_attempts = InMemoryAcquisitionAttemptRepository()
+    second_attempts = InMemoryAcquisitionAttemptRepository()
+
+    run_scheduled_refresh(
+        universe,
+        repository=InMemoryLatestResultRepository(),
+        acquisition_attempt_repository=first_attempts,
+        now=datetime(2026, 7, 21, 16, 0, tzinfo=UTC),
+        transport_factory=lambda _provider_id: ScriptedTransport(
+            _tradier_refresh_responses(expiration)
+        ),
+    )
+    run_scheduled_refresh(
+        universe,
+        repository=InMemoryLatestResultRepository(),
+        acquisition_attempt_repository=second_attempts,
+        now=datetime(2026, 7, 21, 16, 0, 1, tzinfo=UTC),
+        transport_factory=lambda _provider_id: ScriptedTransport(
+            _tradier_refresh_responses(expiration)
+        ),
+    )
+
+    first_cycle = {item.screening_cycle_id for item in first_attempts.query(AttemptQuery())}
+    second_cycle = {item.screening_cycle_id for item in second_attempts.query(AttemptQuery())}
+    assert first_cycle != second_cycle
+
+
+class _AttemptRepositoryThatAlwaysFails:
+    def record(self, attempts: object) -> None:
+        raise RuntimeError("simulated attempt-persistence outage")
+
+    def query(self, query: object) -> tuple[object, ...]:
+        return ()
+
+    def summarize(self, query: object) -> dict[object, int]:
+        return {}
+
+
+def test_attempt_persistence_failure_preserves_the_screening_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A persistence outage for the attempt side-channel must never abort
+    or corrupt the pair's own strategy evaluation, but must never be
+    silently reported as complete either (SPRINT-013 S13-02)."""
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    repository = InMemoryLatestResultRepository()
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+    universe = (("skew_momentum", "AAPL"),)
+
+    outcomes = run_scheduled_refresh(
+        universe,
+        repository=repository,
+        acquisition_attempt_repository=_AttemptRepositoryThatAlwaysFails(),  # type: ignore[arg-type]
+        transport_factory=lambda _provider_id: ScriptedTransport(
+            _tradier_refresh_responses(expiration)
+        ),
+    )
+
+    assert len(outcomes) == 1
+    # The strategy evaluation itself is preserved and still persisted.
+    assert outcomes[0].error is None
+    assert outcomes[0].outcome is not None
+    assert repository.get_one("skew_momentum", "AAPL") is not None
+    # But acquisition accounting is honestly marked incomplete, never
+    # silently reported as if it were complete.
+    assert outcomes[0].attempts_recorded is False

--- a/tests/asa/test_screening_acquisition_attempts_postgres.py
+++ b/tests/asa/test_screening_acquisition_attempts_postgres.py
@@ -174,7 +174,14 @@ def test_no_raw_payloads_headers_or_credentials_in_stored_row(
 ) -> None:
     """Column set itself is the guardrail -- there is no column that could
     hold a raw payload, header, or credential in the first place."""
-    repository.record((_record(outcome=AcquisitionOutcome.STALE_DATA),))
+    repository.record(
+        (
+            _record(
+                outcome=AcquisitionOutcome.STALE_DATA,
+                diagnostic_code=ProviderErrorCode.STALE_DATA,
+            ),
+        )
+    )
     engine = repository._engine  # noqa: SLF001 -- test-only introspection
     with engine.connect() as connection:
         columns = connection.execute(

--- a/tests/asa/test_screening_acquisition_attempts_postgres.py
+++ b/tests/asa/test_screening_acquisition_attempts_postgres.py
@@ -1,0 +1,190 @@
+"""SPRINT-013 S13-02: PostgresAcquisitionAttemptRepository exercised
+against a real (test) Postgres instance -- not the in-memory fake
+tests/market_data/test_attempts.py already covers.
+
+Mirrors tests/asa/test_universal_screening_service_postgres_integration.py's
+own exact pattern: proving the same semantics
+InMemoryAcquisitionAttemptRepository already proves (idempotency on
+(pair_evaluation_id, sequence), stable-ordered filtered/paginated queries,
+outcome-grouped summaries) hold end to end through the real raw-SQL layer.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from asa.integrations.screening_acquisition_attempts_postgres import (
+    PostgresAcquisitionAttemptRepository,
+)
+from domain import MarketCapability
+from market_data import FulfillmentStatus, ProviderErrorCode
+from market_data.attempts import AcquisitionAttemptRecord, AcquisitionOutcome, AttemptQuery
+
+pytestmark = [
+    pytest.mark.postgres,
+    pytest.mark.skipif(
+        not os.getenv("ASA_TEST_DATABASE_URL"),
+        reason="ASA_TEST_DATABASE_URL not set",
+    ),
+]
+
+CAPABILITY = MarketCapability.REAL_TIME_QUOTE_V1
+RECORDED_AT = datetime(2026, 7, 21, 16, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def repository() -> PostgresAcquisitionAttemptRepository:
+    database_url = os.environ["ASA_TEST_DATABASE_URL"]
+    os.environ["ASA_DATABASE_URL"] = database_url
+    command.upgrade(Config("alembic.ini"), "head")
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE screening_acquisition_attempts"))
+    return PostgresAcquisitionAttemptRepository(engine)
+
+
+def _record(
+    *,
+    pair: str = "cycle_1:forward_factor:AAPL",
+    sequence: int = 0,
+    provider_id: str = "primary",
+    outcome: AcquisitionOutcome = AcquisitionOutcome.SUCCESS,
+    diagnostic_code: ProviderErrorCode | None = None,
+    recorded_at: datetime = RECORDED_AT,
+) -> AcquisitionAttemptRecord:
+    failed = outcome is not AcquisitionOutcome.SUCCESS
+    return AcquisitionAttemptRecord(
+        "cycle_1",
+        pair,
+        sequence,
+        CAPABILITY,
+        provider_id,
+        1,
+        FulfillmentStatus.FULFILLED if not failed else FulfillmentStatus.FAILED,
+        outcome,
+        diagnostic_code if failed else None,
+        failed,
+        "a safe summary" if failed else None,
+        recorded_at,
+    )
+
+
+def test_record_and_query_round_trip(
+    repository: PostgresAcquisitionAttemptRepository,
+) -> None:
+    repository.record((_record(),))
+    results = repository.query(AttemptQuery(screening_cycle_id="cycle_1"))
+    assert len(results) == 1
+    assert results[0].pair_evaluation_id == "cycle_1:forward_factor:AAPL"
+    assert results[0].outcome is AcquisitionOutcome.SUCCESS
+    assert results[0].diagnostic_code is None
+    assert results[0].recorded_at == RECORDED_AT
+
+
+def test_record_is_idempotent_on_pair_and_sequence(
+    repository: PostgresAcquisitionAttemptRepository,
+) -> None:
+    repository.record((_record(),))
+    repository.record((_record(),))
+    results = repository.query(AttemptQuery(screening_cycle_id="cycle_1"))
+    assert len(results) == 1
+
+
+def test_does_not_collapse_a_genuinely_new_attempt(
+    repository: PostgresAcquisitionAttemptRepository,
+) -> None:
+    repository.record((_record(sequence=0),))
+    repository.record((_record(sequence=1, provider_id="secondary"),))
+    results = repository.query(AttemptQuery(screening_cycle_id="cycle_1"))
+    assert len(results) == 2
+
+
+def test_diagnostic_code_round_trips(repository: PostgresAcquisitionAttemptRepository) -> None:
+    repository.record(
+        (
+            _record(
+                outcome=AcquisitionOutcome.TRANSPORT_FAILURE,
+                diagnostic_code=ProviderErrorCode.TIMEOUT,
+            ),
+        )
+    )
+    results = repository.query(AttemptQuery(screening_cycle_id="cycle_1"))
+    assert results[0].diagnostic_code is ProviderErrorCode.TIMEOUT
+    assert results[0].outcome is AcquisitionOutcome.TRANSPORT_FAILURE
+
+
+def test_query_filters_and_pagination_are_stable(
+    repository: PostgresAcquisitionAttemptRepository,
+) -> None:
+    repository.record(
+        tuple(
+            _record(
+                pair=f"cycle_1:forward_factor:SYM{i}",
+                sequence=0,
+                recorded_at=RECORDED_AT + timedelta(seconds=i),
+            )
+            for i in range(5)
+        )
+    )
+    first_page = repository.query(AttemptQuery(limit=2, offset=0))
+    second_page = repository.query(AttemptQuery(limit=2, offset=2))
+    assert [item.pair_evaluation_id for item in first_page] == [
+        "cycle_1:forward_factor:SYM0",
+        "cycle_1:forward_factor:SYM1",
+    ]
+    assert [item.pair_evaluation_id for item in second_page] == [
+        "cycle_1:forward_factor:SYM2",
+        "cycle_1:forward_factor:SYM3",
+    ]
+
+
+def test_summarize_groups_by_outcome_ignoring_pagination(
+    repository: PostgresAcquisitionAttemptRepository,
+) -> None:
+    repository.record(
+        (
+            _record(outcome=AcquisitionOutcome.SUCCESS),
+            _record(
+                pair="cycle_1:forward_factor:MSFT",
+                outcome=AcquisitionOutcome.TRANSPORT_FAILURE,
+                diagnostic_code=ProviderErrorCode.TRANSPORT_ERROR,
+            ),
+            _record(
+                pair="cycle_1:forward_factor:GOOG",
+                outcome=AcquisitionOutcome.TRANSPORT_FAILURE,
+                diagnostic_code=ProviderErrorCode.TIMEOUT,
+            ),
+        )
+    )
+    counts = repository.summarize(AttemptQuery(screening_cycle_id="cycle_1", limit=1))
+    assert counts == {
+        AcquisitionOutcome.SUCCESS: 1,
+        AcquisitionOutcome.TRANSPORT_FAILURE: 2,
+    }
+
+
+def test_no_raw_payloads_headers_or_credentials_in_stored_row(
+    repository: PostgresAcquisitionAttemptRepository,
+) -> None:
+    """Column set itself is the guardrail -- there is no column that could
+    hold a raw payload, header, or credential in the first place."""
+    repository.record((_record(outcome=AcquisitionOutcome.STALE_DATA),))
+    engine = repository._engine  # noqa: SLF001 -- test-only introspection
+    with engine.connect() as connection:
+        columns = connection.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'screening_acquisition_attempts'"
+            )
+        ).scalars()
+        assert set(columns) == {
+            "id", "screening_cycle_id", "pair_evaluation_id", "sequence", "capability",
+            "provider_id", "priority", "fulfillment_status", "outcome", "diagnostic_code",
+            "retryable", "safe_summary", "recorded_at",
+        }

--- a/tests/market_data/test_attempts.py
+++ b/tests/market_data/test_attempts.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
 from domain.values import DomainInvariantError
 from market_data import FulfillmentStatus, ProviderErrorCode
 from market_data.attempts import (
+    MAXIMUM_QUERY_LIMIT,
     AcquisitionAttemptRecord,
     AcquisitionOutcome,
+    AttemptQuery,
+    InMemoryAcquisitionAttemptRepository,
     attempt_records_for,
     normalize_acquisition_outcome,
     summary_outcome_for,
@@ -171,3 +174,144 @@ def test_attempt_records_for_sequence_offset_continues_across_capabilities() -> 
         sequence_offset=3,
     )
     assert records[0].sequence == 3
+
+
+# -- InMemoryAcquisitionAttemptRepository (contract also proven for
+# PostgresAcquisitionAttemptRepository in
+# tests/asa/test_screening_acquisition_attempts_postgres.py) --------------
+
+
+def _record(
+    *,
+    pair: str = "cycle_1:forward_factor:AAPL",
+    sequence: int = 0,
+    provider_id: str = "primary",
+    outcome: AcquisitionOutcome = AcquisitionOutcome.SUCCESS,
+    diagnostic_code: ProviderErrorCode | None = None,
+    recorded_at: datetime = RECORDED_AT,
+    capability=CAPABILITY,
+) -> AcquisitionAttemptRecord:
+    failed = outcome is not AcquisitionOutcome.SUCCESS
+    return AcquisitionAttemptRecord(
+        "cycle_1",
+        pair,
+        sequence,
+        capability,
+        provider_id,
+        1,
+        FulfillmentStatus.FULFILLED if not failed else FulfillmentStatus.FAILED,
+        outcome,
+        diagnostic_code if failed else None,
+        failed,
+        "a safe summary" if failed else None,
+        recorded_at,
+    )
+
+
+def test_repository_record_and_query_round_trip() -> None:
+    repo = InMemoryAcquisitionAttemptRepository()
+    repo.record((_record(),))
+    results = repo.query(AttemptQuery(screening_cycle_id="cycle_1"))
+    assert len(results) == 1
+    assert results[0].pair_evaluation_id == "cycle_1:forward_factor:AAPL"
+
+
+def test_repository_record_is_idempotent_on_pair_and_sequence() -> None:
+    """Re-recording the exact same (pair_evaluation_id, sequence) is a
+    no-op -- not a duplicate row, not an error."""
+    repo = InMemoryAcquisitionAttemptRepository()
+    repo.record((_record(),))
+    repo.record((_record(),))
+    results = repo.query(AttemptQuery(screening_cycle_id="cycle_1"))
+    assert len(results) == 1
+
+
+def test_repository_does_not_collapse_a_genuinely_new_attempt() -> None:
+    """A legitimate retry -- a new attempt with the next sequence number --
+    must still get its own row, never collapsed by idempotency."""
+    repo = InMemoryAcquisitionAttemptRepository()
+    repo.record((_record(sequence=0),))
+    repo.record((_record(sequence=1, provider_id="secondary"),))
+    results = repo.query(AttemptQuery(screening_cycle_id="cycle_1"))
+    assert len(results) == 2
+
+
+def test_repository_query_filters_by_provider_capability_outcome_and_time() -> None:
+    repo = InMemoryAcquisitionAttemptRepository()
+    repo.record(
+        (
+            _record(sequence=0, provider_id="primary", outcome=AcquisitionOutcome.SUCCESS),
+            _record(
+                sequence=1,
+                provider_id="secondary",
+                outcome=AcquisitionOutcome.TRANSPORT_FAILURE,
+                diagnostic_code=ProviderErrorCode.TRANSPORT_ERROR,
+                recorded_at=RECORDED_AT + timedelta(minutes=5),
+            ),
+        )
+    )
+    assert len(repo.query(AttemptQuery(provider_id="secondary"))) == 1
+    assert len(repo.query(AttemptQuery(capability=CAPABILITY))) == 2
+    assert len(repo.query(AttemptQuery(outcome=AcquisitionOutcome.TRANSPORT_FAILURE))) == 1
+    assert len(repo.query(AttemptQuery(recorded_after=RECORDED_AT + timedelta(minutes=1)))) == 1
+    assert len(repo.query(AttemptQuery(recorded_before=RECORDED_AT))) == 1
+
+
+def test_repository_query_pagination_and_stable_ordering() -> None:
+    repo = InMemoryAcquisitionAttemptRepository()
+    repo.record(
+        tuple(
+            _record(
+                pair=f"cycle_1:forward_factor:SYM{i}",
+                sequence=0,
+                recorded_at=RECORDED_AT + timedelta(seconds=i),
+            )
+            for i in range(5)
+        )
+    )
+    first_page = repo.query(AttemptQuery(limit=2, offset=0))
+    second_page = repo.query(AttemptQuery(limit=2, offset=2))
+    assert [item.pair_evaluation_id for item in first_page] == [
+        "cycle_1:forward_factor:SYM0",
+        "cycle_1:forward_factor:SYM1",
+    ]
+    assert [item.pair_evaluation_id for item in second_page] == [
+        "cycle_1:forward_factor:SYM2",
+        "cycle_1:forward_factor:SYM3",
+    ]
+
+
+def test_attempt_query_rejects_limit_above_maximum() -> None:
+    with pytest.raises(ValueError):
+        AttemptQuery(limit=MAXIMUM_QUERY_LIMIT + 1)
+
+
+def test_attempt_query_rejects_inverted_time_range() -> None:
+    with pytest.raises(ValueError):
+        AttemptQuery(recorded_after=RECORDED_AT, recorded_before=RECORDED_AT - timedelta(hours=1))
+
+
+def test_repository_summarize_groups_by_outcome_ignoring_pagination() -> None:
+    repo = InMemoryAcquisitionAttemptRepository()
+    repo.record(
+        (
+            _record(sequence=0, outcome=AcquisitionOutcome.SUCCESS),
+            _record(
+                pair="cycle_1:forward_factor:MSFT",
+                sequence=0,
+                outcome=AcquisitionOutcome.TRANSPORT_FAILURE,
+                diagnostic_code=ProviderErrorCode.TRANSPORT_ERROR,
+            ),
+            _record(
+                pair="cycle_1:forward_factor:GOOG",
+                sequence=0,
+                outcome=AcquisitionOutcome.TRANSPORT_FAILURE,
+                diagnostic_code=ProviderErrorCode.TIMEOUT,
+            ),
+        )
+    )
+    counts = repo.summarize(AttemptQuery(screening_cycle_id="cycle_1", limit=1))
+    assert counts == {
+        AcquisitionOutcome.SUCCESS: 1,
+        AcquisitionOutcome.TRANSPORT_FAILURE: 2,
+    }


### PR DESCRIPTION
## Summary

Completes SPRINT-013 S13-02 on top of S13-02a (#269, merged). Adds a
production database migration, the PostgreSQL repository, wiring into
`asa/scheduled_screening.py`, and operations-token-gated query routes.

**This PR does NOT auto-merge even with green CI.** Merging to `main`
triggers Railway's auto-deploy, whose `preDeployCommand`/`startCommand`
both run `alembic upgrade head` -- i.e. merging this PR applies the new
schema to production. Deployment authority is Founder-only per the active
Amendment 013 delegation. Full detail, self-review, migration rollback
plan, and production smoke plan are in the commit message
(`dea2bc2`) -- summarized below.

## What's in this PR

- **Migration** (`migrations/versions/0011_screening_acquisition_attempts.py`):
  additive only -- one new table, six indexes covering every required query
  dimension (cycle/pair/provider/capability/outcome/time), one unique
  constraint `(pair_evaluation_id, sequence)` as the idempotency key. No
  existing table touched.
- **Repository** (`asa/integrations/screening_acquisition_attempts_postgres.py`):
  `record()` idempotent via `ON CONFLICT ... DO NOTHING` (same pattern as
  the existing `PostgresRefreshScheduleClaimRepository`); `query()`/
  `summarize()` share a bounded, stable-ordered WHERE-clause builder.
- **Wiring** (`asa/scheduled_screening.py`): one `screening_cycle_id` per
  invocation, one `pair_evaluation_id` per pair, attempt persistence
  wrapped separately from the strategy evaluation itself -- a persistence
  failure never aborts or corrupts a screening result, but
  `PairOutcome.attempts_recorded` is now `False` and surfaced in CLI/JSON
  output so acquisition accounting is never silently reported complete.
- **Ops routes** (`asa/market_data_ops/routes.py`): `GET
  /ops/screening/attempts` and `GET /ops/screening/attempts/summary`,
  behind the existing hidden-endpoint token auth. Not added to the
  frontend's `openapi.json` -- confirmed the existing `/ops/market-data/
  validate` endpoint is excluded from that contract too, same established
  pattern.

## Validation

- Migration: offline SQL rendering clean both directions (no local
  Postgres in this environment); real upgrade/downgrade will run via
  `product-ci.yml`'s Postgres service container on this PR.
- `tests/asa`: 145 passed, 22 skipped (DB/live-credential gated, expected),
  2 pre-existing failures in `test_railway_runtime.py` confirmed unrelated
  -- reproduce identically on unmodified `main` (Windows can't run the
  bash `&&`/`exec` startCommand these tests spawn as a subprocess; CI runs
  on `ubuntu-latest`).
- `ruff check asa tests/asa`: clean. `mypy asa`: clean, 43 files.
- Full `validate-architecture.yml` scope: 1894 passed, 1 skipped, 0 failed.
- `git diff --check`: clean. Secret scan: manually reviewed, no
  credentials.

## Founder action required

Authorize merge of this migration-bearing PR, acknowledging that the
main-branch merge triggers Railway deployment and `alembic upgrade head`.