### PR TITLE
S13-07: add exc_info=True to asa/scheduled_screening.py's isolated exception handlers

### DIFF
--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -332,6 +332,11 @@ def run_scheduled_refresh(
                         },
                     )
                 except Exception:
+                    # SPRINT-013 S13-07: exc_info=True confirmed missing here
+                    # by real production evidence (2026-08-05 13:41Z cycle --
+                    # every skew_momentum pair logged this event with no
+                    # exception detail at all, even after S13-11's formatter
+                    # fix, since this call site never passed exc_info).
                     _LOGGER.warning(
                         "skew_history_capture_failed",
                         extra={
@@ -339,6 +344,7 @@ def run_scheduled_refresh(
                             "symbol": symbol,
                             "screening_cycle_id": screening_cycle_id,
                         },
+                        exc_info=True,
                     )
             if result.opportunity_id is not None:
                 try:
@@ -356,6 +362,7 @@ def run_scheduled_refresh(
                             "symbol": result.symbol,
                             "opportunity_id": result.opportunity_id,
                         },
+                        exc_info=True,
                     )
             attempts_recorded = True
             try:
@@ -397,6 +404,7 @@ def run_scheduled_refresh(
                         "screening_cycle_id": screening_cycle_id,
                         "pair_evaluation_id": pair_id,
                     },
+                    exc_info=True,
                 )
             outcomes.append(
                 PairOutcome(


### PR DESCRIPTION
Found via real production evidence, not assumed: the first live scheduled cycle observed after S13-11 deployed (2026-08-05T13:41Z, 82 pairs, zero \`strategy_exception\`) logged \`skew_history_capture_failed\` 30 times with zero exception detail, even though S13-11's formatter fix (merged the same night) now renders \`exc_info\` correctly when present. The formatter wasn't the remaining gap -- this call site (and two siblings in the same file) never passed \`exc_info=True\` in the first place.

## Fix
Adds \`exc_info=True\` to all three isolated \`except Exception:\` handlers in \`run_scheduled_refresh()\` (skew-history capture, opportunity-history append, acquisition-attempt recording), matching \`screening/runner.py\`'s own established pattern. No control-flow change.

## Test plan
- [x] \`ruff check\` / \`mypy asa\`: clean.
- [x] \`tests/asa/test_scheduled_screening.py\`: 17 passed.
- [x] Full suite: 2820 passed, 45 skipped, zero regressions.
- [x] \`pre_push_check\`: all 5 gates pass.

No migration. Eligible for auto-merge once CI is green per active SPRINT-013 delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)