### PR TITLE
S13-11: sanitized exception detail in structured logs

### DIFF
--- a/asa/logging.py
+++ b/asa/logging.py
@@ -1,10 +1,116 @@
 import json
 import logging
+import re
+import traceback
 from contextvars import ContextVar
 from datetime import UTC, datetime
+from pathlib import Path
+from types import TracebackType
 from typing import Any
 
 request_id_context: ContextVar[str | None] = ContextVar("request_id", default=None)
+
+# SPRINT-013 S13-11: every field a call site may legitimately attach via
+# logging's own `extra={...}` -- an allowlist, not a blocklist, so an
+# unexpected field a future call site adds is dropped by default rather
+# than silently escaping unreviewed. `strategy_id` was already being
+# passed by screening/runner.py's own exception log line before this
+# fix and was silently dropped here -- the call site was already
+# correct, only this formatter's own allowlist was incomplete.
+_SAFE_EXTRA_FIELDS = (
+    "provider_request_id",
+    "symbol",
+    "provider",
+    "run_id",
+    "run_step",
+    "account_id",
+    "strategy_id",
+    "subject_identity",
+    "screening_cycle_id",
+    "pair_evaluation_id",
+    "capability_id",
+    "capability",
+    "component_id",
+    "safe_error_code",
+    "diagnostic_code",
+    "signal_id",
+)
+_MAX_FIELD_LENGTH = 500
+_MAX_TRACEBACK_FRAMES = 5
+_MAX_CAUSE_DEPTH = 3
+
+# SPRINT-013 S13-11: a message field is free text -- an exception's own
+# str(), or a caller's log message -- that this formatter did not choose
+# the shape of, unlike the allowlisted extra fields above. A raised
+# exception can legitimately embed a request URL or header fragment
+# (e.g. requests/httpx exceptions), so this redacts secret-shaped
+# fragments by pattern rather than trusting every possible exception
+# message to already be safe.
+_BEARER_TOKEN_PATTERN = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9\-_.]+")
+_SECRET_KEY_VALUE_PATTERN = re.compile(
+    r"(?i)\b(token|key|secret|password|api[_-]?key|access[_-]?token|authorization)"
+    r"\s*[=:]\s*[^\s&\"']+"
+)
+
+
+def _redact_secrets(text: str) -> str:
+    text = _BEARER_TOKEN_PATTERN.sub("Bearer [REDACTED]", text)
+    return _SECRET_KEY_VALUE_PATTERN.sub(lambda match: f"{match.group(1)}=[REDACTED]", text)
+
+
+def _bounded(value: str, limit: int = _MAX_FIELD_LENGTH) -> str:
+    redacted = _redact_secrets(value)
+    return redacted if len(redacted) <= limit else f"{redacted[:limit]}...[truncated]"
+
+
+def _stack_location(exc_tb: TracebackType | None) -> list[dict[str, object]]:
+    """File basename, line, and function only -- never a source line's own
+    content and never a local-variable repr, for every frame. Bounded to
+    the innermost frames (closest to where the exception was actually
+    raised, the most diagnostically useful ones), never the full stack.
+    """
+    frames = traceback.extract_tb(exc_tb)[-_MAX_TRACEBACK_FRAMES:]
+    return [
+        {"file": Path(frame.filename).name, "line": frame.lineno, "function": frame.name}
+        for frame in frames
+    ]
+
+
+def _cause_chain(exc: BaseException) -> list[dict[str, object]]:
+    """A bounded summary of __cause__/__context__ chaining (`raise X from Y`
+    or an exception raised while handling another) -- type and truncated
+    message only per link, capped depth, never each link's own full
+    nested traceback (unbounded by construction otherwise).
+    """
+    chain: list[dict[str, object]] = []
+    current = exc.__cause__ or (None if exc.__suppress_context__ else exc.__context__)
+    while current is not None and len(chain) < _MAX_CAUSE_DEPTH:
+        chain.append(
+            {"exception_type": type(current).__name__, "exception_message": _bounded(str(current))}
+        )
+        current = current.__cause__ or (
+            None if current.__suppress_context__ else current.__context__
+        )
+    return chain
+
+
+def _exception_detail(
+    exc_info: (
+        tuple[type[BaseException], BaseException, TracebackType | None]
+        | tuple[None, None, None]
+    ),
+) -> dict[str, object]:
+    exc_type, exc_value, exc_tb = exc_info
+    detail: dict[str, object] = {
+        "exception_type": exc_type.__name__ if exc_type is not None else "UnknownException",
+        "exception_message": _bounded(str(exc_value)) if exc_value is not None else "",
+        "stack_location": _stack_location(exc_tb),
+    }
+    if exc_value is not None:
+        caused_by = _cause_chain(exc_value)
+        if caused_by:
+            detail["caused_by"] = caused_by
+    return detail
 
 
 class JsonFormatter(logging.Formatter):
