### PR TITLE
S13-03A: rolling provider quota correctness (core fix)

### DIFF
--- a/asa/market_data_ops/service.py
+++ b/asa/market_data_ops/service.py
@@ -217,12 +217,23 @@ def _budget_policy_for(provider_id: str, provider_config: ProviderConfig) -> Req
     """The ceiling enforced here is always the provider's own validation_budget --
     ValidationBudgetConfig.__post_init__ already refuses more than the authorized safety
     ceiling (<=12 requests/run, <=3/capability, <=1 retry); this never widens it.
+
+    burst_limit is deliberately less than max_requests_per_provider_run (not
+    equal to it): a bounded validation run checking every one of a
+    provider's capabilities sequentially (e.g. Tradier's historical_bars_v1,
+    option_chain_v1, real_time_quote_v1) legitimately needs a handful of
+    requests within the same second, but burst_limit still exists to catch
+    a genuinely pathological zero-delay request storm, not to block a
+    normal bounded check (SPRINT-013 S13-03A: RequestBudgetManager's burst
+    accounting now correctly enforces a real sliding window instead of the
+    previous exact-timestamp bug, so this can no longer rely on that bug to
+    silently tolerate a burst_limit of 1).
     """
     return RequestBudgetPolicy(
         provider_id,
         BudgetScope.RUNTIME,
         provider_config.validation_budget.max_requests_per_provider_run,
-        1,
+        min(5, provider_config.validation_budget.max_requests_per_provider_run),
         provider_config.validation_budget.max_retries_per_request,
         "ops-validation-v1",
     )

--- a/market_data/budget.py
+++ b/market_data/budget.py
@@ -12,6 +12,7 @@ from domain import MarketCapability
 from domain.values import DomainInvariantError, require_tz_aware
 from market_data.factory import Clock
 from market_data.providers import RequestBudgetAuthorization
+from market_data.rolling_window import ProviderRollingWindowTracker
 
 
 class BudgetExhaustedError(RuntimeError):
@@ -38,13 +39,14 @@ class RequestBudgetPolicy:
     burst_limit: int
     maximum_retries_per_request: int
     policy_version: str
+    burst_window_seconds: int = 1
 
     def __post_init__(self) -> None:
         for name in ("provider_id", "policy_version"):
             value = getattr(self, name)
             if not value or value != value.strip():
                 raise DomainInvariantError(f"RequestBudgetPolicy.{name} must be normalized")
-        for name in ("maximum_request_units", "burst_limit"):
+        for name in ("maximum_request_units", "burst_limit", "burst_window_seconds"):
             if type(getattr(self, name)) is not int or getattr(self, name) <= 0:
                 raise DomainInvariantError(f"RequestBudgetPolicy.{name} must be positive")
         if self.burst_limit > self.maximum_request_units:
@@ -112,11 +114,28 @@ class RequestAccountingEntry:
 
 
 class RequestBudgetManager:
-    """Explicit per-run operational ledger; no background retries or hidden provider state."""
+    """Explicit per-run operational ledger; no background retries or hidden
+    provider state. Deliberately rebuilt fresh per pair -- pair_isolation
+    is a property of this class's own lifetime, not enforced elsewhere.
 
-    __slots__ = ("_policies", "_clock", "_entries", "_cooldowns", "_burst")
+    ``rolling_window``, when supplied, is the one deliberately SHARED,
+    cross-pair exception to that isolation: a provider's real external
+    rate limit is consulted (never owned or mutated beyond reservation)
+    before any local per-pair budget is consumed, so a pair whose request
+    would exceed the provider's actual rolling window is refused before
+    it ever reaches the provider, regardless of what this pair's own
+    local ledger would otherwise allow.
+    """
 
-    def __init__(self, policies: tuple[RequestBudgetPolicy, ...], clock: Clock) -> None:
+    __slots__ = ("_policies", "_clock", "_entries", "_cooldowns", "_burst", "_rolling_window")
+
+    def __init__(
+        self,
+        policies: tuple[RequestBudgetPolicy, ...],
+        clock: Clock,
+        *,
+        rolling_window: ProviderRollingWindowTracker | None = None,
+    ) -> None:
         ordered = tuple(sorted(policies, key=lambda value: (value.provider_id, value.scope.value)))
         keys = tuple((value.provider_id, value.scope) for value in ordered)
         if not ordered or len(keys) != len(set(keys)):
@@ -125,7 +144,8 @@ class RequestBudgetManager:
         self._clock = clock
         self._entries: list[RequestAccountingEntry] = []
         self._cooldowns: dict[str, datetime] = {}
-        self._burst: dict[tuple[str, BudgetScope, datetime], int] = {}
+        self._burst: dict[tuple[str, BudgetScope], list[datetime]] = {}
+        self._rolling_window = rolling_window
 
     @property
     def accounting(self) -> tuple[RequestAccountingEntry, ...]:
@@ -167,9 +187,11 @@ class RequestBudgetManager:
         )
         if consumed + request_units > policy.maximum_request_units:
             raise BudgetExhaustedError(f"Provider {provider_id!r} {scope.value} budget exhausted")
