### PR TITLE
S13-04A.1: enforce one-observation-per-completed-session before S13-04B's migration

### DIFF
--- a/strategy_runtime/historical_evidence.py
+++ b/strategy_runtime/historical_evidence.py
@@ -1,5 +1,7 @@
 """Durable historical evidence: reusable repository port and prospective
-accumulation for canonical historical fact families (SPRINT-013 S13-04).
+accumulation for canonical historical fact families (SPRINT-013 S13-04,
+corrected in S13-04A.1 -- see this module's own docstring sections below
+for exactly what changed and why).
 
 Skew Momentum is the first consumer, not the owner -- this module is
 generic across every historical fact family domain/strategy_evidence.py
@@ -7,8 +9,8 @@ defines. HistoricalSkewRepository is the first concrete port because no
 approved provider can supply historical option-skew truthfully (this
 ticket's own current-state trace, project/reports/SPRINT-013-S13-04-
 trace.md, finding #6), so accumulation must start now, prospectively --
-one qualified snapshot per subject per session -- to ever reach the
-Founder-approved 60-observation lookback / 40-valid minimum
+one qualified snapshot per subject per *trading session* -- to ever reach
+the Founder-approved 60-observation lookback / 40-valid minimum
 (strategies/stonk_manifests.py's own SKEW_MOMENTUM_VERTICAL_MANIFEST
 parameters, approved in issue #255).
 
@@ -19,11 +21,30 @@ implementation is dependency-injected by whatever caller constructs one
 package itself never imports one. Wiring a live adapter to actually call
 record_prospective_skew_observation() every scheduled cycle is S13-04D's
 own scope, deliberately not done here.
+
+S13-04A.1 correction (Founder review of PR #274, before S13-04B freezes
+a schema): the original version keyed repository identity on raw
+``effective_time`` and accepted any observation whose effective_time fell
+anywhere inside the currently *open* session. That let repeated intraday
+scheduled cycles record multiple observations for one trading day and let
+an intraday chain masquerade as "the close" -- directly contradicting the
+approved policy's own ``observation_frequency:
+one_canonical_close_snapshot_per_session`` and this ticket's own
+``canonical_end_of_session_skew_snapshot_contract`` requirement. Fixed by:
+canonicalizing every recorded observation's ``effective_time`` to its own
+trading session's ``closes_at`` (so two attempts for the same session are
+byte-identical once canonicalized, not just approximately the same);
+keying identity on ``(instrument, trading_session_date)`` instead of raw
+timestamp; only ever accepting the most recently *completed* session (an
+open, not-yet-closed session is always rejected, not just a future one);
+and raising on a genuine content conflict (same session, different skew
+values) instead of silently keeping whichever arrived first.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
+from dataclasses import replace
+from datetime import date, datetime
 from typing import Protocol
 
 from domain import CanonicalInstrumentIdentity
@@ -33,26 +54,39 @@ from strategy_runtime.clock import Clock
 
 
 class HistoricalSkewRepository(Protocol):
-    """Append-only, idempotent by (instrument, effective_time): a
-    duplicate snapshot for a session already recorded is a no-op, never a
-    second row and never an overwrite -- once truthfully recorded, a
-    session's own snapshot does not change retroactively, regardless of
-    what a later, differently-valued append() call for the same session
-    might claim. This is the "no value-only identity that collides when
-    values oscillate" requirement, satisfied by construction: the
-    identity key is (instrument, effective_time) alone, values are never
-    part of it.
+    """Append-only, idempotent by (instrument, trading_session_date) --
+    never by raw timestamp, so repeated intraday cycles for the same
+    session can never inflate the recorded history (S13-04A.1). A
+    duplicate append for a session already recorded with the exact same
+    call/put skew values is a no-op; one with *different* values for an
+    already-recorded session is a content conflict (see
+    ConflictingHistoricalObservationError), never a silent overwrite and
+    never a second row.
     """
 
