### PR TITLE
S13-04B: PostgreSQL historical-skew repository and migration

### DIFF
--- a/asa/integrations/historical_skew_postgres.py
+++ b/asa/integrations/historical_skew_postgres.py
@@ -1,0 +1,159 @@
+"""Postgres-backed HistoricalSkewRepository (SPRINT-013 S13-04B).
+
+Implements strategy_runtime.historical_evidence.HistoricalSkewRepository --
+raw SQL through sqlalchemy.Engine/text(), no ORM, matching this codebase's
+established PostgresLatestResultRepository/PostgresObservationHistoryRepository
+pattern exactly.
+
+Uniqueness is enforced in PostgreSQL itself (migrations/versions/0012_
+historical_skew_observations.py's own primary key on (instrument_scheme,
+instrument_value, trading_session_date)), not only in application code --
+append() uses INSERT ... ON CONFLICT DO NOTHING RETURNING, then, only when
+nothing was returned (a row for this session already existed), reads that
+row back and compares financial values. This is race-safe under real
+concurrent writers: the database's own primary key resolves which of two
+truly simultaneous inserts for the same (instrument, session) actually
+wins atomically; both callers then agree, from the row Postgres now
+durably holds, whether their own attempt was a same-values idempotent
+no-op or a genuine content conflict. No naive "check then insert" -- that
+shape has a race window this one does not.
+
+HISTORICAL_SKEW_SCHEMA_VERSION is stamped on every row this repository
+writes. It is not part of HistoricalSkewRepository's own Protocol, and
+domain.strategy_evidence.HistoricalSkewObservation itself is deliberately
+unchanged (see project/reports/SPRINT-013-S13-04-trace.md and PR #274's
+own scope note) -- this is pure persistence-layer bookkeeping, giving a
+future normalization revision a traceable boundary without ever having to
+guess, or silently reinterpret, what an already-recorded row originally
+meant.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+
+from sqlalchemy import Engine, text
+from sqlalchemy.engine import RowMapping
+
+from domain import CanonicalInstrumentIdentity, EvidenceKind, EvidenceReference
+from domain.strategy_evidence import HistoricalSkewObservation
+from strategy_runtime.historical_evidence import ConflictingHistoricalObservationError
+
+HISTORICAL_SKEW_SCHEMA_VERSION = "1.0.0"
+
+
+class PostgresHistoricalSkewRepository:
+    def __init__(self, engine: Engine) -> None:
+        self._engine = engine
+
+    def append(self, observation: HistoricalSkewObservation, *, session_date: date) -> None:
+        with self._engine.begin() as connection:
+            inserted = connection.execute(
+                text("""
+                    INSERT INTO historical_skew_observations (
+                        instrument_scheme, instrument_value, trading_session_date,
+                        call_skew, put_skew, effective_time, evidence, schema_version
+                    ) VALUES (
+                        :instrument_scheme, :instrument_value, :trading_session_date,
+                        :call_skew, :put_skew, :effective_time, :evidence, :schema_version
+                    )
+                    ON CONFLICT (instrument_scheme, instrument_value, trading_session_date)
+                    DO NOTHING
+                    RETURNING instrument_scheme
+                """),
+                _insert_params(observation, session_date),
+            ).first()
+            if inserted is not None:
+                return
+            existing = connection.execute(
+                text("""
+                    SELECT call_skew, put_skew FROM historical_skew_observations
+                    WHERE instrument_scheme = :instrument_scheme
+                      AND instrument_value = :instrument_value
+                      AND trading_session_date = :trading_session_date
+                """),
+                {
+                    "instrument_scheme": observation.instrument.scheme,
+                    "instrument_value": observation.instrument.value,
+                    "trading_session_date": session_date,
+                },
+            ).one()
+            if (existing.call_skew, existing.put_skew) != (
+                observation.call_skew,
+                observation.put_skew,
+            ):
+                raise ConflictingHistoricalObservationError(
+                    f"{observation.instrument} already has a recorded observation "
+                    f"for session {session_date} with different skew values"
+                )
+
+    def history_for(
+        self,
+        instrument: CanonicalInstrumentIdentity,
+        *,
+        as_of: datetime | None = None,
+        maximum_observations: int | None = None,
+    ) -> tuple[HistoricalSkewObservation, ...]:
+        with self._engine.connect() as connection:
+            rows = connection.execute(
+                text("""
+                    SELECT * FROM (
+                        SELECT * FROM historical_skew_observations
+                        WHERE instrument_scheme = :instrument_scheme
+                          AND instrument_value = :instrument_value
+                          AND (
+                              CAST(:as_of AS TIMESTAMP WITH TIME ZONE) IS NULL
+                              OR effective_time <= :as_of
+                          )
+                        ORDER BY trading_session_date DESC
+                        LIMIT :maximum_observations
+                    ) AS latest
+                    ORDER BY trading_session_date ASC
+                """),
+                {
+                    "instrument_scheme": instrument.scheme,
+                    "instrument_value": instrument.value,
+                    "as_of": as_of,
+                    "maximum_observations": maximum_observations,
+                },
+            ).mappings()
+            return tuple(_to_observation(row) for row in rows)
+
+
+def _insert_params(observation: HistoricalSkewObservation, session_date: date) -> dict[str, object]:
+    return {
+        "instrument_scheme": observation.instrument.scheme,
+        "instrument_value": observation.instrument.value,
+        "trading_session_date": session_date,
+        "call_skew": observation.call_skew,
+        "put_skew": observation.put_skew,
+        "effective_time": observation.effective_time,
+        "evidence": json.dumps([_evidence_to_json(item) for item in observation.evidence]),
+        "schema_version": HISTORICAL_SKEW_SCHEMA_VERSION,
+    }
+
+
+def _evidence_to_json(item: EvidenceReference) -> dict[str, object]:
+    return {"kind": item.kind.value, "referenced_id": item.referenced_id, "version": item.version}
+
+
+def _evidence_from_json(payload: list[dict[str, object]]) -> tuple[EvidenceReference, ...]:
+    references: list[EvidenceReference] = []
+    for item in payload:
+        version = item["version"]
+        assert version is None or isinstance(version, int)
+        references.append(
+            EvidenceReference(EvidenceKind(item["kind"]), str(item["referenced_id"]), version)
+        )
+    return tuple(references)
+
+
+def _to_observation(row: RowMapping) -> HistoricalSkewObservation:
+    return HistoricalSkewObservation(
+        instrument=CanonicalInstrumentIdentity(row["instrument_scheme"], row["instrument_value"]),
+        call_skew=row["call_skew"],
+        put_skew=row["put_skew"],
+        effective_time=row["effective_time"],
+        evidence=_evidence_from_json(row["evidence"]),
+    )

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -7,7 +7,24 @@ from asa.config import Settings
 
 config = context.config
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # SPRINT-013 S13-04B: disable_existing_loggers defaults to True, which
+    # silently disables every logger already created in this process that
+    # alembic.ini's own [loggers] section doesn't list (root/sqlalchemy/
+    # alembic only) -- when command.upgrade() runs inside a pytest session
+    # that has already imported application modules (any of them creating
+    # their own logging.getLogger(__name__) at import time, e.g.
+    # asa.portfolio_run), those loggers go dead for the rest of the
+    # process. Confirmed directly: tests/asa/test_logging.py's own caplog
+    # assertion started failing with zero captured records the moment a
+    # Postgres-fixture test file that alphabetically runs before it
+    # (tests/asa/test_historical_skew_postgres_integration.py) began
+    # calling command.upgrade() first in the same pytest session -- not a
+    # defect in that new file's own logic, a latent fragility here that
+    # any future new test file sorting earlier than test_logging.py could
+    # have re-triggered regardless. disable_existing_loggers=False keeps
+    # alembic's own console logging working exactly as configured while
+    # leaving every other logger in this process alone.
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 config.set_main_option("sqlalchemy.url", Settings().database_url)
 target_metadata = None
 

--- a/migrations/versions/0012_historical_skew_observations.py
+++ b/migrations/versions/0012_historical_skew_observations.py
@@ -1,0 +1,79 @@
+"""Create historical_skew_observations -- durable, provider-neutral
+canonical historical skew evidence (SPRINT-013 S13-04B).
+
+Additive only: no existing table is touched. A dedicated table, deliberately
+separate from opportunity_observation_history (0006) -- that table is
+strategy-verdict lifecycle history (lifecycle_stage/verdict/
+recommended_action), this one is canonical market-fact history
+(call_skew/put_skew/evidence), a different ownership layer entirely
+(this ticket's own "do not mix canonical observations and derived
+analytics/strategy-verdict history in one ownership layer" rule).
+
+Canonical uniqueness is (instrument_scheme, instrument_value,
+trading_session_date) -- one row per instrument per trading session,
+never per raw timestamp (S13-04A.1's own correction of the original
+identity). effective_time is stored separately from trading_session_date:
+it is always that session's own canonical close time
+(strategy_runtime.historical_evidence.record_prospective_skew_observation()
+canonicalizes it before any row is ever written), kept as its own column
+because callers query and reason about it as a timestamp, not a date.
+
+schema_version is an explicit column on this table, not a change to
+domain.strategy_evidence.HistoricalSkewObservation itself (that SPRINT-012
+domain type is deliberately left unchanged -- see project/reports/
+SPRINT-013-S13-04-trace.md and PR #274's own scope note). This gives a
+future normalization revision a traceable persistence-layer boundary
+without silently reinterpreting already-recorded sessions under a new
+meaning, per explicit Founder direction on this PR.
+
+One composite primary key index on (instrument_scheme, instrument_value,
+trading_session_date) is the only index this table needs: every query
+shape this ticket requires -- lookup by instrument, a session-date range
+for one instrument, the bounded "latest N sessions" query, and an as-of
+query -- filters and orders by exactly this same leading column set, and
+a B-tree index supports range scans and ORDER BY ... DESC LIMIT N equally
+well in either direction. No separate index was added merely to have one;
+that would duplicate what the primary key already provides.
+
+No retention or deletion policy -- explicitly out of this ticket's scope,
+per its own "do not invent retention limits" instruction. Estimated row
+growth: one row per instrument per trading session, ~252 sessions/year;
+at the current ~30-symbol approved universe, ~7,500 rows/year -- trivial.
+
+Revision ID: 0012
+Revises: 0011
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0012"
+down_revision: str | None = "0011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "historical_skew_observations",
+        sa.Column("instrument_scheme", sa.String(length=32), nullable=False),
+        sa.Column("instrument_value", sa.String(length=64), nullable=False),
+        sa.Column("trading_session_date", sa.Date(), nullable=False),
+        sa.Column("call_skew", sa.Numeric(), nullable=False),
+        sa.Column("put_skew", sa.Numeric(), nullable=False),
+        sa.Column("effective_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("evidence", sa.JSON(), nullable=False),
+        sa.Column("schema_version", sa.String(length=16), nullable=False),
+        sa.PrimaryKeyConstraint(
+            "instrument_scheme",
+            "instrument_value",
+            "trading_session_date",
+            name="pk_historical_skew_observations",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("historical_skew_observations")

--- a/tests/asa/test_historical_skew_postgres_integration.py
+++ b/tests/asa/test_historical_skew_postgres_integration.py
@@ -1,0 +1,318 @@
+"""SPRINT-013 S13-04B: HistoricalSkewRepository exercised end to end
+against a real (test) Postgres instance, through
+PostgresHistoricalSkewRepository -- not the in-memory fake
+tests/strategy_runtime/test_historical_evidence.py already covers.
+
+Parity tests run the identical assertion against both the in-memory
+repository and the real Postgres one, parametrized by a shared fixture,
+so a semantic difference between them shows up as a single parametrized
+test failing for one backend rather than two independently maintained
+(and potentially drifting) test suites.
+
+Migration upgrade/downgrade/re-upgrade round-trip verification is not a
+test in this file: product-ci.yml's own backend job already runs
+`alembic upgrade head` -> `pytest tests/asa` -> `alembic downgrade base
+&& alembic upgrade head` for every PR touching migrations/ -- the exact
+round trip this ticket asks for, already exercised structurally for
+every migration including 0012, not just this one. "Existing tables and
+repositories remain unaffected" is the same guarantee: the full
+tests/asa suite (every other Postgres-backed repository's own tests)
+runs again after the downgrade-then-reupgrade cycle in that same job.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from asa.integrations.historical_skew_postgres import PostgresHistoricalSkewRepository
+from domain import CanonicalInstrumentIdentity, EvidenceKind, EvidenceReference
+from domain.strategy_evidence import HistoricalSkewObservation
+from market_data.session_calendar import UsEquitySessionCalendar
+from strategy_runtime.historical_evidence import ConflictingHistoricalObservationError
+
+pytestmark = [
+    pytest.mark.postgres,
+    pytest.mark.skipif(
+        not os.getenv("ASA_TEST_DATABASE_URL"),
+        reason="ASA_TEST_DATABASE_URL not set",
+    ),
+]
+
+AAPL = CanonicalInstrumentIdentity("figi", "BBG000B9XRY4")
+MSFT = CanonicalInstrumentIdentity("figi", "BBG000BPH459")
+EVIDENCE = (
+    EvidenceReference(EvidenceKind.OBSERVATION, "tradier:option-chain:AAPL", None),
+    EvidenceReference(EvidenceKind.CANONICAL_FACT, "asa:normalized-skew:AAPL", 3),
+)
+CALENDAR = UsEquitySessionCalendar()
+_SESSION_1 = CALENDAR.session(date(2026, 7, 27))
+_SESSION_2 = CALENDAR.session(date(2026, 7, 28))
+
+
+class InMemoryHistoricalSkewRepository:
+    """Identical semantics to the Postgres repository under test -- see
+    tests/strategy_runtime/test_historical_evidence.py's own copy of this
+    fake, which this mirrors exactly, so the parity tests below actually
+    exercise two independent implementations of the same contract.
+    """
+
+    def __init__(self) -> None:
+        self._by_instrument: dict[
+            CanonicalInstrumentIdentity, dict[date, HistoricalSkewObservation]
+        ] = {}
+
+    def append(self, observation: HistoricalSkewObservation, *, session_date: date) -> None:
+        bucket = self._by_instrument.setdefault(observation.instrument, {})
+        existing = bucket.get(session_date)
+        if existing is not None:
+            if (existing.call_skew, existing.put_skew) != (
+                observation.call_skew,
+                observation.put_skew,
+            ):
+                raise ConflictingHistoricalObservationError(
+                    f"{observation.instrument} already has a recorded observation "
+                    f"for session {session_date} with different skew values"
+                )
+            return
+        bucket[session_date] = observation
+
+    def history_for(
+        self,
+        instrument: CanonicalInstrumentIdentity,
+        *,
+        as_of: datetime | None = None,
+        maximum_observations: int | None = None,
+    ) -> tuple[HistoricalSkewObservation, ...]:
+        bucket = self._by_instrument.get(instrument, {})
+        ordered = sorted(bucket.values(), key=lambda item: item.effective_time)
+        if as_of is not None:
+            ordered = [item for item in ordered if item.effective_time <= as_of]
+        if maximum_observations is not None:
+            ordered = ordered[-maximum_observations:]
+        return tuple(ordered)
+
+
+@pytest.fixture
+def postgres_repository() -> PostgresHistoricalSkewRepository:
+    database_url = os.environ["ASA_TEST_DATABASE_URL"]
+    os.environ["ASA_DATABASE_URL"] = database_url
+    command.upgrade(Config("alembic.ini"), "head")
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE historical_skew_observations"))
+    return PostgresHistoricalSkewRepository(engine)
+
+
+@pytest.fixture(params=["in_memory", "postgres"])
+def repository(
+    request: pytest.FixtureRequest,
+) -> InMemoryHistoricalSkewRepository | PostgresHistoricalSkewRepository:
+    if request.param == "in_memory":
+        return InMemoryHistoricalSkewRepository()
+    return request.getfixturevalue("postgres_repository")
+
+
+def _observation(
+    instrument: CanonicalInstrumentIdentity,
+    effective_time: datetime,
+    *,
+    call_skew: Decimal = Decimal("0.0512345"),
+    put_skew: Decimal = Decimal("0.0798765"),
+    evidence: tuple[EvidenceReference, ...] = EVIDENCE,
+) -> HistoricalSkewObservation:
+    return HistoricalSkewObservation(instrument, call_skew, put_skew, effective_time, evidence)
+
+
+class TestRepositoryParity:
+    """Each test runs once per backend (in_memory, postgres) via the
+    ``repository`` fixture's own parametrization.
+    """
+
+    def test_empty_history_is_an_empty_tuple(self, repository) -> None:
+        assert repository.history_for(AAPL) == ()
+
+    def test_duplicate_same_values_insert_remains_one_row(self, repository) -> None:
+        observation = _observation(AAPL, _SESSION_1.closes_at)
+        repository.append(observation, session_date=_SESSION_1.trading_date)
+        repository.append(observation, session_date=_SESSION_1.trading_date)
+
+        assert len(repository.history_for(AAPL)) == 1
+
+    def test_duplicate_conflicting_values_insert_raises(self, repository) -> None:
+        repository.append(
+            _observation(AAPL, _SESSION_1.closes_at, call_skew=Decimal("0.05")),
+            session_date=_SESSION_1.trading_date,
+        )
+        with pytest.raises(ConflictingHistoricalObservationError):
+            repository.append(
+                _observation(AAPL, _SESSION_1.closes_at, call_skew=Decimal("0.99")),
+                session_date=_SESSION_1.trading_date,
+            )
+
+        (only,) = repository.history_for(AAPL)
+        assert only.call_skew == Decimal("0.05")  # untouched by the rejected attempt
+
+    def test_different_sessions_remain_distinct(self, repository) -> None:
+        repository.append(
+            _observation(AAPL, _SESSION_1.closes_at), session_date=_SESSION_1.trading_date
+        )
+        repository.append(
+            _observation(AAPL, _SESSION_2.closes_at), session_date=_SESSION_2.trading_date
+        )
+
+        assert len(repository.history_for(AAPL)) == 2
+
+    def test_different_instruments_never_collide(self, repository) -> None:
+        repository.append(
+            _observation(AAPL, _SESSION_1.closes_at), session_date=_SESSION_1.trading_date
+        )
+        repository.append(
+            _observation(MSFT, _SESSION_1.closes_at), session_date=_SESSION_1.trading_date
+        )
+
+        assert len(repository.history_for(AAPL)) == 1
+        assert len(repository.history_for(MSFT)) == 1
+
+    def test_deterministic_oldest_first_ordering(self, repository) -> None:
+        # Appended out of order -- query must still return oldest first.
+        repository.append(
+            _observation(AAPL, _SESSION_2.closes_at), session_date=_SESSION_2.trading_date
+        )
+        repository.append(
+            _observation(AAPL, _SESSION_1.closes_at), session_date=_SESSION_1.trading_date
+        )
+
+        ordered = repository.history_for(AAPL)
+        assert [item.effective_time for item in ordered] == [
+            _SESSION_1.closes_at,
+            _SESSION_2.closes_at,
+        ]
+
+    def test_as_of_excludes_later_sessions(self, repository) -> None:
+        repository.append(
+            _observation(AAPL, _SESSION_1.closes_at), session_date=_SESSION_1.trading_date
+        )
+        repository.append(
+            _observation(AAPL, _SESSION_2.closes_at), session_date=_SESSION_2.trading_date
+        )
+
+        bounded = repository.history_for(AAPL, as_of=_SESSION_1.closes_at)
+        assert [item.effective_time for item in bounded] == [_SESSION_1.closes_at]
+
+    def test_maximum_observations_returns_latest_n_oldest_first(self, repository) -> None:
+        repository.append(
+            _observation(AAPL, _SESSION_1.closes_at), session_date=_SESSION_1.trading_date
+        )
+        repository.append(
+            _observation(AAPL, _SESSION_2.closes_at), session_date=_SESSION_2.trading_date
+        )
+
+        bounded = repository.history_for(AAPL, maximum_observations=1)
+        assert [item.effective_time for item in bounded] == [_SESSION_2.closes_at]
+
+
+class TestPostgresRoundTrip:
+    def test_first_insert_round_trips_every_canonical_field(
+        self, postgres_repository: PostgresHistoricalSkewRepository
+    ) -> None:
+        observation = _observation(
+            AAPL,
+            _SESSION_1.closes_at,
+            call_skew=Decimal("0.0512345"),
+            put_skew=Decimal("0.0798765"),
+        )
+        postgres_repository.append(observation, session_date=_SESSION_1.trading_date)
+
+        (only,) = postgres_repository.history_for(AAPL)
+        assert only.instrument == AAPL
+        assert only.call_skew == Decimal("0.0512345")
+        assert only.put_skew == Decimal("0.0798765")
+        assert only.effective_time == _SESSION_1.closes_at
+        assert only.evidence == EVIDENCE
+
+    def test_evidence_references_round_trip_deterministically(
+        self, postgres_repository: PostgresHistoricalSkewRepository
+    ) -> None:
+        multi_evidence = (
+            EvidenceReference(EvidenceKind.OBSERVATION, "tradier:a", None),
+            EvidenceReference(EvidenceKind.INDICATOR, "asa:derived:b", 7),
+        )
+        observation = _observation(AAPL, _SESSION_1.closes_at, evidence=multi_evidence)
+        postgres_repository.append(observation, session_date=_SESSION_1.trading_date)
+
+        (only,) = postgres_repository.history_for(AAPL)
+        assert only.evidence == multi_evidence
+
+    def test_utc_aware_effective_time_round_trips_exactly(
+        self, postgres_repository: PostgresHistoricalSkewRepository
+    ) -> None:
+        assert _SESSION_1.closes_at.tzinfo is not None
+        observation = _observation(AAPL, _SESSION_1.closes_at)
+        postgres_repository.append(observation, session_date=_SESSION_1.trading_date)
+
+        (only,) = postgres_repository.history_for(AAPL)
+        assert only.effective_time.astimezone(UTC) == _SESSION_1.closes_at.astimezone(UTC)
+        assert only.effective_time.utcoffset() is not None
+
+    def test_concurrent_identical_inserts_are_idempotent(
+        self, postgres_repository: PostgresHistoricalSkewRepository
+    ) -> None:
+        observation = _observation(AAPL, _SESSION_1.closes_at)
+        barrier = threading.Barrier(2)
+        errors: list[Exception] = []
+
+        def _write() -> None:
+            barrier.wait(timeout=5)
+            try:
+                postgres_repository.append(observation, session_date=_SESSION_1.trading_date)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_write) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        assert errors == []  # identical concurrent writes never raise
+        assert len(postgres_repository.history_for(AAPL)) == 1
+
+    def test_concurrent_conflicting_inserts_do_not_silently_pass(
+        self, postgres_repository: PostgresHistoricalSkewRepository
+    ) -> None:
+        first = _observation(AAPL, _SESSION_1.closes_at, call_skew=Decimal("0.05"))
+        second = _observation(AAPL, _SESSION_1.closes_at, call_skew=Decimal("0.99"))
+        barrier = threading.Barrier(2)
+        errors: list[Exception] = []
+
+        def _write(observation: HistoricalSkewObservation) -> None:
+            barrier.wait(timeout=5)
+            try:
+                postgres_repository.append(observation, session_date=_SESSION_1.trading_date)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=_write, args=(first,)),
+            threading.Thread(target=_write, args=(second,)),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        # Exactly one of the two concurrent writers wins the row; the
+        # other must observe a genuine content conflict, not silently
+        # succeed and not silently do nothing without any signal.
+        assert len(errors) == 1
+        assert isinstance(errors[0], ConflictingHistoricalObservationError)
+        (only,) = postgres_repository.history_for(AAPL)
+        assert only.call_skew in (Decimal("0.05"), Decimal("0.99"))

--- a/tests/asa/test_historical_skew_postgres_integration.py
+++ b/tests/asa/test_historical_skew_postgres_integration.py
@@ -236,7 +236,12 @@ class TestPostgresRoundTrip:
         assert only.call_skew == Decimal("0.0512345")
         assert only.put_skew == Decimal("0.0798765")
         assert only.effective_time == _SESSION_1.closes_at
-        assert only.evidence == EVIDENCE
+        # HistoricalSkewObservation.__post_init__ deterministically sorts
+        # evidence by (kind, referenced_id, version) -- compare against
+        # the constructed observation's own already-sorted field, not the
+        # raw EVIDENCE constant's own input order, which the domain type
+        # itself never preserves verbatim in the first place.
+        assert only.evidence == observation.evidence
 
     def test_evidence_references_round_trip_deterministically(
         self, postgres_repository: PostgresHistoricalSkewRepository
@@ -249,7 +254,10 @@ class TestPostgresRoundTrip:
         postgres_repository.append(observation, session_date=_SESSION_1.trading_date)
 
         (only,) = postgres_repository.history_for(AAPL)
-        assert only.evidence == multi_evidence
+        # Same reason as the sibling test above: compare against what the
+        # domain type actually stored (sorted), not the raw input order.
+        assert only.evidence == observation.evidence
+        assert set(only.evidence) == set(multi_evidence)  # same references, order aside
 
     def test_utc_aware_effective_time_round_trips_exactly(
         self, postgres_repository: PostgresHistoricalSkewRepository


### PR DESCRIPTION
## MERGE STATE: HOLD_FOR_EXPLICIT_FOUNDER_AUTHORIZATION

Auto-merge is **not** requested on this PR. This is a migration-bearing PR -- merging to main triggers Railway's `preDeployCommand`, which runs `alembic upgrade head` against production. Per Founder direction, this PR is for full validation and CI only; do not merge until explicit authorization is given after reviewing this packet.

## Migration revision

`0012`, `down_revision = "0011"`.

## Exact schema, constraints, indexes

```sql
CREATE TABLE historical_skew_observations (
    instrument_scheme VARCHAR(32) NOT NULL,
    instrument_value VARCHAR(64) NOT NULL,
    trading_session_date DATE NOT NULL,
    call_skew NUMERIC NOT NULL,
    put_skew NUMERIC NOT NULL,
    effective_time TIMESTAMP WITH TIME ZONE NOT NULL,
    evidence JSON NOT NULL,
    schema_version VARCHAR(16) NOT NULL,
    CONSTRAINT pk_historical_skew_observations PRIMARY KEY (instrument_scheme, instrument_value, trading_session_date)
);
```

No separate index: the composite primary key's own B-tree already supports every required query shape (instrument lookup, session-date range, bounded "latest N sessions," as-of query) -- all filter/order by exactly this same leading column set, and B-tree indexes support ascending and descending range scans equally well.

## Upgrade/downgrade evidence (rendered offline, both directions)

**Upgrade (0011 → 0012):**
```sql
BEGIN;
CREATE TABLE historical_skew_observations ( ... same as above ... );
UPDATE alembic_version SET version_num='0012' WHERE alembic_version.version_num = '0011';
COMMIT;
```

**Downgrade (0012 → 0011):**
```sql
BEGIN;
DROP TABLE historical_skew_observations;
UPDATE alembic_version SET version_num='0011' WHERE alembic_version.version_num = '0012';
COMMIT;
```

Real upgrade/downgrade/re-upgrade against actual Postgres runs in CI's `backend` job (`product-ci.yml`'s own existing structure: `alembic upgrade head` → `pytest tests/asa` → `alembic downgrade base && alembic upgrade head`) -- the exact round trip required, already exercised for every migration including this one. Results reported below once CI completes.

## Repository semantics

`PostgresHistoricalSkewRepository` (`asa/integrations/historical_skew_postgres.py`) implements `strategy_runtime.historical_evidence.HistoricalSkewRepository` exactly -- matches the corrected in-memory contract (PR #275) field for field. Conflict handling is atomic: `INSERT ... ON CONFLICT (...) DO NOTHING RETURNING`; when nothing is returned, a follow-up read compares `call_skew`/`put_skew` and either no-ops (identical) or raises `ConflictingHistoricalObservationError` (different). Verified directly with a real two-thread concurrency test against real Postgres, not asserted from reasoning alone.

## What this PR does not do

No live Skew Momentum wiring (S13-04D). No comparison-universe/sector-mapping (S13-04C). No strategy file, threshold, verdict, or provider-priority change. **Applying this migration performs no data writes** -- it only creates an empty table; nothing writes to it until a caller is wired, which this PR does not do.

## Tests

- `TestRepositoryParity` (8 × 2 backends = 16): identical assertions against the in-memory fake and real Postgres via one parametrized fixture.
- `TestPostgresRoundTrip` (5): every canonical field round-trips; `EvidenceReference` tuples round-trip deterministically; UTC-aware `effective_time` round-trips exactly; two real concurrency tests (concurrent identical inserts never raise, leave one row; concurrent conflicting inserts leave exactly one winner and exactly one raised error).

## Validation

- `ruff check asa tests/asa`: clean
- `mypy asa`: 44 files, no issues
- `mypy strategy_runtime`: 23 files, no issues
- Full suite: **2115 passed, 44 skipped** (21 new Postgres-gated tests correctly skip with no local DB), zero regressions
- `tests/architecture`: 464 passed
- `tools/pos/lean/pre_push_check.py`: all 5 checks pass
- `git diff --check`: clean

## Estimated data growth

~30 symbols × ~252 trading sessions/year ≈ 7,500 rows/year. Trivial.

## Deployment effect

Additive migration only. On Founder-authorized merge, Railway's `preDeployCommand` runs `alembic upgrade head`, creating the new table. No existing table, column, or data is touched. No application code path writes to this table yet (S13-04D, not in this PR), so production behavior is unchanged until that later ticket lands.

## Post-deploy read-only smoke plan

After merge: confirm `health`/`readiness` remain 200; confirm (read-only) that `alembic_version` reports `0012`; no write-triggering action performed.

## Rollback procedure

`alembic downgrade 0011` drops only `historical_skew_observations` -- no other table affected. Or revert this PR's commit and re-deploy the prior revision.

## Confirmation

No production data writes begin merely from applying this migration -- confirmed above (empty table, no live caller wired yet).

## Unresolved blocker

None new. The S13-04A source-policy blocker (no approved historical-skew provider; prospective-only accumulation) remains open per Founder direction and does not block this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)