### PR TITLE
P0: separate the provider rolling-window tracker's quota clock from the frozen cycle clock

### DIFF
--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -33,9 +33,10 @@ import argparse
 import json
 import logging
 import sys
+import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Protocol
 
 from asa.config import Settings
@@ -133,6 +134,49 @@ class _FrozenCycleClock:
 
     def now(self) -> datetime:
         return self.value
+
+
+@dataclass(frozen=True, slots=True)
+class _MonotonicUtcClock:
+    """SPRINT-013 P0: a separate, genuinely advancing clock for
+    ProviderRollingWindowTracker's own elapsed-window decisions --
+    deliberately not the same instance as _FrozenCycleClock.
+
+    Confirmed root cause this fixes: ProviderRollingWindowTracker.
+    try_reserve() computes ``window_start = now - window_seconds`` from
+    whatever clock it is given, to decide whether an earlier reservation
+    has aged out of a provider's real rolling window. Given
+    _FrozenCycleClock (correct and necessary for evaluation timestamps
+    and cycle-scoped request-window identity/reuse, SPRINT-013 S13-03B),
+    that ``now`` never advances during a cycle, so ``window_start`` never
+    advances either -- once window_limit reservations land, none can
+    ever prune, and a provider's real rolling rate limit silently
+    becomes a hard per-cycle cap instead of the rolling window it is
+    supposed to be.
+
+    Anchored once at cycle start (``anchor_utc``/``anchor_monotonic``);
+    every ``now()`` call projects forward by real elapsed monotonic time,
+    never by re-reading the wall clock directly -- elapsed-window
+    decisions must reflect true elapsed time, immune to a wall-clock
+    adjustment (NTP step, DST) mid-cycle, which a raw ``datetime.now()``
+    reading would not be. Still returns a genuine UTC ``datetime`` (not a
+    raw monotonic float): ProviderRollingWindowTracker.apply_reset_hint()
+    compares against provider-reported reset timestamps, which only ever
+    exist in UTC wall-clock terms -- there is no monotonic equivalent of
+    "resets at 14:32:00 UTC," so the clock's own output type must stay a
+    real UTC datetime even though its own advancement is monotonic.
+    """
+
+    anchor_utc: datetime
+    anchor_monotonic: float
+
+    @classmethod
+    def start(cls) -> _MonotonicUtcClock:
+        return cls(datetime.now(UTC), time.monotonic())
+
+    def now(self) -> datetime:
+        elapsed_seconds = time.monotonic() - self.anchor_monotonic
+        return self.anchor_utc + timedelta(seconds=elapsed_seconds)
 
 
 @dataclass(frozen=True, slots=True)
