### PR TITLE
S14-PR-02: declare typed Earnings Calendar requirements

### DIFF
--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -96,6 +96,7 @@ from strategies import (
     SKEW_MOMENTUM_VERTICAL_MANIFEST,
     STONK_STRATEGY_PLUGINS,
     compile_strategy_graph,
+    earnings_calendar_requirement,
     execute_strategy_graph,
 )
 from strategies.manifest import StrategyManifest
@@ -106,20 +107,13 @@ from strategies.type_system import ComponentValues
 _COMPONENT_REGISTRY = build_plugin_registry(CORE_COMPONENTS, STONK_STRATEGY_PLUGINS)
 _NON_FAIL_VERDICTS = frozenset({"PASS", "WATCH"})
 
-# Earnings Calendar's own frozen expiration_pair_selector node parameters
-# (strategies/stonk_manifests.py) -- duplicated here for the same reason
-# FORWARD_FACTOR_DTE_POLICY is: this ticket's data still needs an
-# externally-selected pair for the parts of each manifest not connected to
-# expiration_select via a graph edge.
-EARNINGS_CALENDAR_DTE_POLICY = {
-    "front_min_dte": 7,
-    "front_max_dte": 21,
-    "back_min_dte": 22,
-    "back_max_dte": 75,
-    "target_gap_days": 30,
-    "gap_tolerance_days": 5,
-}
-EARNINGS_CALENDAR_LOOKAHEAD_DAYS = EARNINGS_CALENDAR_DTE_POLICY["back_max_dte"]
+# SPRINT-014 S14-PR-02: Earnings Calendar's own expiration_pair_selector
+# node parameters are read directly from its manifest (the manifest is the
+# only owner) via strategies.earnings_calendar_requirement() -- no second,
+# independently maintained copy. Resolves SPRINT-013 S13-08's audit finding
+# #1 (project/reports/SPRINT-013-S13-08-audit.md): this was previously a
+# hand-duplicated dict with no accessor onto the manifest's own copy.
+EARNINGS_CALENDAR_REQUIREMENT = earnings_calendar_requirement()
 MAX_FORWARD_FACTOR_PAIR_ATTEMPTS = 5
 
 
