### PR TITLE
S13-10: provider-neutral session-aware freshness for option chains and historical bars

### DIFF
--- a/market_data/finnhub.py
+++ b/market_data/finnhub.py
@@ -14,8 +14,6 @@ from domain import (
     EarningsEvent,
     EvidenceKind,
     EvidenceReference,
-    FreshnessMetadata,
-    FreshnessStatus,
     MarketCapability,
     MarketDataSubject,
     MarketObservation,
@@ -51,7 +49,7 @@ from market_data.providers import (
     normalized_provider_error,
 )
 from market_data.rolling_window import RollingWindowPolicy
-from market_data.session_calendar import classify_quote_freshness
+from market_data.session_calendar import classify_market_data_freshness
 from market_data.transport import (
     ReadOnlyHttpRequest,
     ReadOnlyHttpResponse,
@@ -378,7 +376,6 @@ class FinnhubProvider:
         response: ReadOnlyHttpResponse,
     ) -> MarketObservation:
         received = self._dependencies.clock.now().astimezone(UTC)
-        age = max(0, int((received - effective).total_seconds()))
         present = tuple(field for field in request.required_fields if _present(field, value))
         missing = tuple(field for field in request.required_fields if field not in present)
         provenance = ProviderProvenance("finnhub", response.request_reference, _evidence(response))
@@ -394,21 +391,11 @@ class FinnhubProvider:
             value,
             "v1",
             provenance,
-            (
-                classify_quote_freshness(
-                    received, effective, request.maximum_age_seconds
-                )
-                if isinstance(value, Quote)
-                else FreshnessMetadata(
-                    received,
-                    effective,
-                    request.maximum_age_seconds,
-                    age,
-                    FreshnessStatus.FRESH
-                    if age <= request.maximum_age_seconds
-                    else FreshnessStatus.STALE,
-                )
-            ),
+            # SPRINT-013 S13-10: one shared, session-aware classifier for
+            # every capability, matching market_data/tradier.py exactly --
+            # freshness behavior must be identical across providers for
+            # equivalent canonical observations.
+            classify_market_data_freshness(received, effective, request.maximum_age_seconds),
             CompletenessMetadata(request.required_fields, present, missing),
         )
 

--- a/market_data/session_calendar.py
+++ b/market_data/session_calendar.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
 from enum import StrEnum
@@ -70,16 +71,28 @@ class UsEquitySessionCalendar:
         raise DomainInvariantError("no completed US equity session found in bounded lookback")
 
 