-    def append(self, observation: HistoricalSkewObservation) -> None: ...
+    def append(self, observation: HistoricalSkewObservation, *, session_date: date) -> None: ...
 
     def history_for(
-        self, instrument: CanonicalInstrumentIdentity
+        self,
+        instrument: CanonicalInstrumentIdentity,
+        *,
+        as_of: datetime | None = None,
+        maximum_observations: int | None = None,
     ) -> tuple[HistoricalSkewObservation, ...]:
         """Deterministically ordered oldest-first; an empty tuple when no
         observation has been recorded yet for this instrument -- never
         raises, matching this instrument simply having no history yet as
         a distinct, valid state, not an error.
+
+        ``as_of``, when supplied, excludes any observation whose
+        ``effective_time`` is after it -- "the history as it truthfully
+        stood at evaluation time," not "everything ever recorded since,"
+        so a caller can reproduce what an earlier evaluation actually saw.
+        ``maximum_observations``, when supplied, keeps only the most
+        recent that many after the ``as_of`` filter -- the bounded query
+        strategy policy's own lookback (e.g. "latest 60 completed
+        sessions") needs without requiring an unbounded full-history scan
+        for every request (S13-04A.1's own bounded-query correction).
         """
         ...
 
@@ -60,7 +94,29 @@ class HistoricalSkewRepository(Protocol):
 class SyntheticOrBackdatedObservationError(ValueError):
     """Raised by record_prospective_skew_observation() when an
     observation's effective_time cannot be a genuine, freshly observed
-    snapshot -- see that function's own docstring for the exact rule.
+    end-of-session snapshot -- see that function's own docstring for the
+    exact rule.
+    """
+
+
+class ConflictingHistoricalObservationError(ValueError):
+    """Raised when a trading session already has a recorded skew
+    observation whose call_skew or put_skew values differ from a new
+    append() attempt for the same (instrument, trading_session_date) --
+    S13-04A.1's own correction, replacing the original's silent
+    first-write-wins. Canonical financial evidence must never silently
+    discard a disagreement; a genuine correction requires a separate,
+    explicit, versioned workflow, not an overwrite here.
+
+    Compares only the financial values (call_skew, put_skew), not
+    ``evidence`` -- two independently scheduled cycles recording the same
+    session's close from the same real market state are expected to carry
+    slightly different provenance/evidence references even when they
+    agree on the actual numbers; that is not a conflict. ``effective_time``
+    is not compared either, since record_prospective_skew_observation()
+    always canonicalizes it to the same session close time before this
+    check ever runs -- two observations for the same session are already
+    guaranteed to share it.
     """
 
 
@@ -72,36 +128,43 @@ def record_prospective_skew_observation(
 ) -> None:
     """The one entry point through which a skew snapshot may ever be
     recorded (SPRINT-013 S13-04) -- callers must never call
-    ``repository.append()`` directly, so this rule can never be bypassed.
+    ``repository.append()`` directly, so the rules here can never be
+    bypassed.
 
-    Rejects anything that cannot be a genuine, freshly observed snapshot:
-    a future-dated ``effective_time``, or one older than the most
-    recently completed trading session as of ``clock.now()``. This is
-    what "no synthetic or repeated current-chain backfill" (this
-    ticket's own hard rule) actually enforces in code, not only in
-    review -- a caller cannot construct an observation dated months ago
-    and have it silently accepted as real history.
+    Accepts only a snapshot of the most recently *completed* trading
+    session as of ``clock.now()`` -- a currently open (not yet closed)
+    session is always rejected (S13-04A.1: "one canonical end-of-session
+    snapshot" means the session has actually ended), and so is anything
+    future-dated or older than that one completed session. The recorded
+    observation's own ``effective_time`` is canonicalized to that
+    session's ``closes_at`` before it is ever stored, regardless of the
+    exact moment within that session the caller's own snapshot was
+    actually captured -- "one canonical end-of-session snapshot" means
+    every observation for a given session shares exactly one timestamp,
+    not whichever moment a particular scheduled cycle happened to run at.
 
-    Idempotent by construction: ``repository.append()`` itself is a
-    no-op for an (instrument, effective_time) pair already recorded, so
-    calling this once per scheduled cycle for the same trading session
-    is always safe, however many times a cycle actually runs that
-    session.
+    Idempotent by construction for an unchanged snapshot: repository.
+    append() is a no-op for an (instrument, trading_session_date) pair
+    already recorded with the same values, so calling this once per
+    scheduled cycle for the same trading session is always safe, however
+    many times a cycle actually runs after that session has closed.
     """
     now = clock.now()
     if observation.effective_time > now:
         raise SyntheticOrBackdatedObservationError(
             "historical skew observation effective_time is in the future"
         )