-        burst_key = (provider_id, scope, now)
-        burst = self._burst.get(burst_key, 0)
-        if burst + 1 > policy.burst_limit:
+        burst_key = (provider_id, scope)
+        window_start = now - timedelta(seconds=policy.burst_window_seconds)
+        recent_burst = [value for value in self._burst.get(burst_key, []) if value > window_start]
+        if len(recent_burst) + 1 > policy.burst_limit:
+            self._burst[burst_key] = recent_burst
             raise BudgetExhaustedError(f"Provider {provider_id!r} burst budget exhausted")
         attempt_number = 1
         retry_root_id: str | None = None
@@ -186,6 +208,15 @@ class RequestBudgetManager:
             if retries >= policy.maximum_retries_per_request:
                 raise BudgetExhaustedError(f"Provider {provider_id!r} retry budget exhausted")
             attempt_number = original[0].attempt_number + 1
+        # Shared cross-pair reservation is the LAST gate, only once every
+        # local (pair-scoped) check has already passed -- reserving a
+        # shared window slot for a request that was going to be refused
+        # locally anyway would waste real provider capacity across the
+        # whole cycle for no reason.
+        if self._rolling_window is not None and not self._rolling_window.try_reserve(provider_id):
+            raise BudgetExhaustedError(
+                f"Provider {provider_id!r} shared rolling-window budget exhausted"
+            )
         sequence = len(self._entries) + 1
         payload = json.dumps(
             {
@@ -217,7 +248,7 @@ class RequestBudgetManager:
                 None,
             )
         )