@@ -12,20 +118,20 @@ class JsonFormatter(logging.Formatter):
         payload: dict[str, Any] = {
             "timestamp": datetime.now(UTC).isoformat(),
             "level": record.levelname.lower(),
-            "event": record.getMessage(),
+            "event": _bounded(record.getMessage()),
             "request_id": request_id_context.get(),
         }
-        for key in (
-            "provider_request_id",
-            "symbol",
-            "provider",
-            "run_id",
-            "run_step",
-            "account_id",
-        ):
+        for key in _SAFE_EXTRA_FIELDS:
             value = getattr(record, key, None)
             if value is not None:
-                payload[key] = value
+                payload[key] = _bounded(str(value)) if isinstance(value, str) else value
+        # SPRINT-013 S13-11: exc_info=True on a log call previously produced
+        # no exception detail at all in the emitted JSON -- this formatter
+        # never read record.exc_info. Every field here is individually
+        # bounded and type/location/message only, never a raw traceback
+        # string, a full repr(), or an unbounded nested-exception chain.
+        if record.exc_info:
+            payload.update(_exception_detail(record.exc_info))
         return json.dumps(payload, default=str, separators=(",", ":"))
 
 

--- a/tests/asa/test_logging.py
+++ b/tests/asa/test_logging.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 from pathlib import Path
 from unittest.mock import Mock
 from uuid import uuid4
@@ -44,6 +45,120 @@ def test_structured_market_log_contains_required_correlation_fields() -> None:
     assert payload["run_id"] == "run-123"
     assert payload["run_step"] == "acquire_portfolio"
     assert payload["account_id"] == "taxable-001"
