### PR TITLE
S13-04C: reusable comparison-universe and sector-reference evidence

### DIFF
--- a/strategy_runtime/comparison_universe.py
+++ b/strategy_runtime/comparison_universe.py
@@ -1,0 +1,252 @@
+"""Comparison-universe membership and sector-relative evidence
+(SPRINT-013 S13-04C).
+
+Two Founder-approved policies (issue #255), implemented here as reusable,
+pure functions and static reference data -- no live acquisition, no
+strategy wiring, no persistence. Skew Momentum is the first consumer,
+not the owner; any future strategy needing cross-sectional or
+sector-relative return evidence can call these same functions.
+
+comparison_universe:
+    rule: same_instrument_class_within_active_configured_screening_universe
+    exclude_subject: true
+    same_return_period_required: true
+    minimum_valid_members: 5
+    insufficient_members: UNKNOWN
+
+sector_reference:
+    equities: canonical_GICS_sector_to_Select_Sector_SPDR_benchmark
+    non_sector_or_broad_ETFs: UNKNOWN
+    missing_mapping_or_data: UNKNOWN
+
+Instrument class and sector are never invented here: both are existing
+canonical domain facts (domain.SecurityAssetType, domain.
+SectorClassification) -- this module classifies today's approved
+universe using those existing types, it does not define a parallel one.
+Neither function invents, infers, or guesses membership: candidate
+returns are always caller-supplied (typically already-acquired canonical
+bars for screening.live_acquisition.APPROVED_LIVE_UNIVERSE's own
+members), and classification is always looked up from the static tables
+below, never derived from a ticker string or any other heuristic. An
+instrument absent from these tables is unclassified, and every consumer
+must treat that as UNKNOWN, never a default.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+
+from domain import (
+    CanonicalInstrumentIdentity,
+    CanonicalReturnObservation,
+    ComparisonUniverseReturns,
+    SectorClassification,
+    SectorReferenceReturns,
+    SecurityAssetType,
+)
+
+GICS_TAXONOMY = "GICS"
+GICS_TAXONOMY_VERSION = "2023"
+
+# Founder-approved (issue #255): canonical GICS sector -> Select Sector
+# SPDR benchmark ticker, keyed by the approved policy's own snake_case
+# sector identifiers. Verbatim from the approved policy -- no sector or
+# ticker invented or substituted here.
+GICS_SECTOR_TO_SPDR_BENCHMARK: Mapping[str, str] = {
+    "communication_services": "XLC",
+    "consumer_discretionary": "XLY",
+    "consumer_staples": "XLP",
+    "energy": "XLE",
+    "financials": "XLF",
+    "health_care": "XLV",
+    "industrials": "XLI",
+    "materials": "XLB",
+    "real_estate": "XLRE",
+    "information_technology": "XLK",
+    "utilities": "XLU",
+}
+
+# Standard top-level GICS sector codes (2023 structure) -> the approved
+# policy's own snake_case sector identifiers above. A translation layer,
+# not a second taxonomy: domain.SectorClassification.code carries the
+# canonical GICS numeric code (this codebase's own established
+# convention, see tests/instrument_helpers.py); this table is only how
+# that canonical fact maps onto issue #255's own approved SPDR-mapping
+# vocabulary.
+_GICS_CODE_TO_APPROVED_SECTOR_ID: Mapping[str, str] = {
+    "10": "energy",
+    "15": "materials",
+    "20": "industrials",
+    "25": "consumer_discretionary",
+    "30": "consumer_staples",
+    "35": "health_care",
+    "40": "financials",
+    "45": "information_technology",
+    "50": "communication_services",
+    "55": "utilities",
+    "60": "real_estate",
+}
+
+
+def _instrument(symbol: str) -> CanonicalInstrumentIdentity:
+    return CanonicalInstrumentIdentity("symbol", symbol)
+
+
+def _sector(gics_code: str) -> SectorClassification:
+    return SectorClassification(GICS_TAXONOMY, GICS_TAXONOMY_VERSION, gics_code)
+
+
+# Asset-type classification for every member of screening.live_acquisition.
+# APPROVED_LIVE_UNIVERSE (SPRINT-011/UNI-001's own 30-symbol universe).
+ASSET_TYPE_BY_INSTRUMENT: Mapping[CanonicalInstrumentIdentity, SecurityAssetType] = {
+    # Mega-cap single names
+    _instrument("AAPL"): SecurityAssetType.EQUITY,
+    _instrument("MSFT"): SecurityAssetType.EQUITY,
+    _instrument("NVDA"): SecurityAssetType.EQUITY,
+    _instrument("AMD"): SecurityAssetType.EQUITY,
+    _instrument("GOOGL"): SecurityAssetType.EQUITY,
+    _instrument("AMZN"): SecurityAssetType.EQUITY,
+    _instrument("META"): SecurityAssetType.EQUITY,
+    _instrument("TSLA"): SecurityAssetType.EQUITY,
+    _instrument("AVGO"): SecurityAssetType.EQUITY,
+    _instrument("NFLX"): SecurityAssetType.EQUITY,
+    # Financials
+    _instrument("JPM"): SecurityAssetType.EQUITY,
+    _instrument("BAC"): SecurityAssetType.EQUITY,
+    _instrument("GS"): SecurityAssetType.EQUITY,
+    # Healthcare
+    _instrument("UNH"): SecurityAssetType.EQUITY,
+    _instrument("LLY"): SecurityAssetType.EQUITY,
+    # Industrials / consumer
+    _instrument("HD"): SecurityAssetType.EQUITY,
+    _instrument("WMT"): SecurityAssetType.EQUITY,
+    _instrument("DIS"): SecurityAssetType.EQUITY,
+    # Energy
+    _instrument("XOM"): SecurityAssetType.EQUITY,
+    _instrument("CVX"): SecurityAssetType.EQUITY,
+    # Semis
+    _instrument("INTC"): SecurityAssetType.EQUITY,
+    _instrument("MU"): SecurityAssetType.EQUITY,
+    # Major index / sector ETFs
+    _instrument("SPY"): SecurityAssetType.ETF,
+    _instrument("QQQ"): SecurityAssetType.ETF,
+    _instrument("IWM"): SecurityAssetType.ETF,
+    _instrument("DIA"): SecurityAssetType.ETF,
+    _instrument("XLF"): SecurityAssetType.ETF,
+    _instrument("XLE"): SecurityAssetType.ETF,
+    _instrument("XLK"): SecurityAssetType.ETF,
+    _instrument("GLD"): SecurityAssetType.ETF,
+}
+
+# GICS sector for every equity above. ETFs are deliberately absent --
+# Founder-approved policy: "non_sector_or_broad_ETFs: UNKNOWN" (a fund is
+# never itself GICS-sector-classified, including a single-sector SPDR
+# fund, which exists to *be* a sector's benchmark, not to *belong to*
+# one). GICS codes are well-established, public classifications for
+# these large-cap names, not inferred from ticker or company name.
+SECTOR_BY_INSTRUMENT: Mapping[CanonicalInstrumentIdentity, SectorClassification] = {
+    _instrument("AAPL"): _sector("45"),
+    _instrument("MSFT"): _sector("45"),
+    _instrument("NVDA"): _sector("45"),
+    _instrument("AMD"): _sector("45"),
+    _instrument("GOOGL"): _sector("50"),
+    _instrument("AMZN"): _sector("25"),
+    _instrument("META"): _sector("50"),
+    _instrument("TSLA"): _sector("25"),
+    _instrument("AVGO"): _sector("45"),
+    _instrument("NFLX"): _sector("50"),
+    _instrument("JPM"): _sector("40"),
+    _instrument("BAC"): _sector("40"),
+    _instrument("GS"): _sector("40"),
+    _instrument("UNH"): _sector("35"),
+    _instrument("LLY"): _sector("35"),
+    _instrument("HD"): _sector("25"),
+    _instrument("WMT"): _sector("30"),
+    _instrument("DIS"): _sector("50"),
+    _instrument("XOM"): _sector("10"),
+    _instrument("CVX"): _sector("10"),
+    _instrument("INTC"): _sector("45"),
+    _instrument("MU"): _sector("45"),
+}
+
+
+def approved_sector_id(sector: SectorClassification) -> str | None:
+    """Translate a canonical GICS SectorClassification to issue #255's
+    own approved snake_case sector identifier -- None (UNKNOWN) if this
+    module's translation table has no entry, e.g. a taxonomy/code this
+    approved policy never covered.
+    """
+    if sector.taxonomy != GICS_TAXONOMY:
+        return None
+    return _GICS_CODE_TO_APPROVED_SECTOR_ID.get(sector.code)
+
+
+def select_comparison_universe_returns(
+    subject: CanonicalInstrumentIdentity,
+    subject_period: tuple[datetime, datetime],
+    candidate_returns: tuple[CanonicalReturnObservation, ...],
+    asset_types: Mapping[CanonicalInstrumentIdentity, SecurityAssetType],
+    *,
+    minimum_valid_members: int = 5,
+) -> ComparisonUniverseReturns | None:
+    """The approved comparison_universe rule, applied to caller-supplied
+    candidate returns. Returns None (UNKNOWN) when the subject itself is
+    unclassified or fewer than ``minimum_valid_members`` candidates
+    qualify -- never a partial result silently treated as sufficient.
+
+    A candidate qualifies only if all of: it is not the subject itself
+    (exclude_subject); it shares the subject's own asset type
+    (same_instrument_class_within_active_configured_screening_universe);
+    it is itself classified; and its own return period matches the
+    subject's exactly (same_return_period_required). One candidate
+    failing any of these is simply excluded -- it never corrupts or
+    excludes any other, still-valid candidate.
+    """
+    subject_asset_type = asset_types.get(subject)
+    if subject_asset_type is None:
+        return None
+    qualifying = tuple(
+        item
+        for item in candidate_returns
+        if item.instrument != subject
+        and (item.period_start, item.period_end) == subject_period
+        and asset_types.get(item.instrument) is subject_asset_type
+    )
+    if len(qualifying) < minimum_valid_members:
+        return None
+    return ComparisonUniverseReturns(qualifying)
+
+
+def select_sector_reference_returns(
+    subject: CanonicalInstrumentIdentity,
+    subject_period: tuple[datetime, datetime],
+    sectors: Mapping[CanonicalInstrumentIdentity, SectorClassification],
+    benchmark_returns: tuple[CanonicalReturnObservation, ...],
+) -> SectorReferenceReturns | None:
+    """The approved sector_reference rule. Returns None (UNKNOWN) when the
+    subject has no sector classification (an ETF, or an equity this
+    module's own tables have no entry for), when its sector has no
+    approved SPDR benchmark, or when no supplied benchmark return aligns
+    to the subject's own return period -- never a substituted
+    broad-market return standing in for a genuinely missing sector
+    benchmark.
+    """
+    subject_sector = sectors.get(subject)
+    if subject_sector is None:
+        return None
+    sector_id = approved_sector_id(subject_sector)
+    if sector_id is None:
+        return None
+    benchmark_symbol = GICS_SECTOR_TO_SPDR_BENCHMARK.get(sector_id)
+    if benchmark_symbol is None:
+        return None
+    aligned = tuple(
+        item
+        for item in benchmark_returns
+        if item.instrument == _instrument(benchmark_symbol)
+        and (item.period_start, item.period_end) == subject_period
+    )
+    if not aligned:
+        return None
+    return SectorReferenceReturns(sector_id, aligned)

--- a/tests/architecture/test_comparison_universe_boundaries.py
+++ b/tests/architecture/test_comparison_universe_boundaries.py
@@ -1,0 +1,56 @@
+"""SPRINT-013 S13-04C: architecture boundaries for the reusable
+comparison-universe / sector-reference module.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_MODULE = Path(__file__).parents[2] / "strategy_runtime" / "comparison_universe.py"
+
+_FORBIDDEN_ROOTS = {
+    "sqlalchemy",
+    "psycopg",
+    "psycopg2",
+    "requests",
+    "httpx",
+    "urllib",
+    "alembic",
+    "screening",
+    "strategies",
+    "asa",
+}
+
+
+def _imported_roots(tree: ast.Module) -> set[str]:
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            roots.add(node.module.split(".")[0])
+    return roots
+
+
+def test_comparison_universe_has_no_infrastructure_or_strategy_imports() -> None:
+    tree = ast.parse(_MODULE.read_text())
+    roots = _imported_roots(tree)
+    violations = roots & _FORBIDDEN_ROOTS
+    assert not violations, f"strategy_runtime/comparison_universe.py imports: {violations}"
+
+
+def test_comparison_universe_only_imports_from_permitted_roots() -> None:
+    permitted = {"__future__", "collections", "datetime", "domain"}
+    tree = ast.parse(_MODULE.read_text())
+    roots = _imported_roots(tree)
+    violations = roots - permitted
+    assert not violations, f"strategy_runtime/comparison_universe.py imports: {violations}"
+
+
+def test_comparison_universe_has_no_strategy_identifier_conditionals() -> None:
+    # A reusable module: no branching on a strategy's own name/id anywhere
+    # in its source (Skew Momentum is the first consumer, not the owner).
+    source = _MODULE.read_text()
+    for needle in ("skew_momentum", "SKEW_MOMENTUM", "strategy_id", "strategy_name"):
+        assert needle not in source, f"unexpected strategy-specific reference: {needle}"

--- a/tests/strategy_runtime/test_comparison_universe.py
+++ b/tests/strategy_runtime/test_comparison_universe.py
@@ -1,0 +1,258 @@
+"""SPRINT-013 S13-04C: comparison-universe and sector-reference tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from domain import (
+    CanonicalInstrumentIdentity,
+    CanonicalReturnObservation,
+    EvidenceKind,
+    EvidenceReference,
+    SectorClassification,
+    SecurityAssetType,
+)
+from strategy_runtime.comparison_universe import (
+    ASSET_TYPE_BY_INSTRUMENT,
+    GICS_SECTOR_TO_SPDR_BENCHMARK,
+    SECTOR_BY_INSTRUMENT,
+    approved_sector_id,
+    select_comparison_universe_returns,
+    select_sector_reference_returns,
+)
+
+PERIOD_START = datetime(2026, 1, 2, 14, 30, tzinfo=timezone.utc)
+PERIOD_END = datetime(2026, 1, 2, 21, 0, tzinfo=timezone.utc)
+OTHER_PERIOD_START = datetime(2026, 1, 5, 14, 30, tzinfo=timezone.utc)
+OTHER_PERIOD_END = datetime(2026, 1, 5, 21, 0, tzinfo=timezone.utc)
+
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "obs-1"),)
+
+
+def _instrument(symbol: str) -> CanonicalInstrumentIdentity:
+    return CanonicalInstrumentIdentity("symbol", symbol)
+
+
+def _return(
+    symbol: str,
+    *,
+    period: tuple[datetime, datetime] = (PERIOD_START, PERIOD_END),
+    value: Decimal = Decimal("0.01"),
+) -> CanonicalReturnObservation:
+    start, end = period
+    return CanonicalReturnObservation(
+        instrument=_instrument(symbol),
+        return_value=value,
+        period_start=start,
+        period_end=end,
+        effective_time=end,
+        evidence=EVIDENCE,
+    )
+
+
+EQUITY_PEERS = ["MSFT", "NVDA", "AMD", "AVGO", "INTC"]
+
+
+class TestSelectComparisonUniverseReturns:
+    def test_selects_qualifying_same_class_peers(self) -> None:
+        candidates = tuple(_return(symbol) for symbol in EQUITY_PEERS)
+        result = select_comparison_universe_returns(
+            _instrument("AAPL"),
+            (PERIOD_START, PERIOD_END),
+            candidates,
+            ASSET_TYPE_BY_INSTRUMENT,
+        )
+        assert result is not None
+        assert {item.instrument for item in result.returns} == {
+            _instrument(symbol) for symbol in EQUITY_PEERS
+        }
+
+    def test_excludes_the_subject_itself(self) -> None:
+        candidates = tuple(_return(symbol) for symbol in [*EQUITY_PEERS, "AAPL"])
+        result = select_comparison_universe_returns(
+            _instrument("AAPL"),
+            (PERIOD_START, PERIOD_END),
+            candidates,
+            ASSET_TYPE_BY_INSTRUMENT,
+        )
+        assert result is not None
+        assert _instrument("AAPL") not in {item.instrument for item in result.returns}
+
+    def test_excludes_a_different_asset_type(self) -> None:
+        candidates = tuple(_return(symbol) for symbol in [*EQUITY_PEERS, "SPY", "QQQ"])
+        result = select_comparison_universe_returns(
+            _instrument("AAPL"),
+            (PERIOD_START, PERIOD_END),
+            candidates,
+            ASSET_TYPE_BY_INSTRUMENT,
+        )
+        assert result is not None
+        instruments = {item.instrument for item in result.returns}
+        assert _instrument("SPY") not in instruments
+        assert _instrument("QQQ") not in instruments
+
+    def test_excludes_a_misaligned_return_period_without_excluding_others(self) -> None:
+        misaligned = _return("MU", period=(OTHER_PERIOD_START, OTHER_PERIOD_END))
+        candidates = (*[_return(symbol) for symbol in EQUITY_PEERS], misaligned)
+        result = select_comparison_universe_returns(
+            _instrument("AAPL"),
+            (PERIOD_START, PERIOD_END),
+            candidates,
+            ASSET_TYPE_BY_INSTRUMENT,
+        )
+        assert result is not None
+        instruments = {item.instrument for item in result.returns}
+        assert _instrument("MU") not in instruments
+        assert instruments == {_instrument(symbol) for symbol in EQUITY_PEERS}
+
+    def test_excludes_an_unclassified_candidate_without_excluding_others(self) -> None:
+        unclassified = _return("ZZZZ")
+        candidates = (*[_return(symbol) for symbol in EQUITY_PEERS], unclassified)
+        result = select_comparison_universe_returns(
+            _instrument("AAPL"),
+            (PERIOD_START, PERIOD_END),
+            candidates,
+            ASSET_TYPE_BY_INSTRUMENT,
+        )
+        assert result is not None
+        assert _instrument("ZZZZ") not in {item.instrument for item in result.returns}
+
+    def test_below_minimum_valid_members_is_none(self) -> None:
+        candidates = tuple(_return(symbol) for symbol in EQUITY_PEERS[:4])
+        result = select_comparison_universe_returns(
+            _instrument("AAPL"),
+            (PERIOD_START, PERIOD_END),
+            candidates,
+            ASSET_TYPE_BY_INSTRUMENT,
+        )
+        assert result is None
+
+    def test_unclassified_subject_is_none(self) -> None:
+        candidates = tuple(_return(symbol) for symbol in EQUITY_PEERS)
+        result = select_comparison_universe_returns(
+            _instrument("NOT_IN_UNIVERSE"),
+            (PERIOD_START, PERIOD_END),
+            candidates,
+            ASSET_TYPE_BY_INSTRUMENT,
+        )
+        assert result is None
+
+    def test_custom_minimum_valid_members_is_honored(self) -> None:
+        candidates = tuple(_return(symbol) for symbol in EQUITY_PEERS[:3])
+        result = select_comparison_universe_returns(
+            _instrument("AAPL"),
+            (PERIOD_START, PERIOD_END),
+            candidates,
+            ASSET_TYPE_BY_INSTRUMENT,
+            minimum_valid_members=3,
+        )
+        assert result is not None
+        assert len(result.returns) == 3
+
+
+class TestSelectSectorReferenceReturns:
+    def test_selects_aligned_sector_benchmark(self) -> None:
+        benchmark = (_return("XLK"),)
+        result = select_sector_reference_returns(
+            _instrument("AAPL"),
+            (PERIOD_START, PERIOD_END),
+            SECTOR_BY_INSTRUMENT,
+            benchmark,
+        )
+        assert result is not None
+        assert result.sector_id == "information_technology"
+        assert result.returns[0].instrument == _instrument("XLK")
+
+    def test_unclassified_subject_is_none(self) -> None:
+        result = select_sector_reference_returns(
+            _instrument("SPY"),
+            (PERIOD_START, PERIOD_END),
+            SECTOR_BY_INSTRUMENT,
+            (_return("XLK"),),
+        )
+        assert result is None
+
+    def test_unmapped_sector_is_none(self) -> None:
+        sectors = {
+            _instrument("AAPL"): SectorClassification("GICS", "2023", "99"),
+        }
+        result = select_sector_reference_returns(
+            _instrument("AAPL"),
+            (PERIOD_START, PERIOD_END),
+            sectors,
+            (_return("XLK"),),
+        )
+        assert result is None
+
+    def test_no_aligned_benchmark_return_is_none(self) -> None:
+        misaligned = _return("XLK", period=(OTHER_PERIOD_START, OTHER_PERIOD_END))
+        result = select_sector_reference_returns(
+            _instrument("AAPL"),
+            (PERIOD_START, PERIOD_END),
+            SECTOR_BY_INSTRUMENT,
+            (misaligned,),
+        )
+        assert result is None
+
+    def test_no_benchmark_returns_supplied_is_none(self) -> None:
+        result = select_sector_reference_returns(
+            _instrument("AAPL"),
+            (PERIOD_START, PERIOD_END),
+            SECTOR_BY_INSTRUMENT,
+            (),
+        )
+        assert result is None
+
+
+class TestApprovedSectorId:
+    @pytest.mark.parametrize(
+        ("gics_code", "expected"),
+        [
+            ("10", "energy"),
+            ("15", "materials"),
+            ("20", "industrials"),
+            ("25", "consumer_discretionary"),
+            ("30", "consumer_staples"),
+            ("35", "health_care"),
+            ("40", "financials"),
+            ("45", "information_technology"),
+            ("50", "communication_services"),
+            ("55", "utilities"),
+            ("60", "real_estate"),
+        ],
+    )
+    def test_translates_every_approved_gics_code(self, gics_code: str, expected: str) -> None:
+        sector = SectorClassification("GICS", "2023", gics_code)
+        assert approved_sector_id(sector) == expected
+        assert expected in GICS_SECTOR_TO_SPDR_BENCHMARK
+
+    def test_unknown_gics_code_is_none(self) -> None:
+        sector = SectorClassification("GICS", "2023", "99")
+        assert approved_sector_id(sector) is None
+
+    def test_non_gics_taxonomy_is_none(self) -> None:
+        sector = SectorClassification("OTHER", "1", "45")
+        assert approved_sector_id(sector) is None
+
+
+class TestReferenceTables:
+    def test_every_sector_classified_instrument_has_an_approved_sector_id(self) -> None:
+        for sector in SECTOR_BY_INSTRUMENT.values():
+            assert approved_sector_id(sector) is not None
+
+    def test_every_asset_type_entry_is_equity_or_etf(self) -> None:
+        assert set(ASSET_TYPE_BY_INSTRUMENT.values()) <= {
+            SecurityAssetType.EQUITY,
+            SecurityAssetType.ETF,
+        }
+
+    def test_no_etf_has_a_sector_classification(self) -> None:
+        etfs = {
+            instrument
+            for instrument, asset_type in ASSET_TYPE_BY_INSTRUMENT.items()
+            if asset_type is SecurityAssetType.ETF
+        }
+        assert etfs.isdisjoint(SECTOR_BY_INSTRUMENT.keys())


### PR DESCRIPTION
## Summary
- Implements the Founder-approved (issue #255) `comparison_universe` and `sector_reference` policies as pure, provider-neutral functions in `strategy_runtime/comparison_universe.py`, reusing the existing canonical `domain.SecurityAssetType` / `domain.SectorClassification` contracts rather than inventing a parallel classification type.
- `select_comparison_universe_returns()`: same-instrument-class, exclude-subject, same-return-period, minimum-5-valid-members rules over caller-supplied candidate returns; `None` (UNKNOWN) below threshold or for an unclassified subject; one disqualified candidate never excludes another valid one.
- `select_sector_reference_returns()`: GICS sector → approved Select Sector SPDR benchmark, keyed off issue #255's own snake_case sector vocabulary; `None` for ETFs, unmapped sectors, or a benchmark return whose period doesn't align — never a substituted broad-market proxy.
- Static reference tables (`ASSET_TYPE_BY_INSTRUMENT`, `SECTOR_BY_INSTRUMENT`) classify all 30 `APPROVED_LIVE_UNIVERSE` symbols using real, public GICS/asset-type facts.
- No migration, no strategy wiring, no live acquisition, no persistence — Skew Momentum remains the first consumer, not the owner; wiring is S13-04D.

## Test plan
- [x] `pytest tests/strategy_runtime/test_comparison_universe.py` — 29 tests: qualifying-peer selection, subject exclusion, asset-type filtering, period-alignment filtering (non-corrupting), unclassified-candidate exclusion (non-corrupting), minimum-member threshold (default and custom), unclassified-subject → None, all 11 GICS→sector-id translations, unmapped code → None, non-GICS taxonomy → None, sector-reference alignment/None paths, reference-table consistency (no ETF has a sector, every classified sector has an approved id).
- [x] `pytest tests/architecture/test_comparison_universe_boundaries.py` — 3 tests: no infrastructure/strategy/screening/asa imports, only permitted roots, no strategy-identifier conditionals in source.
- [x] `ruff check` / `mypy domain strategy_runtime asa` clean.
- [x] Full local suite: 2791 passed, 45 skipped.
- [x] `python -m tools.pos.lean.pre_push_check`: all 5 checks pass.

Non-migration, eligible for self-merge under active SPRINT-013 delegation once CI is green (matching S13-04A / S13-04A.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)