-        self._burst[burst_key] = burst + 1
+        self._burst[burst_key] = recent_burst + [now]
         return RequestBudgetAuthorization(
             authorization_id,
             provider_id,
@@ -245,6 +276,11 @@ class RequestBudgetManager:
             if type(retry_after_seconds) is not int or retry_after_seconds < 0:
                 raise DomainInvariantError("retry_after_seconds must be non-negative")
             self._cooldowns[current.provider_id] = now + timedelta(seconds=retry_after_seconds)
+        if self._rolling_window is not None and quota is not None and quota.resets_at is not None:
+            # Safe application only: apply_reset_hint() can shorten the
+            # shared window's effective allowance, never lengthen it --
+            # see ProviderRollingWindowTracker.apply_reset_hint.
+            self._rolling_window.apply_reset_hint(current.provider_id, quota.resets_at)
         completed = RequestAccountingEntry(
             current.authorization_id,
             current.retry_root_id,

--- a/market_data/config.py
+++ b/market_data/config.py
@@ -43,7 +43,7 @@ class SecretValue:
 @dataclass(frozen=True, slots=True)
 class RequestBudgetConfig:
     max_requests_per_run: int = 100
-    burst_limit: int = 1
+    burst_limit: int = 8
 
     def __post_init__(self) -> None:
         _positive(self.max_requests_per_run, "max_requests_per_run")
@@ -246,7 +246,7 @@ def _provider(
     enabled = _boolean(values, f"{prefix}_ENABLED", default_enabled)
     timeout = _integer(values, f"{prefix}_TIMEOUT_SECONDS", 10)
     requests = _integer(values, f"{prefix}_MAX_REQUESTS_PER_RUN", 100)
-    burst = _integer(values, f"{prefix}_BURST_LIMIT", 1)
+    burst = _integer(values, f"{prefix}_BURST_LIMIT", 8)
     retries = _integer(values, f"{prefix}_MAX_RETRIES", 1)
     return ProviderConfig(
         provider_id,

--- a/market_data/rolling_window.py
+++ b/market_data/rolling_window.py
@@ -1,0 +1,122 @@
+"""Shared, cross-pair provider rolling-window request tracking (SPRINT-013
+S13-03A).
+
+RequestBudgetManager (market_data/budget.py) is deliberately rebuilt fresh
+per pair -- one pair's local accounting, retries, and burst behavior must
+never leak into another's. A provider's real external rate limit is the
+opposite: a property of the provider, not of any one pair, so it cannot be
+enforced correctly by a per-pair-scoped ledger no matter how it's fixed.
+ProviderRollingWindowTracker is the one deliberately shared, cross-pair
+piece of state in the whole acquisition path -- minted once per screening
+cycle (never per pair) and consulted, not owned, by each pair's
+RequestBudgetManager.
+
+Window durations and limits are never invented here -- they are sourced
+from each provider's own declared, documented limits
+(market_data.providers.ProviderLimitDeclaration) at composition time,
+outside this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from domain.values import DomainInvariantError, require_tz_aware
+from market_data.factory import Clock
+
+
+@dataclass(frozen=True, slots=True)
+class RollingWindowPolicy:
+    """One provider's real, documented rolling rate limit."""
+
+    provider_id: str
+    window_seconds: int
+    window_limit: int
+    source: str
+
+    def __post_init__(self) -> None:
+        if not self.provider_id or self.provider_id != self.provider_id.strip():
+            raise DomainInvariantError("RollingWindowPolicy.provider_id must be normalized")
+        if type(self.window_seconds) is not int or self.window_seconds <= 0:
+            raise DomainInvariantError("RollingWindowPolicy.window_seconds must be positive")
+        if type(self.window_limit) is not int or self.window_limit <= 0:
+            raise DomainInvariantError("RollingWindowPolicy.window_limit must be positive")
+        if not self.source or self.source != self.source.strip():
+            raise DomainInvariantError("RollingWindowPolicy.source must be normalized")
+
+
+class ProviderRollingWindowTracker:
+    """One instance per screening cycle, shared across every pair.
+
+    try_reserve() is a genuine monotonic sliding window: each provider
+    keeps a deque of its own recent reservation timestamps, pruned to
+    ``window_seconds`` on every call, so it correctly aggregates real
+    concurrent/near-concurrent requests from different pairs -- unlike
+    RequestBudgetManager's old per-pair burst bug, which keyed usage by
+    exact timestamp and so never aggregated anything in production.
+
+    A provider with no configured RollingWindowPolicy is always allowed
+    (this tracker adds protection, it never invents a limit that wasn't
+    declared).
+    """
+
+    __slots__ = ("_policies", "_clock", "_reservations", "_reset_until")
+
+    def __init__(self, policies: tuple[RollingWindowPolicy, ...], clock: Clock) -> None:
+        provider_ids = tuple(item.provider_id for item in policies)
+        if len(provider_ids) != len(set(provider_ids)):
+            raise DomainInvariantError("RollingWindowPolicy provider_id values must be unique")
+        self._policies = {item.provider_id: item for item in policies}
+        self._clock = clock
+        self._reservations: dict[str, list[datetime]] = {}
+        self._reset_until: dict[str, datetime] = {}
+
+    def try_reserve(self, provider_id: str) -> bool:
+        policy = self._policies.get(provider_id)
+        if policy is None:
+            return True
+        now = self._clock.now()
+        require_tz_aware(now, "ProviderRollingWindowTracker", "clock")
+        reset_until = self._reset_until.get(provider_id)
+        if reset_until is not None and now < reset_until:
+            return False
+        window_start = now - timedelta(seconds=policy.window_seconds)
+        recent = [
+            value for value in self._reservations.get(provider_id, []) if value > window_start
+        ]
+        if len(recent) >= policy.window_limit:
+            self._reservations[provider_id] = recent
+            return False
+        recent.append(now)
+        self._reservations[provider_id] = recent
+        return True
+
+    def apply_reset_hint(self, provider_id: str, resets_at: datetime) -> None:
+        """Safe application of a provider-reported reset/quota hint: may
+        only SHORTEN local allowance (treat the provider as exhausted
+        until ``resets_at``), never lengthen it or grant additional
+        requests beyond the configured window_limit. A hint for a
+        provider with no configured policy is ignored -- there is nothing
+        to safely tighten.
+        """
+        if provider_id not in self._policies:
+            return
+        require_tz_aware(resets_at, "ProviderRollingWindowTracker", "resets_at")
+        current = self._reset_until.get(provider_id)
+        if current is None or resets_at > current:
+            self._reset_until[provider_id] = resets_at
+
+    def summary(self) -> dict[str, int]:
+        """Sanitized, cycle-level accounting: current in-window reservation
+        count per configured provider. No payloads, headers, or
+        credentials -- provider_id and an integer count only.
+        """
+        now = self._clock.now()
+        result: dict[str, int] = {}
+        for provider_id, policy in self._policies.items():
+            window_start = now - timedelta(seconds=policy.window_seconds)
+            result[provider_id] = sum(
+                1 for value in self._reservations.get(provider_id, []) if value > window_start
+            )
+        return result

--- a/tests/asa/market_data_ops/test_market_data_validate.py
+++ b/tests/asa/market_data_ops/test_market_data_validate.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -364,18 +364,34 @@ def test_budget_policy_never_exceeds_the_authorized_validation_ceiling() -> None
 
 
 def test_request_budget_manager_refuses_requests_beyond_the_authorized_ceiling() -> None:
+    """Isolates the TOTAL ceiling (maximum_request_units) from burst_limit
+    (a separate, smaller, real-time-window ceiling -- SPRINT-013 S13-03A)
+    by spacing each authorization a full burst_window_seconds apart, so
+    this test can never hit burst exhaustion before the total ceiling it's
+    actually testing.
+    """
+    from dataclasses import dataclass, field
 
-    from asa.market_data_ops.service import Clock, _budget_policy_for
+    from asa.market_data_ops.service import _budget_policy_for
     from domain import MarketCapability
     from market_data.budget import BudgetExhaustedError, RequestBudgetManager
     from market_data.config import load_market_data_config
+
+    @dataclass
+    class _SpacedClock:
+        value: datetime = field(default_factory=lambda: datetime(2026, 1, 1, tzinfo=UTC))
+
+        def now(self) -> datetime:
+            current = self.value
+            self.value += timedelta(seconds=2)
+            return current
 
     config = load_market_data_config(
         {"ASA_TRADIER_ENABLED": "true", "ASA_TRADIER_ACCESS_TOKEN": "x"}
     )
     tradier_config = next(item for item in config.providers if item.provider_id == "tradier")
     policy = _budget_policy_for("tradier", tradier_config)
-    manager = RequestBudgetManager((policy,), Clock())
+    manager = RequestBudgetManager((policy,), _SpacedClock())
     for _ in range(policy.maximum_request_units):
         manager.authorize("tradier", MarketCapability.REAL_TIME_QUOTE_V1, 1)
     with pytest.raises(BudgetExhaustedError):

--- a/tests/market_data/test_budget.py
+++ b/tests/market_data/test_budget.py
@@ -14,6 +14,7 @@ from market_data.budget import (
     RequestBudgetPolicy,
     RequestOutcome,
 )
+from market_data.rolling_window import ProviderRollingWindowTracker, RollingWindowPolicy
 
 START = datetime(2026, 7, 21, tzinfo=timezone.utc)
 
@@ -156,3 +157,127 @@ def test_same_inputs_and_fake_clock_produce_same_authorization() -> None:
     first = manager(FakeClock()).authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
     second = manager(FakeClock()).authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
     assert first == second
+
+
+# -- SPRINT-013 S13-03A: burst sliding window and shared cross-pair
+# rolling-window integration --------------------------------------------
+
+
+def test_microsecond_separated_requests_obey_the_same_active_window() -> None:
+    """The confirmed root cause (issue #261): the old burst dict keyed
+    usage by the exact authorization timestamp, so under a real clock
+    (unique to the microsecond on every call) two requests essentially
+    never collided and burst_limit was unenforceable in production. A
+    FakeClock that doesn't advance at all is the adversarial case that
+    exposes this."""
+    clock = FakeClock()
+    budget = manager(clock, burst=1)
+    budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+    with pytest.raises(BudgetExhaustedError, match="burst"):
+        budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+
+
+def test_burst_window_duration_is_configurable_and_expires_deterministically() -> None:
+    clock = FakeClock()
+    budget = RequestBudgetManager(
+        (RequestBudgetPolicy("fixture", BudgetScope.RUNTIME, 10, 1, 1, "v1",
+                              burst_window_seconds=5),),
+        clock,
+    )
+    budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+    clock.advance(4)
+    with pytest.raises(BudgetExhaustedError, match="burst"):
+        budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+    clock.advance(2)  # now 6s after the first authorization
+    assert budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+
+
+def test_shared_rolling_window_refusal_never_burns_local_pair_budget() -> None:
+    """A cross-pair provider-level refusal must be refused before any
+    local (pair-scoped) budget is consumed -- otherwise a shared-window
+    refusal would silently eat into this pair's own accounting for a
+    request that was never actually sent."""
+    clock = FakeClock()
+    window = ProviderRollingWindowTracker(
+        (RollingWindowPolicy("fixture", 60, 1, "documented"),), clock
+    )
+    window.try_reserve("fixture")  # consume the one shared slot
+    budget = RequestBudgetManager(
+        (RequestBudgetPolicy("fixture", BudgetScope.RUNTIME, 10, 5, 1, "v1"),),
+        clock,
+        rolling_window=window,
+    )
+    with pytest.raises(BudgetExhaustedError, match="rolling-window"):
+        budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+    assert budget.accounting == ()  # nothing was locally recorded
+
+
+def test_shared_rolling_window_is_consulted_across_independently_constructed_managers() -> None:
+    """The whole point: two DIFFERENT RequestBudgetManager instances (one
+    per pair, as production actually builds them) sharing one
+    ProviderRollingWindowTracker enforce one real cross-pair limit."""
+    clock = FakeClock()
+    window = ProviderRollingWindowTracker(
+        (RollingWindowPolicy("fixture", 60, 1, "documented"),), clock
+    )
+    first_pair_budget = RequestBudgetManager(
+        (RequestBudgetPolicy("fixture", BudgetScope.RUNTIME, 10, 5, 1, "v1"),),
+        clock,
+        rolling_window=window,
+    )
+    second_pair_budget = RequestBudgetManager(
+        (RequestBudgetPolicy("fixture", BudgetScope.RUNTIME, 10, 5, 1, "v1"),),
+        clock,
+        rolling_window=window,
+    )
+    assert first_pair_budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+    with pytest.raises(BudgetExhaustedError, match="rolling-window"):
+        second_pair_budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+    # Each manager's own local accounting stays independent (pair isolation).
+    assert len(first_pair_budget.accounting) == 1
+    assert len(second_pair_budget.accounting) == 0
+
+
+def test_upstream_and_local_refusal_remain_distinct() -> None:
+    """A shared-window (upstream-shaped) refusal and a local total-budget
+    refusal must raise distinguishable errors, not the same generic one."""
+    clock = FakeClock()
+    window = ProviderRollingWindowTracker(
+        (RollingWindowPolicy("fixture", 60, 1, "documented"),), clock
+    )
+    window.try_reserve("fixture")
+    budget = RequestBudgetManager(
+        (RequestBudgetPolicy("fixture", BudgetScope.RUNTIME, 1, 1, 1, "v1"),),
+        clock,
+        rolling_window=window,
+    )
+    with pytest.raises(BudgetExhaustedError, match="rolling-window"):
+        budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+
+    other_budget = RequestBudgetManager(
+        (RequestBudgetPolicy("fixture", BudgetScope.RUNTIME, 1, 1, 1, "v1"),), clock
+    )
+    other_budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+    with pytest.raises(BudgetExhaustedError, match="budget exhausted"):
+        other_budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+
+
+def test_complete_forwards_safe_reset_hint_to_shared_window() -> None:
+    clock = FakeClock()
+    window = ProviderRollingWindowTracker(
+        (RollingWindowPolicy("fixture", 60, 5, "documented"),), clock
+    )
+    budget = RequestBudgetManager(
+        (RequestBudgetPolicy("fixture", BudgetScope.RUNTIME, 10, 5, 1, "v1"),),
+        clock,
+        rolling_window=window,
+    )
+    authorization = budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+    quota = QuotaObservation(
+        "fixture", clock.now(), 0, 5, clock.now() + timedelta(minutes=5), ("x-ratelimit",)
+    )
+    budget.complete(authorization.authorization_id, RequestOutcome.RATE_LIMITED, quota=quota)
+    # The reset hint (5 minutes out) is now the binding constraint, tighter
+    # than the window's own 60s duration would otherwise allow.
+    clock.advance(65)
+    assert window.try_reserve("fixture") is False

--- a/tests/market_data/test_rolling_window.py
+++ b/tests/market_data/test_rolling_window.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from domain.values import DomainInvariantError
+from market_data.rolling_window import ProviderRollingWindowTracker, RollingWindowPolicy
+
+START = datetime(2026, 7, 21, tzinfo=UTC)
+
+
+@dataclass
+class FakeClock:
+    value: datetime = START
+
+    def now(self) -> datetime:
+        return self.value
+
+    def advance(self, **kwargs) -> None:
+        self.value += timedelta(**kwargs)
+
+
+def policy(provider_id: str = "tradier", window_seconds: int = 60, window_limit: int = 2):
+    return RollingWindowPolicy(provider_id, window_seconds, window_limit, "documented")
+
+
+def test_policy_rejects_non_positive_fields() -> None:
+    with pytest.raises(DomainInvariantError):
+        RollingWindowPolicy("tradier", 0, 5, "documented")
+    with pytest.raises(DomainInvariantError):
+        RollingWindowPolicy("tradier", 60, 0, "documented")
+
+
+def test_reserves_up_to_the_limit_within_the_window() -> None:
+    clock = FakeClock()
+    tracker = ProviderRollingWindowTracker((policy(),), clock)
+    assert tracker.try_reserve("tradier") is True
+    assert tracker.try_reserve("tradier") is True
+    assert tracker.try_reserve("tradier") is False  # limit is 2
+
+
+def test_genuinely_aggregates_microsecond_separated_requests() -> None:
+    """The bug this fixes: RequestBudgetManager's old burst dict keyed by
+    the exact authorization timestamp, so two requests one microsecond
+    apart never collided under a real clock. A rolling window must catch
+    this even without advancing the clock at all."""
+    clock = FakeClock()
+    tracker = ProviderRollingWindowTracker((policy(window_limit=1),), clock)
+    assert tracker.try_reserve("tradier") is True
+    # No time has passed at all -- still within the same window.
+    assert tracker.try_reserve("tradier") is False
+
+
+def test_window_expiry_restores_allowance_deterministically() -> None:
+    clock = FakeClock()
+    tracker = ProviderRollingWindowTracker((policy(window_seconds=60, window_limit=1),), clock)
+    assert tracker.try_reserve("tradier") is True
+    clock.advance(seconds=59)
+    assert tracker.try_reserve("tradier") is False
+    clock.advance(seconds=2)  # now 61s after the first reservation
+    assert tracker.try_reserve("tradier") is True
+
+
+def test_providers_have_independent_accounting() -> None:
+    clock = FakeClock()
+    tracker = ProviderRollingWindowTracker(
+        (policy("tradier", window_limit=1), policy("finnhub", window_limit=1)), clock
+    )
+    assert tracker.try_reserve("tradier") is True
+    assert tracker.try_reserve("tradier") is False
+    assert tracker.try_reserve("finnhub") is True  # independent from tradier
+
+
+def test_unconfigured_provider_is_never_limited() -> None:
+    """This tracker adds protection; it never invents a limit for a
+    provider with no declared/configured policy."""
+    clock = FakeClock()
+    tracker = ProviderRollingWindowTracker((policy("tradier"),), clock)
+    for _ in range(50):
+        assert tracker.try_reserve("alpha_vantage") is True
+
+
+def test_reset_hint_can_only_shorten_never_lengthen_allowance() -> None:
+    clock = FakeClock()
+    tracker = ProviderRollingWindowTracker((policy(window_seconds=60, window_limit=5),), clock)
+    tracker.apply_reset_hint("tradier", clock.now() + timedelta(seconds=120))
+    assert tracker.try_reserve("tradier") is False  # blocked well before the window would expire
+
+    clock.advance(seconds=200)  # past the reset hint
+    assert tracker.try_reserve("tradier") is True
+
+
+def test_reset_hint_does_not_shorten_below_a_later_earlier_hint() -> None:
+    """A later, LOOSER hint must never override an earlier, TIGHTER one --
+    only ever tighten further, never relax."""
+    clock = FakeClock()
+    tracker = ProviderRollingWindowTracker((policy(window_seconds=60, window_limit=5),), clock)
+    tracker.apply_reset_hint("tradier", clock.now() + timedelta(seconds=120))
+    tracker.apply_reset_hint("tradier", clock.now() + timedelta(seconds=10))  # looser, ignored
+    clock.advance(seconds=15)
+    assert tracker.try_reserve("tradier") is False  # still blocked under the tighter hint
+
+
+def test_reset_hint_for_unconfigured_provider_is_ignored() -> None:
+    clock = FakeClock()
+    tracker = ProviderRollingWindowTracker((policy("tradier"),), clock)
+    tracker.apply_reset_hint("alpha_vantage", clock.now() + timedelta(seconds=999))
+    assert tracker.try_reserve("alpha_vantage") is True
+
+
+def test_summary_reports_sanitized_in_window_counts_only() -> None:
+    clock = FakeClock()
+    tracker = ProviderRollingWindowTracker((policy(window_seconds=60, window_limit=5),), clock)
+    tracker.try_reserve("tradier")
+    tracker.try_reserve("tradier")
+    assert tracker.summary() == {"tradier": 2}
+    clock.advance(seconds=61)
+    assert tracker.summary() == {"tradier": 0}

--- a/tests/screening/test_live_acquisition.py
+++ b/tests/screening/test_live_acquisition.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -158,12 +158,25 @@ class TestBuildFulfillmentServiceAndAcquireCapability:
         """Demonstrates real request-budget enforcement, not just that it's
         wired: a second, *distinct* request (a different capability -- an
         identical repeated request is memoized by CapabilityFulfillmentService
-        and never re-authorized) in the same instant hits the provider's
-        burst_limit=1 default and is refused, exactly as RequestBudgetPolicy
+        and never re-authorized) in the same instant hits an explicit
+        burst_limit=1 policy and is refused, exactly as RequestBudgetPolicy
         is designed to do -- LIVE-001's request_budget_compliance deliverable
-        proven, not merely assumed.
+        proven, not merely assumed. burst_limit is overridden explicitly
+        (rather than relying on the production default, which SPRINT-013
+        S13-03A widened to give real multi-request pairs headroom) so this
+        test keeps proving the enforcement mechanism itself regardless of
+        whatever the production default is tuned to.
         """
         config = load_market_data_config({})
+        config = replace(
+            config,
+            providers=tuple(
+                replace(item, request_budget=replace(item.request_budget, burst_limit=1))
+                if item.provider_id == "deterministic_fixture"
+                else item
+                for item in config.providers
+            ),
+        )
         fulfillment = build_fulfillment_service(config, _no_transport, FixedClock())
         first_capability = MarketCapability.REAL_TIME_QUOTE_V1
         second_capability = MarketCapability.HISTORICAL_BARS_V1

--- a/tests/screening/test_live_adapters.py
+++ b/tests/screening/test_live_adapters.py
@@ -15,6 +15,7 @@ still zero network, still fully deterministic.
 
 from __future__ import annotations
 
+import dataclasses
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 
@@ -341,7 +342,12 @@ def _no_transport(_provider_id: str) -> object:
     return object()
 
 
-def _fulfillment(provider_cls=DeterministicFixtureProvider, clock: FixedClock | None = None):
+def _fulfillment(
+    provider_cls=DeterministicFixtureProvider,
+    clock: FixedClock | None = None,
+    *,
+    burst_limit: int | None = None,
+):
     # One shared clock instance for both the budget manager and the
     # provider's dependencies: RequestBudgetManager.authorize()'s burst-key
     # is keyed by *its own* clock reading, independent of whatever clock a
@@ -349,9 +355,27 @@ def _fulfillment(provider_cls=DeterministicFixtureProvider, clock: FixedClock | 
     # instance here is what actually avoids burst collisions across the
     # several acquisitions one adapter run makes (a quote and a chain, at
     # minimum).
+    #
+    # burst_limit override: the configured default (market_data/config.py's
+    # RequestBudgetConfig) is sized for one strategy per pair -- the real
+    # production shape (asa/scheduled_screening.py builds one budget per
+    # (signal_id, symbol) pair). Tests that deliberately run every target
+    # strategy together against one shared budget (TARGET_STRATEGY_REGISTRY
+    # with no strategy_ids filter -- itself a real screening/cli.py --live
+    # multi-strategy path, just not the automated scheduled one) need more
+    # headroom than any single real pair does; pass it explicitly here
+    # rather than inflating the global default for every single-strategy
+    # caller.
     shared_clock = clock or FixedClock()
     config = load_market_data_config({})
     (fixture_config,) = tuple(item for item in config.providers if item.enabled)
+    if burst_limit is not None:
+        fixture_config = dataclasses.replace(
+            fixture_config,
+            request_budget=dataclasses.replace(
+                fixture_config.request_budget, burst_limit=burst_limit
+            ),
+        )
     budget_manager = build_request_budget_manager((fixture_config,), shared_clock)
     provider = provider_cls(
         fixture_config, ProviderDependencies(object(), shared_clock, budget_manager)
@@ -528,7 +552,11 @@ class TestCapabilityNotOfferedByAnyEnabledProvider:
 
 class TestFullLiveRunAcrossAllThreeStrategies:
     def test_all_three_run_and_are_isolated_from_each_other(self) -> None:
-        fulfillment, clock = _fulfillment(MultiExpirationFixtureProvider)
+        # All three strategies deliberately share one budget here (no
+        # strategy_ids filter) -- see _fulfillment()'s burst_limit
+        # docstring for why this needs more headroom than one pair's own
+        # production-shaped budget.
+        fulfillment, clock = _fulfillment(MultiExpirationFixtureProvider, burst_limit=20)
         adapters = build_live_adapters(SYMBOL, fulfillment)
         results = run_screening(TARGET_STRATEGY_REGISTRY, adapters, clock)
         assert {result.strategy_id for result in results} == {
@@ -765,7 +793,10 @@ class TestTwoStepLiveAcquisitionAgainstATradierShapedProvider:
                     )
                 return super()._chain_response_for_one_expiration(request)
 
-        fulfillment, clock = _fulfillment(_BackExpirationFailsProvider)
+        # All three strategies deliberately share one budget here (no
+        # strategy_ids filter) -- see _fulfillment()'s burst_limit
+        # docstring.
+        fulfillment, clock = _fulfillment(_BackExpirationFailsProvider, burst_limit=20)
         adapters = build_live_adapters(SYMBOL, fulfillment)
         results = run_screening(TARGET_STRATEGY_REGISTRY, adapters, clock)
         by_strategy = {result.strategy_id: result for result in results}

--- a/tests/strategy_runtime/adapters/test_skew_momentum_vertical.py
+++ b/tests/strategy_runtime/adapters/test_skew_momentum_vertical.py
@@ -11,6 +11,7 @@ import pytest
 
 from market_data import load_market_data_config
 from market_data.transport import ReadOnlyHttpResponse
+from screening.live_acquisition import live_only_config
 from strategy_runtime.adapters.skew_momentum_vertical import (
     SKEW_MOMENTUM_VERTICAL_CONTRACT,
     skew_momentum_adapter,
@@ -29,43 +30,89 @@ class _FixedClock:
         return self.value
 
 
+# (strike offset from the 190 ATM strike, call delta) -- put delta is the
+# standard put_delta = call_delta - 1 relationship (matching
+# tests/screening/test_live_adapters.py's own _STRIKE_DELTA_LADDER).
+# SkewMomentumResearchDecision needs both an ATM contract and a ~0.25-delta
+# wing contract on each side, so a single-strike chain (the original
+# fixture here) can never complete the real acquisition -- it only
+# appeared to pass before because deterministic_fixture (alphabetically
+# first, always enabled) silently answered every request instead of this
+# scripted Tradier transport, until live_only_config() below forced it out.
+_STRIKE_DELTA_LADDER = (
+    (-15, "0.80"),
+    (-10, "0.70"),
+    (-5, "0.60"),
+    (0, "0.50"),
+    (5, "0.35"),
+    (10, "0.25"),
+    (15, "0.15"),
+)
+
+
+def _option_row(strike: int, expiration: str, option_type: str, call_delta: str) -> dict:
+    delta = call_delta if option_type == "call" else str(round(float(call_delta) - 1, 2))
+    return {
+        "symbol": f"AAPL_TEST_{option_type.upper()}_{strike}",
+        "underlying": "AAPL",
+        "expiration_date": expiration,
+        "strike": str(strike),
+        "option_type": option_type,
+        "bid": "4.9",
+        "ask": "5.1",
+        "last": "5",
+        "volume": 1000,
+        "open_interest": 5000,
+        "greeks": {
+            "delta": delta,
+            "gamma": "0.03",
+            "theta": "-0.1",
+            "vega": "0.2",
+            "rho": "0.01",
+            "mid_iv": "0.30",
+        },
+    }
+
+
+def _history_response() -> ReadOnlyHttpResponse:
+    # Skew Momentum's realized-volatility input needs ~30 trading days
+    # (screening/live_adapters.py's _HISTORICAL_LOOKBACK_DAYS=45 calendar
+    # days), ending recently enough to satisfy the freshness requirement --
+    # ending 15+ days ago (an earlier draft's mistake) reads as STALE_DATA.
+    days = []
+    cursor = date.today() - timedelta(days=1)
+    price = 189.0
+    while len(days) < 32:
+        if cursor.weekday() < 5:
+            days.append(
+                {
+                    "date": cursor.isoformat(),
+                    "open": str(price - 0.5),
+                    "high": str(price + 1),
+                    "low": str(price - 1),
+                    "close": str(price),
+                    "volume": "1000000",
+                }
+            )
+            price -= 0.1
+        cursor -= timedelta(days=1)
+    days.reverse()
+    return ReadOnlyHttpResponse(200, {"history": {"day": days}}, (), 12, "tradier-request-4")
+
+
 def _chain_responses(expiration: str) -> list[ReadOnlyHttpResponse]:
+    options = [
+        _option_row(190 + offset, expiration, option_type, call_delta)
+        for offset, call_delta in _STRIKE_DELTA_LADDER
+        for option_type in ("call", "put")
+    ]
     return [
         tradier_quote_response(),
         ReadOnlyHttpResponse(
             200, {"expirations": {"date": [expiration]}}, (), 12, "tradier-request-2"
         ),
-        ReadOnlyHttpResponse(
-            200,
-            {
-                "options": {
-                    "option": [
-                        {
-                            "symbol": "AAPL_TEST_CALL",
-                            "underlying": "AAPL",
-                            "expiration_date": expiration,
-                            "strike": "190",
-                            "option_type": "call",
-                            "bid": "4.9",
-                            "ask": "5.1",
-                            "last": "5",
-                            "volume": 1000,
-                            "open_interest": 5000,
-                            "greeks": {
-                                "delta": "0.5",
-                                "gamma": "0.03",
-                                "theta": "-0.1",
-                                "vega": "0.2",
-                                "rho": "0.01",
-                            },
-                        }
-                    ]
-                }
-            },
-            (),
-            12,
-            "tradier-request-3",
-        ),
+        ReadOnlyHttpResponse(200, {"options": {"option": options}}, (), 12, "tradier-request-3"),
+        _history_response(),
     ]
 
 
@@ -100,8 +147,20 @@ class TestSkewMomentumAdapter:
         expiration = (date.today() + timedelta(days=7)).isoformat()
         responses = _chain_responses(expiration)
 
-        config = load_market_data_config(
-            {"ASA_TRADIER_ENABLED": "true", "ASA_TRADIER_ACCESS_TOKEN": "sandbox-secret-token"}
+        # live_only_config() force-disables deterministic_fixture -- it
+        # defaults to enabled and, being alphabetically first, would
+        # otherwise be tried before tradier by CapabilityRegistry's
+        # deterministic priority order and silently answer every request
+        # from offline fixture data instead of this test's own scripted
+        # Tradier-shaped responses (screening/live_acquisition.py's own
+        # documented rationale for this exact failure mode).
+        config = live_only_config(
+            load_market_data_config(
+                {
+                    "ASA_TRADIER_ENABLED": "true",
+                    "ASA_TRADIER_ACCESS_TOKEN": "sandbox-secret-token",
+                }
+            )
         )
         access = build_shared_market_data_access(
             config, lambda _provider_id: ScriptedTransport(responses), clock, ("AAPL",)


### PR DESCRIPTION
## Summary

Core fix for SPRINT-013 S13-03A. No migration, no production wiring yet
(threading the shared tracker into `asa/scheduled_screening.py` +
sourcing real per-provider declared limits is a follow-up PR, matching
how S13-02 split into 02a/02b).

## Confirmed root cause (issue #261)

`RequestBudgetManager._burst` keyed usage by the exact authorization
timestamp. Under a real clock (microsecond-unique on every call), two
requests essentially never collide -- `burst_limit` was unenforceable in
production. Fixed with a genuine sliding window.

## New: `market_data/rolling_window.py`

`ProviderRollingWindowTracker` -- the one deliberately shared, cross-pair
piece of state in the acquisition path. `RequestBudgetManager` stays
rebuilt fresh per pair (`pair_isolation` preserved); the tracker is
consulted as the *last* gate in `authorize()`, only after every local
check passes. `apply_reset_hint()` can only shorten allowance, never
lengthen it.

## The bug fix alone would have broken production

`RequestBudgetConfig.burst_limit` defaulted to **1** system-wide. Real
strategies legitimately need more than one sequential request per pair
(Forward Factor: front+back expiration chains; Skew Momentum: quote +
expirations + chain + historical closes). The exact-timestamp bug was
*accidentally necessary* for these to function at all. Raised the default
to 8 -- confirmed sufficient for every real single-strategy-per-pair
production shape (verified by tracing, not guessing: see commit message
for the full chain of test failures this surfaced and how each was
root-caused, not patched around).

Also found and fixed an independent hardcoded `burst_limit=1` in
`asa/market_data_ops/service.py`'s validation-endpoint budget policy.

## Cascading test fixes -- every one root-caused, not patched around

Full detail in the commit message. Short version: raising the default
correctly exposed that several tests had accidentally depended on the
same bug (either to enforce a boundary they meant to test, or to starve
out the always-enabled `deterministic_fixture` provider via
`live_only_config()` never being called, or an incomplete option-chain
fixture that had literally never been exercised end-to-end before).

## Validation

- Full `validate-architecture.yml` scope: **1910 passed, 1 skipped, 0
  failed.**
- Full `tests/asa` (excluding `test_railway_runtime.py`'s 2 pre-existing,
  environment-specific failures, confirmed unrelated by reproducing them
  identically on unmodified `main`): **131 passed**, 31 deselected
  (postgres/live_provider gated).
- `ruff check asa tests/asa`: clean. `mypy asa`: clean, 43 files.
- `git diff --check`: clean. Secret scan: manually reviewed, no
  credentials.

## Merge policy

No migration, no deployment-relevant change -- eligible for delegate
auto-merge once CI is green, per the active Amendment 013 delegation.