+
+
+def _record_with_exc_info(exc: BaseException, msg: str = "operation failed") -> logging.LogRecord:
+    try:
+        raise exc
+    except type(exc):
+        record = logging.LogRecord(
+            name="asa.test",
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=1,
+            msg=msg,
+            args=(),
+            exc_info=sys.exc_info(),
+        )
+    return record
+
+
+class TestSanitizedExceptionDetail:
+    """SPRINT-013 S13-11 (issue #242): exc_info=True previously produced no
+    exception detail at all in the emitted JSON -- JsonFormatter never
+    read record.exc_info. These tests exercise the fix directly against
+    the formatter, the shared logging boundary, not a specific call site.
+    """
+
+    def test_exc_info_produces_exception_type_and_useful_safe_detail(self) -> None:
+        record = _record_with_exc_info(ValueError("no put contracts at expiration 2026-08-21"))
+        payload = json.loads(JsonFormatter().format(record))
+        assert payload["exception_type"] == "ValueError"
+        assert "no put contracts at expiration" in payload["exception_message"]
+        assert payload["stack_location"]
+        assert payload["stack_location"][0]["file"] == "test_logging.py"
+        assert isinstance(payload["stack_location"][0]["line"], int)
+
+    def test_traceback_information_survives_json_formatting(self) -> None:
+        record = _record_with_exc_info(RuntimeError("boom"))
+        formatted = JsonFormatter().format(record)
+        # One valid JSON value, not multiple lines -- json.loads would
+        # raise on anything but a single well-formed document.
+        payload = json.loads(formatted)
+        assert "\n" not in formatted
+        assert payload["exception_type"] == "RuntimeError"
+        for frame in payload["stack_location"]:
+            assert set(frame) == {"file", "line", "function"}
+
+    def test_secrets_in_the_exception_message_are_redacted(self) -> None:
+        record = _record_with_exc_info(
+            ValueError(
+                "request to https://api.example.com/v1/quote?symbol=AAPL&token=sk-live-abc123 "
+                "failed with header Authorization: Bearer sk-live-verysecrettoken"
+            )
+        )
+        payload = json.loads(JsonFormatter().format(record))
+        assert "sk-live-abc123" not in payload["exception_message"]
+        assert "sk-live-verysecrettoken" not in payload["exception_message"]
+        assert "[REDACTED]" in payload["exception_message"]
+
+    def test_provider_shaped_payload_fragments_never_escape_via_extra(self) -> None:
+        record = _record_with_exc_info(ValueError("boom"))
+        record.raw_response = {"api_key": "super-secret", "quotes": [{"bid": 1}] * 500}
+        record.headers = {"Authorization": "Bearer super-secret-header-token"}
+        payload = json.loads(JsonFormatter().format(record))
+        assert "raw_response" not in payload
+        assert "headers" not in payload
+        assert "super-secret" not in json.dumps(payload)
+
+    def test_nested_exceptions_remain_bounded(self) -> None:
+        try:
+            try:
+                try:
+                    try:
+                        raise ValueError("level 0")
+                    except ValueError as inner:
+                        raise TypeError("level 1") from inner
+                except TypeError as inner:
+                    raise KeyError("level 2") from inner
+            except KeyError as inner:
+                raise RuntimeError("level 3") from inner
+        except RuntimeError as exc:
+            record = logging.LogRecord(
+                name="asa.test",
+                level=logging.WARNING,
+                pathname=__file__,
+                lineno=1,
+                msg="deeply nested failure",
+                args=(),
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+        payload = json.loads(JsonFormatter().format(record))
+        assert payload["exception_type"] == "RuntimeError"
+        assert len(payload["caused_by"]) <= 3
+
+    def test_ordinary_non_exception_logs_are_unchanged(self) -> None:
+        record = logging.LogRecord(
+            name="asa.market",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="quote_observation_saved",
+            args=(),
+            exc_info=None,
+        )
+        record.symbol = "AAPL"
+        payload = json.loads(JsonFormatter().format(record))
+        assert payload["event"] == "quote_observation_saved"
+        assert payload["symbol"] == "AAPL"
+        assert "exception_type" not in payload
+        assert "stack_location" not in payload
+
+    def test_output_is_one_railway_compatible_json_line(self) -> None:
+        record = _record_with_exc_info(ValueError("multi\nline\nmessage"))
+        formatted = JsonFormatter().format(record)
+        assert "\n" not in formatted
+        assert json.loads(formatted)["exception_message"] == "multi\nline\nmessage"
 
 
 def test_run_step_log_uses_provider_supplied_by_port(


### PR DESCRIPTION
Fixes #242.

## Root cause
`asa/logging.py`'s `JsonFormatter.format()` builds its output from a fixed allowlist of extra fields plus timestamp/level/event/request_id -- it never read `record.exc_info` at all. `screening/runner.py`'s own exception handler already correctly calls `logger.warning(msg, exc_info=True, extra={"strategy_id": ...})`, but the formatter silently discarded both the exception detail AND `strategy_id` (not in the old allowlist). The call site was already correct; only the shared formatter was incomplete.

## Fix
- `exc_info=True` now produces `exception_type` (class name), `exception_message` (redacted + bounded), `stack_location` (innermost 5 frames, file basename/line/function only -- no source content, no variable reprs).
- `__cause__`/`__context__` chains get a bounded `caused_by` summary (capped at 3 levels).
- New pattern-based secret redaction applied to every free-text field (log message, exception message, cause-chain messages) -- an exception's own `str()` can legitimately embed a URL or header fragment from an underlying HTTP client.
- `_SAFE_EXTRA_FIELDS` extended with `strategy_id`, `capability_id`, `component_id`, `safe_error_code`, `diagnostic_code` -- still a strict allowlist, so a call site attaching a raw payload/headers dict via `extra={}` still can't leak it.

## Test plan
- [x] `tests/asa/test_logging.py`: 7 new tests -- exception detail present, traceback survives JSON formatting as one valid line, secrets redacted, provider-shaped extra fragments never escape, nested exceptions bounded (4-level chain caps at 3), ordinary logs unchanged, output stays one Railway-compatible JSON line for a multi-line message.
- [x] `ruff check` / `mypy asa`: clean.
- [x] Full suite: 2820 passed, 45 skipped (zero regressions).
- [x] `tests/architecture`: 467 passed.
- [x] `pre_push_check`: all 5 gates pass.

No migration, no call-site changes. Eligible for auto-merge once CI is green per active SPRINT-013 delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)