@@ -520,7 +514,7 @@ def build_live_earnings_calendar_adapter(
             MarketCapability.EARNINGS_CALENDAR_V1,
             now,
             ("earnings_date",),
-            effective_end=now + timedelta(days=EARNINGS_CALENDAR_LOOKAHEAD_DAYS),
+            effective_end=now + timedelta(days=EARNINGS_CALENDAR_REQUIREMENT.lookahead_days),
         )
         quote = _acquire_or_raise(
             fulfillment,
@@ -540,12 +534,12 @@ def build_live_earnings_calendar_adapter(
         selected = select_earnings_relative_expiration_pair(
             candidates,
             earnings_date,
-            front_min_dte=EARNINGS_CALENDAR_DTE_POLICY["front_min_dte"],
-            front_max_dte=EARNINGS_CALENDAR_DTE_POLICY["front_max_dte"],
-            back_min_dte=EARNINGS_CALENDAR_DTE_POLICY["back_min_dte"],
-            back_max_dte=EARNINGS_CALENDAR_DTE_POLICY["back_max_dte"],
-            target_gap_days=EARNINGS_CALENDAR_DTE_POLICY["target_gap_days"],
-            gap_tolerance_days=EARNINGS_CALENDAR_DTE_POLICY["gap_tolerance_days"],
+            front_min_dte=EARNINGS_CALENDAR_REQUIREMENT.expiration_policy.front_min_dte,
+            front_max_dte=EARNINGS_CALENDAR_REQUIREMENT.expiration_policy.front_max_dte,
+            back_min_dte=EARNINGS_CALENDAR_REQUIREMENT.expiration_policy.back_min_dte,
+            back_max_dte=EARNINGS_CALENDAR_REQUIREMENT.expiration_policy.back_max_dte,
+            target_gap_days=EARNINGS_CALENDAR_REQUIREMENT.expiration_policy.target_gap_days,
+            gap_tolerance_days=EARNINGS_CALENDAR_REQUIREMENT.expiration_policy.gap_tolerance_days,
         )
         if selected is None:
             raise StrategyAdapterError(

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -8,6 +8,12 @@ order (Constitution Law 4: Strategies consume knowledge, they do not
 gather it).
 """
 
+from strategies.component_registry import (
+    REGISTRY_IDENTITY_NAMESPACE,
+    REGISTRY_IDENTITY_VERSION,
+    SUPPORTED_COMPONENT_CAPABILITIES,
+    ComponentRegistry,
+)
 from strategies.components import (
     COMPONENT_IDENTITY_NAMESPACE,
     COMPONENT_IDENTITY_VERSION,
@@ -20,12 +26,6 @@ from strategies.components import (
     StrategyTypeReference,
     component_definition_data,
     component_identity,
-)
-from strategies.component_registry import (
-    REGISTRY_IDENTITY_NAMESPACE,
-    REGISTRY_IDENTITY_VERSION,
-    SUPPORTED_COMPONENT_CAPABILITIES,
-    ComponentRegistry,
 )
 from strategies.core_components import (
     CORE_COMPONENTS,
@@ -63,22 +63,8 @@ from strategies.errors import (
     MissingIndicatorInputError,
     NoContributingFactsError,
     StrategyError,
-    UnsupportedManifestSchemaError,
     UnknownStrategyIdError,
-)
-from strategies.runtime import (
-    EVALUATION_IDENTITY_NAMESPACE,
-    EVALUATION_IDENTITY_VERSION,
-    GRAPH_IDENTITY_NAMESPACE,
-    GRAPH_IDENTITY_VERSION,
-    GRAPH_RUNTIME_VERSION,
-    CompiledNode,
-    CompiledStrategyGraph,
-    ExecutionTrace,
-    GraphExecutionResult,
-    TraceEvent,
-    compile_strategy_graph,
-    execute_strategy_graph,
+    UnsupportedManifestSchemaError,
 )
 from strategies.expressions import (
     EXPRESSION_IDENTITY_NAMESPACE,
@@ -91,6 +77,12 @@ from strategies.expressions import (
     ExpressionTrace,
     compile_expression,
     evaluate_expression,
+)
+from strategies.library import (
+    STONK_STRATEGY_LIBRARY,
+    STRATEGY_LIBRARY_IDENTITY_NAMESPACE,
+    STRATEGY_LIBRARY_VERSION,
+    StrategyLibrary,
 )
 from strategies.manifest import (
     MANIFEST_IDENTITY_NAMESPACE,
@@ -113,12 +105,11 @@ from strategies.manifest import (
     manifest_identity,
     manifest_to_data,
     manifest_value_to_data,
+    node_parameter_value,
     serialize_manifest,
     validate_semantic_version,
     validate_strategy_identifier,
 )
-from strategies.registry import DEFAULT_REGISTRY, StrategyRegistry
-from strategies.reference_strategy import MOVING_AVERAGE_CROSSOVER_MANIFEST
 from strategies.plugins import (
     PLUGIN_IDENTITY_NAMESPACE,
     PLUGIN_IDENTITY_VERSION,
@@ -127,15 +118,36 @@ from strategies.plugins import (
     StrategyPlugin,
     build_plugin_registry,
 )
+from strategies.reference_strategy import MOVING_AVERAGE_CROSSOVER_MANIFEST
+from strategies.registry import DEFAULT_REGISTRY, StrategyRegistry
+from strategies.requirements import (
+    EarningsCalendarExpirationPolicy,
+    EarningsCalendarRequirement,
+    earnings_calendar_requirement,
+)
+from strategies.runtime import (
+    EVALUATION_IDENTITY_NAMESPACE,
+    EVALUATION_IDENTITY_VERSION,
+    GRAPH_IDENTITY_NAMESPACE,
+    GRAPH_IDENTITY_VERSION,
+    GRAPH_RUNTIME_VERSION,
+    CompiledNode,
+    CompiledStrategyGraph,
+    ExecutionTrace,
+    GraphExecutionResult,
+    TraceEvent,
+    compile_strategy_graph,
+    execute_strategy_graph,
+)
 from strategies.signal import StrategySignal
 from strategies.stonk_components import (
     OPTIONS_STONK_COMPONENTS,
     SHARED_STONK_COMPONENTS,
     CalendarStructure,
-    DtePairSelector,
     DeltaNearestLeg,
     DeterministicSecurityCap,
     DoubleCalendarStructure,
+    DtePairSelector,
     EarningsEventWindow,
     ExpirationPairProjection,
     ExpirationPairSelector,
@@ -150,11 +162,6 @@ from strategies.stonk_components import (
     VerticalStructure,
     WeightedScoreWithCeiling,
 )
-from strategies.stonk_plugins import (
-    STONK_OPTIONS_PLUGIN,
-    STONK_SHARED_PLUGIN,
-    STONK_STRATEGY_PLUGINS,
-)
 from strategies.stonk_manifests import (
     EARNINGS_CALENDAR_MANIFEST,
     FORWARD_FACTOR_CALENDAR_MANIFEST,
@@ -162,11 +169,10 @@ from strategies.stonk_manifests import (
     STOCK_MOMENTUM_MANIFEST,
     STONK_STRATEGY_MANIFESTS,
 )
-from strategies.library import (
-    STRATEGY_LIBRARY_IDENTITY_NAMESPACE,
-    STRATEGY_LIBRARY_VERSION,
-    STONK_STRATEGY_LIBRARY,
-    StrategyLibrary,
+from strategies.stonk_plugins import (
+    STONK_OPTIONS_PLUGIN,
+    STONK_SHARED_PLUGIN,
+    STONK_STRATEGY_PLUGINS,
 )
 from strategies.type_system import (
     DEFAULT_TYPE_SYSTEM,
@@ -209,6 +215,8 @@ __all__ = [
     "ComponentRegistry",
     "ComponentValues",
     "DuplicateStrategyRegistrationError",
+    "EarningsCalendarExpirationPolicy",
+    "EarningsCalendarRequirement",
     "EXPRESSION_IDENTITY_NAMESPACE",
     "EXPRESSION_IDENTITY_VERSION",
     "EXPRESSION_LANGUAGE_VERSION",
@@ -312,6 +320,7 @@ __all__ = [
     "compile_expression",
     "compile_strategy_graph",
     "deserialize_manifest",
+    "earnings_calendar_requirement",
     "evaluate_strategy",
     "evaluate_expression",
     "execute_strategy_graph",
@@ -319,6 +328,7 @@ __all__ = [
     "manifest_identity",
     "manifest_to_data",
     "manifest_value_to_data",
+    "node_parameter_value",
     "opportunity_identity",
     "serialize_manifest",
     "validate_semantic_version",

--- a/strategies/manifest.py
+++ b/strategies/manifest.py
@@ -519,6 +519,36 @@ def manifest_identity(manifest: StrategyManifest) -> str:
     return hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
 
 
+def node_parameter_value(
+    manifest: StrategyManifest, node_id: str, parameter_name: str
+) -> ManifestValue:
+    """Read one node's own effective parameter value directly from the
+    manifest -- the queryable manifest-parameter accessor SPRINT-013
+    S13-08's audit found missing (project/reports/SPRINT-013-S13-08-audit.md,
+    finding #1: a duplicate-ownership violation blocked on "a queryable
+    manifest-parameter accessor that does not exist today").
+
+    A strategy's own manifest is already the single canonical authority for
+    node parameters (ADR-010); this only exposes a read path onto data the
+    manifest already stores, so a consumer (e.g. strategies/requirements.py)
+    never needs its own hand-typed copy of a value the manifest already
+    declares. Deterministic and order-independent: StrategyManifest.__post_init__
+    already canonically sorts nodes and each node's own parameters, so this
+    lookup depends only on (manifest, node_id, parameter_name), never on
+    construction or iteration order.
+    """
+    for node in manifest.nodes:
+        if node.node_id != node_id:
+            continue
+        for parameter in node.parameters:
+            if parameter.name == parameter_name:
+                return parameter.value
+        raise ManifestValidationError(
+            f"node {node_id!r} has no parameter {parameter_name!r}"
+        )
+    raise ManifestValidationError(f"manifest {manifest.strategy_id!r} has no node {node_id!r}")
+
+
 def _require_object(value: object, path: str) -> dict[str, object]:
     if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
         raise ManifestSerializationError(f"{path} must be a JSON object")

--- a/strategies/requirements.py
+++ b/strategies/requirements.py
@@ -1,0 +1,92 @@
+"""Typed, deterministic strategy data requirement projections (SPRINT-014
+S14-PR-02).
+
+A requirement projection reads a strategy's own manifest -- the single
+canonical authority for its parameters (ADR-010) -- and produces a typed,
+frozen description of what evidence that strategy needs. It performs no
+provider call, no acquisition, no I/O of any kind: every value here already
+exists in the manifest, this module only gives it a typed, queryable shape
+instead of a hand-duplicated copy.
+
+This directly resolves SPRINT-013 S13-08's audit finding #1
+(project/reports/SPRINT-013-S13-08-audit.md): Earnings Calendar's DTE
+selection policy was duplicated between screening/live_adapters.py's own
+hardcoded dict and strategies/stonk_manifests.py's expiration_select node
+parameters, with no accessor to read the manifest's own copy instead of
+re-typing it. screening/live_adapters.py now sources its policy from
+earnings_calendar_requirement() below; the manifest is the only owner.
+
+Scope (SPRINT-014 S14-PR-02): Earnings Calendar only, per this ticket's own
+migration_strategy. A future ticket may generalize this pattern to other
+strategies once a second consumer proves the shape is actually reusable
+(SPRINT-013's own "extract only after semantic identity is proven" rule).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from domain import MarketCapability
+from strategies.manifest import StrategyManifest, node_parameter_value
+from strategies.stonk_manifests import EARNINGS_CALENDAR_MANIFEST
+
+
+@dataclass(frozen=True, slots=True)
+class EarningsCalendarExpirationPolicy:
+    """Earnings Calendar's own front/back expiration-pair selection policy,
+    read from its manifest's expiration_select node -- never a second,
+    independently maintained copy.
+    """
+
+    front_min_dte: int
+    front_max_dte: int
+    back_min_dte: int
+    back_max_dte: int
+    target_gap_days: int
+    gap_tolerance_days: int
+
+
+@dataclass(frozen=True, slots=True)
+class EarningsCalendarRequirement:
+    """Complete typed data requirement for one Earnings Calendar
+    evaluation: which market capabilities it needs and the expiration
+    policy governing which contracts within those capabilities are
+    selected. Acquisition planning (SPRINT-014 S14-PR-03) consumes this;
+    it never constructs its own copy of these values.
+    """
+
+    capabilities: tuple[MarketCapability, ...]
+    expiration_policy: EarningsCalendarExpirationPolicy
+    lookahead_days: int
+
+
+def _int_parameter(manifest: StrategyManifest, node_id: str, parameter_name: str) -> int:
+    value = node_parameter_value(manifest, node_id, parameter_name)
+    assert isinstance(value, int) and not isinstance(value, bool)
+    return value
+
+
+def earnings_calendar_requirement(
+    manifest: StrategyManifest = EARNINGS_CALENDAR_MANIFEST,
+) -> EarningsCalendarRequirement:
+    """Project Earnings Calendar's typed data requirement from its own
+    manifest. Deterministic and order-independent: depends only on the
+    manifest's own already-canonically-ordered content, never on wall
+    clock, randomness, or call order. Performs no provider call.
+    """
+    capabilities = tuple(
+        MarketCapability(item.name) for item in manifest.required_market_capabilities
+    )
+    expiration_policy = EarningsCalendarExpirationPolicy(
+        front_min_dte=_int_parameter(manifest, "expiration_select", "front_min_dte"),
+        front_max_dte=_int_parameter(manifest, "expiration_select", "front_max_dte"),
+        back_min_dte=_int_parameter(manifest, "expiration_select", "back_min_dte"),
+        back_max_dte=_int_parameter(manifest, "expiration_select", "back_max_dte"),
+        target_gap_days=_int_parameter(manifest, "expiration_select", "target_gap_days"),
+        gap_tolerance_days=_int_parameter(manifest, "expiration_select", "gap_tolerance_days"),
+    )
+    return EarningsCalendarRequirement(
+        capabilities=capabilities,
+        expiration_policy=expiration_policy,
+        lookahead_days=expiration_policy.back_max_dte,
+    )

--- a/tests/strategies/test_requirements.py
+++ b/tests/strategies/test_requirements.py
@@ -1,0 +1,123 @@
+"""SPRINT-014 S14-PR-02: typed requirement projection tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain import MarketCapability
+from strategies import (
+    EARNINGS_CALENDAR_MANIFEST,
+    CapabilityRequirement,
+    ComponentReference,
+    EarningsCalendarExpirationPolicy,
+    ManifestMetadata,
+    ManifestValidationError,
+    NodeSpec,
+    OutputSpec,
+    ParameterSpec,
+    StrategyManifest,
+    earnings_calendar_requirement,
+    node_parameter_value,
+)
+
+
+def _manifest_with_nodes(*nodes: NodeSpec) -> StrategyManifest:
+    return StrategyManifest(
+        "1.1.0",
+        "test_strategy",
+        "1.0.0",
+        ManifestMetadata("Test"),
+        (),
+        (),
+        nodes,
+        (),
+        (OutputSpec("value", nodes[0].node_id, "out", "value"),),
+        required_market_capabilities=(CapabilityRequirement("real_time_quote_v1", "1.0.0"),),
+    )
+
+
+def _node(node_id: str, *parameters: ParameterSpec) -> NodeSpec:
+    return NodeSpec(node_id, ComponentReference("ns", "component", "1.0.0"), parameters)
+
+
+class TestNodeParameterValue:
+    def test_reads_an_existing_parameter(self) -> None:
+        node = _node("n", ParameterSpec("x", "Integer", 7))
+        manifest = _manifest_with_nodes(node)
+        assert node_parameter_value(manifest, "n", "x") == 7
+
+    def test_unknown_node_raises(self) -> None:
+        node = _node("n", ParameterSpec("x", "Integer", 7))
+        manifest = _manifest_with_nodes(node)
+        with pytest.raises(ManifestValidationError, match="no node"):
+            node_parameter_value(manifest, "missing", "x")
+
+    def test_unknown_parameter_raises(self) -> None:
+        node = _node("n", ParameterSpec("x", "Integer", 7))
+        manifest = _manifest_with_nodes(node)
+        with pytest.raises(ManifestValidationError, match="no parameter"):
+            node_parameter_value(manifest, "n", "missing")
+
+    def test_order_independent(self) -> None:
+        # Two nodes, parameters supplied in reverse order at construction --
+        # StrategyManifest.__post_init__ already canonically sorts both, so
+        # the lookup result must be identical regardless of input order.
+        node_a = _node("a", ParameterSpec("y", "Integer", 2), ParameterSpec("x", "Integer", 1))
+        node_b = _node("b", ParameterSpec("z", "Integer", 3))
+        forward = _manifest_with_nodes(node_a, node_b)
+        backward = _manifest_with_nodes(node_b, node_a)
+        forward_value = node_parameter_value(forward, "a", "x")
+        backward_value = node_parameter_value(backward, "a", "x")
+        assert forward_value == backward_value == 1
+
+
+class TestEarningsCalendarRequirement:
+    def test_capabilities_match_the_manifest(self) -> None:
+        requirement = earnings_calendar_requirement()
+        assert set(requirement.capabilities) == {
+            MarketCapability.EARNINGS_CALENDAR_V1,
+            MarketCapability.REAL_TIME_QUOTE_V1,
+            MarketCapability.OPTION_CHAIN_V1,
+            MarketCapability.HISTORICAL_BARS_V1,
+        }
+
+    def test_expiration_policy_matches_the_manifests_expiration_select_node(
+        self,
+    ) -> None:
+        requirement = earnings_calendar_requirement()
+        assert requirement.expiration_policy == EarningsCalendarExpirationPolicy(
+            front_min_dte=7,
+            front_max_dte=21,
+            back_min_dte=22,
+            back_max_dte=75,
+            target_gap_days=30,
+            gap_tolerance_days=5,
+        )
+
+    def test_lookahead_days_is_derived_from_back_max_dte(self) -> None:
+        requirement = earnings_calendar_requirement()
+        assert requirement.lookahead_days == requirement.expiration_policy.back_max_dte
+
+    def test_deterministic_across_calls(self) -> None:
+        assert earnings_calendar_requirement() == earnings_calendar_requirement()
+
+    def test_uses_the_real_earnings_calendar_manifest_by_default(self) -> None:
+        default_call = earnings_calendar_requirement()
+        explicit_call = earnings_calendar_requirement(EARNINGS_CALENDAR_MANIFEST)
+        assert default_call == explicit_call
+
+    def test_performs_no_provider_call(self) -> None:
+        # Pure data transformation: the module this function lives in must
+        # never import a transport, provider SDK, or database driver.
+        import ast
+        from pathlib import Path
+
+        tree = ast.parse(Path("strategies/requirements.py").read_text())
+        roots: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                roots.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                roots.add(node.module.split(".")[0])
+        forbidden = {"requests", "httpx", "urllib", "sqlalchemy", "psycopg", "psycopg2"}
+        assert not roots & forbidden


### PR DESCRIPTION
## Ticket

SPRINT-014 S14-PR-02 (`docs/sprints/SPRINT-014.yaml`), depends on: S14-PR-01 (merged, `ROOT_CAUSE_ACCEPTED`).

## Summary

New `strategies/requirements.py`: `EarningsCalendarRequirement` / `EarningsCalendarExpirationPolicy`, projected from `EARNINGS_CALENDAR_MANIFEST` via a new generic manifest-parameter accessor (`strategies.manifest.node_parameter_value`). Pure data transformation -- no provider call, no I/O, deterministic and order-independent.

Resolves SPRINT-013 S13-08's audit finding #1 (`project/reports/SPRINT-013-S13-08-audit.md`): `screening/live_adapters.py`'s `EARNINGS_CALENDAR_DTE_POLICY` was a hand-duplicated dict of the manifest's own `expiration_select` node parameters, with no accessor to read the manifest's copy instead of re-typing it. `screening/live_adapters.py` now sources `EARNINGS_CALENDAR_REQUIREMENT` from `earnings_calendar_requirement()` -- the manifest is the only owner. Values are unchanged (verified equal to the removed dict before deletion) -- no behavior change to the live adapter.

Declaration-only, per this ticket's own scope: no acquisition, no capability-fulfillment wiring, no strategy other than Earnings Calendar touched.

## Tests

- New: `tests/strategies/test_requirements.py` (10 tests).
- Full `tests/strategies` + `tests/screening`: 427 passed.
- `tests/architecture` + `tests/asa` (excluding environment-specific `test_railway_runtime.py`): 633 passed, 43 skipped.
- `ruff check` on changed files: clean.
- `mypy strategies screening`: 12 pre-existing baseline errors unchanged (confirmed via `git stash` comparison) -- zero new errors.

## Self-review

- Read set expanded to include `screening/live_adapters.py`, justified by this ticket's own acceptance criterion ("no hidden acquisition constant remains in screening or adapters").
- Requirement code performs no provider call (test-enforced import guard).
- No scope, authority, or invariant expansion.

## Rollback

Revert this commit. No migration, no persisted-data shape change.

## Verdict

Ready for independent Architect gate (`per_pr_gate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)