-    earliest_acceptable = calendar.latest_completed_session(now).opens_at
-    if observation.effective_time < earliest_acceptable:
+    completed = calendar.latest_completed_session(now)
+    if not completed.opens_at <= observation.effective_time <= completed.closes_at:
         raise SyntheticOrBackdatedObservationError(
-            "historical skew observation effective_time predates the most "
-            "recently completed trading session -- prospective accumulation "
-            "only ever records the current session's own snapshot, never a "
-            "backdated one"
+            "historical skew observation effective_time does not fall within "
+            "the most recently completed trading session -- prospective "
+            "accumulation only ever records that one session's own "
+            "end-of-session snapshot, never an open session's intraday "
+            "chain and never a backdated one"
         )
-    repository.append(observation)
+    canonical = replace(observation, effective_time=completed.closes_at)
+    repository.append(canonical, session_date=completed.trading_date)
 
 
 def historical_coverage(

--- a/tests/architecture/test_historical_evidence_boundaries.py
+++ b/tests/architecture/test_historical_evidence_boundaries.py
@@ -42,7 +42,15 @@ def test_historical_evidence_only_imports_from_permitted_roots() -> None:
     # asa, screening, or a concrete Postgres integration (this ticket's
     # own "persistence/integrations owns durable historical storage" rule
     # means the concrete adapter lives in asa/integrations, not here).
-    permitted = {"__future__", "typing", "datetime", "domain", "market_data", "strategy_runtime"}
+    permitted = {
+        "__future__",
+        "dataclasses",
+        "typing",
+        "datetime",
+        "domain",
+        "market_data",
+        "strategy_runtime",
+    }
     tree = ast.parse(_MODULE.read_text())
     roots = _imported_roots(tree)
     violations = roots - permitted

--- a/tests/strategy_runtime/test_historical_evidence.py
+++ b/tests/strategy_runtime/test_historical_evidence.py
@@ -1,20 +1,22 @@
-"""SPRINT-013 S13-04A: canonical historical evidence repository port and
-prospective accumulation, exercised against an in-memory fake -- the same
-role every other strategy_runtime persistence Protocol test plays.
+"""SPRINT-013 S13-04A (corrected in S13-04A.1): canonical historical
+evidence repository port and prospective accumulation, exercised against
+an in-memory fake -- the same role every other strategy_runtime
+persistence Protocol test plays.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 
 import pytest
 
 from domain import CanonicalInstrumentIdentity, EvidenceKind, EvidenceReference
 from domain.strategy_evidence import HistoricalSkewObservation
-from market_data.session_calendar import UsEquitySessionCalendar
+from market_data.session_calendar import MarketSession, UsEquitySessionCalendar
 from strategy_runtime.historical_evidence import (
+    ConflictingHistoricalObservationError,
     HistoricalSkewRepository,
     SyntheticOrBackdatedObservationError,
     historical_coverage,
@@ -25,6 +27,11 @@ AAPL = CanonicalInstrumentIdentity("figi", "BBG000B9XRY4")
 MSFT = CanonicalInstrumentIdentity("figi", "BBG000BPH459")
 EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "tradier:option-chain:AAPL"),)
 CALENDAR = UsEquitySessionCalendar()
+
+# Two real, deterministic, already-closed Monday/Tuesday sessions -- avoids
+# depending on whatever real calendar date these tests happen to run on.
+_SESSION_1 = CALENDAR.session(date(2026, 7, 27))
+_SESSION_2 = CALENDAR.session(date(2026, 7, 28))
 
 
 @dataclass
@@ -38,18 +45,38 @@ class _FixedClock:
 class InMemoryHistoricalSkewRepository:
     def __init__(self) -> None:
         self._by_instrument: dict[
-            CanonicalInstrumentIdentity, dict[datetime, HistoricalSkewObservation]
+            CanonicalInstrumentIdentity, dict[date, HistoricalSkewObservation]
         ] = {}
 
-    def append(self, observation: HistoricalSkewObservation) -> None:
+    def append(self, observation: HistoricalSkewObservation, *, session_date: date) -> None:
         bucket = self._by_instrument.setdefault(observation.instrument, {})
-        bucket.setdefault(observation.effective_time, observation)
+        existing = bucket.get(session_date)
+        if existing is not None:
+            if (existing.call_skew, existing.put_skew) != (
+                observation.call_skew,
+                observation.put_skew,
+            ):
+                raise ConflictingHistoricalObservationError(
+                    f"{observation.instrument} already has a recorded observation "
+                    f"for session {session_date} with different skew values"
+                )
+            return
+        bucket[session_date] = observation
 
     def history_for(
-        self, instrument: CanonicalInstrumentIdentity
+        self,
+        instrument: CanonicalInstrumentIdentity,
+        *,
+        as_of: datetime | None = None,
+        maximum_observations: int | None = None,
     ) -> tuple[HistoricalSkewObservation, ...]:
         bucket = self._by_instrument.get(instrument, {})
