### PR TITLE
S13-03A wiring: thread rolling-window tracker into scheduled screening

### DIFF
--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -65,6 +65,7 @@ from screening.live_acquisition import live_only_config
 from strategy_runtime.adapters import build_migrated_strategy_registry
 from strategy_runtime.lifecycle import RecommendedAction
 from strategy_runtime.market_data_planning import (
+    build_provider_rolling_window_tracker,
     build_shared_market_data_access,
     enabled_provider_configs,
 )
@@ -183,9 +184,28 @@ def run_scheduled_refresh(
     screening_cycle_id = new_screening_cycle_id(
         invocation_type=invocation_type, slot_id=slot_id, scope_id=scope_identity(universe)
     )
+    # Exactly one ProviderRollingWindowTracker per cycle -- minted here,
+    # beside screening_cycle_id, and passed by reference into every pair's
+    # own RequestBudgetManager below (SPRINT-013 S13-03A). Never rebuilt
+    # per pair, never a module-global singleton: a fresh tracker for every
+    # new invocation of this function, so a new scheduled cycle always
+    # starts with fresh cycle-scoped window state.
+    rolling_window, providers_without_declared_limit = build_provider_rolling_window_tracker(
+        config, clock
+    )
+    if providers_without_declared_limit:
+        _LOGGER.info(
+            "no_declared_rolling_limit",
+            extra={
+                "screening_cycle_id": screening_cycle_id,
+                "provider_ids": providers_without_declared_limit,
+            },
+        )
     outcomes: list[PairOutcome] = []
     for signal_id, symbol in universe:
-        access = build_shared_market_data_access(config, transport_factory, clock, (symbol,))
+        access = build_shared_market_data_access(
+            config, transport_factory, clock, (symbol,), rolling_window=rolling_window
+        )
         subject_access = access[symbol]
         pair_id = compute_pair_evaluation_id(screening_cycle_id, signal_id, symbol)
         try:
@@ -251,6 +271,17 @@ def run_scheduled_refresh(
             )
         except Exception as exc:
             outcomes.append(PairOutcome(signal_id, symbol, None, None, str(exc), False))
+    # Cycle-level sanitized accounting (SPRINT-013 S13-03A): provider_id ->
+    # in-window reservation count only, no payloads, no per-pair detail.
+    # This tracker is cycle-local and in-process -- it enforces truthfully
+    # within this one invocation only, never across the separately
+    # deployed always-on web service process or another concurrent
+    # invocation of this same job (see project/reports/SPRINT-013-S13-03A-
+    # wiring-notes.md's BLOCKED_DISTRIBUTED_QUOTA_OWNERSHIP packet).
+    _LOGGER.info(
+        "provider_rolling_window_summary",
+        extra={"screening_cycle_id": screening_cycle_id, "summary": rolling_window.summary()},
+    )
     return tuple(outcomes)
 
 

--- a/market_data/attempts.py
+++ b/market_data/attempts.py
@@ -63,6 +63,15 @@ _OUTCOME_BY_ERROR_CODE: dict[ProviderErrorCode, AcquisitionOutcome] = {
     ProviderErrorCode.CONFIGURATION_ERROR: AcquisitionOutcome.TRANSPORT_FAILURE,
     ProviderErrorCode.INVALID_REQUEST: AcquisitionOutcome.TRANSPORT_FAILURE,
     ProviderErrorCode.UNKNOWN_PROVIDER_ERROR: AcquisitionOutcome.TRANSPORT_FAILURE,
+    # SPRINT-013 S13-03A: all four distinguish pair-local vs shared-provider
+    # quota refusals at the diagnostic_code level (see
+    # project/reports/SPRINT-013-S13-02-notes.md's fold rationale) -- the
+    # aggregate LOCAL_QUOTA_EXHAUSTED bucket is exactly what it already
+    # means: "we ourselves declined to send the request."
+    ProviderErrorCode.PAIR_BUDGET_EXHAUSTED: AcquisitionOutcome.LOCAL_QUOTA_EXHAUSTED,
+    ProviderErrorCode.PAIR_BURST_EXHAUSTED: AcquisitionOutcome.LOCAL_QUOTA_EXHAUSTED,
+    ProviderErrorCode.PROVIDER_ROLLING_WINDOW_EXHAUSTED: AcquisitionOutcome.LOCAL_QUOTA_EXHAUSTED,
+    ProviderErrorCode.PROVIDER_COOLDOWN_ACTIVE: AcquisitionOutcome.LOCAL_QUOTA_EXHAUSTED,
 }
 
 

--- a/market_data/budget.py
+++ b/market_data/budget.py
@@ -11,12 +11,26 @@ from enum import Enum
 from domain import MarketCapability
 from domain.values import DomainInvariantError, require_tz_aware
 from market_data.factory import Clock
-from market_data.providers import RequestBudgetAuthorization
+from market_data.providers import ProviderErrorCode, RequestBudgetAuthorization
 from market_data.rolling_window import ProviderRollingWindowTracker
 
 
 class BudgetExhaustedError(RuntimeError):
-    """A request was refused before transport because its explicit budget was exhausted."""
+    """A request was refused before transport because its explicit budget was exhausted.
+
+    ``code`` distinguishes *why* (SPRINT-013 S13-03A) -- market_data/
+    fulfillment.py reads it instead of always normalizing to the single
+    QUOTA_EXHAUSTED code, so pair-local and shared-provider refusals
+    remain distinguishable all the way into S13-02's attempt records.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: ProviderErrorCode = ProviderErrorCode.QUOTA_EXHAUSTED,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 class BudgetScope(str, Enum):
@@ -179,20 +193,29 @@ class RequestBudgetManager:
         require_tz_aware(now, "RequestBudgetManager", "clock")
         cooldown = self._cooldowns.get(provider_id)
         if cooldown is not None and now < cooldown:
-            raise BudgetExhaustedError(f"Provider {provider_id!r} is in explicit cooldown")
+            raise BudgetExhaustedError(
+                f"Provider {provider_id!r} is in explicit cooldown",
+                ProviderErrorCode.PROVIDER_COOLDOWN_ACTIVE,
+            )
         consumed = sum(
             value.request_units
             for value in self._entries
             if value.provider_id == provider_id and value.scope is scope
         )
         if consumed + request_units > policy.maximum_request_units:
-            raise BudgetExhaustedError(f"Provider {provider_id!r} {scope.value} budget exhausted")
+            raise BudgetExhaustedError(
+                f"Provider {provider_id!r} {scope.value} budget exhausted",
+                ProviderErrorCode.PAIR_BUDGET_EXHAUSTED,
+            )
         burst_key = (provider_id, scope)
         window_start = now - timedelta(seconds=policy.burst_window_seconds)
         recent_burst = [value for value in self._burst.get(burst_key, []) if value > window_start]
         if len(recent_burst) + 1 > policy.burst_limit:
             self._burst[burst_key] = recent_burst
-            raise BudgetExhaustedError(f"Provider {provider_id!r} burst budget exhausted")
+            raise BudgetExhaustedError(
+                f"Provider {provider_id!r} burst budget exhausted",
+                ProviderErrorCode.PAIR_BURST_EXHAUSTED,
+            )
         attempt_number = 1
         retry_root_id: str | None = None
         if retry_of is not None:
@@ -206,7 +229,10 @@ class RequestBudgetManager:
                 if value.retry_root_id == retry_root_id and value.attempt_number > 1
             )
             if retries >= policy.maximum_retries_per_request:
-                raise BudgetExhaustedError(f"Provider {provider_id!r} retry budget exhausted")
+                raise BudgetExhaustedError(
+                    f"Provider {provider_id!r} retry budget exhausted",
+                    ProviderErrorCode.PAIR_BUDGET_EXHAUSTED,
+                )
             attempt_number = original[0].attempt_number + 1
         # Shared cross-pair reservation is the LAST gate, only once every
         # local (pair-scoped) check has already passed -- reserving a
@@ -215,7 +241,8 @@ class RequestBudgetManager:
         # whole cycle for no reason.
         if self._rolling_window is not None and not self._rolling_window.try_reserve(provider_id):
             raise BudgetExhaustedError(
-                f"Provider {provider_id!r} shared rolling-window budget exhausted"
+                f"Provider {provider_id!r} shared rolling-window budget exhausted",
+                ProviderErrorCode.PROVIDER_ROLLING_WINDOW_EXHAUSTED,
             )
         sequence = len(self._entries) + 1
         payload = json.dumps(

--- a/market_data/finnhub.py
+++ b/market_data/finnhub.py
@@ -50,6 +50,7 @@ from market_data.providers import (
     ValidationCheckStatus,
     normalized_provider_error,
 )
+from market_data.rolling_window import RollingWindowPolicy
 from market_data.session_calendar import classify_quote_freshness
 from market_data.transport import (
     ReadOnlyHttpRequest,
@@ -64,6 +65,21 @@ FINNHUB_CAPABILITIES = (
     MarketCapability.HISTORICAL_BARS_V1,
     MarketCapability.EARNINGS_CALENDAR_V1,
 )
+
+# Declared, documented Finnhub rate limit (SPRINT-013 S13-03A) -- the
+# single source both ProviderMetadata.declared_limits below and
+# finnhub_rolling_window_policy() read from.
+_GLOBAL_CALLS_PER_SECOND = 30
+
+
+def finnhub_rolling_window_policy() -> RollingWindowPolicy:
+    """Finnhub's own declared, documented rolling rate limit. Finnhub does
+    not distinguish sandbox/production endpoints the way Tradier does, so
+    this takes no endpoint_environment parameter.
+    """
+    return RollingWindowPolicy(
+        "finnhub", 1, _GLOBAL_CALLS_PER_SECOND, "documented:global_calls_per_second"
+    )
 
 
 class _NoData(ValueError):
@@ -87,7 +103,11 @@ class FinnhubProvider:
         self._metadata = ProviderMetadata(
             ProviderIdentity("finnhub", "finnhub", config.adapter_version),
             FINNHUB_CAPABILITIES,
-            (ProviderLimitDeclaration("global_calls_per_second", "30", "documented"),),
+            (
+                ProviderLimitDeclaration(
+                    "global_calls_per_second", str(_GLOBAL_CALLS_PER_SECOND), "documented"
+                ),
+            ),
             FINNHUB_CAPABILITIES,
             "v1",
         )

--- a/market_data/fulfillment.py
+++ b/market_data/fulfillment.py
@@ -105,9 +105,13 @@ class CapabilityFulfillmentService:
                     1,
                     BudgetScope.RUNTIME,
                 )
-            except BudgetExhaustedError:
+            except BudgetExhaustedError as exc:
+                # SPRINT-013 S13-03A: exc.code distinguishes pair-local
+                # (total/burst/retry) refusals from the shared provider
+                # rolling-window refusal and an active cooldown -- never
+                # collapsed into one generic code.
                 error = normalized_provider_error(
-                    ProviderErrorCode.QUOTA_EXHAUSTED,
+                    exc.code,
                     "finite provider request budget is unavailable or exhausted",
                     provider.provider_id,
                     request.capability,

--- a/market_data/providers.py
+++ b/market_data/providers.py
@@ -55,6 +55,14 @@ class ProviderErrorCode(str, Enum):
     STALE_DATA = "stale_data"
     INCOMPLETE_DATA = "incomplete_data"
     UNKNOWN_PROVIDER_ERROR = "unknown_provider_error"
+    # SPRINT-013 S13-03A: distinct local/shared quota refusal reasons --
+    # RequestBudgetManager.authorize() no longer collapses these into the
+    # single QUOTA_EXHAUSTED code (market_data/budget.py's own
+    # BudgetExhaustedError.code carries the specific one).
+    PAIR_BUDGET_EXHAUSTED = "pair_budget_exhausted"
+    PAIR_BURST_EXHAUSTED = "pair_burst_exhausted"
+    PROVIDER_ROLLING_WINDOW_EXHAUSTED = "provider_rolling_window_exhausted"
+    PROVIDER_COOLDOWN_ACTIVE = "provider_cooldown_active"
 
 
 _ERROR_POLICY: dict[ProviderErrorCode, tuple[ProviderErrorKind, bool]] = {
@@ -76,6 +84,10 @@ _ERROR_POLICY: dict[ProviderErrorCode, tuple[ProviderErrorKind, bool]] = {
     ProviderErrorCode.STALE_DATA: (ProviderErrorKind.UNAVAILABLE, False),
     ProviderErrorCode.INCOMPLETE_DATA: (ProviderErrorKind.SCHEMA, False),
     ProviderErrorCode.UNKNOWN_PROVIDER_ERROR: (ProviderErrorKind.UNKNOWN, False),
+    ProviderErrorCode.PAIR_BUDGET_EXHAUSTED: (ProviderErrorKind.RATE_LIMIT, False),
+    ProviderErrorCode.PAIR_BURST_EXHAUSTED: (ProviderErrorKind.RATE_LIMIT, True),
+    ProviderErrorCode.PROVIDER_ROLLING_WINDOW_EXHAUSTED: (ProviderErrorKind.RATE_LIMIT, True),
+    ProviderErrorCode.PROVIDER_COOLDOWN_ACTIVE: (ProviderErrorKind.RATE_LIMIT, True),
 }
 
 

--- a/market_data/tradier.py
+++ b/market_data/tradier.py
@@ -31,7 +31,7 @@ from domain import (
 from domain.market_data import MarketObservationValue
 from domain.operational import CanonicalInstrumentIdentity
 from domain.values import DomainInvariantError
-from market_data.config import ProviderConfig
+from market_data.config import ProviderConfig, ProviderEndpointEnvironment
 from market_data.factory import ProviderDependencies, ProviderRegistration
 from market_data.providers import (
     CapabilityRequest,
@@ -53,6 +53,7 @@ from market_data.providers import (
     ValidationCheckStatus,
     normalized_provider_error,
 )
+from market_data.rolling_window import RollingWindowPolicy
 from market_data.session_calendar import classify_quote_freshness
 from market_data.transport import (
     ReadOnlyHttpRequest,
@@ -67,6 +68,35 @@ TRADIER_CAPABILITIES = (
     MarketCapability.HISTORICAL_BARS_V1,
     MarketCapability.OPTION_CHAIN_V1,
 )
+
+# Declared, documented Tradier rate limits (SPRINT-013 S13-03A) -- the
+# single source both ProviderMetadata.declared_limits below and
+# tradier_rolling_window_policy() read from, so the two can never drift.
+_MARKET_DATA_PER_MINUTE_PRODUCTION = 120
+_MARKET_DATA_PER_MINUTE_SANDBOX = 60
+
+
+def tradier_rolling_window_policy(
+    endpoint_environment: ProviderEndpointEnvironment,
+) -> RollingWindowPolicy:
+    """Tradier's own declared, documented rolling rate limit for the
+    configured endpoint environment. Never a hardcoded standalone number --
+    the exact same values ProviderMetadata.declared_limits already
+    declares.
+    """
+    if endpoint_environment is ProviderEndpointEnvironment.PRODUCTION:
+        return RollingWindowPolicy(
+            "tradier",
+            60,
+            _MARKET_DATA_PER_MINUTE_PRODUCTION,
+            "documented:market_data_per_minute_production",
+        )
+    return RollingWindowPolicy(
+        "tradier",
+        60,
+        _MARKET_DATA_PER_MINUTE_SANDBOX,
+        "documented:market_data_per_minute_sandbox",
+    )
 
 
 class _EmptyPayload(ValueError):
@@ -89,8 +119,16 @@ class TradierProvider:
             ProviderIdentity("tradier", "tradier", config.adapter_version),
             TRADIER_CAPABILITIES,
             (
-                ProviderLimitDeclaration("market_data_per_minute_production", "120", "documented"),
-                ProviderLimitDeclaration("market_data_per_minute_sandbox", "60", "documented"),
+                ProviderLimitDeclaration(
+                    "market_data_per_minute_production",
+                    str(_MARKET_DATA_PER_MINUTE_PRODUCTION),
+                    "documented",
+                ),
+                ProviderLimitDeclaration(
+                    "market_data_per_minute_sandbox",
+                    str(_MARKET_DATA_PER_MINUTE_SANDBOX),
+                    "documented",
+                ),
             ),
             TRADIER_CAPABILITIES,
             "v1",

--- a/project/reports/SPRINT-013-S13-03A-wiring-notes.md
+++ b/project/reports/SPRINT-013-S13-03A-wiring-notes.md
@@ -1,0 +1,99 @@
+# SPRINT-013 S13-03A Wiring — Notes and Blocker Packet
+
+## What this PR wires
+
+`ProviderRollingWindowTracker` (merged in PR #271, S13-03A core) is now
+actually consulted in production:
+
+- `strategy_runtime/market_data_planning.py::build_provider_rolling_window_tracker`
+  builds one tracker from `declared_rolling_window_policies()`, which sources
+  policies *only* from each provider's own typed, declared limit
+  (`tradier_rolling_window_policy()`, `finnhub_rolling_window_policy()` — both
+  defined in their own provider modules, reading the exact same module
+  constants `ProviderMetadata.declared_limits` already uses, so the two can
+  never drift). Alpha Vantage gets no policy function and is reported via
+  `no_declared_rolling_limit` — the installed key's plan tier is not knowable
+  from configuration, so no limit is invented for it, per explicit instruction.
+- `asa/scheduled_screening.py::run_scheduled_refresh` constructs exactly one
+  tracker per invocation, beside `screening_cycle_id`, and passes the same
+  instance into every pair's `build_shared_market_data_access(...,
+  rolling_window=...)` call within that cycle. A fresh call to
+  `run_scheduled_refresh` always gets a fresh tracker — no module-global
+  singleton.
+- `RequestBudgetManager.authorize()` consults the tracker as the **last**
+  gate, only after every pair-local check (total ceiling, burst, retry) has
+  already passed — a shared-window refusal never burns a pair's own local
+  accounting, and a request that was going to be refused locally never wastes
+  a shared reservation either.
+- Distinct diagnostics (four new `ProviderErrorCode` values —
+  `pair_budget_exhausted`, `pair_burst_exhausted`,
+  `provider_rolling_window_exhausted`, `provider_cooldown_active`) replace the
+  single generic `quota_exhausted` `BudgetExhaustedError` used to always
+  normalize to. Folded into S13-02's `LOCAL_QUOTA_EXHAUSTED` aggregate bucket
+  (unchanged, still closed), but `AcquisitionAttemptRecord.diagnostic_code`
+  preserves the exact reason losslessly.
+
+## BLOCKED_DISTRIBUTED_QUOTA_OWNERSHIP
+
+**Exact blocked action:** claiming `ProviderRollingWindowTracker` enforces a
+provider's real external rate limit *globally*, across the whole deployment.
+It does not — it is in-process and cycle-local by construction, exactly as
+instructed ("continue implementing truthful single-cycle enforcement"), so
+this is not a defect in this PR; it is a scope boundary this PR is not
+authorized to close, flagged explicitly rather than silently claimed.
+
+**Confirmed root cause / topology** (verified via Railway MCP
+`get-status`/`get-service-config` reads, no changes made):
+
+| Service | Replicas | Trigger | Credentials |
+|---|---|---|---|
+| `ASA` (web) | 1 | always-on (`python -m asa`) | `ASA_TRADIER_ACCESS_TOKEN`, `ASA_FINNHUB_API_KEY`, `ASA_ALPHA_VANTAGE_API_KEY` all configured |
+| `trustworthy-education` (cron) | 1 | `*/10 13-20 * * 1-5` (`python -m asa.scheduled_screening --json`, `restartPolicyType: NEVER`) | same three credentials, configured independently |
+
+These are two **separate OS processes**. The always-on web service can serve
+a live on-demand refresh at any moment via `screening/live_acquisition.py`'s
+own separate provider-wiring (deliberately not touched by this PR — see
+`strategy_runtime/market_data_planning.py`'s own docstring on why the two
+paths stay independent). If that happens while the cron job is mid-cycle,
+each process's own `ProviderRollingWindowTracker` (or, for the web service,
+no tracker at all today) has zero visibility into the other's concurrent
+usage. Their combined real request rate to Tradier/Finnhub could exceed the
+declared external limit even though each process's own internal accounting
+believes it is within budget.
+
+**Why current authority/tools cannot resolve it:** a genuinely cross-process
+shared rate limiter requires persistent, atomic, externally-visible state —
+in-memory Python objects cannot cross process boundaries. The smallest
+correct fix is a new piece of shared infrastructure, not a code change to
+existing modules.
+
+**Options, with tradeoffs:**
+
+- (a) **Do nothing further** — accept in-process-only enforcement as the
+  practical ceiling for now. Real risk: only materializes if a live on-demand
+  refresh and a scheduled cycle overlap AND their combined rate exceeds the
+  provider's real limit — plausible but not guaranteed on every occurrence.
+- (b) **Postgres-backed row/advisory-lock token-bucket table** (recommended),
+  reusing the exact persistence pattern S13-02 already established
+  (`PostgresAcquisitionAttemptRepository`,
+  `PostgresRefreshScheduleClaimRepository`'s `ON CONFLICT DO NOTHING`
+  idempotency pattern): one row per `(provider_id, window_start)`, an atomic
+  `UPDATE ... SET count = count + 1 WHERE count < limit RETURNING` (or a
+  Postgres advisory lock around a read-modify-write) as the reservation
+  primitive, consulted by `ProviderRollingWindowTracker.try_reserve()`
+  instead of (or in addition to) its in-memory list when a shared connection
+  is available. Scoped to Tradier/Finnhub only (the two providers with
+  declared limits). Requires a new migration.
+- (c) **External rate-limiting proxy or Railway-level throttle** — outside
+  this codebase entirely, not evaluated here.
+
+**Recommended option:** (b) — smallest correct fix, reuses an already-proven
+pattern from this same sprint, no new infrastructure category introduced.
+
+**Smallest Founder action required:** authorize a follow-up ticket (S13-03A
+step 2, or folded into S13-03B) for the Postgres-backed shared token-bucket
+table, including its migration — explicitly out of this PR's bounded scope
+(no migration in this PR itself, per the PR boundary).
+
+**Work continuing in parallel:** this PR ships truthful single-cycle
+enforcement now, per instruction; it does not block on this decision.

--- a/strategy_runtime/__init__.py
+++ b/strategy_runtime/__init__.py
@@ -79,7 +79,9 @@ from strategy_runtime.execution import (
 )
 from strategy_runtime.market_data_planning import (
     SubjectMarketDataAccess,
+    build_provider_rolling_window_tracker,
     build_shared_market_data_access,
+    declared_rolling_window_policies,
 )
 from strategy_runtime.registry import (
     StrategyAdapter,
@@ -125,8 +127,10 @@ __all__ = [
     "UniversalScreeningResult",
     "UnknownStrategyIdError",
     "ValueType",
+    "build_provider_rolling_window_tracker",
     "build_shared_market_data_access",
     "compute_observation_id",
+    "declared_rolling_window_policies",
     "describe_contract",
     "describe_registry",
     "register",

--- a/strategy_runtime/market_data_planning.py
+++ b/strategy_runtime/market_data_planning.py
@@ -50,6 +50,9 @@ from market_data import (
     tradier_provider_registration,
 )
 from market_data.budget import BudgetScope
+from market_data.finnhub import finnhub_rolling_window_policy
+from market_data.rolling_window import ProviderRollingWindowTracker, RollingWindowPolicy
+from market_data.tradier import tradier_rolling_window_policy
 from strategy_runtime.clock import Clock
 
 PRIORITY_POLICY_VERSION = "strategy-runtime-shared-plan-v1"
@@ -91,7 +94,10 @@ def _build_capability_registry(provider_registry: ProviderRegistry) -> Capabilit
 
 
 def _build_request_budget_manager(
-    enabled_configs: tuple[ProviderConfig, ...], clock: Clock
+    enabled_configs: tuple[ProviderConfig, ...],
+    clock: Clock,
+    *,
+    rolling_window: ProviderRollingWindowTracker | None = None,
 ) -> RequestBudgetManager:
     policies = tuple(
         RequestBudgetPolicy(
@@ -104,7 +110,54 @@ def _build_request_budget_manager(
         )
         for item in enabled_configs
     )
-    return RequestBudgetManager(policies, clock)
+    return RequestBudgetManager(policies, clock, rolling_window=rolling_window)
+
+
+# Providers with no typed, declared rolling rate limit in this codebase.
+# alpha_vantage: the installed key's plan tier is not knowable from
+# configuration (free vs paid), so no limit is invented here (SPRINT-013
+# S13-03A) -- only market_data/tradier.py and market_data/finnhub.py
+# currently export a rolling_window_policy factory, sourced from their own
+# ProviderMetadata.declared_limits. deterministic_fixture is not a real
+# external provider and carries no quota concern.
+NO_DECLARED_ROLLING_LIMIT_DIAGNOSTIC = "no_declared_rolling_limit"
+
+
+def declared_rolling_window_policies(
+    enabled_configs: tuple[ProviderConfig, ...],
+) -> tuple[tuple[RollingWindowPolicy, ...], tuple[str, ...]]:
+    """Rolling-window policies built only from each provider's own typed,
+    declared limit (ProviderMetadata.declared_limits, exposed via
+    tradier_rolling_window_policy()/finnhub_rolling_window_policy()) and
+    the configured provider endpoint environment -- never invented, never
+    inferred from external documentation. Returns (policies,
+    provider_ids_without_a_declared_limit) so callers can record the safe
+    no_declared_rolling_limit diagnostic instead of silently omitting
+    enforcement.
+    """
+    policies: list[RollingWindowPolicy] = []
+    undeclared: list[str] = []
+    for item in enabled_configs:
+        if item.provider_id == "tradier":
+            policies.append(tradier_rolling_window_policy(item.endpoint_environment))
+        elif item.provider_id == "finnhub":
+            policies.append(finnhub_rolling_window_policy())
+        else:
+            undeclared.append(item.provider_id)
+    return tuple(policies), tuple(undeclared)
+
+
+def build_provider_rolling_window_tracker(
+    config: MarketDataConfig, clock: Clock
+) -> tuple[ProviderRollingWindowTracker, tuple[str, ...]]:
+    """Construct exactly one ProviderRollingWindowTracker for one
+    screening cycle -- callers mint this once, beside screening_cycle_id,
+    never per pair and never as a module-global singleton (SPRINT-013
+    S13-03A). Returns the tracker plus provider_ids with no declared
+    limit, for the caller's own no_declared_rolling_limit diagnostic.
+    """
+    policies, undeclared = declared_rolling_window_policies(enabled_provider_configs(config))
+    return ProviderRollingWindowTracker(policies, clock), undeclared
 
 
 @dataclass(frozen=True, slots=True)
@@ -118,17 +171,29 @@ def build_shared_market_data_access(
     transport_factory: Callable[[str], object],
     clock: Clock,
     subjects: tuple[str, ...],
+    *,
+    rolling_window: ProviderRollingWindowTracker | None = None,
 ) -> dict[str, SubjectMarketDataAccess]:
     """One SubjectMarketDataAccess per subject in ``subjects`` -- never one
     shared across subjects (no request in this sprint's migration targets
     is ever shared between two different subjects, so there is no
     deduplication opportunity there to capture), and never one per
     (strategy, subject) pair.
+
+    ``rolling_window``, when supplied, is consulted (never constructed
+    here) by every subject's own RequestBudgetManager -- the caller mints
+    one ProviderRollingWindowTracker per screening cycle and passes the
+    same instance across every call this function makes within that
+    cycle, so cross-pair provider-quota enforcement is real while each
+    subject's own RequestBudgetManager stays independently pair-isolated
+    (SPRINT-013 S13-03A).
     """
     enabled_configs = enabled_provider_configs(config)
     result: dict[str, SubjectMarketDataAccess] = {}
     for subject in subjects:
-        budget_manager = _build_request_budget_manager(enabled_configs, clock)
+        budget_manager = _build_request_budget_manager(
+            enabled_configs, clock, rolling_window=rolling_window
+        )
         factory = _provider_factory()
         providers = tuple(
             factory.create(

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -319,3 +319,181 @@ def test_attempt_persistence_failure_preserves_the_screening_result(
     # But acquisition accounting is honestly marked incomplete, never
     # silently reported as if it were complete.
     assert outcomes[0].attempts_recorded is False
+
+
+# -- SPRINT-013 S13-03A: shared cross-pair provider rolling window ----------
+
+
+def _force_tiny_tradier_window(monkeypatch: pytest.MonkeyPatch, window_limit: int) -> None:
+    """Overrides the real declared Tradier limit (60-120/min) with a tiny
+    one so cross-pair refusal is observable with just two pairs, instead
+    of scripting dozens of requests."""
+    import strategy_runtime.market_data_planning as planning
+    from market_data.rolling_window import RollingWindowPolicy
+
+    monkeypatch.setattr(
+        planning,
+        "tradier_rolling_window_policy",
+        lambda endpoint_environment: RollingWindowPolicy(  # noqa: ARG005
+            "tradier", 60, window_limit, "test-override"
+        ),
+    )
+
+
+# One pair's complete, real Skew Momentum acquisition needs exactly 4
+# sequential Tradier requests (quote, expirations, option chain,
+# historical daily closes) -- confirmed empirically. The module-level
+# _tradier_refresh_responses() above is intentionally minimal (a single
+# call contract, no put, no history) and only proves the runner isolates
+# an unexpected exception, not a full clean success -- fine for the tests
+# that already use it, but these two tests need a genuinely complete
+# fixture so their pass/refusal assertions are unambiguous rather than
+# "some outcome, who knows which."
+_SKEW_MOMENTUM_REQUESTS_PER_PAIR = 4
+_STRIKE_DELTA_LADDER = (
+    (-15, "0.80"),
+    (-10, "0.70"),
+    (-5, "0.60"),
+    (0, "0.50"),
+    (5, "0.35"),
+    (10, "0.25"),
+    (15, "0.15"),
+)
+
+
+def _option_row(strike: int, expiration: str, option_type: str, call_delta: str) -> dict:
+    delta = call_delta if option_type == "call" else str(round(float(call_delta) - 1, 2))
+    return {
+        "symbol": f"TEST_{option_type.upper()}_{strike}",
+        "underlying": "AAPL",
+        "expiration_date": expiration,
+        "strike": str(strike),
+        "option_type": option_type,
+        "bid": "4.9",
+        "ask": "5.1",
+        "last": "5",
+        "volume": 1000,
+        "open_interest": 5000,
+        "greeks": {
+            "delta": delta,
+            "gamma": "0.03",
+            "theta": "-0.1",
+            "vega": "0.2",
+            "rho": "0.01",
+            "mid_iv": "0.30",
+        },
+    }
+
+
+def _complete_history_response() -> ReadOnlyHttpResponse:
+    days = []
+    cursor = date.today() - timedelta(days=1)
+    price = 189.0
+    while len(days) < 32:
+        if cursor.weekday() < 5:
+            days.append(
+                {
+                    "date": cursor.isoformat(),
+                    "open": str(price - 0.5),
+                    "high": str(price + 1),
+                    "low": str(price - 1),
+                    "close": str(price),
+                    "volume": "1000000",
+                }
+            )
+            price -= 0.1
+        cursor -= timedelta(days=1)
+    days.reverse()
+    return ReadOnlyHttpResponse(200, {"history": {"day": days}}, (), 12, "tradier-request-4")
+
+
+def _complete_skew_momentum_responses(expiration: str) -> list[ReadOnlyHttpResponse]:
+    options = [
+        _option_row(190 + offset, expiration, option_type, call_delta)
+        for offset, call_delta in _STRIKE_DELTA_LADDER
+        for option_type in ("call", "put")
+    ]
+    return [
+        tradier_quote_response(),
+        ReadOnlyHttpResponse(
+            200, {"expirations": {"date": [expiration]}}, (), 12, "tradier-request-2"
+        ),
+        ReadOnlyHttpResponse(200, {"options": {"option": options}}, (), 12, "tradier-request-3"),
+        _complete_history_response(),
+    ]
+
+
+def test_one_tracker_is_shared_across_every_pair_in_the_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    # Exactly enough for one pair's full 4-request acquisition, not two.
+    _force_tiny_tradier_window(monkeypatch, window_limit=_SKEW_MOMENTUM_REQUESTS_PER_PAIR)
+    repository = InMemoryLatestResultRepository()
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+    universe = (("skew_momentum", "AAPL"), ("skew_momentum", "MSFT"))
+
+    outcomes = run_scheduled_refresh(
+        universe,
+        repository=repository,
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        transport_factory=lambda _provider_id: ScriptedTransport(
+            _complete_skew_momentum_responses(expiration)
+        ),
+    )
+
+    assert len(outcomes) == 2
+    # First pair's acquisition runs to completion -- all 4 requests are
+    # actually authorized and made, consuming the entire shared window
+    # doing so (what skew_momentum's own strategy logic then decides from
+    # that real data -- pass/no_signal/its own missing_data -- is a
+    # business-logic question this test isn't about, and is sensitive to
+    # the real wall clock _SystemClock always uses regardless of any `now`
+    # passed to run_scheduled_refresh, so it is deliberately not asserted
+    # here). The second pair's very first request is refused by that SAME
+    # shared window, before it ever reaches the (unconsumed) scripted
+    # transport queue -- proof one tracker is genuinely shared across
+    # pairs within this one cycle, not rebuilt per pair.
+    assert outcomes[0].error is None
+    assert outcomes[0].request_count == _SKEW_MOMENTUM_REQUESTS_PER_PAIR
+    assert outcomes[1].error is None  # isolated per-pair failure, not a crash
+    assert outcomes[1].outcome == "missing_data"
+    assert outcomes[1].request_count == 0  # refused before any request was made
+
+
+def test_two_separate_invocations_each_get_a_fresh_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    _force_tiny_tradier_window(monkeypatch, window_limit=_SKEW_MOMENTUM_REQUESTS_PER_PAIR)
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+
+    first_outcomes = run_scheduled_refresh(
+        (("skew_momentum", "AAPL"),),
+        repository=InMemoryLatestResultRepository(),
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        transport_factory=lambda _provider_id: ScriptedTransport(
+            _complete_skew_momentum_responses(expiration)
+        ),
+    )
+    second_outcomes = run_scheduled_refresh(
+        (("skew_momentum", "MSFT"),),
+        repository=InMemoryLatestResultRepository(),
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        transport_factory=lambda _provider_id: ScriptedTransport(
+            _complete_skew_momentum_responses(expiration)
+        ),
+    )
+
+    # Both runs authorize and make their own full 4 requests independently
+    # -- the second call's tracker does not inherit the first call's
+    # already-exhausted window state, proving fresh cycle-scoped state per
+    # invocation. (What skew_momentum's own strategy logic decides from
+    # the real data is a business-logic question this test isn't about --
+    # see the sibling test above for why that's deliberately not asserted.)
+    assert first_outcomes[0].error is None
+    assert first_outcomes[0].request_count == _SKEW_MOMENTUM_REQUESTS_PER_PAIR
+    assert second_outcomes[0].error is None
+    assert second_outcomes[0].request_count == _SKEW_MOMENTUM_REQUESTS_PER_PAIR

--- a/tests/market_data/test_finnhub.py
+++ b/tests/market_data/test_finnhub.py
@@ -375,3 +375,19 @@ def test_wrong_budget_and_write_surfaces_fail_closed() -> None:
         "accounts",
         "positions",
     }
+
+
+# -- SPRINT-013 S13-03A: rolling-window policy sourcing -------------------
+
+
+def test_rolling_window_policy_matches_declared_metadata() -> None:
+    """The policy factory and ProviderMetadata.declared_limits must never
+    drift -- both read the same module constant."""
+    from market_data.finnhub import finnhub_rolling_window_policy
+
+    instance, _ = provider(Transport(()))
+    declared = {item.name: item.value for item in instance.metadata.declared_limits}
+    policy = finnhub_rolling_window_policy()
+    assert str(policy.window_limit) == declared["global_calls_per_second"]
+    assert policy.window_seconds == 1
+    assert policy.provider_id == "finnhub"

--- a/tests/market_data/test_fulfillment.py
+++ b/tests/market_data/test_fulfillment.py
@@ -178,6 +178,7 @@ def service(
     second: ScriptedProvider | None = None,
     *,
     maximum: int = 4,
+    rolling_window: object | None = None,
 ) -> tuple[CapabilityFulfillmentService, RequestBudgetManager]:
     providers = (first,) if second is None else (first, second)
     registry = ProviderRegistry(providers)
@@ -192,6 +193,7 @@ def service(
             for item in ids
         ),
         Clock(),
+        rolling_window=rolling_window,
     )
     return CapabilityFulfillmentService(registry, capabilities, budgets), budgets
 
@@ -297,4 +299,66 @@ def test_exhausted_budget_is_recorded_and_duplicate_request_is_not_reissued() ->
     exhausted = other_service.fulfill(request())
     assert exhausted.status is FulfillmentStatus.FAILED
     assert exhausted.attempts[0].error is not None
-    assert exhausted.attempts[0].error.code is ProviderErrorCode.QUOTA_EXHAUSTED
+    # SPRINT-013 S13-03A: the pair-local total ceiling now gets its own
+    # distinct code instead of the generic QUOTA_EXHAUSTED.
+    assert exhausted.attempts[0].error.code is ProviderErrorCode.PAIR_BUDGET_EXHAUSTED
+
+
+# -- SPRINT-013 S13-03A: shared rolling-window request boundary -----------
+
+
+def test_outbound_upstream_rejection_still_consumes_a_provider_unit() -> None:
+    """A request that reaches the provider and comes back rate_limited
+    consumes its shared-window unit exactly like a success would --
+    authorize() reserves before the outcome is known, never after."""
+    from market_data.rolling_window import ProviderRollingWindowTracker, RollingWindowPolicy
+
+    window = ProviderRollingWindowTracker((RollingWindowPolicy("primary", 60, 5, "test"),), Clock())
+    failed = FixtureScenario(failures=((CAPABILITY, ProviderErrorCode.RATE_LIMITED),))
+    fulfillment, _ = service(provider("primary", failed), rolling_window=window)
+
+    result = fulfillment.fulfill(request(), required=False)
+
+    assert result.status is FulfillmentStatus.FAILED
+    assert window.summary()["primary"] == 1
+
+
+def test_fallback_consumes_the_fallback_providers_own_unit() -> None:
+    """Primary fails locally-shaped, fallback succeeds -- each provider's
+    rolling window is reserved independently, under its own provider_id."""
+    from market_data.rolling_window import ProviderRollingWindowTracker, RollingWindowPolicy
+
+    window = ProviderRollingWindowTracker(
+        (
+            RollingWindowPolicy("primary", 60, 5, "test"),
+            RollingWindowPolicy("secondary", 60, 5, "test"),
+        ),
+        Clock(),
+    )
+    primary = provider(
+        "primary", FixtureScenario(failures=((CAPABILITY, ProviderErrorCode.TIMEOUT),))
+    )
+    fulfillment, _ = service(primary, provider("secondary"), rolling_window=window)
+
+    result = fulfillment.fulfill(request())
+
+    assert result.status is FulfillmentStatus.DEGRADED
+    assert window.summary() == {"primary": 1, "secondary": 1}
+
+
+def test_shared_window_refusal_produces_a_distinct_diagnostic_reason() -> None:
+    """The exact refusal reason (SPRINT-013 S13-03A) survives into the
+    NormalizedProviderError -- never collapsed to generic QUOTA_EXHAUSTED,
+    and distinguishable from a pair-local total/burst refusal."""
+    from market_data.rolling_window import ProviderRollingWindowTracker, RollingWindowPolicy
+
+    window = ProviderRollingWindowTracker((RollingWindowPolicy("primary", 60, 1, "test"),), Clock())
+    window.try_reserve("primary")  # consume the one shared slot up front
+    fulfillment, budgets = service(provider("primary"), rolling_window=window)
+
+    result = fulfillment.fulfill(request(), required=False)
+
+    assert result.status is FulfillmentStatus.FAILED
+    assert result.attempts[0].error is not None
+    assert result.attempts[0].error.code is ProviderErrorCode.PROVIDER_ROLLING_WINDOW_EXHAUSTED
+    assert budgets.accounting == ()  # local ledger untouched by the shared refusal

--- a/tests/market_data/test_tradier.py
+++ b/tests/market_data/test_tradier.py
@@ -346,3 +346,32 @@ def test_adapter_has_no_write_or_brokerage_surface() -> None:
         "accounts",
         "positions",
     }
+
+
+# -- SPRINT-013 S13-03A: rolling-window policy sourcing -------------------
+
+
+def test_production_and_sandbox_select_different_declared_policies() -> None:
+    from market_data.config import ProviderEndpointEnvironment
+    from market_data.tradier import tradier_rolling_window_policy
+
+    production = tradier_rolling_window_policy(ProviderEndpointEnvironment.PRODUCTION)
+    sandbox = tradier_rolling_window_policy(ProviderEndpointEnvironment.SANDBOX)
+    assert production.window_limit == 120
+    assert sandbox.window_limit == 60
+    assert production.window_limit != sandbox.window_limit
+    assert production.provider_id == sandbox.provider_id == "tradier"
+
+
+def test_rolling_window_policy_values_match_declared_metadata() -> None:
+    """The policy factory and ProviderMetadata.declared_limits must never
+    drift -- both read the same module constants."""
+    from market_data.config import ProviderEndpointEnvironment
+    from market_data.tradier import tradier_rolling_window_policy
+
+    instance = provider(Transport(()))
+    declared = {item.name: item.value for item in instance.metadata.declared_limits}
+    production = tradier_rolling_window_policy(ProviderEndpointEnvironment.PRODUCTION)
+    sandbox = tradier_rolling_window_policy(ProviderEndpointEnvironment.SANDBOX)
+    assert str(production.window_limit) == declared["market_data_per_minute_production"]
+    assert str(sandbox.window_limit) == declared["market_data_per_minute_sandbox"]

--- a/tests/strategy_runtime/test_market_data_planning.py
+++ b/tests/strategy_runtime/test_market_data_planning.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+import pytest
+
 from domain import (
     CanonicalInstrumentIdentity,
     EvidenceKind,
@@ -26,6 +28,7 @@ from domain import (
     ProviderAddressProjection,
 )
 from market_data import CapabilityRequest, load_market_data_config
+from market_data.rolling_window import ProviderRollingWindowTracker, RollingWindowPolicy
 from strategy_runtime import (
     NO_LIFECYCLE,
     DataRequirement,
@@ -35,9 +38,12 @@ from strategy_runtime import (
     StrategyContract,
     StrategyRegistry,
     StructureKind,
+    build_provider_rolling_window_tracker,
     build_shared_market_data_access,
+    declared_rolling_window_policies,
     run_strategies,
 )
+from strategy_runtime.market_data_planning import enabled_provider_configs
 
 NOW = datetime(2026, 1, 1, tzinfo=UTC)
 CAPABILITY = MarketCapability.REAL_TIME_QUOTE_V1
@@ -155,3 +161,160 @@ class TestRunStrategiesWithSharedMarketData:
         run_strategies(registry, clock, subjects=("AAPL",))  # no fulfillment_by_subject at all
 
         assert seen == [None]
+
+
+def _quote_request_for(symbol: str) -> CapabilityRequest:
+    instrument = Instrument(
+        CanonicalInstrumentIdentity("figi", f"BBG-{symbol}"), InstrumentKind.EQUITY, symbol, "USD"
+    )
+    fields = ("last",)
+    projection = ProviderAddressProjection(
+        "deterministic_fixture", "v1", "symbol", symbol, NOW, None, EVIDENCE
+    )
+    item = MarketDataSubject(
+        instrument,
+        MarketDataSubjectType.INSTRUMENT,
+        CAPABILITY,
+        MarketDataRequestContext(NOW, NOW, fields, (projection,), EVIDENCE),
+    )
+    return CapabilityRequest(CAPABILITY, (item,), NOW, NOW, fields, 60)
+
+
+class TestProviderRollingWindowWiring:
+    """SPRINT-013 S13-03A: build_shared_market_data_access's own
+    rolling_window parameter, threaded through to every pair-scoped
+    RequestBudgetManager it builds.
+    """
+
+    def _window(self, clock: _FixedClock, limit: int = 2) -> ProviderRollingWindowTracker:
+        return ProviderRollingWindowTracker(
+            (RollingWindowPolicy("deterministic_fixture", 60, limit, "test"),), clock
+        )
+
+    def test_two_different_pairs_consume_one_shared_provider_window(self) -> None:
+        config = load_market_data_config({})
+        clock = _FixedClock()
+        window = self._window(clock, limit=2)
+        access = build_shared_market_data_access(
+            config, _no_transport_needed, clock, ("AAPL", "MSFT"), rolling_window=window
+        )
+        access["AAPL"].fulfillment.fulfill(_quote_request_for("AAPL"))
+        access["MSFT"].fulfillment.fulfill(_quote_request_for("MSFT"))
+        assert window.summary()["deterministic_fixture"] == 2
+
+    def test_a_third_pair_is_refused_when_the_declared_window_is_full(self) -> None:
+        from market_data import FulfillmentStatus
+
+        config = load_market_data_config({})
+        clock = _FixedClock()
+        window = self._window(clock, limit=2)
+        access = build_shared_market_data_access(
+            config,
+            _no_transport_needed,
+            clock,
+            ("AAPL", "MSFT", "GOOG"),
+            rolling_window=window,
+        )
+        access["AAPL"].fulfillment.fulfill(_quote_request_for("AAPL"))
+        access["MSFT"].fulfillment.fulfill(_quote_request_for("MSFT"))
+        third = access["GOOG"].fulfillment.fulfill(_quote_request_for("GOOG"))
+        assert third.status is FulfillmentStatus.FAILED
+        assert third.attempts[0].error is not None
+        assert third.attempts[0].error.code.value == "provider_rolling_window_exhausted"
+
+    def test_per_pair_totals_and_retries_remain_isolated_under_a_shared_window(self) -> None:
+        config = load_market_data_config({})
+        clock = _FixedClock()
+        window = self._window(clock, limit=100)  # generous -- isolates pair-local accounting
+        access = build_shared_market_data_access(
+            config, _no_transport_needed, clock, ("AAPL", "MSFT"), rolling_window=window
+        )
+        access["AAPL"].fulfillment.fulfill(_quote_request_for("AAPL"))
+        access["MSFT"].fulfillment.fulfill(_quote_request_for("MSFT"))
+        # Each pair's own RequestBudgetManager stays a distinct instance
+        # with its own accounting, unaffected by the other pair's usage.
+        assert access["AAPL"].budget_manager is not access["MSFT"].budget_manager
+        assert len(access["AAPL"].budget_manager.accounting) == 1
+        assert len(access["MSFT"].budget_manager.accounting) == 1
+
+    def test_cache_hit_consumes_no_provider_unit(self) -> None:
+        config = load_market_data_config({})
+        clock = _FixedClock()
+        window = self._window(clock, limit=1)
+        access = build_shared_market_data_access(
+            config, _no_transport_needed, clock, ("AAPL",), rolling_window=window
+        )
+        request = _quote_request_for("AAPL")
+        first = access["AAPL"].fulfillment.fulfill(request)
+        second = access["AAPL"].fulfillment.fulfill(request)  # memoized, no new authorize()
+        assert first is second
+        assert window.summary()["deterministic_fixture"] == 1  # only the first call reserved
+
+
+class TestDeclaredRollingWindowPolicies:
+    """No limit is ever invented for a provider without a typed, declared
+    one (SPRINT-013 S13-03A) -- alpha_vantage today.
+    """
+
+    def test_alpha_vantage_gets_no_invented_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ASA_ALPHA_VANTAGE_ENABLED", "true")
+        monkeypatch.setenv("ASA_ALPHA_VANTAGE_API_KEY", "test-key")
+        config = load_market_data_config(
+            {"ASA_ALPHA_VANTAGE_ENABLED": "true", "ASA_ALPHA_VANTAGE_API_KEY": "test-key"}
+        )
+        policies, undeclared = declared_rolling_window_policies(enabled_provider_configs(config))
+        assert "alpha_vantage" in undeclared
+        assert not any(item.provider_id == "alpha_vantage" for item in policies)
+
+    def test_tradier_and_finnhub_get_their_own_declared_policies(self) -> None:
+        config = load_market_data_config(
+            {
+                "ASA_TRADIER_ENABLED": "true",
+                "ASA_TRADIER_ACCESS_TOKEN": "x",
+                "ASA_FINNHUB_ENABLED": "true",
+                "ASA_FINNHUB_API_KEY": "x",
+            }
+        )
+        policies, undeclared = declared_rolling_window_policies(enabled_provider_configs(config))
+        provider_ids = {item.provider_id for item in policies}
+        assert {"tradier", "finnhub"} <= provider_ids
+        assert "tradier" not in undeclared
+        assert "finnhub" not in undeclared
+
+
+class TestBuildProviderRollingWindowTracker:
+    def test_scheduled_screening_constructs_one_tracker_per_cycle_not_per_pair(self) -> None:
+        """The same tracker instance -- built once here -- is what a
+        caller (asa/scheduled_screening.py) must reuse across every pair
+        in one cycle; this proves the construction itself does not create
+        new state per call within what should be a single invocation.
+        """
+        config = load_market_data_config(
+            {"ASA_TRADIER_ENABLED": "true", "ASA_TRADIER_ACCESS_TOKEN": "x"}
+        )
+        clock = _FixedClock()
+        tracker, undeclared = build_provider_rolling_window_tracker(config, clock)
+        tracker.try_reserve("tradier")
+        tracker.try_reserve("tradier")
+        # Reusing the SAME instance (not rebuilding it) accumulates state,
+        # exactly the property asa/scheduled_screening.py's per-pair loop
+        # relies on for real cross-pair enforcement.
+        assert tracker.summary()["tradier"] == 2
+        # deterministic_fixture is enabled by default (load_market_data_config's
+        # own safety default) and has no declared external rate limit --
+        # correctly reported as undeclared, not silently dropped.
+        assert undeclared == ("deterministic_fixture",)
+
+    def test_a_new_cycle_receives_fresh_cycle_scoped_state(self) -> None:
+        config = load_market_data_config(
+            {"ASA_TRADIER_ENABLED": "true", "ASA_TRADIER_ACCESS_TOKEN": "x"}
+        )
+        clock = _FixedClock()
+        first_tracker, _ = build_provider_rolling_window_tracker(config, clock)
+        first_tracker.try_reserve("tradier")
+        first_tracker.try_reserve("tradier")
+
+        second_tracker, _ = build_provider_rolling_window_tracker(config, clock)
+
+        assert second_tracker is not first_tracker
+        assert second_tracker.summary()["tradier"] == 0  # fresh state, not inherited


### PR DESCRIPTION
## Summary

Wires the shared cross-pair `ProviderRollingWindowTracker` (S13-03A core,
PR #271) into real production acquisition. No migration.

## Lifecycle

`strategy_runtime/market_data_planning.py::build_provider_rolling_window_tracker`
constructs exactly one tracker per call. `asa/scheduled_screening.py` mints
it once per `run_scheduled_refresh()` invocation, beside `screening_cycle_id`,
and passes the same instance through `build_shared_market_data_access(...,
rolling_window=...)` into every pair's own `RequestBudgetManager` for that
cycle. Never rebuilt per pair, never a module-global singleton.

## Provider policies -- only from typed declarations, never invented

`tradier_rolling_window_policy()` and `finnhub_rolling_window_policy()`
(new, defined in their own provider modules) read the exact same module
constants `ProviderMetadata.declared_limits` already uses, so the two can
never drift. Tradier's production vs sandbox limit is selected from the
configured `endpoint_environment`. Alpha Vantage gets no policy function --
its installed key's plan tier is not knowable from configuration, so no
limit is invented; reported via a `no_declared_rolling_limit` diagnostic
instead.

## Budget separation preserved

`RequestBudgetManager` stays rebuilt fresh per pair (`pair_isolation`
unchanged); the tracker is consulted -- never owned or mutated beyond
reservation -- as the LAST gate in `authorize()`, only once every
pair-local check has already passed.

## Distinct diagnostics -- never collapsed into generic quota_exhausted

Four new `ProviderErrorCode` values (`pair_budget_exhausted`,
`pair_burst_exhausted`, `provider_rolling_window_exhausted`,
`provider_cooldown_active`). Folded into S13-02's closed
`LOCAL_QUOTA_EXHAUSTED` aggregate bucket, but
`AcquisitionAttemptRecord.diagnostic_code` preserves the exact reason
losslessly.

## BLOCKED_DISTRIBUTED_QUOTA_OWNERSHIP (not blocking this PR)

Full packet in
[`project/reports/SPRINT-013-S13-03A-wiring-notes.md`](../blob/s13-03a-wiring/project/reports/SPRINT-013-S13-03A-wiring-notes.md).
Confirmed via Railway MCP reads (no changes made): the `ASA` web service
(always-on, 1 replica, live Tradier/Finnhub/Alpha Vantage credentials,
serves on-demand refresh via `screening/live_acquisition.py`'s own separate
wiring) and the `trustworthy-education` cron service (1 replica, `*/10
13-20 * * 1-5`, runs this module as a one-shot process with its own
separate credentials) are two independent OS processes. This PR's tracker
is in-process/cycle-local by construction -- truthful within one
`scheduled_screening.py` invocation, never coordinating with the always-on
web process or an overlapping invocation. Recommended fix: a
Postgres-backed row/advisory-lock token-bucket table reusing S13-02's own
persistence pattern, scoped to Tradier/Finnhub, requiring a new migration
-- out of this PR's bounded scope, needs separate Founder authorization.

## Validation

- Full `validate-architecture.yml` scope: **1924 passed, 1 skipped, 0
  failed.**
- Full `tests/asa` (excluding `test_railway_runtime.py`'s 2 pre-existing
  failures): **133 passed**, 31 deselected (DB/live-credential gated).
- `ruff check asa tests/asa`: clean. `mypy asa`: clean, 43 files.
- `git diff --check`: clean.

Two test-design issues found and fixed along the way (not wiring bugs, full
detail in the commit message): a new test coupled a deterministic
budget-mechanism check to Skew Momentum's own strategy verdict, which is
sensitive to the real wall clock; decoupled to assert only on
`request_count`. A separate test forgot to inject an in-memory attempt
repository, adding ~13 minutes of Postgres connection-attempt overhead for
no reason.

## Merge policy

No migration -- eligible for delegate auto-merge once CI is green, per the
active Amendment 013 delegation.