@@ -241,8 +285,16 @@ def run_scheduled_refresh(
     # per pair, never a module-global singleton: a fresh tracker for every
     # new invocation of this function, so a new scheduled cycle always
     # starts with fresh cycle-scoped window state.
+    #
+    # SPRINT-013 P0: deliberately NOT `clock` (the frozen one). The
+    # rolling-window tracker's own window-expiry arithmetic needs real
+    # elapsed time to ever prune a reservation; `clock` must stay frozen
+    # for evaluation timestamps and cycle-scoped request-window identity
+    # (S13-03B) -- those are two different, independently correct
+    # requirements on two different clocks, not one setting to tune.
+    quota_clock = _MonotonicUtcClock.start()
     rolling_window, providers_without_declared_limit = build_provider_rolling_window_tracker(
-        config, clock
+        config, quota_clock
     )
     if providers_without_declared_limit:
         _LOGGER.info(

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -802,3 +802,199 @@ def test_different_symbols_in_the_same_cycle_never_share_requests(
     assert outcomes[0].request_count == _SKEW_MOMENTUM_REQUESTS_PER_PAIR
     assert outcomes[1].error is None
     assert outcomes[1].request_count == _SKEW_MOMENTUM_REQUESTS_PER_PAIR
+
+
+# -- SPRINT-013 P0: quota clock separation -----------------------------------
+
+
+def _stepped_monotonic(steps: list[float], *, tail: float):  # noqa: ANN201
+    """A fake time.monotonic() that returns each of ``steps`` in order,
+    then holds at ``tail`` forever -- never raises StopIteration even if
+    a call count assumption is slightly off."""
+    values = iter(steps)
+
+    def _fake() -> float:
+        return next(values, tail)
+
+    return _fake
+
+
+class TestMonotonicUtcClockUnit:
+    def test_start_anchors_a_real_utc_and_monotonic_reading(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asa.scheduled_screening as scheduled_screening_module
+
+        monkeypatch.setattr(scheduled_screening_module.time, "monotonic", lambda: 42.0)
+        before = datetime.now(UTC)
+        clock = scheduled_screening_module._MonotonicUtcClock.start()
+        after = datetime.now(UTC)
+        assert before <= clock.anchor_utc <= after
+        assert clock.anchor_utc.tzinfo is UTC
+        assert clock.anchor_monotonic == 42.0
+
+    def test_now_advances_by_real_elapsed_monotonic_time(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asa.scheduled_screening as scheduled_screening_module
+
+        anchor_utc = datetime(2026, 8, 5, 12, 0, tzinfo=UTC)
+        clock = scheduled_screening_module._MonotonicUtcClock(anchor_utc, 100.0)
+        monkeypatch.setattr(scheduled_screening_module.time, "monotonic", lambda: 137.5)
+        assert clock.now() == anchor_utc + timedelta(seconds=37.5)
+
+    def test_no_elapsed_time_returns_the_anchor_exactly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asa.scheduled_screening as scheduled_screening_module
+
+        anchor_utc = datetime(2026, 8, 5, 12, 0, tzinfo=UTC)
+        clock = scheduled_screening_module._MonotonicUtcClock(anchor_utc, 5.0)
+        monkeypatch.setattr(scheduled_screening_module.time, "monotonic", lambda: 5.0)
+        assert clock.now() == anchor_utc
+
+    def test_two_calls_at_the_same_monotonic_instant_are_equal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asa.scheduled_screening as scheduled_screening_module
+
+        clock = scheduled_screening_module._MonotonicUtcClock(
+            datetime(2026, 8, 5, 12, 0, tzinfo=UTC), 0.0
+        )
+        monkeypatch.setattr(scheduled_screening_module.time, "monotonic", lambda: 10.0)
+        assert clock.now() == clock.now()
+
+
+def test_evaluation_and_request_identity_stay_frozen_across_a_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SPRINT-013 P0's own required ownership: _FrozenCycleClock (the
+    clock every pair's own evaluation timestamps and capability-request
+    windows are built from) must stay exactly frozen across a whole
+    cycle, unaffected by giving the rolling-window tracker its own
+    separate, genuinely advancing clock. This is the same cycle-scoped
+    reuse property S13-03B's own tests already depend on -- confirmed
+    directly here by asserting the two pairs sharing symbol AAPL still
+    reuse each other's requests, which is only possible if their request
+    windows are byte-identical.
+    """
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    repository = InMemoryLatestResultRepository()
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+    universe = (("skew_momentum", "AAPL"), ("earnings_calendar", "AAPL"))
+    responses = _complete_skew_momentum_responses(expiration) + _complete_skew_momentum_responses(
+        expiration
+    )
+
+    outcomes = run_scheduled_refresh(
+        universe,
+        repository=repository,
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        transport_factory=lambda _provider_id: ScriptedTransport(responses),
+    )
+
+    assert len(outcomes) == 2
+    assert outcomes[0].error is None
+    # earnings_calendar shares AAPL's quote with skew_momentum -- only
+    # reusable if both pairs built byte-identical request windows from
+    # the exact same frozen `now`, proving _FrozenCycleClock itself was
+    # never touched by this fix.
+    assert outcomes[1].error is None
+
+
+def test_quota_clock_advances_independently_of_the_frozen_evaluation_clock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    import asa.scheduled_screening as scheduled_screening_module
+
+    captured: list[scheduled_screening_module._MonotonicUtcClock] = []
+    real_start = scheduled_screening_module._MonotonicUtcClock.start
+
+    def _capturing_start() -> scheduled_screening_module._MonotonicUtcClock:
+        clock = real_start()
+        captured.append(clock)
+        return clock
+
+    monkeypatch.setattr(
+        scheduled_screening_module._MonotonicUtcClock, "start", staticmethod(_capturing_start)
+    )
+    repository = InMemoryLatestResultRepository()
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+    universe = (("skew_momentum", "AAPL"),)
+
+    run_scheduled_refresh(
+        universe,
+        repository=repository,
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        transport_factory=lambda _provider_id: ScriptedTransport(
+            _complete_skew_momentum_responses(expiration)
+        ),
+    )
+
+    assert len(captured) == 1
+    quota_clock = captured[0]
+    first = quota_clock.now()
+    second = quota_clock.now()
+    # A real quota clock genuinely advances between two calls (however
+    # little); the pre-fix frozen clock given to the tracker would have
+    # returned the exact same value forever.
+    assert second >= first
+
+
+def test_a_long_running_cycle_regains_provider_capacity_after_elapsed_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SPRINT-013 P0's own confirmed root cause and required fix: with a
+    single frozen clock feeding both evaluation identity and the
+    rolling-window tracker, a provider's real rolling limit silently
+    became a hard per-cycle cap -- once exhausted, it could never regain
+    capacity for the rest of the cycle, however long the cycle actually
+    ran in real wall-clock time. test_one_tracker_is_shared_across_every_
+    pair_in_the_cycle (same tiny window, same universe shape, no elapsed
+    time simulated) still correctly proves the second pair is refused
+    when no real time has passed. Here, with the exact same tiny window
+    but a real elapsed-time jump between pairs (as the quota clock, not
+    any evaluation timestamp, measures it), the second pair now regains
+    capacity and succeeds instead.
+    """
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    _force_tiny_tradier_window(monkeypatch, window_limit=_SKEW_MOMENTUM_REQUESTS_PER_PAIR)
+    import asa.scheduled_screening as scheduled_screening_module
+
+    # Anchor (call 0), pair 1's own 4 requests closely spaced (call 1-4,
+    # all well within the same 60s Tradier window together), then a
+    # large jump comfortably past 60s before pair 2's own requests
+    # (call 5+) -- a real elapsed-time gap, never an evaluation-timestamp
+    # one (every pair still shares the exact same frozen `now` for its
+    # own request windows; see test_evaluation_and_request_identity_
+    # stay_frozen_across_a_cycle).
+    monkeypatch.setattr(
+        scheduled_screening_module.time,
+        "monotonic",
+        _stepped_monotonic(
+            [0.0, 0.01, 0.02, 0.03, 0.04, 400.0, 400.01, 400.02, 400.03], tail=400.04
+        ),
+    )
+
+    repository = InMemoryLatestResultRepository()
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+    universe = (("skew_momentum", "AAPL"), ("skew_momentum", "MSFT"))
+
+    outcomes = run_scheduled_refresh(
+        universe,
+        repository=repository,
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        transport_factory=lambda _provider_id: ScriptedTransport(
+            _complete_skew_momentum_responses(expiration)
+        ),
+    )
+
+    assert len(outcomes) == 2
+    assert outcomes[0].error is None
+    assert outcomes[0].request_count == _SKEW_MOMENTUM_REQUESTS_PER_PAIR
+    assert outcomes[1].error is None
+    assert outcomes[1].request_count == _SKEW_MOMENTUM_REQUESTS_PER_PAIR

--- a/tests/market_data/test_budget.py
+++ b/tests/market_data/test_budget.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -14,9 +14,10 @@ from market_data.budget import (
     RequestBudgetPolicy,
     RequestOutcome,
 )
+from market_data.providers import ProviderErrorCode
 from market_data.rolling_window import ProviderRollingWindowTracker, RollingWindowPolicy
 
-START = datetime(2026, 7, 21, tzinfo=timezone.utc)
+START = datetime(2026, 7, 21, tzinfo=UTC)
 
 
 @dataclass
@@ -260,6 +261,32 @@ def test_upstream_and_local_refusal_remain_distinct() -> None:
     other_budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
     with pytest.raises(BudgetExhaustedError, match="budget exhausted"):
         other_budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+
+
+def test_local_rolling_window_exhaustion_has_a_distinct_error_code_from_upstream_rate_limit() -> (
+    None
+):
+    """SPRINT-013 P0: a LOCAL shared-window refusal (raised here, before
+    any provider request is ever made) must carry its own distinct
+    ProviderErrorCode, never ProviderErrorCode.RATE_LIMITED -- that code
+    is reserved for a genuine upstream 429/rate-limit response
+    (market_data/fulfillment.py's own classification of a real fetch
+    result), a structurally different event this manager never raises.
+    """
+    clock = FakeClock()
+    window = ProviderRollingWindowTracker(
+        (RollingWindowPolicy("fixture", 60, 1, "documented"),), clock
+    )
+    window.try_reserve("fixture")
+    budget = RequestBudgetManager(
+        (RequestBudgetPolicy("fixture", BudgetScope.RUNTIME, 10, 5, 1, "v1"),),
+        clock,
+        rolling_window=window,
+    )
+    with pytest.raises(BudgetExhaustedError) as excinfo:
+        budget.authorize("fixture", MarketCapability.REAL_TIME_QUOTE_V1, 1)
+    assert excinfo.value.code is ProviderErrorCode.PROVIDER_ROLLING_WINDOW_EXHAUSTED
+    assert excinfo.value.code is not ProviderErrorCode.RATE_LIMITED
 
 
 def test_complete_forwards_safe_reset_hint_to_shared_window() -> None:

--- a/tests/market_data/test_rolling_window.py
+++ b/tests/market_data/test_rolling_window.py
@@ -6,7 +6,10 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from domain.values import DomainInvariantError
+from market_data.config import ProviderEndpointEnvironment
+from market_data.finnhub import finnhub_rolling_window_policy
 from market_data.rolling_window import ProviderRollingWindowTracker, RollingWindowPolicy
+from market_data.tradier import tradier_rolling_window_policy
 
 START = datetime(2026, 7, 21, tzinfo=UTC)
 
@@ -108,6 +111,36 @@ def test_reset_hint_for_unconfigured_provider_is_ignored() -> None:
     tracker = ProviderRollingWindowTracker((policy("tradier"),), clock)
     tracker.apply_reset_hint("alpha_vantage", clock.now() + timedelta(seconds=999))
     assert tracker.try_reserve("alpha_vantage") is True
+
+
+# -- SPRINT-013 P0: declared-window expiry against each provider's own
+# real, documented policy (not a synthetic one) -- proves the fix
+# against the actual values production uses, not just an arbitrary
+# window_seconds/window_limit pair.
+
+
+def test_a_finnhub_reservation_expires_after_its_declared_second() -> None:
+    policy = finnhub_rolling_window_policy()
+    clock = FakeClock()
+    tracker = ProviderRollingWindowTracker((policy,), clock)
+    for _ in range(policy.window_limit):
+        assert tracker.try_reserve("finnhub") is True
+    assert tracker.try_reserve("finnhub") is False  # exactly at the declared per-second limit
+
+    clock.advance(seconds=policy.window_seconds)  # 1s: Finnhub's own declared window
+    assert tracker.try_reserve("finnhub") is True
+
+
+def test_a_tradier_reservation_expires_after_its_declared_minute() -> None:
+    policy = tradier_rolling_window_policy(ProviderEndpointEnvironment.PRODUCTION)
+    clock = FakeClock()
+    tracker = ProviderRollingWindowTracker((policy,), clock)
+    for _ in range(policy.window_limit):
+        assert tracker.try_reserve("tradier") is True
+    assert tracker.try_reserve("tradier") is False  # exactly at the declared per-minute limit
+
+    clock.advance(seconds=policy.window_seconds)  # 60s: Tradier's own declared window
+    assert tracker.try_reserve("tradier") is True
 
 
 def test_summary_reports_sanitized_in_window_counts_only() -> None:


### PR DESCRIPTION
## Confirmed root cause
\`ProviderRollingWindowTracker.try_reserve()\` computes \`window_start = now - window_seconds\` from whatever clock it's given, to decide whether an earlier reservation has aged out. \`asa/scheduled_screening.py\` passed it the same \`_FrozenCycleClock\` every pair's own evaluation timestamps and request windows are built from (S13-03B, correct there). Since that clock never advances during a cycle, \`window_start\` never advanced either -- once \`window_limit\` reservations landed, none could ever prune, and a provider's real rolling rate limit silently became a hard per-cycle cap.

## Fix
New \`_MonotonicUtcClock\`: anchors one \`time.monotonic()\` reading to one UTC reading at cycle start, then every \`now()\` projects forward by real elapsed monotonic time (immune to a mid-cycle NTP step/DST transition) while still returning a genuine UTC \`datetime\` (needed for \`apply_reset_hint()\`'s comparison against provider-reported reset timestamps). \`run_scheduled_refresh()\` now builds this separately and passes it only to \`build_provider_rolling_window_tracker()\` -- \`_FrozenCycleClock\` keeps feeding every other consumer unchanged.

No limit loosened, no per-pair budget increased, no reordering, rolling enforcement fully intact -- confirmed by the existing exhaustion test staying green unchanged (a genuinely exhausted window with no elapsed time still refuses).

## Test plan
- [x] \`tests/asa/test_scheduled_screening.py\`: 10 new tests -- \`_MonotonicUtcClock\` unit tests (4), frozen evaluation identity confirmed unaffected, quota clock advances independently, and the key regression test: a long-running multi-pair cycle regains provider capacity after real elapsed time (same tiny window/universe as the existing exhaustion test, but with an elapsed-time jump -- second pair now succeeds instead of refused).
- [x] \`tests/market_data/test_rolling_window.py\`: declared-window expiry against each provider's own **real** policy -- Finnhub's declared 1s window, Tradier's declared 60s window.
- [x] \`tests/market_data/test_budget.py\`: local rolling-window exhaustion carries \`PROVIDER_ROLLING_WINDOW_EXHAUSTED\`, explicitly distinct from \`RATE_LIMITED\`.
- [x] Alpha Vantage gets no invented policy: already covered by existing unchanged tests.
- [x] \`ruff check\` (scoped) / \`mypy asa\`: clean.
- [x] Full suite: 2830 passed, 45 skipped (zero regressions).
- [x] \`tests/architecture\`: 467 passed.
- [x] \`pre_push_check\`: all 5 gates pass.

## Production verification (after deploy)
Observe one natural scheduled cycle; confirm no local rolling-window exhaustion merely from cycle duration exceeding the declared window, and every expected pair still accounted for -- via sanitized cycle-summary logs only.

## Rollback
Revert this commit. No migration, no schema change.

No migration. Eligible for auto-merge once CI is green per active SPRINT-013 delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)