-        return tuple(sorted(bucket.values(), key=lambda item: item.effective_time))
+        ordered = sorted(bucket.values(), key=lambda item: item.effective_time)
+        if as_of is not None:
+            ordered = [item for item in ordered if item.effective_time <= as_of]
+        if maximum_observations is not None:
+            ordered = ordered[-maximum_observations:]
+        return tuple(ordered)
 
 
 def _observation(
@@ -62,10 +89,18 @@ def _observation(
     return HistoricalSkewObservation(instrument, call_skew, put_skew, effective_time, EVIDENCE)
 
 
-def _a_session_close() -> datetime:
-    # A real, deterministic, already-closed session -- avoids depending on
-    # whatever real calendar date this test happens to run on.
-    return CALENDAR.session(datetime(2026, 7, 27).date()).closes_at  # Monday
+def _append_directly(
+    repository: InMemoryHistoricalSkewRepository,
+    instrument: CanonicalInstrumentIdentity,
+    session: MarketSession,
+    *,
+    call_skew: Decimal = Decimal("0.05"),
+    put_skew: Decimal = Decimal("0.07"),
+) -> None:
+    observation = _observation(
+        instrument, session.closes_at, call_skew=call_skew, put_skew=put_skew
+    )
+    repository.append(observation, session_date=session.trading_date)
 
 
 class TestHistoricalSkewRepositoryProtocolContract:
@@ -75,127 +110,173 @@ class TestHistoricalSkewRepositoryProtocolContract:
 
     def test_canonical_identity_is_idempotent(self) -> None:
         repository = InMemoryHistoricalSkewRepository()
-        session = _a_session_close()
-        repository.append(_observation(AAPL, session, call_skew=Decimal("0.05")))
-        repository.append(_observation(AAPL, session, call_skew=Decimal("0.05")))
+        _append_directly(repository, AAPL, _SESSION_1, call_skew=Decimal("0.05"))
+        _append_directly(repository, AAPL, _SESSION_1, call_skew=Decimal("0.05"))
 
         assert len(repository.history_for(AAPL)) == 1
 
-    def test_value_oscillation_does_not_collide_with_an_earlier_observation(self) -> None:
-        # A duplicate append for the same (instrument, effective_time) but
-        # with DIFFERENT values must not silently overwrite the first --
-        # the first truthfully recorded snapshot wins, never a later
-        # differently-valued claim for the same already-recorded session.
+    def test_conflicting_content_for_an_already_recorded_session_is_rejected(self) -> None:
+        # A second append for the same session with DIFFERENT skew values
+        # must raise, never silently overwrite or silently keep the first
+        # (S13-04A.1's own correction of the original silent-first-write
+        # behavior a Founder review flagged before S13-04B's migration).
         repository = InMemoryHistoricalSkewRepository()
-        session = _a_session_close()
-        repository.append(_observation(AAPL, session, call_skew=Decimal("0.05")))
-        repository.append(_observation(AAPL, session, call_skew=Decimal("0.99")))
+        _append_directly(repository, AAPL, _SESSION_1, call_skew=Decimal("0.05"))
+
+        with pytest.raises(ConflictingHistoricalObservationError):
+            _append_directly(repository, AAPL, _SESSION_1, call_skew=Decimal("0.99"))
 
         (only,) = repository.history_for(AAPL)
-        assert only.call_skew == Decimal("0.05")
+        assert only.call_skew == Decimal("0.05")  # untouched by the rejected attempt
 
     def test_different_sessions_remain_distinct(self) -> None:
         repository = InMemoryHistoricalSkewRepository()
-        first = _a_session_close()
-        second = CALENDAR.session(datetime(2026, 7, 28).date()).closes_at
-        repository.append(_observation(AAPL, first))
-        repository.append(_observation(AAPL, second))
+        _append_directly(repository, AAPL, _SESSION_1)
+        _append_directly(repository, AAPL, _SESSION_2)
 
         assert len(repository.history_for(AAPL)) == 2
 
     def test_different_subjects_never_collide(self) -> None:
         repository = InMemoryHistoricalSkewRepository()
-        session = _a_session_close()
-        repository.append(_observation(AAPL, session))
-        repository.append(_observation(MSFT, session))
+        _append_directly(repository, AAPL, _SESSION_1)
+        _append_directly(repository, MSFT, _SESSION_1)
 
         assert len(repository.history_for(AAPL)) == 1
         assert len(repository.history_for(MSFT)) == 1
 
     def test_query_ordering_is_deterministic_oldest_first(self) -> None:
         repository = InMemoryHistoricalSkewRepository()
-        first = _a_session_close()
-        second = CALENDAR.session(datetime(2026, 7, 28).date()).closes_at
         # Appended out of order -- query must still return oldest first.
-        repository.append(_observation(AAPL, second))
-        repository.append(_observation(AAPL, first))
+        _append_directly(repository, AAPL, _SESSION_2)
+        _append_directly(repository, AAPL, _SESSION_1)
 
         ordered = repository.history_for(AAPL)
-        assert [item.effective_time for item in ordered] == [first, second]
+        assert [item.effective_time for item in ordered] == [
+            _SESSION_1.closes_at,
+            _SESSION_2.closes_at,
+        ]
 
     def test_utc_normalization(self) -> None:
         repository = InMemoryHistoricalSkewRepository()
-        session = _a_session_close()
-        assert session.tzinfo is not None
-        repository.append(_observation(AAPL, session))
+        assert _SESSION_1.closes_at.tzinfo is not None
+        _append_directly(repository, AAPL, _SESSION_1)
         (only,) = repository.history_for(AAPL)
         assert only.effective_time.astimezone(UTC).utcoffset() == timedelta(0)
+
+    def test_as_of_excludes_observations_after_the_given_time(self) -> None:
+        repository = InMemoryHistoricalSkewRepository()
+        _append_directly(repository, AAPL, _SESSION_1)
+        _append_directly(repository, AAPL, _SESSION_2)
+
+        bounded = repository.history_for(AAPL, as_of=_SESSION_1.closes_at)
+        assert [item.effective_time for item in bounded] == [_SESSION_1.closes_at]
+
+    def test_maximum_observations_keeps_only_the_most_recent(self) -> None:
+        repository = InMemoryHistoricalSkewRepository()
+        _append_directly(repository, AAPL, _SESSION_1)
+        _append_directly(repository, AAPL, _SESSION_2)
+
+        bounded = repository.history_for(AAPL, maximum_observations=1)
+        assert [item.effective_time for item in bounded] == [_SESSION_2.closes_at]
 
 
 class TestRecordProspectiveSkewObservation:
     def test_one_qualified_session_creates_one_observation(self) -> None:
         repository = InMemoryHistoricalSkewRepository()
-        session = _a_session_close()
-        clock = _FixedClock(session + timedelta(minutes=5))
+        clock = _FixedClock(_SESSION_2.opens_at + timedelta(hours=1))  # session 1 now completed
 
         record_prospective_skew_observation(
-            repository, clock, CALENDAR, _observation(AAPL, session)
+            repository, clock, CALENDAR, _observation(AAPL, _SESSION_1.closes_at)
         )
 
         assert len(repository.history_for(AAPL)) == 1
 
-    def test_duplicate_same_session_snapshot_is_idempotent(self) -> None:
+    def test_effective_time_is_canonicalized_to_the_session_close(self) -> None:
+        # A snapshot captured mid-session (e.g. one minute after open) is
+        # still recorded against that session's own official close time,
+        # not the moment it happened to be captured -- "one canonical
+        # end-of-session snapshot" means every observation for a session
+        # shares exactly one timestamp.
         repository = InMemoryHistoricalSkewRepository()
-        session = _a_session_close()
-        clock = _FixedClock(session + timedelta(minutes=5))
+        clock = _FixedClock(_SESSION_2.opens_at + timedelta(hours=1))
+        captured_mid_session = _SESSION_1.opens_at + timedelta(minutes=1)
 
         record_prospective_skew_observation(
-            repository, clock, CALENDAR, _observation(AAPL, session)
+            repository, clock, CALENDAR, _observation(AAPL, captured_mid_session)
+        )
+
+        (only,) = repository.history_for(AAPL)
+        assert only.effective_time == _SESSION_1.closes_at
+
+    def test_duplicate_same_session_snapshot_is_idempotent(self) -> None:
+        repository = InMemoryHistoricalSkewRepository()
+        clock = _FixedClock(_SESSION_2.opens_at + timedelta(hours=1))
+
+        record_prospective_skew_observation(
+            repository, clock, CALENDAR, _observation(AAPL, _SESSION_1.closes_at)
         )
         record_prospective_skew_observation(
-            repository, clock, CALENDAR, _observation(AAPL, session)
+            repository, clock, CALENDAR, _observation(AAPL, _SESSION_1.closes_at)
         )
+
+        assert len(repository.history_for(AAPL)) == 1
+
+    def test_repeated_intraday_cycles_cannot_inflate_one_sessions_count(self) -> None:
+        # The exact regression this correction exists to prevent: several
+        # scheduled cycles, each capturing its own live chain at a
+        # different moment, must still collapse to exactly one recorded
+        # observation for the one session they all actually belong to.
+        repository = InMemoryHistoricalSkewRepository()
+        clock = _FixedClock(_SESSION_2.opens_at + timedelta(hours=1))
+
+        for minute in (5, 65, 125, 185):
+            record_prospective_skew_observation(
+                repository,
+                clock,
+                CALENDAR,
+                _observation(AAPL, _SESSION_1.opens_at + timedelta(minutes=minute)),
+            )
 
         assert len(repository.history_for(AAPL)) == 1
 
     def test_future_dated_observation_is_rejected(self) -> None:
         repository = InMemoryHistoricalSkewRepository()
-        session = _a_session_close()
-        clock = _FixedClock(session - timedelta(days=1))  # "now" is before the snapshot
+        clock = _FixedClock(_SESSION_1.closes_at - timedelta(days=1))
 
         with pytest.raises(SyntheticOrBackdatedObservationError):
             record_prospective_skew_observation(
-                repository, clock, CALENDAR, _observation(AAPL, session)
+                repository, clock, CALENDAR, _observation(AAPL, _SESSION_1.closes_at)
             )
         assert repository.history_for(AAPL) == ()
 
     def test_backdated_observation_is_rejected(self) -> None:
         repository = InMemoryHistoricalSkewRepository()
-        old_session = CALENDAR.session(datetime(2026, 1, 5).date()).closes_at
-        now = datetime(2026, 7, 27, 20, 0, tzinfo=UTC)
+        old_session = CALENDAR.session(date(2026, 1, 5))
+        clock = _FixedClock(_SESSION_2.opens_at + timedelta(hours=1))
+
+        with pytest.raises(SyntheticOrBackdatedObservationError):
+            record_prospective_skew_observation(
+                repository, clock, CALENDAR, _observation(AAPL, old_session.closes_at)
+            )
+        assert repository.history_for(AAPL) == ()
+
+    def test_current_open_session_snapshot_is_rejected(self) -> None:
+        # S13-04A.1's own correction: a snapshot from the session that is
+        # currently open (not yet closed) as of "now" must be rejected,
+        # not accepted -- only the most recently *completed* session's
+        # own close may ever be recorded.
+        repository = InMemoryHistoricalSkewRepository()
+        now = _SESSION_2.opens_at + timedelta(hours=1)  # session 2 is still open at "now"
         clock = _FixedClock(now)
 
         with pytest.raises(SyntheticOrBackdatedObservationError):
             record_prospective_skew_observation(
-                repository, clock, CALENDAR, _observation(AAPL, old_session)
+                repository,
+                clock,
+                CALENDAR,
+                _observation(AAPL, _SESSION_2.opens_at + timedelta(minutes=30)),
             )
         assert repository.history_for(AAPL) == ()
-
-    def test_current_open_session_snapshot_is_accepted(self) -> None:
-        # The most recently completed (prior) session's own opens_at is
-        # the floor -- a snapshot from the currently open (not yet
-        # closed) session is chronologically after that floor and must
-        # still be accepted, not only a fully closed session's snapshot.
-        repository = InMemoryHistoricalSkewRepository()
-        current_session_open = CALENDAR.session(datetime(2026, 7, 28).date()).opens_at
-        now = current_session_open + timedelta(hours=2)
-        clock = _FixedClock(now)
-
-        record_prospective_skew_observation(
-            repository, clock, CALENDAR, _observation(AAPL, current_session_open)
-        )
-
-        assert len(repository.history_for(AAPL)) == 1
 
 
 class TestHistoricalCoverage:
@@ -203,13 +284,14 @@ class TestHistoricalCoverage:
         assert historical_coverage(()) == (0, None)
 
     def test_count_and_earliest_reflect_oldest_first_ordering(self) -> None:
-        first = _a_session_close()
-        second = CALENDAR.session(datetime(2026, 7, 28).date()).closes_at
-        observations = (_observation(AAPL, first), _observation(AAPL, second))
+        observations = (
+            _observation(AAPL, _SESSION_1.closes_at),
+            _observation(AAPL, _SESSION_2.closes_at),
+        )
 
         count, earliest = historical_coverage(observations)
         assert count == 2
-        assert earliest == first
+        assert earliest == _SESSION_1.closes_at
 
     def test_40_valid_observations_inside_60_lookback_is_representable(self) -> None:
         # Not a manifest-gate test (that lives at the strategy-policy layer,
@@ -218,11 +300,16 @@ class TestHistoricalCoverage:
         # 60-observation lookback / 40-valid-minimum policy from ever being
         # satisfiable once real accumulation has run long enough.
         repository = InMemoryHistoricalSkewRepository()
-        base = _a_session_close()
-        for offset in range(60):
-            repository.append(_observation(AAPL, base + timedelta(days=offset)))
+        cursor = date(2026, 1, 5)
+        recorded_closes: list[datetime] = []
+        while len(recorded_closes) < 60:
+            session = CALENDAR.session(cursor)
+            if session is not None:
+                _append_directly(repository, AAPL, session)
+                recorded_closes.append(session.closes_at)
+            cursor += timedelta(days=1)
 
         history = repository.history_for(AAPL)
         count, earliest = historical_coverage(history)
         assert count == 60
-        assert earliest == base
+        assert earliest == recorded_closes[0]


### PR DESCRIPTION
## Objective

Corrective patch on S13-04A (PR #274, merged `0664a2a`) before S13-04B freezes a Postgres schema around a defective identity. Founder review found a real gap: session cardinality was not enforced.

## Confirmed against the actual merged code

Repository identity was keyed on raw `effective_time`, and `record_prospective_skew_observation()` accepted any timestamp inside the *currently open* session -- directly contradicting the approved policy's own `observation_frequency: one_canonical_close_snapshot_per_session`. This wasn't a theoretical gap: `test_current_open_session_snapshot_is_accepted` was a real, passing test proving it. Left unfixed into S13-04B's schema, repeated intraday scheduled cycles could each record a distinct observation for the same trading day, inflating the historical count and reporting sufficient history weeks before it was truthfully so.

## Fix

- Identity is now `(instrument, trading_session_date)`, never raw timestamp.
- `record_prospective_skew_observation()` canonicalizes every accepted observation's `effective_time` to that session's own `closes_at` before storing -- one timestamp per session, regardless of capture moment.
- A snapshot from the currently open session is now **rejected**, not accepted.
- A conflicting second append (same session, different skew values) now raises `ConflictingHistoricalObservationError` instead of silent first-write-wins. Compares only the financial values -- canonicalization already makes `effective_time` identical across retries for the same session, so this is a values-only check by construction.
- `history_for()` gained `as_of` and `maximum_observations` -- a bounded query instead of an unbounded full-history scan.

## Deliberately not changed here

- `domain/strategy_evidence.py`'s `HistoricalSkewObservation` itself is untouched -- session identity is a persistence-layer concern, computed via the session calendar, not a new field on an already-shipped SPRINT-012 domain type.
- Comparison-universe typed instrument-class/sector metadata (review finding #7) is S13-04C's own scope.
- Source-blocker wording precision (review finding #6) -- noted for future reports.

## Tests

19 tests (was 15) in `tests/strategy_runtime/test_historical_evidence.py`, rewritten around the new identity. New: conflicting-content rejection, effective-time canonicalization, **the exact regression this correction exists to prevent** (repeated intraday cycles collapse to one observation), current-open-session rejection (replaces the prior, now-wrong acceptance test), bounded-query coverage.

## Validation

- `ruff check asa tests/asa`: clean
- `mypy strategy_runtime`, `mypy asa`: 66 files combined, no issues
- Full suite: **2115 passed, 23 skipped, zero regressions**
- `tests/architecture`: 464 passed
- `tools/pos/lean/pre_push_check.py`: all 5 checks pass

No migration, no schema change. Eligible for delegate auto-merge once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)