-def classify_quote_freshness(
+def classify_market_data_freshness(
     as_of: datetime,
     effective_time: datetime,
     threshold_seconds: int,
     *,
     calendar: UsEquitySessionCalendar | None = None,
 ) -> FreshnessMetadata:
-    """Classify age without rejecting expected closed-session evidence."""
-    require_tz_aware(as_of, "classify_quote_freshness", "as_of")
-    require_tz_aware(effective_time, "classify_quote_freshness", "effective_time")
+    """Provider-neutral, capability-neutral freshness classification
+    (SPRINT-013 S13-10): age within threshold is FRESH; age beyond
+    threshold is PRIOR_SESSION, not STALE, when ``effective_time`` falls
+    within the most recently completed US equity session as of ``as_of``
+    -- classifying age without rejecting expected closed-session evidence.
+    Used identically for a real-time quote, an option chain's own
+    canonical timestamp (see median_observed_at), and any other
+    capability's observation -- one owner for this decision, not a
+    per-capability or per-provider duplicate (previously only quotes got
+    this treatment; option chains fell back to a naive binary FRESH/STALE
+    check with no session awareness at all, silently rejecting a
+    legitimate just-closed session's chain as STALE_DATA).
+    """
+    require_tz_aware(as_of, "classify_market_data_freshness", "as_of")
+    require_tz_aware(effective_time, "classify_market_data_freshness", "effective_time")
     age = max(0, int((as_of - effective_time).total_seconds()))
     if age <= threshold_seconds:
         status = FreshnessStatus.FRESH
@@ -91,6 +104,27 @@ def classify_quote_freshness(
             else FreshnessStatus.STALE
         )
     return FreshnessMetadata(as_of, effective_time, threshold_seconds, age, status)
+
+
+def median_observed_at(candidates: Sequence[datetime]) -> datetime:
+    """Deterministic, response-order-independent canonical timestamp for a
+    set of per-record observation timestamps (SPRINT-013 S13-10) -- e.g.
+    one option chain's own per-contract last-trade times. A single very
+    old outlier (one illiquid contract that hasn't traded in days) cannot
+    alone make the whole chain look stale the way the earliest value
+    would; a single very new outlier cannot alone make it look fresher
+    than it really is the way the latest value would. The median is the
+    one aggregate robust to an outlier in either direction, computed here
+    purely over already-parsed timestamps -- no provider-specific parsing.
+    """
+    if not candidates:
+        raise ValueError("median_observed_at requires at least one candidate")
+    ordered = sorted(candidates)
+    midpoint = len(ordered) // 2
+    if len(ordered) % 2 == 1:
+        return ordered[midpoint]
+    earlier, later = ordered[midpoint - 1], ordered[midpoint]
+    return earlier + (later - earlier) / 2
 
 
 def _observed(day: date) -> date:

--- a/market_data/tradier.py
+++ b/market_data/tradier.py
@@ -13,8 +13,6 @@ from domain import (
     EvidenceKind,
     EvidenceReference,
     ExpirationCycle,
-    FreshnessMetadata,
-    FreshnessStatus,
     MarketCapability,
     MarketDataSubject,
     MarketObservation,
@@ -54,7 +52,7 @@ from market_data.providers import (
     normalized_provider_error,
 )
 from market_data.rolling_window import RollingWindowPolicy
-from market_data.session_calendar import classify_quote_freshness
+from market_data.session_calendar import classify_market_data_freshness, median_observed_at
 from market_data.transport import (
     ReadOnlyHttpRequest,
     ReadOnlyHttpResponse,
@@ -356,19 +354,12 @@ class TradierProvider:
         evidence = _evidence(response)
         present = tuple(field for field in request.required_fields if _field_present(field, value))
         missing = tuple(field for field in request.required_fields if field not in present)
-        age = max(0, int((received - effective).total_seconds()))
-        freshness = (
-            classify_quote_freshness(received, effective, request.maximum_age_seconds)
-            if isinstance(value, Quote)
-            else FreshnessMetadata(
-                received,
-                effective,
-                request.maximum_age_seconds,
-                age,
-                FreshnessStatus.FRESH
-                if age <= request.maximum_age_seconds
-                else FreshnessStatus.STALE,
-            )
+        # SPRINT-013 S13-10: one shared, session-aware classifier for every
+        # capability -- not just Quote. An option chain (or any other
+        # non-quote capability) acquired shortly after the session closes
+        # is now correctly PRIOR_SESSION, not silently rejected STALE_DATA.
+        freshness = classify_market_data_freshness(
+            received, effective, request.maximum_age_seconds
         )
         provenance = ProviderProvenance("tradier", response.request_reference, evidence)
         identity = market_observation_identity(
@@ -464,14 +455,18 @@ def _is_monthly_expiration(value: date) -> bool:
     return value.weekday() == 4 and 15 <= value.day <= 21
 
 
-def _observed_at(row: Mapping[str, object], fallback: datetime) -> datetime:
+def _row_observed_at_or_none(row: Mapping[str, object]) -> datetime | None:
     raw = row.get("trade_date") or row.get("timestamp")
     if isinstance(raw, (int, float)):
         divisor = 1000 if raw > 10_000_000_000 else 1
         return datetime.fromtimestamp(raw / divisor, tz=UTC)
     if isinstance(raw, str):
         return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(UTC)
-    return fallback
+    return None
+
+
+def _observed_at(row: Mapping[str, object], fallback: datetime) -> datetime:
+    return _row_observed_at_or_none(row) or fallback
 
 
 def _required_observed_at(row: Mapping[str, object]) -> datetime:
@@ -526,7 +521,18 @@ def _chain(
 ) -> OptionChain:
     if not rows:
         raise ValueError("empty option chain")
-    observed = max(_observed_at(row, received_at) for row in rows)
+    # SPRINT-013 S13-10: the chain's own canonical timestamp is the median
+    # of every contract row's own genuine trade timestamp (rows missing
+    # one entirely are excluded, never silently treated as "now" -- a
+    # missing timestamp must never inflate apparent freshness). Median,
+    # not min/max: a single very old illiquid contract cannot alone make
+    # an otherwise-current chain look stale, and a single very recently
+    # touched contract cannot alone make an otherwise-stale chain look
+    # fresh. Never response order (median_observed_at sorts internally).
+    valid_times = tuple(
+        parsed for row in rows if (parsed := _row_observed_at_or_none(row)) is not None
+    )
+    observed = median_observed_at(valid_times) if valid_times else received_at
     evidence = _evidence(response)
     symbol = str(rows[0].get("underlying") or subject.canonical_instrument.display_symbol)
     security = _security(subject, symbol)

--- a/tests/market_data/test_finnhub.py
+++ b/tests/market_data/test_finnhub.py
@@ -203,6 +203,36 @@ def test_candle_success_validates_status_arrays_and_utc_timestamps() -> None:
     assert dict(transport.requests[0].query)["resolution"] == "D"
 
 
+def test_historical_bar_after_close_from_the_latest_session_is_not_rejected_stale() -> None:
+    """SPRINT-013 S13-10: provider-neutral parity with market_data/tradier.py
+    -- a non-quote observation (here, a daily bar) whose age exceeds the
+    request's own threshold must be rescued to PRIOR_SESSION when it
+    genuinely falls within the latest completed session, on Finnhub
+    exactly as on Tradier, not just silently STALE the way the pre-fix
+    duplicated fallback always classified every non-quote observation.
+    """
+    friday_bar_start = datetime(2026, 7, 24, 0, tzinfo=UTC)
+    saturday = datetime(2026, 7, 25, 16, tzinfo=UTC)
+    body = {
+        "s": "ok",
+        "o": [205],
+        "h": [212],
+        "l": [204],
+        "c": [210],
+        "v": [50000000],
+        "t": [int(friday_bar_start.timestamp())],
+    }
+    transport = Transport((response(body),))
+    adapter, _ = provider(transport, clock=Clock(saturday))
+    requested = replace(
+        request(MarketCapability.HISTORICAL_BARS_V1, ("open", "high", "low", "close", "volume")),
+        maximum_age_seconds=3600,
+    )
+    result = adapter.fetch(requested, authorization())
+    assert result.error is None
+    assert result.observations[0].freshness.status.value == "prior_session"
+
+
 @pytest.mark.parametrize(
     ("symbol", "event_date", "hour"),
     (("AAPL", "2026-08-01", "amc"), ("NVDA", "2026-08-19", "bmo")),

--- a/tests/market_data/test_session_calendar.py
+++ b/tests/market_data/test_session_calendar.py
@@ -9,7 +9,8 @@ from domain.values import DomainInvariantError
 from market_data.session_calendar import (
     MarketSessionStatus,
     UsEquitySessionCalendar,
-    classify_quote_freshness,
+    classify_market_data_freshness,
+    median_observed_at,
 )
 
 
@@ -37,38 +38,74 @@ class TestSessionAwareFreshness:
             20,
             tzinfo=UTC,
         )
-        result = classify_quote_freshness(evaluated_at, effective, 3600)
+        result = classify_market_data_freshness(evaluated_at, effective, 3600)
         assert result.status is FreshnessStatus.PRIOR_SESSION
 
     def test_same_day_after_close_is_prior_session(self) -> None:
-        result = classify_quote_freshness(
+        result = classify_market_data_freshness(
             _utc(2026, 7, 24, 23), _utc(2026, 7, 24, 20), 3600
         )
         assert result.status is FreshnessStatus.PRIOR_SESSION
 
     def test_market_open_recent_quote_is_fresh(self) -> None:
-        result = classify_quote_freshness(
+        result = classify_market_data_freshness(
             _utc(2026, 7, 24, 15), _utc(2026, 7, 24, 14, 59), 3600
         )
         assert result.status is FreshnessStatus.FRESH
 
     def test_market_open_expired_quote_is_stale(self) -> None:
-        result = classify_quote_freshness(
+        result = classify_market_data_freshness(
             _utc(2026, 7, 24, 18), _utc(2026, 7, 24, 16), 3600
         )
         assert result.status is FreshnessStatus.STALE
 
     def test_quote_older_than_latest_completed_session_is_stale(self) -> None:
-        result = classify_quote_freshness(
+        result = classify_market_data_freshness(
             _utc(2026, 7, 26, 16), _utc(2026, 7, 23, 20), 3600
         )
         assert result.status is FreshnessStatus.STALE
 
     def test_naive_time_is_rejected(self) -> None:
         with pytest.raises(DomainInvariantError):
-            classify_quote_freshness(
+            classify_market_data_freshness(
                 datetime(2026, 7, 25, 16), _utc(2026, 7, 24, 20), 3600
             )
+
+
+class TestMedianObservedAt:
+    def test_odd_count_returns_the_middle_value(self) -> None:
+        early, middle, late = _utc(2026, 7, 24, 14), _utc(2026, 7, 24, 15), _utc(2026, 7, 24, 16)
+        assert median_observed_at([late, early, middle]) == middle
+
+    def test_even_count_returns_the_midpoint_of_the_two_middle_values(self) -> None:
+        values = [
+            _utc(2026, 7, 24, 14),
+            _utc(2026, 7, 24, 15),
+            _utc(2026, 7, 24, 16),
+            _utc(2026, 7, 24, 17),
+        ]
+        expected = _utc(2026, 7, 24, 15) + (_utc(2026, 7, 24, 16) - _utc(2026, 7, 24, 15)) / 2
+        assert median_observed_at(values) == expected
+
+    def test_result_is_identical_regardless_of_input_order(self) -> None:
+        values = [_utc(2026, 7, 24, 9), _utc(2026, 7, 24, 20), _utc(2026, 7, 24, 12)]
+        forward = median_observed_at(values)
+        reversed_order = median_observed_at(list(reversed(values)))
+        assert forward == reversed_order
+
+    def test_single_value_is_returned_unchanged(self) -> None:
+        only = _utc(2026, 7, 24, 12)
+        assert median_observed_at([only]) == only
+
+    def test_empty_sequence_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least one candidate"):
+            median_observed_at([])
+
+    def test_one_far_outlier_does_not_dominate_a_larger_cluster(self) -> None:
+        cluster = [_utc(2026, 7, 24, 15, minute) for minute in (0, 1, 2, 3, 4)]
+        far_outlier = _utc(2026, 7, 20, 0)
+        result = median_observed_at([*cluster, far_outlier])
+        assert _utc(2026, 7, 24, 15, 0) <= result <= _utc(2026, 7, 24, 15, 4)
 
 
 class TestSessionCalendar:

--- a/tests/market_data/test_tradier.py
+++ b/tests/market_data/test_tradier.py
@@ -9,6 +9,7 @@ from domain import (
     CanonicalInstrumentIdentity,
     EvidenceKind,
     EvidenceReference,
+    FreshnessStatus,
     Instrument,
     InstrumentKind,
     MarketCapability,
@@ -102,7 +103,11 @@ def subject(
 
 
 def request(
-    capability: MarketCapability, fields: tuple[str, ...], *, expiration: bool = False
+    capability: MarketCapability,
+    fields: tuple[str, ...],
+    *,
+    expiration: bool = False,
+    maximum_age_seconds: int = 86400 * 10,
 ) -> CapabilityRequest:
     item = subject(capability, fields, expiration=expiration)
     return CapabilityRequest(
@@ -111,7 +116,7 @@ def request(
         item.request_context.semantic_start,
         item.request_context.semantic_end,
         fields,
-        86400 * 10,
+        maximum_age_seconds,
     )
 
 
@@ -188,6 +193,61 @@ def test_weekend_quote_from_friday_session_is_prior_session() -> None:
     assert result.observations[0].freshness.status.value == "prior_session"
 
 
+def test_quote_during_open_session_is_fresh() -> None:
+    open_session_instant = datetime(2026, 7, 24, 15, 0, tzinfo=UTC)  # Friday, mid-session
+    just_traded = open_session_instant - timedelta(seconds=30)
+    transport = Transport(
+        (
+            response(
+                {
+                    "quotes": {
+                        "quote": {
+                            "symbol": "AAPL",
+                            "bid": 209.9,
+                            "ask": 210.1,
+                            "last": 210,
+                            "trade_date": int(just_traded.timestamp() * 1000),
+                        }
+                    }
+                }
+            ),
+        )
+    )
+    requested = replace(
+        request(MarketCapability.REAL_TIME_QUOTE_V1, ("bid", "ask", "last")),
+        maximum_age_seconds=3600,
+    )
+    result = provider(transport, Clock(open_session_instant)).fetch(requested, authorization())
+    assert result.error is None
+    assert result.observations[0].freshness.status is FreshnessStatus.FRESH
+
+
+def test_option_chain_during_open_session_is_fresh() -> None:
+    open_session_instant = datetime(2026, 7, 24, 15, 0, tzinfo=UTC)
+    just_traded = open_session_instant - timedelta(seconds=30)
+    row = {
+        "symbol": "AAPL260821C00210000",
+        "underlying": "AAPL",
+        "expiration_date": "2026-08-21",
+        "strike": "210",
+        "option_type": "call",
+        "last": "5",
+        "trade_date": int(just_traded.timestamp() * 1000),
+    }
+    transport = Transport((response({"options": {"option": [row]}}),))
+    result = provider(transport, clock=Clock(value=open_session_instant)).fetch(
+        request(
+            MarketCapability.OPTION_CHAIN_V1,
+            ("contracts",),
+            expiration=True,
+            maximum_age_seconds=3600,
+        ),
+        authorization(),
+    )
+    assert result.error is None
+    assert result.observations[0].freshness.status is FreshnessStatus.FRESH
+
+
 def test_daily_history_normalizes_decimal_ohlcv() -> None:
     transport = Transport(
         (
@@ -249,7 +309,13 @@ def test_option_chain_preserves_greeks_iv_and_liquidity() -> None:
     assert transport.requests[0].path == "/v1/markets/options/chains"
 
 
-def test_option_chain_freshness_uses_newest_contract_not_first_response_row() -> None:
+def test_option_chain_freshness_is_the_median_not_the_first_response_row() -> None:
+    """SPRINT-013 S13-10: the chain's own canonical timestamp is a
+    deterministic aggregate (median) over every contract's own genuine
+    trade time -- never the first row's own value, and never simply the
+    single newest either (an aggregate robust to an outlier in *either*
+    direction, not a max/min that only guards one direction).
+    """
     old = {
         "symbol": "AAPL260821C00210000",
         "underlying": "AAPL",
@@ -271,7 +337,134 @@ def test_option_chain_freshness_uses_newest_contract_not_first_response_row() ->
         authorization(),
     )
     assert result.error is None
-    assert result.observations[0].effective_time == NOW - timedelta(minutes=5)
+    old_time = NOW - timedelta(days=3)
+    recent_time = NOW - timedelta(minutes=5)
+    expected_median = old_time + (recent_time - old_time) / 2
+    assert result.observations[0].effective_time == expected_median
+
+
+def test_option_chain_freshness_is_identical_regardless_of_response_row_order() -> None:
+    old = {
+        "symbol": "AAPL260821C00210000",
+        "underlying": "AAPL",
+        "expiration_date": "2026-08-21",
+        "strike": "210",
+        "option_type": "call",
+        "last": "5",
+        "trade_date": int((NOW - timedelta(minutes=90)).timestamp() * 1000),
+    }
+    middle = {
+        **old,
+        "symbol": "AAPL260821C00212000",
+        "strike": "212",
+        "trade_date": old["trade_date"],
+    }
+    recent = {
+        **old,
+        "symbol": "AAPL260821C00215000",
+        "strike": "215",
+        "trade_date": int((NOW - timedelta(minutes=5)).timestamp() * 1000),
+    }
+    forward = Transport((response({"options": {"option": [old, middle, recent]}}),))
+    reversed_order = Transport((response({"options": {"option": [recent, middle, old]}}),))
+    forward_result = provider(forward).fetch(
+        request(MarketCapability.OPTION_CHAIN_V1, ("contracts",), expiration=True),
+        authorization(),
+    )
+    reversed_result = provider(reversed_order).fetch(
+        request(MarketCapability.OPTION_CHAIN_V1, ("contracts",), expiration=True),
+        authorization(),
+    )
+    assert forward_result.error is None
+    assert reversed_result.error is None
+    assert (
+        forward_result.observations[0].effective_time
+        == reversed_result.observations[0].effective_time
+    )
+
+
+def test_option_chain_after_close_with_a_session_old_contract_is_not_rejected_stale() -> None:
+    """SPRINT-013 S13-10 (issue #162): a chain acquired well after the
+    session closed, whose own contracts' last trades are from that same
+    now-completed session, must be accepted as PRIOR_SESSION evidence --
+    not silently rejected STALE_DATA the way the pre-fix binary
+    FRESH/STALE check (no session awareness) always did once age exceeded
+    the request's own maximum_age_seconds.
+    """
+    after_close = datetime(2026, 7, 24, 23, 0, tzinfo=UTC)  # Friday, ~7h after 20:00 UTC close
+    same_session_trade = datetime(2026, 7, 24, 19, 55, tzinfo=UTC)
+    row = {
+        "symbol": "AAPL260821C00210000",
+        "underlying": "AAPL",
+        "expiration_date": "2026-08-21",
+        "strike": "210",
+        "option_type": "call",
+        "last": "5",
+        "trade_date": int(same_session_trade.timestamp() * 1000),
+    }
+    transport = Transport((response({"options": {"option": [row]}}),))
+    result = provider(transport, clock=Clock(value=after_close)).fetch(
+        request(
+            MarketCapability.OPTION_CHAIN_V1,
+            ("contracts",),
+            expiration=True,
+            maximum_age_seconds=3600,
+        ),
+        authorization(),
+    )
+    assert result.error is None
+    assert result.observations[0].freshness.status is FreshnessStatus.PRIOR_SESSION
+
+
+def test_option_chain_genuinely_older_than_the_latest_session_remains_stale() -> None:
+    after_close = datetime(2026, 7, 24, 23, 0, tzinfo=UTC)
+    two_sessions_ago_trade = datetime(2026, 7, 22, 19, 55, tzinfo=UTC)
+    row = {
+        "symbol": "AAPL260821C00210000",
+        "underlying": "AAPL",
+        "expiration_date": "2026-08-21",
+        "strike": "210",
+        "option_type": "call",
+        "last": "5",
+        "trade_date": int(two_sessions_ago_trade.timestamp() * 1000),
+    }
+    transport = Transport((response({"options": {"option": [row]}}),))
+    result = provider(transport, clock=Clock(value=after_close)).fetch(
+        request(
+            MarketCapability.OPTION_CHAIN_V1,
+            ("contracts",),
+            expiration=True,
+            maximum_age_seconds=3600,
+        ),
+        authorization(),
+    )
+    assert result.error is None
+    assert result.observations[0].freshness.status is FreshnessStatus.STALE
+
+
+def test_option_chain_with_no_contract_timestamps_falls_back_to_retrieval_time() -> None:
+    """Missing timestamps must never be silently treated as fabricated
+    market time -- but this is existing, pre-S13-10 behavior (median over
+    zero valid candidates falls back to the request's own retrieval time,
+    same as the prior max()-based implementation did), not a new
+    allowance: this test locks it in, not introduces it.
+    """
+    row = {
+        "symbol": "AAPL260821C00210000",
+        "underlying": "AAPL",
+        "expiration_date": "2026-08-21",
+        "strike": "210",
+        "option_type": "call",
+        "last": "5",
+    }
+    transport = Transport((response({"options": {"option": [row]}}),))
+    result = provider(transport).fetch(
+        request(MarketCapability.OPTION_CHAIN_V1, ("contracts",), expiration=True),
+        authorization(),
+    )
+    assert result.error is None
+    assert result.observations[0].effective_time == NOW
+    assert result.observations[0].freshness.status is FreshnessStatus.FRESH
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #162. Substantially explains and addresses #245 (see analysis below).

## Root cause
Only `Quote` observations ever received session-aware freshness classification. Every other capability (option chain, historical bars, earnings events) fell back to a naive binary FRESH/STALE check with no session awareness, duplicated identically in `market_data/tradier.py` and `market_data/finnhub.py`. `CapabilityFulfillmentService.fulfill()`'s own `_quality_error()` gate rejects anything not in `{FRESH, DELAYED, PRIOR_SESSION}` as `STALE_DATA` -- so an option chain acquired shortly after close, once age exceeded the request's own `maximum_age_seconds` (3600s), was silently rejected outright, surfacing as the generic "could not be completed or normalized" message.

## Combined S13-09/S13-10 diagnosis
`earnings_calendar` acquires both a quote AND a combined two-expiration option chain, directly exposing it to this chain-freshness gap. `EARNINGS_CALENDAR_V1` itself was ruled out (both providers stamp `EarningsEvent.observed_at` as current retrieval time, never itself triggering staleness). This is the shared market-data boundary defect referenced from both issues, per the instruction not to build nine symbol-specific patches.

## Fix
- `market_data/session_calendar.py`: `classify_quote_freshness` → `classify_market_data_freshness` (behavior-preserving rename, one shared owner). New `median_observed_at()`: deterministic, order-independent aggregate robust to an outlier in either direction.
- `market_data/tradier.py`: chain's own canonical timestamp is now the median of every contract's genuine trade timestamp (missing ones excluded, never treated as "now"). All capabilities route through the shared classifier, not just Quote.
- `market_data/finnhub.py`: identical `_observation()` change for provider parity.

## Test plan
- [x] `tests/market_data/test_session_calendar.py`: 6 new `TestMedianObservedAt` tests.
- [x] `tests/market_data/test_tradier.py`: median-not-first-row, order-independence, option-chain-after-close-is-PRIOR_SESSION (the exact #162 regression), genuinely-stale-remains-stale, missing-timestamps-preserve-existing-fallback, quote/chain-during-open-session-is-fresh.
- [x] `tests/market_data/test_finnhub.py`: provider-parity regression proving identical classification on the second provider.
- [x] `ruff check` (scoped) / `mypy` on touched files: clean.
- [x] Full suite: 2813 passed, 45 skipped (13 new tests, zero regressions).
- [x] `tests/architecture`: 467 passed.
- [x] `pre_push_check`: all 5 gates pass.

## Remaining scope
Production verification that this resolves the 9 reported `earnings_calendar` symbols is S13-07's job once deployed. If any residual earnings_calendar-specific failure remains, it will be re-classified as a narrower S13-09 follow-up, not assumed away.

Non-migration -- eligible for auto-merge once CI is green per active SPRINT-013 delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)