### PR TITLE
S14-PR-05: shadow and cut over Earnings Calendar to subject-first evidence

### DIFF
--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -35,14 +35,22 @@ from asa.api.screening_models import (
     SignalCapabilityResponse,
 )
 from market_data import load_market_data_config_from_environment
+from market_data.attempts import AcquisitionAttemptRepository
 from market_data.live_transport import build_live_transport
 from market_data.session_schedule import ON_DEMAND_COOLDOWN
+from market_data.subject_plan import SubjectAcquisitionPlan
 from screening.live_acquisition import APPROVED_LIVE_UNIVERSE, live_only_config
+from screening.sealed_earnings_calendar import (
+    acquire_sealed_earnings_calendar_evidence,
+    default_resolution_policy_by_capability,
+)
+from strategy_runtime.adapters import build_migrated_strategy_registry
 from strategy_runtime.catalog import SignalCatalogEntry
 from strategy_runtime.lifecycle import RecommendedAction
 from strategy_runtime.market_data_planning import (
     build_shared_market_data_access,
     enabled_provider_configs,
+    provider_metadata_for,
 )
 from strategy_runtime.persistence import (
     LatestResultRepository,
@@ -185,6 +193,7 @@ def build_screening_router(
     *,
     capabilities_catalog: tuple[SignalCatalogEntry, ...],
     history_repository: ObservationHistoryRepository,
+    acquisition_attempt_repository: AcquisitionAttemptRepository,
 ) -> APIRouter:
     router = APIRouter(prefix="/api/v1", dependencies=[Depends(authorize)])
 
@@ -333,14 +342,59 @@ def build_screening_router(
             )
         access = build_shared_market_data_access(config, transport_factory, clock, (symbol,))
         subject_access = access[symbol]
+        # SPRINT-014 S14-PR-05: registry is rebuilt per request (never
+        # reused from the module-level one passed into this function,
+        # which registered its own legacy composition binding with no
+        # subject at all, at app startup, before any symbol was known) --
+        # forward_factor/skew_momentum's own legacy binding closure needs
+        # this exact request's subject_access.fulfillment to close over,
+        # mirroring asa/scheduled_screening.py's own identical ordering.
+        request_registry = build_migrated_strategy_registry(
+            legacy_fulfillment_by_subject={symbol: subject_access.fulfillment}
+        )
+        sealed_evidence_by_subject = None
+        if signal == "earnings_calendar":
+            try:
+                provider_metadata = provider_metadata_for(config, transport_factory, clock)
+                plan = SubjectAcquisitionPlan(
+                    symbol,
+                    subject_access.fulfillment,
+                    attempt_repository=acquisition_attempt_repository,
+                    plan_id=f"on-demand-refresh:{signal}:{symbol}:{clock.now().isoformat()}",
+                    clock=clock,
+                )
+                sealed_evidence = acquire_sealed_earnings_calendar_evidence(
+                    symbol,
+                    plan,
+                    clock,
+                    provider_metadata=provider_metadata,
+                    resolution_policy_by_capability=default_resolution_policy_by_capability(
+                        provider_metadata
+                    ),
+                )
+                sealed_evidence_by_subject = {symbol: sealed_evidence}
+            except Exception:
+                # Same isolation as the scheduled path: a failure here
+                # falls through to earnings_calendar_adapter's own
+                # existing "requires sealed subject-first evidence"
+                # handling, which strategy_runtime's generic per-adapter
+                # exception boundary already converts into a graceful
+                # ADAPTER_EXCEPTION result, not a 500.
+                _LOGGER.warning(
+                    "sealed earnings calendar evidence acquisition failed for "
+                    "on-demand refresh",
+                    extra={"signal_id": signal, "symbol": symbol},
+                    exc_info=True,
+                )
         try:
             result = refresh(
-                registry,
+                request_registry,
                 repository,
                 clock,
                 strategy_id=signal,
                 symbol=symbol,
                 fulfillment_by_subject={symbol: subject_access.fulfillment},
+                sealed_evidence_by_subject=sealed_evidence_by_subject,
             )
         except RuntimeError:
             if prior is None:
@@ -355,7 +409,7 @@ def build_screening_router(
         if result.opportunity_id is not None:
             try:
                 record_opportunity_observation(
-                    registry,
+                    request_registry,
                     history_repository,
                     result,
                     recommended_action=RecommendedAction.NO_ACTION,

--- a/asa/bootstrap.py
+++ b/asa/bootstrap.py
@@ -136,6 +136,7 @@ def build_application(
             screening_registry,
             agent_authorize,
             selected.market_data_transport_factory or build_transport_for_provider,
+            acquisition_attempt_repository=acquisition_attempt_repository,
             capabilities_catalog=build_migrated_signal_catalog(),
             history_repository=observation_history_repository,
         )

--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -55,6 +55,7 @@ from market_data.attempts import AcquisitionAttemptRepository, attempt_records_f
 from market_data.live_transport import build_live_transport
 from market_data.session_calendar import UsEquitySessionCalendar
 from market_data.session_schedule import SessionRefreshSchedule
+from market_data.subject_plan import SubjectAcquisitionPlan
 from screening import APPROVED_LIVE_UNIVERSE, EARNINGS_CALENDAR_UNIVERSE
 from screening.cycle_identity import (
     manual_invocation_slot_id,
@@ -66,6 +67,10 @@ from screening.cycle_identity import (
 )
 from screening.live_acquisition import live_only_config
 from screening.live_adapters import capture_skew_snapshot
+from screening.sealed_earnings_calendar import (
+    acquire_sealed_earnings_calendar_evidence,
+    default_resolution_policy_by_capability,
+)
 from strategy_runtime.adapters import build_migrated_strategy_registry
 from strategy_runtime.historical_evidence import (
     ConflictingHistoricalObservationError,
@@ -78,6 +83,7 @@ from strategy_runtime.market_data_planning import (
     build_provider_rolling_window_tracker,
     build_shared_market_data_access,
     enabled_provider_configs,
+    provider_metadata_for,
 )
 from strategy_runtime.persistence import LatestResultRepository, ObservationHistoryRepository
 from strategy_runtime.service import record_opportunity_observation, refresh
@@ -204,9 +210,20 @@ def run_scheduled_refresh(
     claim_repository: RefreshScheduleClaimRepository | None = None,
     enforce_schedule: bool = False,
     now: datetime | None = None,
+    earnings_calendar_cutover_enabled: bool = True,
 ) -> tuple[PairOutcome, ...]:
     """Run one bounded refresh per pair in ``universe``, in order,
     persisting every result. One pair's failure never stops the others.
+
+    ``earnings_calendar_cutover_enabled`` (SPRINT-014 S14-PR-05's required
+    rollback switch): set False to restore the pre-cutover imperative
+    Earnings Calendar acquisition path (strategy_runtime.adapters.
+    legacy_earnings_calendar_adapter, itself unchanged reuse of screening.
+    live_adapters.build_live_earnings_calendar_adapter) without deleting
+    anything -- this cycle's own sealed-evidence acquisition is simply
+    skipped, never run, so no new evidence this switch might discard is
+    ever produced in the first place. Every other pair (forward_factor,
+    skew_momentum) is entirely unaffected either way.
 
     One CapabilityFulfillmentService (and its own request budget) is built
     per unique *subject* for the whole cycle (SPRINT-013 S13-03B) -- not
@@ -268,7 +285,6 @@ def run_scheduled_refresh(
         or PostgresHistoricalSkewRepository(create_postgres_engine(Settings().database_url))
     )
     session_calendar = UsEquitySessionCalendar()
-    registry = build_migrated_strategy_registry()
     config = live_only_config(load_market_data_config_from_environment())
     if not enabled_provider_configs(config):
         raise RuntimeError(
@@ -316,6 +332,29 @@ def run_scheduled_refresh(
     access = build_shared_market_data_access(
         config, transport_factory, clock, unique_symbols, rolling_window=rolling_window
     )
+    # SPRINT-014 S14-PR-05: access is built before registry (previously the
+    # reverse) because forward_factor/skew_momentum's own legacy
+    # composition binding (strategy_runtime/adapters/__init__.py's
+    # build_migrated_strategy_registry(legacy_fulfillment_by_subject=...))
+    # is constructed at registry-build time now, not threaded through
+    # RuntimeContext per call (I-09) -- it needs every subject's already-
+    # built SubjectMarketDataAccess.fulfillment to close over.
+    registry = build_migrated_strategy_registry(
+        legacy_fulfillment_by_subject={
+            symbol: subject_access.fulfillment for symbol, subject_access in access.items()
+        },
+        earnings_calendar_cutover_enabled=earnings_calendar_cutover_enabled,
+    )
+    # Provider metadata is independent of subject -- built once per cycle
+    # from the same enabled config and transport_factory access itself
+    # uses, so seal_subject_snapshot()'s own "bounded metadata for every
+    # included provider" invariant (market_data/snapshot.py) is always
+    # satisfied for whichever providers actually served this cycle's
+    # earnings_calendar pairs.
+    provider_metadata = provider_metadata_for(config, transport_factory, clock)
+    earnings_calendar_resolution_policy = default_resolution_policy_by_capability(
+        provider_metadata
+    )
     reuse_counts = {
         "provider_calls": 0,
         "reuse_hits": 0,
@@ -339,6 +378,68 @@ def run_scheduled_refresh(
             # a shared symbol's request_count across the pairs that share it.
             call_log_start = len(subject_access.fulfillment.call_log)
             budget_accounting_start = len(subject_access.budget_manager.accounting)
+            sealed_evidence_by_subject = None
+            if signal_id == "earnings_calendar" and earnings_calendar_cutover_enabled:
+                # SPRINT-014 S14-PR-05: the one subject-first path in this
+                # cycle. plan_id reuses this pair's own pair_id -- a plan
+                # is scoped one-per-(subject, cycle) here, and earnings_
+                # calendar has exactly one signal per symbol in this
+                # universe, so pair_id already uniquely identifies it.
+                # Known, accepted limitation inherited from S14-PR-03's own
+                # design: SubjectAcquisitionPlan stamps *both*
+                # screening_cycle_id and pair_evaluation_id on its own
+                # internally persisted attempt records with this single
+                # plan_id, not the cycle's real screening_cycle_id --
+                # still uniquely traceable (pair_id embeds screening_cycle_id
+                # as its own prefix) but not byte-identical to how every
+                # other pair in this cycle records the same field.
+                # Acquisition happens here, in the composition root, not
+                # inside strategy_runtime.service.refresh()'s own
+                # per-strategy call -- so a failure here is NOT
+                # automatically caught by screening/runner.py's generic
+                # per-adapter exception boundary the way every other
+                # strategy's own acquisition-inside-the-adapter failures
+                # are. Isolated explicitly here instead: on failure,
+                # sealed_evidence_by_subject stays None and refresh()
+                # still runs -- earnings_calendar_adapter's own existing
+                # "requires sealed subject-first evidence" RuntimeError
+                # then reaches runner.py's boundary exactly as it would
+                # for any other adapter exception, so a misconfiguration
+                # (e.g. a required provider not enabled) reports
+                # PairOutcome.error=None with an adapter_exception outcome,
+                # identical to the pre-cutover live path's own behavior for
+                # the same failure -- never a cycle-level infrastructure
+                # failure for what is, from every other pair's perspective,
+                # an ordinary strategy-evaluation failure.
+                try:
+                    plan = SubjectAcquisitionPlan(
+                        symbol,
+                        subject_access.fulfillment,
+                        attempt_repository=resolved_acquisition_attempt_repository,
+                        plan_id=pair_id,
+                        clock=clock,
+                    )
+                    sealed_evidence = acquire_sealed_earnings_calendar_evidence(
+                        symbol,
+                        plan,
+                        clock,
+                        provider_metadata=provider_metadata,
+                        resolution_policy_by_capability=earnings_calendar_resolution_policy,
+                    )
+                    sealed_evidence_by_subject = {symbol: sealed_evidence}
+                except Exception:
+                    _LOGGER.warning(
+                        "sealed earnings calendar evidence acquisition failed -- "
+                        "falling through to earnings_calendar_adapter's own "
+                        "missing-evidence handling",
+                        extra={
+                            "signal_id": signal_id,
+                            "symbol": symbol,
+                            "screening_cycle_id": screening_cycle_id,
+                            "pair_evaluation_id": pair_id,
+                        },
+                        exc_info=True,
+                    )
             result = refresh(
                 registry,
                 resolved_repository,
@@ -346,6 +447,7 @@ def run_scheduled_refresh(
                 strategy_id=signal_id,
                 symbol=symbol,
                 fulfillment_by_subject={symbol: subject_access.fulfillment},
+                sealed_evidence_by_subject=sealed_evidence_by_subject,
                 historical_skew_repository=resolved_historical_skew_repository,
             )
             pair_calls = subject_access.fulfillment.call_log[call_log_start:]
@@ -436,6 +538,21 @@ def run_scheduled_refresh(
                         reuse_counts["incomplete_cache_bypasses"] += 1
                     elif decision is ReuseDecision.FRESH_AFTER_OTHER_BYPASS:
                         reuse_counts["requests_not_eligible_for_reuse"] += 1
+                    if signal_id == "earnings_calendar" and earnings_calendar_cutover_enabled:
+                        # Already durably persisted -- SubjectAcquisitionPlan
+                        # records every attempt itself, inside
+                        # acquire_sealed_earnings_calendar_evidence() above,
+                        # before this pair ever reaches refresh(). Recording
+                        # it again here under this cycle's own
+                        # (screening_cycle_id, pair_id) keying would
+                        # duplicate the same attempt under two different
+                        # scoping identities, not add new evidence. When the
+                        # rollback switch is active, earnings_calendar runs
+                        # the legacy path instead and has made no plan-level
+                        # attempt records at all -- this pair's own calls
+                        # must be recorded normally, exactly like every
+                        # other (non-earnings_calendar) pair below.
+                        continue
                     records = attempt_records_for(
                         fulfillment_result,
                         screening_cycle_id=screening_cycle_id,

--- a/project/reports/SPRINT-014-S14-PR-05-shadow-cutover.md
+++ b/project/reports/SPRINT-014-S14-PR-05-shadow-cutover.md
@@ -1,0 +1,247 @@
+# SPRINT-014 S14-PR-05: Shadow and Cut Over Earnings Calendar
+
+Self-review packet for the Architect's own required CUTOVER_PASS review. This PR is
+**not** auto-merged even on an ordinary architecture PASS, per the Architect's explicit
+"PROCEED with S14-PR-05" directive — it is opened and left for the Founder's own
+personal review of this packet and the final live composition.
+
+## 1. What changed
+
+Earnings Calendar is cut over from imperative, strategy-driven acquisition
+(`screening.live_adapters.build_live_earnings_calendar_adapter`, still present,
+untouched) to the subject-first evidence path built by S14-PR-02/03/04:
+`SubjectAcquisitionPlan` → `seal_subject_snapshot` → `project_canonical_fact` /
+`materialize_derived_fact` → `SubjectSealedEvidence` → `RuntimeContext.sealed_evidence`.
+
+New:
+- `screening/earnings_calendar_fact_ids.py` — the 7 derived/canonical fact-ID
+  constants, standalone so the adapter never imports the acquisition orchestrator.
+- `screening/sealed_earnings_calendar.py` — the acquisition orchestrator
+  (`acquire_sealed_earnings_calendar_evidence`), living in `screening/` per ADR-010
+  ("screening owns acquisition planning and orchestration"), called only by the
+  composition root, never by the adapter.
+- `strategy_runtime/evidence.py` — `SubjectSealedEvidence`, the one read-only bundle
+  `RuntimeContext` may now carry instead of a live fulfillment object (I-09).
+
+Rewritten:
+- `strategy_runtime/context.py` — `RuntimeContext.fulfillment` removed; replaced with
+  `sealed_evidence: SubjectSealedEvidence | None`.
+- `strategy_runtime/execution.py`, `strategy_runtime/service.py` — threaded
+  `sealed_evidence_by_subject` instead of `fulfillment_by_subject` into
+  `RuntimeContext`; `refresh()` kept `fulfillment_by_subject` as a required parameter,
+  used only for temporal-metadata bookkeeping (unchanged logic).
+- `strategy_runtime/adapters/earnings_calendar.py` — acquisition-free
+  `earnings_calendar_adapter(context)`; reads only `context.sealed_evidence`.
+- `strategy_runtime/adapters/forward_factor.py`, `.../skew_momentum_vertical.py` —
+  two-arg (`context`, `fulfillment`), unchanged financial logic, now composed via a
+  legacy binding at registry-construction time instead of through `RuntimeContext`.
+- `strategy_runtime/adapters/__init__.py` — `build_migrated_strategy_registry()`'s
+  legacy composition binding for FF/SM, plus the new `earnings_calendar_cutover_enabled`
+  rollback switch (§5).
+
+## 2. Bugs found and fixed, in discovery order (all via running tests, none by
+   reasoning alone)
+
+1. `KeyError: 'deterministic_fixture'` — test config needed `live_only_config(...)`.
+2. `TypeError: 'OptionChain' object is not iterable` — extracted
+   `normalize_expiration_response()` as a shared pure function
+   (`screening/live_context.py`) so the plan-backed expiration resolution reuses the
+   same response-shape normalization `acquire_expirations()` already had.
+3. Missing `cast` import surfaced by the above refactor (`screening/live_context.py`).
+4. A redundant `cast(...)` removed once the plan-backed function returned a properly
+   typed value directly.
+5. `IndexError: pop from empty list` from Finnhub's transport — Finnhub declares
+   `REAL_TIME_QUOTE_V1`/`HISTORICAL_BARS_V1`/`EARNINGS_CALENDAR_V1` and is tried before
+   Tradier alphabetically (`strategy_runtime/market_data_planning.py`'s own priority
+   policy); fixed by giving tests an endpoint-routed transport double instead of a
+   finite scripted queue.
+6. `MarketObservation.observation_id is not content-derived` — combining front+back
+   option-chain observations into one sealed result must recompute the observation id
+   from the combined value before `dataclasses.replace()`.
+7. `Observation resolution requires one value per provider` — `HISTORICAL_BARS_V1` is
+   a genuine time series (30 daily bars), structurally incompatible with
+   `ObservationResolver.resolve()`'s one-observation-per-provider design (correct,
+   unmodified PR-04 code). Fixed by never sealing `HISTORICAL_BARS_V1` into the
+   snapshot at all — the raw closes remain durably recorded via the plan's own attempt
+   persistence regardless, and the meaningful derived value (`realized_vol`) is still
+   captured as a proper `DerivedFact`.
+8. `Snapshot lacks bounded metadata for an included provider` — `seal_subject_snapshot`
+   requires real `ProviderMetadata` for every provider whose observations appear.
+   Fixed by adding `strategy_runtime.market_data_planning.provider_metadata_for()`, a
+   small public helper reused by both the shadow-parity test and the real composition
+   root — never a test-only construction.
+9. `CanonicalFact.value is not an immutable normalized value (date)` — canonical facts
+   require a tz-aware `datetime`, not a bare `date` (unlike `DerivedFact.value`, whose
+   type explicitly allows `date`). Fixed by normalizing the earnings date to midnight
+   UTC before projection.
+10. `ExpirationCycle requires a monthly or weekly classification` — reconstructing an
+    `ExpirationCycle` from sealed derived facts had defaulted `monthly=False,
+    weekly=False`, which is unread by every strategy component but still fails the
+    domain's own construction invariant. Fixed by reusing
+    `screening.live_context._is_monthly_expiration`, the exact same classification
+    every other `ExpirationCycle` in this codebase is built from.
+11. Test-only: `ScreeningResult.strategy_native_score` / `UniversalScreeningResult
+    .metrics["strategy_native_score"]` — the shadow-parity test's score comparison used
+    a nonexistent `.score` attribute on both sides; fixed to the real field/encoding.
+12. **Composition-root regression, found only after wiring `asa/scheduled_screening.py`**:
+    `acquire_sealed_earnings_calendar_evidence` was called directly in the composition
+    root's own per-pair loop, outside `screening/runner.py`'s generic per-adapter
+    exception boundary every other strategy's own acquisition failures are absorbed by.
+    A capability with zero enabled providers (`DomainInvariantError: No priority policy
+    for earnings_calendar_v1`) then surfaced as a hard `PairOutcome.error` (an
+    infrastructure failure) instead of a graceful, non-crashing outcome — a real,
+    demonstrated behavioral difference from the pre-cutover path, not a hypothetical
+    one. Fixed by isolating the acquisition call in its own try/except: on failure,
+    `sealed_evidence_by_subject` stays unset and `refresh()` still runs;
+    `earnings_calendar_adapter`'s own existing "requires sealed subject-first evidence"
+    guard then reaches `strategy_runtime/execution.py`'s generic per-adapter boundary
+    exactly as any other adapter exception would, restoring parity.
+13. **Second composition root, found only by running the full suite**:
+    `asa/api/screening_routes.py`'s on-demand refresh endpoint
+    (`POST /api/v1/screening/{signal}/{symbol}/refresh`) builds its `StrategyRegistry`
+    once at app startup, before any request's subject is known — its legacy
+    composition binding for forward_factor/skew_momentum therefore closed over an
+    *empty* `legacy_fulfillment_by_subject`, unconditionally raising "requires shared
+    market data access" for every on-demand refresh of either strategy. Not a
+    hypothetical: `tests/asa/test_ai_agent_workflow.py`,
+    `tests/asa/test_bootstrap_first_run.py`, and
+    `tests/asa/test_screening_refresh_route.py` all failed against skew_momentum
+    through this exact endpoint. See §4.
+
+## 3. Legacy composition binding (Forward Factor / Skew Momentum)
+
+Unchanged from the design already reviewed and accepted for this ticket:
+`build_migrated_strategy_registry(legacy_fulfillment_by_subject=...)` builds two
+wrapper closures matching `StrategyRegistry`'s single-argument adapter type, calling
+the real two-argument `forward_factor_adapter`/`skew_momentum_adapter` with
+`legacy_fulfillment_by_subject.get(context.subject)`. No strategy conditionals were
+added to `strategy_runtime/execution.py`; no parallel top-level subsystem was created.
+Owner and deletion condition documented in `strategy_runtime/adapters/__init__.py`'s
+own module docstring, unchanged: delete when each strategy is itself migrated.
+
+## 4. Read-set expansion, and why (Architect directive #4)
+
+Beyond `asa/scheduled_screening.py`, this PR also touches `asa/api/screening_routes.py`
+and `asa/bootstrap.py` — **not** originally named in the Architect's own scope
+enumeration, but a necessary consequence of the same constraint (I-09: RuntimeContext
+must be fulfillment-free) applying to *every* composition root, not only the scheduled
+one:
+
+- `asa/api/screening_routes.py`'s `refresh_screening_result` now rebuilds the
+  `StrategyRegistry` **per request**, after `access` (the request's own
+  `SubjectMarketDataAccess`) is built, with the correct
+  `legacy_fulfillment_by_subject={symbol: subject_access.fulfillment}` — mirroring
+  `asa/scheduled_screening.py`'s own ordering, for the same reason (the legacy binding
+  closure needs the request's real subject, unknowable at app-startup time). Without
+  this, forward_factor/skew_momentum's own on-demand refresh was completely broken
+  (§2.13), not a degraded edge case.
+- The same endpoint also gained Earnings Calendar sealed-evidence support (a
+  `SubjectAcquisitionPlan` + `acquire_sealed_earnings_calendar_evidence` call scoped to
+  one ad-hoc request, `plan_id` built from `on-demand-refresh:{signal}:{symbol}:
+  {clock.now().isoformat()}` for per-invocation uniqueness), with the same acquisition-
+  failure isolation as the scheduled path (§2.12) — otherwise `POST
+  .../earnings_calendar/{symbol}/refresh` would unconditionally raise, since
+  `sealed_evidence_by_subject` was never threaded through at all.
+- `build_screening_router()` gained a new required `acquisition_attempt_repository`
+  parameter (the same repository instance `asa/bootstrap.py` already builds for
+  `build_operations_router`) so the on-demand plan has somewhere to durably persist its
+  own attempts, matching S14-PR-03's own "every attempt durable" requirement (I-04)
+  rather than silently skipping persistence for this one call path.
+
+This expansion was not discovered by reading the ticket text — it was discovered by
+running the full test suite (`pytest`, not just the touched-file subset) after the
+scheduled-path wiring was already green, which is why it is called out explicitly here
+rather than folded silently into §1.
+
+## 5. Rollback switch (Architect directive #5)
+
+`asa.scheduled_screening.run_scheduled_refresh(earnings_calendar_cutover_enabled: bool
+= True)`:
+- `True` (default): unchanged, as built by this PR.
+- `False`: `build_migrated_strategy_registry(earnings_calendar_cutover_enabled=False)`
+  registers `strategy_runtime.adapters.legacy_earnings_calendar_adapter` for Earnings
+  Calendar instead — a straight two-argument reuse of
+  `screening.live_adapters.build_live_earnings_calendar_adapter` (untouched by this
+  PR), composed via the exact same legacy-binding closure pattern FF/SM already use.
+  The composition root's own sealed-evidence acquisition block is skipped entirely
+  (never runs, never persists anything) when the switch is off, so disabling it can
+  never discard or shadow any evidence a caller separately, deliberately acquired.
+
+Deletion condition (documented in `strategy_runtime/adapters/earnings_calendar.py`'s
+own docstring): delete `legacy_earnings_calendar_adapter` together with
+`screening.live_adapters.build_live_earnings_calendar_adapter` in S14-PR-07 — not
+before.
+
+**Tested**, not merely built:
+- `tests/strategy_runtime/adapters/test_registry.py::TestEarningsCalendarCutoverSwitch`
+  — three unit tests proving the switch selects the intended adapter deterministically
+  (each path's own distinct missing-dependency error message is the observable signal),
+  independent of any live-fixture success/failure.
+- `tests/asa/test_scheduled_screening.py::
+  test_earnings_calendar_cutover_disabled_restores_the_legacy_attempt_scoping` —
+  end-to-end through `run_scheduled_refresh`, proving the disabled switch produces at
+  least one real, durably persisted attempt scoped under the cycle's own real
+  `screening_cycle_id` (the plan-scoped identity, which stamps its own `plan_id` onto
+  both `screening_cycle_id` and `pair_evaluation_id`, never appears).
+
+## 6. Known, accepted limitation (not fixed in this PR)
+
+`SubjectAcquisitionPlan.plan_id` (S14-PR-03's own, already-merged design) stamps a
+single string onto *both* `screening_cycle_id` and `pair_evaluation_id` for its
+internally persisted attempt records. Earnings Calendar's own plan is built with
+`plan_id = pair_id` (this pair's own `screening_cycle_id:earnings_calendar:symbol`
+composite) — traceable back to the real cycle (the real `screening_cycle_id` is its own
+prefix), but not byte-identical to how every other pair in the same cycle records that
+field. Inherited from S14-PR-03, not introduced or altered here; not touched, since
+`market_data/subject_plan.py` is already-merged, already-tested code outside this
+ticket's own scope.
+
+## 7. CUTOVER_PASS checklist (Architect directive #5, item by item)
+
+- **Exact output parity, or a specifically identified and versioned intentional
+  difference.** Shadow-parity test
+  (`tests/strategy_runtime/adapters/test_earnings_calendar.py::
+  test_full_sealed_acquisition_matches_the_pre_cutover_live_path`) confirms the old and
+  new paths reach the same PASS/NO_SIGNAL classification and the same numeric
+  `strategy_native_score` for identical scripted evidence — verified genuinely
+  reaching a real PASS with a real score (62.5), not a degenerate both-fail case
+  (confirmed by direct reproduction, not test-output assumption alone). One
+  intentional, documented difference: §2.12/§4 — a capability with literally zero
+  enabled providers, and only through the new path, would (absent the fix already
+  applied) surface as an infrastructure failure rather than a graceful outcome; this is
+  now fixed to match the old path's own behavior exactly, not left as an open
+  difference.
+- **Zero provider calls originating from the Earnings strategy or its adapter.**
+  `strategy_runtime/adapters/earnings_calendar.py` imports no provider, transport, or
+  fulfillment type at all (only `market_data.CapabilityFulfillmentService` as a type
+  hint for the *legacy* rollback function); its own architecture boundary is enforced
+  by `tests/architecture/test_screening_boundaries.py`'s new
+  `test_strategy_runtime_dependency_is_not_circular` plus the existing permitted-roots
+  sweep.
+- **One subject plan and one shared exhausted-failure/UNKNOWN outcome.**
+  `SubjectAcquisitionPlan` (S14-PR-03, unmodified) is built once per subject per cycle
+  and reused for every capability request the orchestrator makes.
+- **Every Earnings evaluation references its sealed snapshot digest and derived-fact
+  identities.** Asserted directly in the shadow-parity test
+  (`sealed_evidence.snapshot.snapshot_digest` truthy); every derived fact's own ID is
+  built via `derived_fact_id(feature_id, subject, snapshot.snapshot_digest)`.
+- **A tested rollback switch that restores only the old Earnings path without deleting
+  new evidence.** §5.
+- **Full suite, production-equivalent cycle, and shadow evidence all green.** Full
+  suite: 2895 passed, 45 skipped, 0 failed (`pytest`, excludes nothing but genuinely
+  environment-gapped Postgres-integration tests already marked `@pytest.mark.postgres`,
+  unrelated to this PR). `ruff check` and `mypy` (strict, `asa` package) both clean
+  across every file this PR touches.
+- **No residual Earnings acquisition path remains reachable after the switch.** Not yet
+  applicable — S14-PR-07 (delete superseded path) is the ticket that removes the old
+  path entirely; this PR's own rollback switch is why it must stay reachable until
+  then.
+
+## 8. Test-count reconciliation
+
+Prior audit note (2872 vs 2879) was already reconciled and confirmed correct at 2872
+before this PR began. This PR adds 1 new test file (`screening/sealed_earnings_calendar.py`
+has no direct test file of its own — exercised through
+`tests/strategy_runtime/adapters/test_earnings_calendar.py`) and extends 6 existing
+ones; current full-suite total is 2895 passed (2321 outside `tests/pos`, 574 inside),
+45 skipped, 0 failed, reproduced twice.

--- a/screening/earnings_calendar_fact_ids.py
+++ b/screening/earnings_calendar_fact_ids.py
@@ -1,0 +1,22 @@
+"""Earnings Calendar sealed-evidence derived-fact identifiers (SPRINT-014
+S14-PR-05).
+
+Deliberately a standalone, side-effect-free module with no other imports:
+screening.sealed_earnings_calendar (the acquisition orchestrator, writer)
+and strategy_runtime.adapters.earnings_calendar (the acquisition-free
+adapter, reader) both import these names, and the adapter must never pull
+in acquisition-shaped code even transitively (SubjectAcquisitionPlan,
+CapabilityFulfillmentResult, provider/transport types) merely to agree on
+a fact's name -- confirmed by tests/architecture that this module imports
+nothing beyond the standard library.
+"""
+
+from __future__ import annotations
+
+TERM_STRUCTURE_RICHNESS_FACT = "earnings_calendar_term_structure_richness"
+IV_REALIZED_RICHNESS_FACT = "earnings_calendar_iv_realized_volatility_richness"
+FRONT_EXPIRATION_DATE_FACT = "earnings_calendar_front_expiration_date"
+FRONT_DAYS_TO_EXPIRATION_FACT = "earnings_calendar_front_days_to_expiration"
+BACK_EXPIRATION_DATE_FACT = "earnings_calendar_back_expiration_date"
+BACK_DAYS_TO_EXPIRATION_FACT = "earnings_calendar_back_days_to_expiration"
+TARGET_STRIKE_FACT = "earnings_calendar_target_strike"

--- a/screening/live_context.py
+++ b/screening/live_context.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from typing import cast
 
 from analytics.atm_selection import select_atm_strike
 from domain import (
@@ -290,6 +291,29 @@ def build_capability_subject(
     )
 
 
+def normalize_expiration_response(
+    values: tuple[object, ...], as_of: date
+) -> tuple[ExpirationCycle, ...] | None:
+    """The response-shape normalization acquire_expirations() itself
+    applies once its own capability request has already been resolved
+    (SPRINT-014 S14-PR-05 factors this pure step out so a plan-backed
+    resolver can reuse it without duplicating the two accepted response
+    shapes -- Tradier's own per-expiration observations, or a single
+    OptionChain a fixture/other provider might return instead). Returns
+    None for an unrecognized shape or a result that normalizes to zero
+    expirations -- never raises, so a caller can treat it as UNKNOWN.
+    """
+    if all(isinstance(value, ExpirationCycle) for value in values):
+        cycles: tuple[ExpirationCycle, ...] = cast(tuple[ExpirationCycle, ...], values)
+    elif len(values) == 1 and isinstance(values[0], OptionChain):
+        cycles = expirations_from_chain(values[0], as_of)
+    else:
+        return None
+    unique_by_date = {cycle.expiration_date: cycle for cycle in cycles}
+    ordered = tuple(unique_by_date[expiration] for expiration in sorted(unique_by_date))
+    return ordered or None
+
+
 def acquire_expirations(
     fulfillment: CapabilityFulfillmentService,
     symbol: str,
@@ -345,23 +369,12 @@ def acquire_expirations(
             f"a valid request for live option expirations for {symbol} "
             "could not be completed or normalized",
         )
-    as_of = now.date()
     values = tuple(observation.value for observation in result.observations)
-    if all(isinstance(value, ExpirationCycle) for value in values):
-        cycles: tuple[ExpirationCycle, ...] = values  # type: ignore[assignment]
-    elif len(values) == 1 and isinstance(values[0], OptionChain):
-        cycles = expirations_from_chain(values[0], as_of)
-    else:
+    ordered = normalize_expiration_response(values, now.date())
+    if ordered is None:
         raise StrategyAdapterError(
             ScreeningOutcomeStatus.MISSING_DATA,
             f"live option expiration response for {symbol} was neither a clean "
-            "expiration list nor a single option chain",
-        )
-    unique_by_date = {cycle.expiration_date: cycle for cycle in cycles}
-    ordered = tuple(unique_by_date[expiration] for expiration in sorted(unique_by_date))
-    if not ordered:
-        raise StrategyAdapterError(
-            ScreeningOutcomeStatus.MISSING_DATA,
-            f"live provider returned zero option expirations for {symbol}",
+            "expiration list nor a single option chain, or normalized to zero expirations",
         )
     return ordered

--- a/screening/sealed_earnings_calendar.py
+++ b/screening/sealed_earnings_calendar.py
@@ -1,0 +1,670 @@
+"""Subject-first, acquisition-sealing evidence builder for Earnings
+Calendar (SPRINT-014 S14-PR-05).
+
+Replaces screening.live_adapters.build_live_earnings_calendar_adapter's
+own *acquisition* sequence with the same steps routed through a
+market_data.subject_plan.SubjectAcquisitionPlan instead of calling
+CapabilityFulfillmentService.fulfill() directly -- every attempt (success
+and failure) is durably recorded and shared (S14-PR-01's own root-cause
+fix), and no capability is fetched more than once even if selection logic
+needs to look at it twice. The selection logic itself (which two
+expirations to trade) is the exact same pure function
+(analytics.expiration_selection.select_earnings_relative_expiration_pair)
+this ticket's own two-phase pattern requires: it runs after bootstrap
+evidence (quote, earnings event, available expirations) is resolved and
+before the full union (both expirations' chains, daily closes) is
+requested -- no provider access of its own.
+
+This module is acquisition orchestration -- it belongs in screening/
+(ADR-010: "screening owns acquisition planning and orchestration"),
+called only by the composition root (asa/scheduled_screening.py), never
+by strategy_runtime.adapters.earnings_calendar's own adapter function.
+The adapter reads only the sealed SubjectSealedEvidence bundle this
+module returns; it never imports this module, SubjectAcquisitionPlan, or
+any provider-shaped type (verified by tests/architecture).
+
+Financial logic is unchanged and reused verbatim: normalize_richness,
+compute_iv_realized_spread, compute_realized_volatility,
+select_atm_strike_at_expiration, combine_option_chains, and the manifest/
+graph compilation live in screening.live_adapters/context_builders exactly
+as they did before this ticket -- only how the underlying observations
+are acquired changed.
+
+Only two of the three requested capabilities (EARNINGS_CALENDAR_V1,
+REAL_TIME_QUOTE_V1, OPTION_CHAIN_V1) are unconditionally attempted every
+cycle; HISTORICAL_BARS_V1 (daily closes) is only requested once front/back
+selection and the combined chain both succeed (the two-phase union), so it
+is never listed as a MarketSnapshot-level "required" capability -- doing
+so would make SnapshotRequest's own required-is-a-subset-of-requested
+invariant fail on every cycle where it was never attempted.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, date, datetime, time, timedelta
+from decimal import Decimal
+from typing import cast
+
+from analytics.derived_fact_materialization import derived_fact_id, materialize_derived_fact
+from analytics.derived_facts import (
+    DERIVED_FACT_REGISTRY,
+    REALIZED_VOLATILITY,
+    compute_iv_realized_spread,
+)
+from analytics.expiration_selection import (
+    ExpirationCandidate,
+    select_earnings_relative_expiration_pair,
+)
+from analytics.features import DerivedFact, DerivedFactQualityStatus, DerivedFactSet
+from analytics.realized_volatility import compute_realized_volatility
+from domain import (
+    EarningsEvent,
+    ExpirationCycle,
+    MarketCapability,
+    OHLCVBar,
+    OptionChain,
+    OptionType,
+    Quote,
+)
+from domain.canonical_fact import CanonicalFact
+from domain.market_data import market_observation_identity
+from domain.references import EvidenceKind, EvidenceReference
+from facts.canonical_projection import project_canonical_fact
+from market_data.fulfillment import CapabilityFulfillmentResult, FulfillmentStatus
+from market_data.providers import CapabilityRequest, ProviderMetadata
+from market_data.resolution import ResolutionPolicy
+from market_data.session_calendar import MarketSessionStatus, UsEquitySessionCalendar
+from market_data.subject_plan import SubjectAcquisitionPlan
+from market_data.subject_snapshot import seal_subject_snapshot
+from market_data.temporal import (
+    DEFAULT_FRESHNESS_REQUIREMENT,
+    FreshnessRequirement,
+    UsabilityStatus,
+    evaluate_temporal_usability,
+)
+from screening.earnings_calendar_fact_ids import (
+    BACK_DAYS_TO_EXPIRATION_FACT,
+    BACK_EXPIRATION_DATE_FACT,
+    FRONT_DAYS_TO_EXPIRATION_FACT,
+    FRONT_EXPIRATION_DATE_FACT,
+    IV_REALIZED_RICHNESS_FACT,
+    TARGET_STRIKE_FACT,
+    TERM_STRUCTURE_RICHNESS_FACT,
+)
+from screening.live_adapters import _earnings_date, _spot_price
+from screening.live_context import (
+    build_capability_subject,
+    combine_option_chains,
+    normalize_expiration_response,
+    select_atm_strike_at_expiration,
+)
+from strategies.requirements import earnings_calendar_requirement
+from strategies.scoring import normalize_richness
+from strategies.stonk_manifests import EARNINGS_CALENDAR_MANIFEST
+from strategy_runtime.clock import Clock
+from strategy_runtime.evidence import SubjectSealedEvidence
+
+_ANALYTICS_UNIT_DECIMAL_RATIO = "decimal_ratio"
+_ANALYTICS_UNIT_CALENDAR_DATE = "calendar_date"
+_ANALYTICS_UNIT_DAYS = "days"
+_ANALYTICS_UNIT_USD_STRIKE = "usd_strike"
+_ALWAYS_REQUESTED_CAPABILITIES = (
+    MarketCapability.EARNINGS_CALENDAR_V1,
+    MarketCapability.REAL_TIME_QUOTE_V1,
+    MarketCapability.OPTION_CHAIN_V1,
+)
+
+_RESOLUTION_POLICY_VERSION = "earnings-calendar-sealed-v1"
+# Earnings Calendar's own sealing-time policy: how fresh a resolved
+# observation must be, and which fields count as "complete," per
+# capability -- distinct from FreshnessRequirement above (an
+# acquisition-time usability gate over one provider's raw response, not a
+# per-capability resolution-time gate over the observations a
+# CapabilityFulfillmentService actually returned).
+_REQUIRED_FIELDS_BY_CAPABILITY: dict[MarketCapability, tuple[str, ...]] = {
+    MarketCapability.EARNINGS_CALENDAR_V1: ("earnings_date",),
+    MarketCapability.REAL_TIME_QUOTE_V1: ("last",),
+    MarketCapability.OPTION_CHAIN_V1: ("contracts",),
+}
+_FRESHNESS_THRESHOLD_SECONDS_BY_CAPABILITY: dict[MarketCapability, int] = {
+    MarketCapability.EARNINGS_CALENDAR_V1: 3600 * 24 * 90,
+    MarketCapability.REAL_TIME_QUOTE_V1: 3600,
+    MarketCapability.OPTION_CHAIN_V1: 3600,
+}
+
+
+def default_resolution_policy_by_capability(
+    provider_metadata: tuple[ProviderMetadata, ...],
+) -> dict[MarketCapability, ResolutionPolicy]:
+    """One ResolutionPolicy per capability in _ALWAYS_REQUESTED_CAPABILITIES,
+    with provider_priority derived from exactly the ``provider_metadata``
+    the caller is about to pass into acquire_sealed_earnings_calendar_evidence
+    -- never a separately hand-maintained provider list, so a provider
+    CapabilityFulfillmentService legitimately selected can never be
+    silently rejected here as "not in policy." Alphabetical ordering
+    matches strategy_runtime.market_data_planning's own
+    _build_capability_registry() fulfillment-layer priority exactly, so
+    sealing-time preference never disagrees with which provider actually
+    served the request.
+    """
+    policies: dict[MarketCapability, ResolutionPolicy] = {}
+    for capability in _ALWAYS_REQUESTED_CAPABILITIES:
+        provider_priority = tuple(
+            sorted(
+                item.identity.provider_id
+                for item in provider_metadata
+                if capability in item.capabilities
+            )
+        )
+        if not provider_priority:
+            continue
+        policies[capability] = ResolutionPolicy(
+            _RESOLUTION_POLICY_VERSION,
+            provider_priority,
+            _FRESHNESS_THRESHOLD_SECONDS_BY_CAPABILITY[capability],
+            _REQUIRED_FIELDS_BY_CAPABILITY[capability],
+        )
+    return policies
+
+
+def _resolve_or_none(
+    plan: SubjectAcquisitionPlan,
+    symbol: str,
+    capability: MarketCapability,
+    now: datetime,
+    required_fields: tuple[str, ...],
+    *,
+    expiration: date | None = None,
+    effective_start: datetime | None = None,
+    effective_end: datetime | None = None,
+    freshness_requirement: FreshnessRequirement = DEFAULT_FRESHNESS_REQUIREMENT,
+) -> tuple[CapabilityFulfillmentResult, object | None]:
+    """Plan-backed counterpart of screening.live_adapters._acquire_or_raise:
+    identical subject/request construction and temporal-usability check,
+    but returns (result, value_or_None) instead of raising, so the caller
+    seals whatever evidence exists rather than aborting the whole cycle on
+    the first missing capability.
+    """
+    request_start = effective_start or now
+    request_end = effective_end or now
+    subject = build_capability_subject(
+        symbol,
+        capability,
+        now,
+        effective_start=request_start,
+        effective_end=request_end,
+        required_fields=required_fields,
+        expiration=expiration,
+    )
+    request = CapabilityRequest(
+        capability, (subject,), request_start, request_end, required_fields, 3600
+    )
+    result = plan.resolve(request)
+    if result.status is FulfillmentStatus.FAILED or not result.observations:
+        return result, None
+    observation = result.observations[0]
+    market_is_open = UsEquitySessionCalendar().status_at(now) is MarketSessionStatus.OPEN
+    usability = evaluate_temporal_usability(
+        observation.freshness, freshness_requirement, market_is_open=market_is_open
+    )
+    if usability.status is UsabilityStatus.REJECTED:
+        return result, None
+    return result, observation.value
+
+
+def _resolve_expirations_or_none(
+    plan: SubjectAcquisitionPlan, symbol: str, now: datetime
+) -> tuple[CapabilityFulfillmentResult, tuple[ExpirationCycle, ...] | None]:
+    """Plan-backed counterpart of screening.live_context.acquire_expirations.
+
+    Requires exact FulfillmentStatus.FULFILLED (not DEGRADED) matching
+    acquire_expirations's own stricter check -- a single MarketObservation
+    per expiration, or one combined OptionChain observation, is only
+    trustworthy from a primary-provider response, unlike a plain scalar
+    capability where a fallback-provider DEGRADED result is still usable.
+    Reuses normalize_expiration_response() verbatim -- the same response-
+    shape normalization acquire_expirations() itself applies.
+    """
+    subject = build_capability_subject(
+        symbol, MarketCapability.OPTION_CHAIN_V1, now, required_fields=("expirations",)
+    )
+    request = CapabilityRequest(
+        MarketCapability.OPTION_CHAIN_V1, (subject,), now, now, ("expirations",), 3600
+    )
+    result = plan.resolve(request)
+    if result.status is not FulfillmentStatus.FULFILLED or not result.observations:
+        return result, None
+    values = tuple(observation.value for observation in result.observations)
+    return result, normalize_expiration_response(values, now.date())
+
+
+def _resolve_closes_or_none(
+    plan: SubjectAcquisitionPlan, symbol: str, now: datetime, *, lookback_days: int
+) -> tuple[CapabilityFulfillmentResult, tuple[Decimal, ...] | None]:
+    """Plan-backed counterpart of screening.live_adapters._acquire_daily_closes."""
+    lookback_start = now - timedelta(days=lookback_days)
+    subject = build_capability_subject(
+        symbol,
+        MarketCapability.HISTORICAL_BARS_V1,
+        now,
+        effective_start=lookback_start,
+        effective_end=now,
+        required_fields=("close",),
+    )
+    request = CapabilityRequest(
+        MarketCapability.HISTORICAL_BARS_V1,
+        (subject,),
+        lookback_start,
+        now,
+        ("close",),
+        int(timedelta(days=lookback_days + 1).total_seconds()),
+    )
+    result = plan.resolve(request)
+    if result.status is FulfillmentStatus.FAILED or not result.observations:
+        return result, None
+    ordered = sorted(result.observations, key=lambda item: item.effective_time)
+    closes = tuple(cast(OHLCVBar, item.value).close for item in ordered)
+    if len(closes) < 2:
+        return result, None
+    return result, closes
+
+
+def _combined_chain_result(
+    front_result: CapabilityFulfillmentResult,
+    combined_chain: OptionChain,
+) -> CapabilityFulfillmentResult:
+    """One sealed result representing both expirations' contracts as a
+    single logical OPTION_CHAIN_V1 reading -- the same "one logical
+    market-data snapshot" modeling choice combine_option_chains() itself
+    already documents, applied one level up so MarketSnapshotBuilder's own
+    one-fulfillment-per-capability contract (ASA-ARCH-007, unmodified)
+    never needs to accept two OPTION_CHAIN_V1 results for one snapshot.
+    Reuses the front result's already-validated attempt/observation shell
+    via dataclasses.replace(); capability, subject, effective_time,
+    provenance, freshness, and completeness all remain exactly as the
+    front acquisition already established them -- only the observation's
+    own value becomes the combined chain. observation_id is recomputed
+    (never carried over): MarketObservation's own __post_init__ requires
+    it to be content-derived from every field including value, so reusing
+    the front-only observation's own id here would fail that check the
+    instant value stops matching what produced it.
+    """
+    front_observation = front_result.observations[0]
+    new_observation_id = market_observation_identity(
+        front_observation.provenance.provider_id,
+        front_observation.capability,
+        front_observation.subject,
+        front_observation.effective_time,
+        combined_chain,
+        front_observation.schema_version,
+    )
+    combined_observation = dataclasses.replace(
+        front_observation, value=combined_chain, observation_id=new_observation_id
+    )
+    combined_attempt = dataclasses.replace(
+        front_result.attempts[0], observations=(combined_observation,)
+    )
+    return dataclasses.replace(
+        front_result, attempts=(combined_attempt,) + front_result.attempts[1:]
+    )
+
+
+def acquire_sealed_earnings_calendar_evidence(
+    symbol: str,
+    plan: SubjectAcquisitionPlan,
+    clock: Clock,
+    *,
+    provider_metadata: tuple[ProviderMetadata, ...],
+    freshness_requirement: FreshnessRequirement = DEFAULT_FRESHNESS_REQUIREMENT,
+    resolution_policy_by_capability: dict[MarketCapability, ResolutionPolicy],
+) -> SubjectSealedEvidence:
+    """Two-phase acquisition (bootstrap -> pure selection -> union),
+    sealed into one MarketSnapshot with projected canonical and derived
+    facts. Always returns a bundle -- a missing or insufficient capability
+    is reflected as an absent canonical/derived fact and an unresolved
+    snapshot capability, never an exception. The adapter (strategy_runtime.
+    adapters.earnings_calendar) is the one place that decides what an
+    absent fact means for its own result.
+    """
+    now = clock.now()
+    requirement = earnings_calendar_requirement()
+
+    # -- Phase 1: bootstrap evidence -----------------------------------
+    event_result, event_value = _resolve_or_none(
+        plan,
+        symbol,
+        MarketCapability.EARNINGS_CALENDAR_V1,
+        now,
+        ("earnings_date",),
+        effective_end=now + timedelta(days=requirement.lookahead_days),
+    )
+    quote_result, quote_value = _resolve_or_none(
+        plan,
+        symbol,
+        MarketCapability.REAL_TIME_QUOTE_V1,
+        now,
+        ("last",),
+        freshness_requirement=freshness_requirement,
+    )
+    expirations_result, expirations_value = _resolve_expirations_or_none(plan, symbol, now)
+
+    spot_price: Decimal | None = None
+    if quote_value is not None:
+        try:
+            spot_price = _spot_price(cast(Quote, quote_value))
+        except Exception:  # noqa: BLE001 -- no usable price means UNKNOWN, not a crash
+            spot_price = None
+
+    # -- Strategy-owned selection: pure, no provider access -------------
+    chain_result = expirations_result
+    closes_result: CapabilityFulfillmentResult | None = None
+    term_richness: Decimal | None = None
+    iv_rv_richness: Decimal | None = None
+    realized_vol: Decimal | None = None
+    selected_front_cycle: ExpirationCycle | None = None
+    selected_back_cycle: ExpirationCycle | None = None
+    selected_target_strike: Decimal | None = None
+
+    if event_value is not None and expirations_value is not None and spot_price is not None:
+        available_expirations = expirations_value
+        candidates = tuple(
+            ExpirationCandidate(cycle.expiration_date, cycle.days_to_expiration)
+            for cycle in available_expirations
+        )
+        earnings_date = _earnings_date(cast(EarningsEvent, event_value))
+        selected = select_earnings_relative_expiration_pair(
+            candidates,
+            earnings_date,
+            front_min_dte=requirement.expiration_policy.front_min_dte,
+            front_max_dte=requirement.expiration_policy.front_max_dte,
+            back_min_dte=requirement.expiration_policy.back_min_dte,
+            back_max_dte=requirement.expiration_policy.back_max_dte,
+            target_gap_days=requirement.expiration_policy.target_gap_days,
+            gap_tolerance_days=requirement.expiration_policy.gap_tolerance_days,
+        )
+        if selected is not None:
+            front_candidate, back_candidate = selected
+            front_cycle = next(
+                cycle
+                for cycle in available_expirations
+                if cycle.expiration_date == front_candidate.expiration_date
+            )
+            back_cycle = next(
+                cycle
+                for cycle in available_expirations
+                if cycle.expiration_date == back_candidate.expiration_date
+            )
+
+            # -- Phase 2: union of the remaining demand ------------------
+            front_result, front_chain_value = _resolve_or_none(
+                plan,
+                symbol,
+                MarketCapability.OPTION_CHAIN_V1,
+                now,
+                ("contracts",),
+                expiration=front_cycle.expiration_date,
+            )
+            back_result, back_chain_value = _resolve_or_none(
+                plan,
+                symbol,
+                MarketCapability.OPTION_CHAIN_V1,
+                now,
+                ("contracts",),
+                expiration=back_cycle.expiration_date,
+            )
+
+            if front_chain_value is not None and back_chain_value is not None:
+                combined_chain = combine_option_chains(
+                    (cast(OptionChain, front_chain_value), cast(OptionChain, back_chain_value)),
+                    observed_at=now,
+                )
+                chain_result = _combined_chain_result(front_result, combined_chain)
+                front_contract = back_contract = None
+                try:
+                    front_strike = select_atm_strike_at_expiration(
+                        combined_chain, front_cycle.expiration_date, spot_price, OptionType.CALL
+                    )
+                    back_strike = select_atm_strike_at_expiration(
+                        combined_chain, back_cycle.expiration_date, spot_price, OptionType.CALL
+                    )
+                    (front_contract,) = combined_chain.find(
+                        expiration=front_cycle.expiration_date,
+                        strike=front_strike,
+                        option_type=OptionType.CALL,
+                    )
+                    (back_contract,) = combined_chain.find(
+                        expiration=back_cycle.expiration_date,
+                        strike=back_strike,
+                        option_type=OptionType.CALL,
+                    )
+                except Exception:  # noqa: BLE001 -- any selection failure leaves richness UNKNOWN
+                    front_contract = back_contract = None
+                if (
+                    front_contract is not None
+                    and back_contract is not None
+                    and front_contract.implied_volatility is not None
+                    and back_contract.implied_volatility is not None
+                ):
+                    selected_front_cycle = front_cycle
+                    selected_back_cycle = back_cycle
+                    selected_target_strike = front_strike
+                    term_richness = normalize_richness(
+                        front_contract.implied_volatility - back_contract.implied_volatility
+                    )
+                    closes_result, closes_value = _resolve_closes_or_none(
+                        plan, symbol, now, lookback_days=45
+                    )
+                    if closes_value is not None:
+                        realized_vol = compute_realized_volatility(closes_value)
+                        iv_rv_richness = normalize_richness(
+                            compute_iv_realized_spread(
+                                front_contract.implied_volatility, realized_vol
+                            )
+                        )
+                    else:
+                        realized_vol = None
+
+    # -- Seal: one MarketSnapshot for whatever was actually resolved ----
+    # HISTORICAL_BARS_V1 is deliberately never sealed into the snapshot:
+    # its own observations are a genuine time series (many observations
+    # from one provider, one per trading day), not competing candidate
+    # values for one fact -- ObservationResolver.resolve() requires at
+    # most one observation per provider and rejects anything else
+    # ("Observation resolution requires one value per provider"), which is
+    # correct for quote/event/chain (each is one point-in-time fact) but
+    # a genuine shape mismatch for a series. The raw closes are still
+    # durably recorded via the plan's own attempt persistence (S14-PR-03)
+    # regardless; the meaningful derived value (realized_vol) is captured
+    # below as a proper DerivedFact.
+    sealed_results = [event_result, quote_result, chain_result]
+
+    snapshot = seal_subject_snapshot(
+        tuple(sealed_results),
+        as_of=now,
+        required_capabilities=_ALWAYS_REQUESTED_CAPABILITIES,
+        resolution_policy_by_capability=resolution_policy_by_capability,
+        provider_metadata=provider_metadata,
+    )
+
+    # -- Project canonical facts (scalars only, never a raw chain/event) --
+    canonical_facts: list[CanonicalFact] = []
+    resolution_by_capability = {item.capability: item for item in snapshot.resolution_results}
+    quote_resolution = resolution_by_capability.get(MarketCapability.REAL_TIME_QUOTE_V1)
+    if quote_resolution is not None and spot_price is not None:
+        fact = project_canonical_fact(
+            quote_resolution,
+            value=spot_price,
+            fact_id=f"spot_price:{symbol}:{snapshot.snapshot_digest}",
+            version=1,
+            fact_type="spot_price",
+            created_time=now,
+        )
+        if fact is not None:
+            canonical_facts.append(fact)
+    event_resolution = resolution_by_capability.get(MarketCapability.EARNINGS_CALENDAR_V1)
+    if event_resolution is not None and event_value is not None:
+        # CanonicalFact.value must satisfy domain.values.require_normalized,
+        # which accepts tz-aware datetimes but not a bare date -- unlike
+        # DerivedFact.value (analytics/features.py's DerivedFactValue),
+        # which explicitly allows date and is used as-is below for the
+        # expiration-date facts.
+        earnings_date_value = datetime.combine(
+            _earnings_date(cast(EarningsEvent, event_value)), time.min, tzinfo=UTC
+        )
+        fact = project_canonical_fact(
+            event_resolution,
+            value=earnings_date_value,
+            fact_id=f"earnings_date:{symbol}:{snapshot.snapshot_digest}",
+            version=1,
+            fact_type="earnings_date",
+            created_time=now,
+        )
+        if fact is not None:
+            canonical_facts.append(fact)
+
+    # -- Materialize derived facts ---------------------------------------
+    derived_facts: list[DerivedFact] = []
+    evidence = (EvidenceReference(EvidenceKind.CANONICAL_FACT, snapshot.snapshot_id),)
+    if realized_vol is not None:
+        derived_facts.append(
+            materialize_derived_fact(
+                DERIVED_FACT_REGISTRY,
+                REALIZED_VOLATILITY,
+                symbol,
+                snapshot.snapshot_digest,
+                value=realized_vol,
+                unit=_ANALYTICS_UNIT_DECIMAL_RATIO,
+                effective_time=now,
+                input_evidence=evidence,
+                quality_status=DerivedFactQualityStatus.VALID,
+            )
+        )
+    # term_structure_richness / iv_realized_volatility_richness are
+    # strategy-owned policy, not generic analytics (SPRINT-013 S13-08
+    # audit finding #6, project/reports/SPRINT-013-S13-08-audit.md:
+    # "richness normalization [is] strategy/manifest-owned policy, not
+    # core analytics" -- confirmed, not reversed here). They are
+    # DerivedFacts (a deterministic point-in-time calculation over
+    # canonical evidence, analytics/features.py's own definition) but
+    # deliberately constructed directly rather than through
+    # materialize_derived_fact()'s shared AnalyticsRegistry lookup, which
+    # would misrepresent them as generic, any-strategy-reusable features.
+    # formula_version is the strategy's own manifest version -- the
+    # correct authority for a strategy-owned formula's version, not a
+    # registry entry that does not and should not exist for it.
+    if term_richness is not None:
+        derived_facts.append(
+            DerivedFact(
+                derived_fact_id=derived_fact_id(
+                    TERM_STRUCTURE_RICHNESS_FACT, symbol, snapshot.snapshot_digest
+                ),
+                value=term_richness,
+                unit=_ANALYTICS_UNIT_DECIMAL_RATIO,
+                formula_version=EARNINGS_CALENDAR_MANIFEST.strategy_version,
+                effective_time=now,
+                input_evidence=evidence,
+                quality_status=DerivedFactQualityStatus.VALID,
+            )
+        )
+    if iv_rv_richness is not None:
+        derived_facts.append(
+            DerivedFact(
+                derived_fact_id=derived_fact_id(
+                    IV_REALIZED_RICHNESS_FACT, symbol, snapshot.snapshot_digest
+                ),
+                value=iv_rv_richness,
+                unit=_ANALYTICS_UNIT_DECIMAL_RATIO,
+                formula_version=EARNINGS_CALENDAR_MANIFEST.strategy_version,
+                effective_time=now,
+                input_evidence=evidence,
+                quality_status=DerivedFactQualityStatus.VALID,
+            )
+        )
+    # The front/back expiration selection and its target strike are
+    # likewise strategy-owned (the manifest's own expiration_select node
+    # parameters govern which pair is chosen -- SPRINT-014 S14-PR-02).
+    # ExpirationCycle itself is not a DerivedFactValue (that type is a
+    # closed Decimal | int | bool | date | tuple[Decimal, ...] union,
+    # analytics/features.py's own definition) -- its two fields the graph
+    # actually reads (expiration_date, days_to_expiration; monthly/weekly
+    # are read nowhere in strategies/stonk_components.py or screening/
+    # context_builders.py, confirmed by grep) are sealed individually so
+    # the adapter can reconstruct an equivalent ExpirationCycle without
+    # ever re-running selection itself.
+    if (
+        selected_front_cycle is not None
+        and selected_back_cycle is not None
+        and selected_target_strike is not None
+    ):
+        derived_facts.append(
+            DerivedFact(
+                derived_fact_id=derived_fact_id(
+                    FRONT_EXPIRATION_DATE_FACT, symbol, snapshot.snapshot_digest
+                ),
+                value=selected_front_cycle.expiration_date,
+                unit=_ANALYTICS_UNIT_CALENDAR_DATE,
+                formula_version=EARNINGS_CALENDAR_MANIFEST.strategy_version,
+                effective_time=now,
+                input_evidence=evidence,
+                quality_status=DerivedFactQualityStatus.VALID,
+            )
+        )
+        derived_facts.append(
+            DerivedFact(
+                derived_fact_id=derived_fact_id(
+                    FRONT_DAYS_TO_EXPIRATION_FACT, symbol, snapshot.snapshot_digest
+                ),
+                value=selected_front_cycle.days_to_expiration,
+                unit=_ANALYTICS_UNIT_DAYS,
+                formula_version=EARNINGS_CALENDAR_MANIFEST.strategy_version,
+                effective_time=now,
+                input_evidence=evidence,
+                quality_status=DerivedFactQualityStatus.VALID,
+            )
+        )
+        derived_facts.append(
+            DerivedFact(
+                derived_fact_id=derived_fact_id(
+                    BACK_EXPIRATION_DATE_FACT, symbol, snapshot.snapshot_digest
+                ),
+                value=selected_back_cycle.expiration_date,
+                unit=_ANALYTICS_UNIT_CALENDAR_DATE,
+                formula_version=EARNINGS_CALENDAR_MANIFEST.strategy_version,
+                effective_time=now,
+                input_evidence=evidence,
+                quality_status=DerivedFactQualityStatus.VALID,
+            )
+        )
+        derived_facts.append(
+            DerivedFact(
+                derived_fact_id=derived_fact_id(
+                    BACK_DAYS_TO_EXPIRATION_FACT, symbol, snapshot.snapshot_digest
+                ),
+                value=selected_back_cycle.days_to_expiration,
+                unit=_ANALYTICS_UNIT_DAYS,
+                formula_version=EARNINGS_CALENDAR_MANIFEST.strategy_version,
+                effective_time=now,
+                input_evidence=evidence,
+                quality_status=DerivedFactQualityStatus.VALID,
+            )
+        )
+        derived_facts.append(
+            DerivedFact(
+                derived_fact_id=derived_fact_id(
+                    TARGET_STRIKE_FACT, symbol, snapshot.snapshot_digest
+                ),
+                value=selected_target_strike,
+                unit=_ANALYTICS_UNIT_USD_STRIKE,
+                formula_version=EARNINGS_CALENDAR_MANIFEST.strategy_version,
+                effective_time=now,
+                input_evidence=evidence,
+                quality_status=DerivedFactQualityStatus.VALID,
+            )
+        )
+
+    return SubjectSealedEvidence(
+        snapshot=snapshot,
+        canonical_facts=tuple(canonical_facts),
+        derived_facts=DerivedFactSet(tuple(derived_facts)),
+    )

--- a/strategy_runtime/__init__.py
+++ b/strategy_runtime/__init__.py
@@ -20,8 +20,18 @@ lives in strategy_runtime.result: the one canonical result envelope every
 strategy's adapter returns. EPIC-3 (Shared Data Planning) lives in
 strategy_runtime.market_data_planning: one market_data.
 CapabilityFulfillmentService per subject, shared by every strategy that
-evaluates it within a run, threaded through RuntimeContext.fulfillment by
-run_strategies()'s own optional fulfillment_by_subject parameter. EPIC-4
+evaluates it within a run. SPRINT-014 (Restore Subject-First Fact
+Pipeline) removed that service from RuntimeContext entirely (I-09:
+strategy-facing code receives no provider, transport, budget, or
+fulfillment object) -- strategy_runtime.evidence.SubjectSealedEvidence
+(sealed MarketSnapshot plus projected canonical/derived facts) is the one
+read-only bundle a migrated strategy may receive instead, threaded
+through RuntimeContext.sealed_evidence by run_strategies()'s own optional
+sealed_evidence_by_subject parameter. A strategy not yet migrated to the
+subject-first path receives its own CapabilityFulfillmentService through
+strategy_runtime.adapters.build_migrated_strategy_registry()'s own
+explicitly named, temporary legacy composition binding instead -- see
+that module's own docstring for its owner and deletion condition. EPIC-4
 (Universal Options Framework) lives in strategy_runtime.options: domain's
 own already-validated OptionLeg/OptionStructure adopted directly as the
 canonical option package representation, analytics.expiration_selection's
@@ -79,6 +89,7 @@ from strategy_runtime.errors import (
     StrategyContractViolationError,
     UnknownStrategyIdError,
 )
+from strategy_runtime.evidence import SubjectSealedEvidence
 from strategy_runtime.execution import (
     ExecutionStatus,
     RuntimeExecutionSummary,
@@ -131,6 +142,7 @@ __all__ = [
     "StrategyRegistry",
     "StructureKind",
     "SubjectMarketDataAccess",
+    "SubjectSealedEvidence",
     "TypedValue",
     "UniversalScreeningResult",
     "UnknownStrategyIdError",

--- a/strategy_runtime/adapters/__init__.py
+++ b/strategy_runtime/adapters/__init__.py
@@ -1,4 +1,5 @@
-"""Migrated strategy adapters (SPRINT-009/EPIC-7).
+"""Migrated strategy adapters (SPRINT-009/EPIC-7, revised by SPRINT-014
+S14-PR-05).
 
 One module per migrated strategy: forward_factor, skew_momentum_vertical,
 earnings_calendar. Each declares its own StrategyContract (EPIC-2) and a
@@ -15,10 +16,37 @@ deployed API's own route handlers remains a separate, deliberately
 deferred step (see project/reports/SPRINT-009.md); importing this
 subpackage has no side effect on the currently-shipped
 /api/v1/screening* surface on its own.
+
+## Legacy fulfillment composition binding (SPRINT-014 S14-PR-05)
+
+RuntimeContext no longer carries a fulfillment object (I-09). Earnings
+Calendar is migrated to the subject-first evidence path
+(RuntimeContext.sealed_evidence) and its adapter takes no fulfillment
+parameter at all. Forward Factor and Skew Momentum have not yet been
+migrated -- their adapter functions each take an explicit second
+``fulfillment: CapabilityFulfillmentService | None`` parameter, and
+build_migrated_strategy_registry() closes over
+``legacy_fulfillment_by_subject`` to supply it, entirely outside
+RuntimeContext. StrategyRegistry's own adapter type
+(strategy_runtime.registry.StrategyAdapter) is single-argument
+(Callable[[RuntimeContext], TResult]); the two wrapper closures below are
+what StrategyRegistry actually holds, matching that type exactly, while
+each legacy strategy's own module keeps its real two-argument signature.
+
+Owner: SPRINT-014 Worker (delegate under GOV-AMD-001 Amendment 013).
+Deletion condition: delete ``legacy_fulfillment_by_subject``, the two
+wrapper closures, and forward_factor_adapter's/skew_momentum_adapter's own
+``fulfillment`` parameter the moment each strategy is itself migrated to
+the subject-first path (tracked as follow-on tickets after this sprint
+closes) -- not before, and not incidentally as part of an unrelated change.
 """
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from types import MappingProxyType
+
+from market_data import CapabilityFulfillmentService
 from strategies import (
     EARNINGS_CALENDAR_MANIFEST,
     FORWARD_FACTOR_CALENDAR_MANIFEST,
@@ -27,6 +55,7 @@ from strategies import (
 from strategy_runtime.adapters.earnings_calendar import (
     EARNINGS_CALENDAR_CONTRACT,
     earnings_calendar_adapter,
+    legacy_earnings_calendar_adapter,
 )
 from strategy_runtime.adapters.forward_factor import (
     FORWARD_FACTOR_CONTRACT,
@@ -37,18 +66,39 @@ from strategy_runtime.adapters.skew_momentum_vertical import (
     skew_momentum_adapter,
 )
 from strategy_runtime.catalog import SignalCatalogEntry
+from strategy_runtime.context import RuntimeContext
 from strategy_runtime.manifest_contract import validate_manifest_contract
 from strategy_runtime.registry import StrategyRegistry
 from strategy_runtime.result import UniversalScreeningResult
 
 __all__ = ["build_migrated_signal_catalog", "build_migrated_strategy_registry"]
 
+_NO_LEGACY_FULFILLMENT: Mapping[str, CapabilityFulfillmentService] = MappingProxyType({})
 
-def build_migrated_strategy_registry() -> StrategyRegistry[UniversalScreeningResult]:
+
+def build_migrated_strategy_registry(
+    *,
+    legacy_fulfillment_by_subject: Mapping[
+        str, CapabilityFulfillmentService
+    ] = _NO_LEGACY_FULFILLMENT,
+    earnings_calendar_cutover_enabled: bool = True,
+) -> StrategyRegistry[UniversalScreeningResult]:
     """All three EPIC-7 migration targets, registered together -- the one
     place this sprint's own "three production strategies execute through
     one shared runtime" success criterion is assembled and directly
     checkable (see tests/strategy_runtime/adapters/test_registry.py).
+
+    ``legacy_fulfillment_by_subject`` (SPRINT-014 S14-PR-05, see this
+    module's own docstring) supplies Forward Factor's and Skew Momentum's
+    own fulfillment service, captured by closure at registry-construction
+    time -- never through RuntimeContext. Earnings Calendar's own adapter
+    reads no fulfillment at all, legacy or otherwise -- UNLESS
+    ``earnings_calendar_cutover_enabled=False`` (S14-PR-05's own required
+    rollback switch), in which case Earnings Calendar is registered
+    against legacy_earnings_calendar_adapter instead, reusing the same
+    legacy_fulfillment_by_subject binding FF/SM already use. Restores only
+    the old Earnings Calendar path -- it never deletes or bypasses any
+    already-sealed evidence a caller separately acquired this cycle.
     """
     pairs = (
         (FORWARD_FACTOR_CALENDAR_MANIFEST, FORWARD_FACTOR_CONTRACT),
@@ -57,11 +107,28 @@ def build_migrated_strategy_registry() -> StrategyRegistry[UniversalScreeningRes
     )
     for manifest, contract in pairs:
         validate_manifest_contract(manifest, contract)
+
+    def _forward_factor_legacy_binding(context: RuntimeContext) -> UniversalScreeningResult:
+        return forward_factor_adapter(context, legacy_fulfillment_by_subject.get(context.subject))
+
+    def _skew_momentum_legacy_binding(context: RuntimeContext) -> UniversalScreeningResult:
+        return skew_momentum_adapter(context, legacy_fulfillment_by_subject.get(context.subject))
+
+    def _earnings_calendar_legacy_binding(context: RuntimeContext) -> UniversalScreeningResult:
+        return legacy_earnings_calendar_adapter(
+            context, legacy_fulfillment_by_subject.get(context.subject)
+        )
+
+    earnings_calendar_binding = (
+        earnings_calendar_adapter
+        if earnings_calendar_cutover_enabled
+        else _earnings_calendar_legacy_binding
+    )
     return StrategyRegistry(
         (
-            (FORWARD_FACTOR_CONTRACT, forward_factor_adapter),
-            (SKEW_MOMENTUM_VERTICAL_CONTRACT, skew_momentum_adapter),
-            (EARNINGS_CALENDAR_CONTRACT, earnings_calendar_adapter),
+            (FORWARD_FACTOR_CONTRACT, _forward_factor_legacy_binding),
+            (SKEW_MOMENTUM_VERTICAL_CONTRACT, _skew_momentum_legacy_binding),
+            (EARNINGS_CALENDAR_CONTRACT, earnings_calendar_binding),
         )
     )
 

--- a/strategy_runtime/adapters/earnings_calendar.py
+++ b/strategy_runtime/adapters/earnings_calendar.py
@@ -1,53 +1,69 @@
 """Earnings Calendar migrated onto the universal runtime
-(SPRINT-009/EPIC-7) -- the lifecycle-tracking migration target EPIC-5's
+(SPRINT-009/EPIC-7) -- cut over to the subject-first evidence path by
+SPRINT-014 S14-PR-05, the lifecycle-tracking migration target EPIC-5's
 generic engine (strategy_runtime.lifecycle) is proven against.
 
-Reuses screening.adapters.TARGET_STRATEGY_REGISTRY and
-screening.live_adapters.build_live_earnings_calendar_adapter directly --
-this sprint's own quality.preserve rule for "execution graph" means
-Earnings Calendar's actual financial logic is reused unmodified, never
-reimplemented.
+This adapter performs zero acquisition of any kind: it reads only
+context.sealed_evidence (strategy_runtime.evidence.SubjectSealedEvidence),
+assembled by the composition root before this adapter ever runs
+(screening.sealed_earnings_calendar.acquire_sealed_earnings_calendar_evidence,
+called from asa/scheduled_screening.py) -- never a CapabilityFulfillment
+Service, never a provider, never a transport (I-09). Financial logic
+(compile_strategy_graph/execute_strategy_graph over
+strategies/stonk_manifests.py's own EARNINGS_CALENDAR_MANIFEST, and every
+compute_* function the sealed evidence's own derived facts were built
+from) is unchanged and reused verbatim -- this ticket's own quality.
+preserve rule.
 
 Lifecycle scope, deliberately narrower than a full state machine and
-recorded as such, not silently: screening.live_adapters's own earnings
-calendar adapter is itself stateless (one evaluation, no memory of prior
-observations) -- it has never tracked lifecycle, and this ticket's own
-scope is migrating that existing evaluation logic onto the new runtime,
-not adding brand-new stateful behavior to screening/'s own execution
-graph (which quality.preserve rules out touching). What this migration
+recorded as such, not silently: the underlying execution graph is
+stateless (one evaluation, no memory of prior observations) -- it has
+never tracked lifecycle, and this ticket's own scope is migrating
+existing evaluation logic onto the subject-first path, not adding
+brand-new stateful behavior to the execution graph. What this adapter
 adds is real, not simulated: every successful observation is assigned a
 real opportunity_id (strategy_runtime.lifecycle.compute_opportunity_id())
 and a real lifecycle_stage, validated against this contract's own
-declared states (strategy_runtime.lifecycle.validate_lifecycle_stage()) --
-proving EPIC-5's engine is genuinely usable by a real strategy, which is
-this ticket's own acceptance criterion. The stage assigned reflects only
-the current observation's own outcome (PASS -> "confirmed", NO_SIGNAL ->
-"watching") -- a true multi-observation transition function (e.g. "was
-watching, earnings just got confirmed, now assign 'confirmed'") requires
-reading prior persisted history through EPIC-8's own
-ObservationHistoryRepository, which is production-integration work for
-whichever ticket actually wires a live repository into a live adapter --
-properly scoped to EPIC-9 or a SPRINT-010 follow-up, not this one.
+declared states.
 
-Opportunity identity is also deliberately simplified: (strategy_id,
-symbol) only, treating "the AAPL earnings calendar opportunity" as one
-evolving identity per symbol rather than distinguishing separate
-earnings cycles (Q1 vs Q2, etc.) as separate opportunities. Distinguishing
-cycles requires the confirmed earnings date itself, which
-screening.live_adapters's own ScreeningResult does not currently expose
-in an extractable, structured field -- exposing it would mean changing
-that existing, preserved execution graph's own output shape, out of
-this ticket's scope. Recorded as a known limitation and a concrete
-recommendation for a follow-up sprint, not silently accepted.
+Opportunity identity is deliberately simplified: (strategy_id, symbol)
+only, unchanged from the pre-cutover behavior -- not a regression
+introduced by this ticket.
 """
 
 from __future__ import annotations
 
-from domain import MarketCapability
+from datetime import date
+from decimal import Decimal
+from typing import cast
+
+from analytics.derived_fact_materialization import derived_fact_id
+from domain import EarningsEvent, ExpirationCycle, MarketCapability, OptionChain
+from market_data import CapabilityFulfillmentService
 from screening import run_screening
 from screening.adapters import TARGET_STRATEGY_REGISTRY
-from screening.live_adapters import build_live_earnings_calendar_adapter
-from screening.results import ScreeningOutcomeStatus
+from screening.clock import Clock as ScreeningClock
+from screening.context_builders import build_earnings_calendar_context
+from screening.earnings_calendar_fact_ids import (
+    BACK_DAYS_TO_EXPIRATION_FACT,
+    BACK_EXPIRATION_DATE_FACT,
+    FRONT_DAYS_TO_EXPIRATION_FACT,
+    FRONT_EXPIRATION_DATE_FACT,
+    IV_REALIZED_RICHNESS_FACT,
+    TARGET_STRIKE_FACT,
+    TERM_STRUCTURE_RICHNESS_FACT,
+)
+from screening.live_adapters import (
+    _COMPONENT_REGISTRY,
+    _live_result,
+    build_live_earnings_calendar_adapter,
+)
+from screening.live_context import _is_monthly_expiration
+from screening.registry import ScreeningStrategyDefinition
+from screening.results import ScreeningOutcomeStatus, ScreeningResult
+from screening.runner import StrategyAdapter, StrategyAdapterError
+from strategies import compile_strategy_graph, execute_strategy_graph
+from strategies.stonk_manifests import EARNINGS_CALENDAR_MANIFEST
 from strategy_runtime.adapters._screening_bridge import translate_screening_result
 from strategy_runtime.context import RuntimeContext
 from strategy_runtime.contract import (
@@ -60,6 +76,7 @@ from strategy_runtime.contract import (
     StrategyContract,
     StructureKind,
 )
+from strategy_runtime.evidence import SubjectSealedEvidence
 from strategy_runtime.lifecycle import compute_opportunity_id, validate_lifecycle_stage
 from strategy_runtime.result import UniversalScreeningResult, compute_observation_id
 
@@ -105,15 +122,174 @@ _STAGE_BY_OUTCOME = {
 }
 
 
+def _reconstruct_expiration_cycle(
+    expiration_date: date, days_to_expiration: int, *, as_of: date, evidence: tuple[object, ...]
+) -> ExpirationCycle:
+    """monthly/weekly are never read by any strategy component or context
+    builder (confirmed by grep across strategies/stonk_components.py and
+    screening/context_builders.py) -- graph output never depends on which
+    value they carry. ExpirationCycle.__post_init__ still requires exactly
+    the same classification the pre-cutover path computes (a bare False,
+    False pair fails its "requires a monthly or weekly classification"
+    invariant), so the exact same third-Friday check screening/live_context.py
+    already uses to build every other ExpirationCycle in this codebase is
+    reused here rather than reinvented. evidence/as_of are
+    provenance/traceability fields, unread by any comparison or filtering
+    logic in the graph.
+    """
+    monthly = _is_monthly_expiration(expiration_date)
+    return ExpirationCycle(
+        expiration_date=expiration_date,
+        days_to_expiration=days_to_expiration,
+        monthly=monthly,
+        weekly=not monthly,
+        as_of=as_of,
+        evidence=evidence,  # type: ignore[arg-type]
+    )
+
+
+def _sealed_earnings_calendar_adapter(
+    symbol: str, sealed_evidence: SubjectSealedEvidence
+) -> StrategyAdapter:
+    def _run(
+        definition: ScreeningStrategyDefinition, clock: ScreeningClock, run_id: str
+    ) -> ScreeningResult:
+        snapshot = sealed_evidence.snapshot
+        as_of = snapshot.as_of.date()
+        resolution_by_capability = {item.capability: item for item in snapshot.resolution_results}
+
+        chain_resolution = resolution_by_capability.get(MarketCapability.OPTION_CHAIN_V1)
+        event_resolution = resolution_by_capability.get(MarketCapability.EARNINGS_CALENDAR_V1)
+        if (
+            chain_resolution is None
+            or chain_resolution.selected_observation is None
+            or event_resolution is None
+            or event_resolution.selected_observation is None
+        ):
+            raise StrategyAdapterError(
+                ScreeningOutcomeStatus.MISSING_DATA,
+                f"sealed evidence for {symbol} has no resolved option chain or earnings event",
+            )
+        chain = cast(OptionChain, chain_resolution.selected_observation.value)
+        event = cast(EarningsEvent, event_resolution.selected_observation.value)
+
+        def _fact(feature_id: str) -> object | None:
+            fact_id = derived_fact_id(feature_id, symbol, snapshot.snapshot_digest)
+            try:
+                return sealed_evidence.derived_facts.get(fact_id).value
+            except KeyError:
+                return None
+
+        front_date = _fact(FRONT_EXPIRATION_DATE_FACT)
+        front_dte = _fact(FRONT_DAYS_TO_EXPIRATION_FACT)
+        back_date = _fact(BACK_EXPIRATION_DATE_FACT)
+        back_dte = _fact(BACK_DAYS_TO_EXPIRATION_FACT)
+        target_strike = _fact(TARGET_STRIKE_FACT)
+        term_richness = _fact(TERM_STRUCTURE_RICHNESS_FACT)
+        iv_rv_richness = _fact(IV_REALIZED_RICHNESS_FACT)
+        if (
+            front_date is None
+            or front_dte is None
+            or back_date is None
+            or back_dte is None
+            or target_strike is None
+            or term_richness is None
+            or iv_rv_richness is None
+        ):
+            raise StrategyAdapterError(
+                ScreeningOutcomeStatus.MISSING_DATA,
+                f"sealed evidence for {symbol} has no expiration selection or richness facts "
+                "-- no expiration pair spans its earnings date within policy, or an "
+                "at-the-money contract had no implied_volatility",
+            )
+
+        front = _reconstruct_expiration_cycle(
+            cast(date, front_date), cast(int, front_dte), as_of=as_of, evidence=chain.evidence
+        )
+        back = _reconstruct_expiration_cycle(
+            cast(date, back_date), cast(int, back_dte), as_of=as_of, evidence=chain.evidence
+        )
+        context = build_earnings_calendar_context(
+            chain,
+            event,
+            front,
+            back,
+            as_of,
+            target_strike=cast(Decimal, target_strike),
+            term_structure_richness=cast(Decimal, term_richness),
+            iv_realized_volatility_richness=cast(Decimal, iv_rv_richness),
+        )
+        graph = compile_strategy_graph(EARNINGS_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
+        result = execute_strategy_graph(graph, context)
+        return _live_result(
+            definition,
+            clock,
+            run_id,
+            symbol,
+            EARNINGS_CALENDAR_MANIFEST,
+            result.outputs,
+            "score",
+            chain.evidence,
+        )
+
+    return _run
+
+
 def earnings_calendar_adapter(context: RuntimeContext) -> UniversalScreeningResult:
-    if context.fulfillment is None:
+    if context.sealed_evidence is None:
         raise RuntimeError(
-            "earnings_calendar requires shared market data access "
-            "(strategy_runtime.market_data_planning, EPIC-3) -- RuntimeContext.fulfillment is None"
+            "earnings_calendar requires sealed subject-first evidence "
+            "(screening.sealed_earnings_calendar, SPRINT-014 S14-PR-05) -- "
+            "RuntimeContext.sealed_evidence is None"
+        )
+    adapter = _sealed_earnings_calendar_adapter(context.subject, context.sealed_evidence)
+    (result,) = run_screening(
+        TARGET_STRATEGY_REGISTRY,
+        {"earnings_calendar": adapter},
+        context.clock,
+        strategy_ids=("earnings_calendar",),
+    )
+    observation_id = compute_observation_id(context.run_id, "earnings_calendar", context.subject)
+
+    stage = _STAGE_BY_OUTCOME.get(result.outcome_status)
+    opportunity_id = None
+    if stage is not None:
+        validate_lifecycle_stage(EARNINGS_CALENDAR_CONTRACT, stage)
+        opportunity_id = compute_opportunity_id("earnings_calendar", context.subject)
+
+    return translate_screening_result(
+        result,
+        symbol=context.subject,
+        observation_id=observation_id,
+        opportunity_id=opportunity_id,
+        lifecycle_stage=stage,
+    )
+
+
+def legacy_earnings_calendar_adapter(
+    context: RuntimeContext, fulfillment: CapabilityFulfillmentService | None
+) -> UniversalScreeningResult:
+    """The pre-cutover imperative acquisition path (build_live_earnings_
+    calendar_adapter, screening.live_adapters -- untouched by S14-PR-05),
+    kept reachable only as S14-PR-05's own required rollback switch
+    (asa.scheduled_screening.run_scheduled_refresh's
+    earnings_calendar_cutover_enabled=False). Two-argument, matching
+    forward_factor_adapter's/skew_momentum_adapter's own legacy-binding
+    shape, NOT registered by default -- build_migrated_strategy_registry()
+    only wires this in when the caller explicitly disables the cutover.
+
+    Deletion condition: delete this function together with
+    screening.live_adapters.build_live_earnings_calendar_adapter and
+    every other superseded acquisition path, in S14-PR-07 -- not before.
+    """
+    if fulfillment is None:
+        raise RuntimeError(
+            "earnings_calendar (legacy path) requires shared market data access "
+            "(strategy_runtime.market_data_planning, EPIC-3) -- fulfillment is None"
         )
     live_adapter = build_live_earnings_calendar_adapter(
         context.subject,
-        context.fulfillment,
+        fulfillment,
         freshness_requirement=context.contract.freshness_requirement,
     )
     (result,) = run_screening(

--- a/strategy_runtime/adapters/forward_factor.py
+++ b/strategy_runtime/adapters/forward_factor.py
@@ -21,6 +21,7 @@ calendar evidence for the confirmed-event exclusion gate.
 from __future__ import annotations
 
 from domain import MarketCapability
+from market_data import CapabilityFulfillmentService
 from screening import run_screening
 from screening.adapters import TARGET_STRATEGY_REGISTRY
 from screening.live_adapters import build_live_forward_factor_adapter
@@ -64,15 +65,23 @@ FORWARD_FACTOR_CONTRACT = StrategyContract(
 )
 
 
-def forward_factor_adapter(context: RuntimeContext) -> UniversalScreeningResult:
-    if context.fulfillment is None:
+def forward_factor_adapter(
+    context: RuntimeContext, fulfillment: CapabilityFulfillmentService | None
+) -> UniversalScreeningResult:
+    """``fulfillment`` is Forward Factor's own legacy composition binding
+    (SPRINT-014 S14-PR-05) -- supplied by strategy_runtime.adapters.
+    build_migrated_strategy_registry()'s own registry-construction-time
+    closure, never carried on RuntimeContext (I-09). See that module's own
+    docstring for this binding's owner and deletion condition.
+    """
+    if fulfillment is None:
         raise RuntimeError(
             "forward_factor requires shared market data access "
-            "(strategy_runtime.market_data_planning, EPIC-3) -- RuntimeContext.fulfillment is None"
+            "(strategy_runtime.adapters, legacy fulfillment binding) -- fulfillment is None"
         )
     live_adapter = build_live_forward_factor_adapter(
         context.subject,
-        context.fulfillment,
+        fulfillment,
         freshness_requirement=context.contract.freshness_requirement,
     )
     (result,) = run_screening(

--- a/strategy_runtime/adapters/skew_momentum_vertical.py
+++ b/strategy_runtime/adapters/skew_momentum_vertical.py
@@ -22,6 +22,7 @@ this.
 from __future__ import annotations
 
 from domain import MarketCapability
+from market_data import CapabilityFulfillmentService
 from screening import run_screening
 from screening.adapters import TARGET_STRATEGY_REGISTRY
 from screening.live_adapters import build_live_skew_momentum_adapter
@@ -64,15 +65,23 @@ SKEW_MOMENTUM_VERTICAL_CONTRACT = StrategyContract(
 )
 
 
-def skew_momentum_adapter(context: RuntimeContext) -> UniversalScreeningResult:
-    if context.fulfillment is None:
+def skew_momentum_adapter(
+    context: RuntimeContext, fulfillment: CapabilityFulfillmentService | None
+) -> UniversalScreeningResult:
+    """``fulfillment`` is Skew Momentum's own legacy composition binding
+    (SPRINT-014 S14-PR-05) -- supplied by strategy_runtime.adapters.
+    build_migrated_strategy_registry()'s own registry-construction-time
+    closure, never carried on RuntimeContext (I-09). See that module's own
+    docstring for this binding's owner and deletion condition.
+    """
+    if fulfillment is None:
         raise RuntimeError(
             "skew_momentum requires shared market data access "
-            "(strategy_runtime.market_data_planning, EPIC-3) -- RuntimeContext.fulfillment is None"
+            "(strategy_runtime.adapters, legacy fulfillment binding) -- fulfillment is None"
         )
     live_adapter = build_live_skew_momentum_adapter(
         context.subject,
-        context.fulfillment,
+        fulfillment,
         freshness_requirement=context.contract.freshness_requirement,
         historical_skew_repository=context.historical_skew_repository,
     )

--- a/strategy_runtime/context.py
+++ b/strategy_runtime/context.py
@@ -1,25 +1,35 @@
-"""Strategy execution context (SPRINT-009/EPIC-1, extended by EPIC-3).
+"""Strategy execution context (SPRINT-009/EPIC-1, extended by SPRINT-014
+S14-PR-05).
 
-What a strategy adapter receives to evaluate one subject. ``fulfillment``
-is EPIC-3's own extension (Shared Data Planning): the
-market_data.CapabilityFulfillmentService shared by every strategy in the
-same run that evaluates the same subject, so an identical CapabilityRequest
-two strategies both make is only ever fulfilled once
-(strategy_runtime.market_data_planning). None for a strategy contract
-that declares no market_data/option_data/earnings requirement, or when a
-caller runs strategies without shared data planning at all (EPIC-1's own
-run_strategies() remains fully usable without it) -- a strategy that
-needs it should assert it is not None itself, since only that strategy's
-own contract can know it always will be for a correctly-run pipeline.
+What a strategy adapter receives to evaluate one subject. RuntimeContext is
+deliberately provider- and fulfillment-free (SPRINT-014 invariant I-09:
+strategy-facing code receives no provider, transport, budget, or
+fulfillment object) -- ``sealed_evidence`` is the one thing a migrated,
+subject-first strategy may read instead: an already-sealed
+MarketSnapshot plus already-projected canonical and derived facts
+(strategy_runtime.evidence.SubjectSealedEvidence), assembled by the
+composition root *before* any strategy runs, never acquired by the
+strategy itself. None for a strategy contract that has not been migrated
+to the subject-first path yet, or for a caller that never builds it.
+
+EPIC-3's own market_data.CapabilityFulfillmentService (Shared Data
+Planning) previously flowed through this context as ``fulfillment`` for
+every registered strategy uniformly. SPRINT-014 removed that field: a
+strategy not yet migrated to the subject-first path (Forward Factor,
+Skew Momentum, as of S14-PR-05) receives its fulfillment service through
+an explicitly named, temporary legacy composition binding built directly
+into strategy_runtime.adapters.build_migrated_strategy_registry() --
+outside RuntimeContext, never as a field here again. See that module's
+own docstring for the binding's owner and deletion condition.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
-from market_data import CapabilityFulfillmentService
 from strategy_runtime.clock import Clock
 from strategy_runtime.contract import StrategyContract
+from strategy_runtime.evidence import SubjectSealedEvidence
 from strategy_runtime.historical_evidence import HistoricalSkewRepository
 
 
@@ -29,8 +39,8 @@ class RuntimeContext:
     subject: str
     clock: Clock
     run_id: str
-    fulfillment: CapabilityFulfillmentService | None = None
+    sealed_evidence: SubjectSealedEvidence | None = None
     # SPRINT-013 S13-04D: None for a strategy contract that never consumes
     # historical evidence, or when a caller runs strategies without it at
-    # all -- same optionality convention as fulfillment above.
+    # all -- same optionality convention as sealed_evidence above.
     historical_skew_repository: HistoricalSkewRepository | None = None

--- a/strategy_runtime/evidence.py
+++ b/strategy_runtime/evidence.py
@@ -1,0 +1,44 @@
+"""Read-only sealed evidence bundle for subject-first strategies
+(SPRINT-014 S14-PR-05).
+
+The one thing a migrated strategy's RuntimeContext may carry instead of a
+live CapabilityFulfillmentService (I-09: strategy-facing code receives no
+provider, transport, budget, or fulfillment object). SubjectSealedEvidence
+bundles three already-owned, already-frozen types -- it does not define or
+duplicate any of them: MarketSnapshot (market_data/snapshot.py) is sealed
+before this ticket ever runs; canonical_facts (domain.canonical_fact.
+CanonicalFact, projected via facts/canonical_projection.py) and
+derived_facts (analytics.features.DerivedFactSet, materialized via
+analytics/derived_fact_materialization.py) are read-only projections over
+that same sealed snapshot. A strategy consuming this bundle can acquire
+nothing further -- there is no provider, transport, or budget object
+anywhere in this type for it to reach through.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from analytics.features import DerivedFactSet
+from domain.canonical_fact import CanonicalFact
+from market_data.snapshot import MarketSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class SubjectSealedEvidence:
+    snapshot: MarketSnapshot
+    canonical_facts: tuple[CanonicalFact, ...]
+    derived_facts: DerivedFactSet
+
+    def __post_init__(self) -> None:
+        fact_ids = tuple(item.fact_id for item in self.canonical_facts)
+        if len(set(fact_ids)) != len(fact_ids):
+            raise ValueError("SubjectSealedEvidence.canonical_facts fact_ids must be unique")
+        ordered = tuple(sorted(self.canonical_facts, key=lambda item: item.fact_id))
+        object.__setattr__(self, "canonical_facts", ordered)
+
+    def canonical_fact(self, fact_id: str) -> CanonicalFact | None:
+        for fact in self.canonical_facts:
+            if fact.fact_id == fact_id:
+                return fact
+        return None

--- a/strategy_runtime/execution.py
+++ b/strategy_runtime/execution.py
@@ -22,10 +22,10 @@ from datetime import datetime
 from enum import Enum
 from typing import Generic, TypeVar
 
-from market_data import CapabilityFulfillmentService
 from strategy_runtime.clock import Clock
 from strategy_runtime.context import RuntimeContext
 from strategy_runtime.errors import StrategyContractViolationError
+from strategy_runtime.evidence import SubjectSealedEvidence
 from strategy_runtime.historical_evidence import HistoricalSkewRepository
 from strategy_runtime.registry import StrategyRegistry
 from strategy_runtime.validation import validate_result
@@ -106,14 +106,16 @@ def _run_one(
     subject: str,
     clock: Clock,
     run_id: str,
-    fulfillment_by_subject: Mapping[str, CapabilityFulfillmentService] | None,
+    sealed_evidence_by_subject: Mapping[str, SubjectSealedEvidence] | None,
     historical_skew_repository: HistoricalSkewRepository | None,
 ) -> StrategyExecutionResult[TResult]:
     adapter = registry.adapter_for(strategy_id)
     contract = registry.contract_for(strategy_id)
-    fulfillment = fulfillment_by_subject.get(subject) if fulfillment_by_subject else None
+    sealed_evidence = (
+        sealed_evidence_by_subject.get(subject) if sealed_evidence_by_subject else None
+    )
     context = RuntimeContext(
-        contract, subject, clock, run_id, fulfillment, historical_skew_repository
+        contract, subject, clock, run_id, sealed_evidence, historical_skew_repository
     )
     started_at = clock.now()
     try:
@@ -159,7 +161,7 @@ def run_strategies(
     *,
     subjects: tuple[str, ...],
     strategy_ids: tuple[str, ...] | None = None,
-    fulfillment_by_subject: Mapping[str, CapabilityFulfillmentService] | None = None,
+    sealed_evidence_by_subject: Mapping[str, SubjectSealedEvidence] | None = None,
     historical_skew_repository: HistoricalSkewRepository | None = None,
 ) -> tuple[StrategyExecutionResult[TResult], ...]:
     """Run every requested registered strategy against every requested
@@ -175,15 +177,18 @@ def run_strategies(
     determinism guarantee screening/runner.py's own run_screening()
     already provides for its own narrower scope.
 
-    ``fulfillment_by_subject`` (EPIC-3, Shared Data Planning) is optional
-    and defaults to None -- every EPIC-1 caller that never needed shared
-    market data access continues to work completely unmodified. When
-    given (typically strategy_runtime.market_data_planning.
-    build_shared_market_data_access()'s own output), every strategy
-    evaluating the same subject receives the identical
-    CapabilityFulfillmentService instance via RuntimeContext.fulfillment,
-    so an identical request any two of them make is only ever fulfilled
-    once.
+    ``sealed_evidence_by_subject`` (SPRINT-014 S14-PR-05) is optional and
+    defaults to None -- every caller that never needed subject-first
+    evidence continues to work completely unmodified. When given, every
+    strategy evaluating the same subject receives the identical
+    SubjectSealedEvidence instance via RuntimeContext.sealed_evidence; a
+    strategy contract not yet migrated to the subject-first path simply
+    never reads it. Note this parameter never populates a live
+    CapabilityFulfillmentService anywhere in RuntimeContext (I-09) -- a
+    strategy not yet migrated receives its fulfillment service through
+    strategy_runtime.adapters.build_migrated_strategy_registry()'s own
+    explicitly named legacy composition binding instead, built outside
+    this function entirely.
 
     ``historical_skew_repository`` (SPRINT-013 S13-04D) is likewise
     optional and defaults to None; when given, every strategy receives the
@@ -209,7 +214,7 @@ def run_strategies(
             subject,
             clock,
             run_id,
-            fulfillment_by_subject,
+            sealed_evidence_by_subject,
             historical_skew_repository,
         )
         for strategy_id in requested_strategy_ids

--- a/strategy_runtime/market_data_planning.py
+++ b/strategy_runtime/market_data_planning.py
@@ -51,6 +51,7 @@ from market_data import (
 )
 from market_data.budget import BudgetScope
 from market_data.finnhub import finnhub_rolling_window_policy
+from market_data.providers import ProviderMetadata
 from market_data.rolling_window import ProviderRollingWindowTracker, RollingWindowPolicy
 from market_data.tradier import tradier_rolling_window_policy
 from strategy_runtime.clock import Clock
@@ -158,6 +159,35 @@ def build_provider_rolling_window_tracker(
     """
     policies, undeclared = declared_rolling_window_policies(enabled_provider_configs(config))
     return ProviderRollingWindowTracker(policies, clock), undeclared
+
+
+def provider_metadata_for(
+    config: MarketDataConfig,
+    transport_factory: Callable[[str], object],
+    clock: Clock,
+) -> tuple[ProviderMetadata, ...]:
+    """ProviderMetadata for every enabled provider, independent of subject.
+
+    seal_subject_snapshot()'s own provider_metadata argument requires
+    bounded metadata for every provider whose observations appear in the
+    sealed snapshot (market_data/snapshot.py's
+    "Snapshot lacks bounded metadata for an included provider" invariant).
+    Providers are constructed the same way build_shared_market_data_access
+    constructs them for actual fulfillment -- a throwaway
+    RequestBudgetManager is built only because ProviderDependencies
+    requires one; metadata is fixed at construction time and never
+    depends on it or on any live request.
+    """
+    enabled_configs = enabled_provider_configs(config)
+    budget_manager = _build_request_budget_manager(enabled_configs, clock)
+    factory = _provider_factory()
+    return tuple(
+        factory.create(
+            item,
+            ProviderDependencies(transport_factory(item.provider_id), clock, budget_manager),
+        ).metadata
+        for item in enabled_configs
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/strategy_runtime/service.py
+++ b/strategy_runtime/service.py
@@ -38,6 +38,7 @@ from market_data.temporal import (
     evaluate_temporal_usability,
 )
 from strategy_runtime.clock import Clock
+from strategy_runtime.evidence import SubjectSealedEvidence
 from strategy_runtime.execution import ExecutionStatus, run_strategies
 from strategy_runtime.historical_evidence import HistoricalSkewRepository
 from strategy_runtime.lifecycle import (
@@ -206,11 +207,28 @@ def refresh(
     strategy_id: str,
     symbol: str,
     fulfillment_by_subject: Mapping[str, CapabilityFulfillmentService],
+    sealed_evidence_by_subject: Mapping[str, SubjectSealedEvidence] | None = None,
     historical_skew_repository: HistoricalSkewRepository | None = None,
 ) -> UniversalScreeningResult:
     """Recompute exactly one strategy against exactly one subject via the
     existing migrated adapters, then persist and return the new state --
     never a whole-universe or whole-strategy-set refresh.
+
+    ``fulfillment_by_subject`` (SPRINT-014 S14-PR-05) is no longer threaded
+    into RuntimeContext (I-09) -- it is used here only to compute this
+    result's own temporal metadata (freshness/usability/age), which reads
+    whatever a subject's shared CapabilityFulfillmentService already
+    accumulated this cycle regardless of which mechanism populated it
+    (a legacy strategy's own direct fulfill() calls, or a subject-first
+    plan wrapping that same service, as Earnings Calendar's own sealed
+    evidence acquisition does -- see screening.sealed_earnings_calendar).
+    A strategy not yet migrated still receives its own fulfillment service
+    through strategy_runtime.adapters.build_migrated_strategy_registry()'s
+    own legacy composition binding, entirely outside this function.
+
+    ``sealed_evidence_by_subject`` (SPRINT-014 S14-PR-05) is optional and
+    forwarded to run_strategies() unchanged, populating RuntimeContext.
+    sealed_evidence for a migrated strategy's own subject.
 
     ``historical_skew_repository`` (SPRINT-013 S13-04D) is optional and
     forwarded to run_strategies() unchanged; only a strategy contract that
@@ -222,7 +240,7 @@ def refresh(
         clock,
         subjects=(symbol,),
         strategy_ids=(strategy_id,),
-        fulfillment_by_subject=fulfillment_by_subject,
+        sealed_evidence_by_subject=sealed_evidence_by_subject,
         historical_skew_repository=historical_skew_repository,
     )
     if (

--- a/tests/architecture/test_screening_boundaries.py
+++ b/tests/architecture/test_screening_boundaries.py
@@ -51,30 +51,77 @@ def _screening_files() -> list[Path]:
 
 
 class TestScreeningImportScope:
-    """screening/ imports only screening, domain, strategies, analytics, and
-    market_data (SCREEN-004 adapters wrap existing strategies; ANALYTICS-003
-    context builders use analytics/ for Forward Factor's derived inputs;
-    LIVE-001 reuses market_data/'s own canonical, provider-neutral
-    acquisition pipeline instead of building a new one) -- these
-    dependencies are intentional and one-directional: none of strategies/,
-    analytics/, or market_data/ is permitted to import screening, enforced
-    separately by their own allowlists (test_strategy_boundaries.py,
-    test_analytics_boundaries.py, and market_data/'s own existing
-    boundary tests). market_data/ is the sanctioned canonical acquisition
-    layer, not a raw provider SDK -- the raw providers/ package stays
-    prohibited below; no provider-specific code may enter screening/
-    directly.
+    """screening/ imports only screening, domain, strategies, analytics,
+    market_data, facts, and strategy_runtime (SCREEN-004 adapters wrap
+    existing strategies; ANALYTICS-003 context builders use analytics/ for
+    Forward Factor's derived inputs; LIVE-001 reuses market_data/'s own
+    canonical, provider-neutral acquisition pipeline instead of building a
+    new one) -- these dependencies are intentional and one-directional:
+    none of strategies/, analytics/, or market_data/ is permitted to
+    import screening, enforced separately by their own allowlists
+    (test_strategy_boundaries.py, test_analytics_boundaries.py, and
+    market_data/'s own existing boundary tests). facts/ is the sanctioned
+    CanonicalFact projection layer (test_s14_pr04_boundaries.py already
+    forbids facts/canonical_projection.py from importing back into
+    screening/, so this stays one-directional too).
+
+    strategy_runtime is the one deliberate exception to one-directional
+    layering: SPRINT-014 S14-PR-05's ownership model names screening/ and
+    strategy_runtime/ as joint owners of "generic_orchestration" under
+    ADR-010, and screening/sealed_earnings_calendar.py -- the acquisition
+    orchestrator that assembles a subject's SubjectSealedEvidence
+    (strategy_runtime/evidence.py) before RuntimeContext ever sees it --
+    is the composition root's supplier for that exact type. This does not
+    create a circular *import*: strategy_runtime/adapters/earnings_calendar.py
+    (the only strategy_runtime module that imports from screening/) never
+    imports screening/sealed_earnings_calendar.py, and
+    strategy_runtime/evidence.py never imports screening/ at all.
+
+    market_data/ is the sanctioned canonical acquisition layer, not a raw
+    provider SDK -- the raw providers/ package stays prohibited below; no
+    provider-specific code may enter screening/ directly.
     """
 
     @pytest.mark.parametrize("py_file", _screening_files())
     def test_only_permitted_roots(self, py_file: Path) -> None:
         permitted = (
-            {"screening", "domain", "strategies", "analytics", "market_data"} | STDLIB_ALLOWED
+            {
+                "screening",
+                "domain",
+                "strategies",
+                "analytics",
+                "market_data",
+                "facts",
+                "strategy_runtime",
+            }
+            | STDLIB_ALLOWED
         )
         imported = _imported_roots(py_file)
         assert imported <= permitted, (
             f"{py_file.name} imports outside {permitted}: {imported - permitted}"
         )
+
+    def test_strategy_runtime_dependency_is_not_circular(self) -> None:
+        """The screening<->strategy_runtime exception above is safe only
+        because it never closes an actual import cycle: the acquisition
+        orchestrator (screening/sealed_earnings_calendar.py) is never
+        imported by the one strategy_runtime module that imports from
+        screening/ (strategy_runtime/adapters/earnings_calendar.py), and
+        strategy_runtime/evidence.py -- the type screening/ depends on --
+        never imports screening/ at all.
+        """
+        adapter_file = REPO_ROOT / "strategy_runtime" / "adapters" / "earnings_calendar.py"
+        adapter_tree = ast.parse(adapter_file.read_text())
+        imported_modules = {
+            node.module
+            for node in ast.walk(adapter_tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        assert "screening.sealed_earnings_calendar" not in imported_modules
+
+        evidence_file = REPO_ROOT / "strategy_runtime" / "evidence.py"
+        evidence_roots = _imported_roots(evidence_file)
+        assert "screening" not in evidence_roots
 
     @pytest.mark.parametrize("py_file", _screening_files())
     def test_prohibited_imports_absent(self, py_file: Path) -> None:

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -475,6 +475,101 @@ def test_non_skew_momentum_pairs_never_touch_the_historical_skew_repository(
     assert historical_skew_repository.append_calls == []
 
 
+# -- SPRINT-014 S14-PR-05: earnings_calendar_cutover_enabled rollback -------
+
+
+_ALWAYS_UNAVAILABLE = ReadOnlyHttpResponse(500, {}, (), 12, "always-unavailable")
+
+
+class _RoutedTransport:
+    """Endpoint-keyed transport double (mirrors tests/strategy_runtime/
+    adapters/test_earnings_calendar.py's own identical helper) -- unlike a
+    finite ScriptedTransport queue, this never runs out and never raises a
+    raw IndexError a real transport could never produce, letting Finnhub
+    receive only its own real earnings response while anything else it's
+    asked for fails over to Tradier cleanly (both declare overlapping
+    quote/historical-bars capabilities).
+    """
+
+    def __init__(self, responses_by_endpoint: dict[str, ReadOnlyHttpResponse]) -> None:
+        self._responses_by_endpoint = dict(responses_by_endpoint)
+
+    def get(self, request: object) -> ReadOnlyHttpResponse:
+        endpoint_class = getattr(request, "endpoint_class", None)
+        return self._responses_by_endpoint.get(endpoint_class, _ALWAYS_UNAVAILABLE)
+
+
+def _finnhub_earnings_response(event_date: str) -> ReadOnlyHttpResponse:
+    return ReadOnlyHttpResponse(
+        200,
+        {"earningsCalendar": [{"symbol": "AAPL", "date": event_date, "hour": "amc"}]},
+        (),
+        12,
+        "finnhub-request-earnings",
+    )
+
+
+def test_earnings_calendar_cutover_disabled_restores_the_legacy_attempt_scoping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Proves the rollback switch actually changes which acquisition path
+    runs, without needing a full live-fixture round trip through either
+    path: SubjectAcquisitionPlan (the cutover-enabled path) stamps its own
+    plan_id onto *both* screening_cycle_id and pair_evaluation_id for its
+    internally persisted attempts (market_data/subject_plan.py -- plan_id
+    here is set to this pair's own pair_id, so its recorded
+    screening_cycle_id is *not* the cycle's real screening_cycle_id every
+    other pair shares). With the switch disabled, earnings_calendar's own
+    attempts go through the same manual per-pair recording every other
+    (non-earnings_calendar) pair uses, sharing the cycle's real
+    screening_cycle_id like everything else -- provable only if
+    earnings_calendar's own legacy acquisition actually records at least
+    one attempt, hence Finnhub is enabled and scripted here (unlike this
+    file's other earnings_calendar fixtures, which deliberately leave it
+    unconfigured to exercise the zero-attempt "no priority policy" case
+    instead).
+    """
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    monkeypatch.setenv("ASA_FINNHUB_ENABLED", "true")
+    monkeypatch.setenv("ASA_FINNHUB_API_KEY", "sandbox-secret-key")
+    repository = InMemoryLatestResultRepository()
+    attempt_repository = InMemoryAcquisitionAttemptRepository()
+    universe = (("skew_momentum", "AAPL"), ("earnings_calendar", "AAPL"))
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+    earnings_date = (date.today() + timedelta(days=20)).isoformat()
+    transports = {
+        "tradier": ScriptedTransport(_tradier_refresh_responses(expiration)),
+        "finnhub": _RoutedTransport(
+            {"earnings_calendar": _finnhub_earnings_response(earnings_date)}
+        ),
+    }
+
+    outcomes = run_scheduled_refresh(
+        universe,
+        repository=repository,
+        acquisition_attempt_repository=attempt_repository,
+        transport_factory=lambda provider_id: transports[provider_id],
+        earnings_calendar_cutover_enabled=False,
+    )
+
+    assert len(outcomes) == 2
+    recorded = attempt_repository.query(AttemptQuery(limit=100))
+    assert recorded
+    cycle_ids = {item.screening_cycle_id for item in recorded}
+    # One shared cycle id across *every* pair, including earnings_calendar
+    # -- the plan-scoped identity (a different screening_cycle_id per
+    # plan_id) never appears when the switch is disabled.
+    assert len(cycle_ids) == 1
+    cycle_id = next(iter(cycle_ids))
+    earnings_calendar_pair_ids = {
+        item.pair_evaluation_id
+        for item in recorded
+        if item.pair_evaluation_id == f"{cycle_id}:earnings_calendar:AAPL"
+    }
+    assert earnings_calendar_pair_ids  # at least one real attempt was recorded
+
+
 def test_a_conflicting_historical_observation_does_not_fail_the_pair(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -934,9 +1029,27 @@ def test_evaluation_and_request_identity_stay_frozen_across_a_cycle(
     directly here by asserting the two pairs sharing symbol AAPL still
     reuse each other's requests, which is only possible if their request
     windows are byte-identical.
+
+    SPRINT-014 S14-PR-05: finnhub is now also enabled -- earnings_calendar's
+    own sealed evidence acquisition requires seal_subject_snapshot()'s
+    SnapshotRequest to have a real CapabilityFulfillmentResult (real
+    provider attempts, even a failed one) for every one of its required
+    capabilities, including EARNINGS_CALENDAR_V1 (market_data/snapshot.py's
+    "required_capabilities must be a subset of requested_capabilities"
+    invariant) -- unlike the pre-cutover live path, it cannot represent
+    "no provider was even configured for this capability" at all. With
+    only tradier enabled (this test's pre-PR-05 configuration), EARNINGS_
+    CALENDAR_V1 has zero declared providers, so plan.resolve() raises
+    before any attempt is ever recorded; enabling finnhub here (still with
+    no finnhub-shaped response scripted, so its own request still fails,
+    just as a normal, representable per-provider failure) restores this
+    test's own, unrelated purpose -- proving cross-pair request-window
+    identity -- without depending on earnings_calendar actually succeeding.
     """
     monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
     monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    monkeypatch.setenv("ASA_FINNHUB_ENABLED", "true")
+    monkeypatch.setenv("ASA_FINNHUB_API_KEY", "sandbox-secret-key")
     repository = InMemoryLatestResultRepository()
     expiration = (date.today() + timedelta(days=7)).isoformat()
     universe = (("skew_momentum", "AAPL"), ("earnings_calendar", "AAPL"))

--- a/tests/strategy_runtime/adapters/test_earnings_calendar.py
+++ b/tests/strategy_runtime/adapters/test_earnings_calendar.py
@@ -1,37 +1,53 @@
-"""SPRINT-009/EPIC-7: Earnings Calendar migrated onto the universal
-runtime -- the lifecycle-tracking migration target.
+"""SPRINT-009/EPIC-7, cut over by SPRINT-014 S14-PR-05: Earnings Calendar
+migrated onto the universal runtime and, in this ticket, onto the
+subject-first evidence path.
 
-Only the failure path is exercised with a full live-acquisition round
-trip here: earnings_calendar's own live adapter acquires an earnings
-event (EARNINGS_CALENDAR_V1, Finnhub-shaped) before anything else, and
-scripting a realistic Finnhub earnings-calendar response is deliberately
-out of this test's scope -- an empty/exhausted ScriptedTransport reliably
-produces a non-success, isolated outcome, which is exactly what this
-test needs to prove earnings_calendar's own stage-assignment logic
-(no stage for a non-success outcome). The successful PASS/NO_SIGNAL ->
-stage mapping itself is not re-tested here: it reuses
-_screening_bridge.translate_screening_result, already proven by
-forward_factor's and skew_momentum's own full successful-path tests.
+The failure path (test_requires_sealed_evidence) exercises the adapter's
+own missing-evidence guard directly. The success path
+(test_full_sealed_acquisition_matches_the_pre_cutover_live_path) is this
+ticket's own primary CUTOVER_PASS evidence: it runs the SAME scripted
+provider responses through both the pre-cutover live path
+(screening.live_adapters.build_live_earnings_calendar_adapter, still
+present and unmodified for Forward Factor/Skew Momentum's own use) and
+the new subject-first path (screening.sealed_earnings_calendar +
+strategy_runtime.adapters.earnings_calendar.earnings_calendar_adapter),
+and asserts identical outcome status and score -- exact output parity for
+identical underlying market data, proving the architecture changed
+(acquisition ownership, sealed evidence, zero provider calls from the
+strategy) without changing what Earnings Calendar's own financial logic
+actually decides.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, timedelta
 
 import pytest
 
 from domain import MarketCapability
 from market_data import load_market_data_config
+from market_data.attempts import InMemoryAcquisitionAttemptRepository
+from market_data.resolution import ResolutionPolicy
+from market_data.subject_plan import SubjectAcquisitionPlan
+from market_data.transport import ReadOnlyHttpResponse
+from screening import run_screening
+from screening.adapters import TARGET_STRATEGY_REGISTRY
+from screening.live_acquisition import live_only_config
+from screening.live_adapters import build_live_earnings_calendar_adapter
+from screening.sealed_earnings_calendar import acquire_sealed_earnings_calendar_evidence
 from strategy_runtime.adapters.earnings_calendar import (
     EARNINGS_CALENDAR_CONTRACT,
     earnings_calendar_adapter,
 )
 from strategy_runtime.context import RuntimeContext
 from strategy_runtime.contract import LifecycleModel
-from strategy_runtime.market_data_planning import build_shared_market_data_access
+from strategy_runtime.market_data_planning import (
+    build_shared_market_data_access,
+    provider_metadata_for,
+)
 from strategy_runtime.result import EvaluationState
-from tests.asa.market_data_ops.fakes import ScriptedTransport
+from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
 
 
 @dataclass
@@ -40,6 +56,121 @@ class _FixedClock:
 
     def now(self) -> datetime:
         return self.value
+
+
+_ALWAYS_UNAVAILABLE = ReadOnlyHttpResponse(500, {}, (), 12, "always-unavailable")
+
+
+class _RoutedTransport:
+    """A transport double keyed by endpoint_class, falling back to a
+    genuine HTTP 500 (ProviderErrorCode.PROVIDER_UNAVAILABLE for both
+    Tradier and Finnhub, confirmed in their own _http_error handling) for
+    any endpoint not explicitly scripted -- unlike a finite ScriptedTransport
+    queue, this never runs out and never raises a raw IndexError a real
+    transport could never produce. Both Finnhub and Tradier declare
+    overlapping capabilities (quote, historical bars); this is what lets a
+    fixture give Finnhub only its own real earnings response while letting
+    everything else it might be asked for fail over to Tradier cleanly.
+    """
+
+    def __init__(self, responses_by_endpoint: dict[str, ReadOnlyHttpResponse]) -> None:
+        self._responses_by_endpoint = dict(responses_by_endpoint)
+        self.requests: list[object] = []
+
+    def get(self, request: object) -> ReadOnlyHttpResponse:
+        self.requests.append(request)
+        endpoint_class = getattr(request, "endpoint_class", None)
+        return self._responses_by_endpoint.get(endpoint_class, _ALWAYS_UNAVAILABLE)
+
+
+_RESOLUTION_POLICIES = {
+    MarketCapability.EARNINGS_CALENDAR_V1: ResolutionPolicy(
+        "v1", ("finnhub",), 3600 * 24 * 90, ("earnings_date",)
+    ),
+    MarketCapability.REAL_TIME_QUOTE_V1: ResolutionPolicy("v1", ("tradier",), 3600, ("last",)),
+    MarketCapability.OPTION_CHAIN_V1: ResolutionPolicy(
+        "v1", ("tradier",), 3600, ("contracts",)
+    ),
+    MarketCapability.HISTORICAL_BARS_V1: ResolutionPolicy(
+        "v1", ("tradier",), 3600 * 24 * 46, ("close",)
+    ),
+}
+
+
+def _tradier_option(
+    symbol: str, expiration: str, strike: str, option_type: str, delta: str
+) -> dict[str, object]:
+    return {
+        "symbol": symbol,
+        "underlying": "AAPL",
+        "expiration_date": expiration,
+        "strike": strike,
+        "option_type": option_type,
+        "bid": "4.9",
+        "ask": "5.1",
+        "last": "5",
+        "volume": 1000,
+        "open_interest": 5000,
+        "greeks": {
+            "delta": delta,
+            "gamma": "0.03",
+            "theta": "-0.1",
+            "vega": "0.2",
+            "mid_iv": "0.5",
+        },
+    }
+
+
+def _tradier_expirations_response(front: str, back: str) -> ReadOnlyHttpResponse:
+    return ReadOnlyHttpResponse(
+        200, {"expirations": {"date": [front, back]}}, (), 12, "tradier-request-expirations"
+    )
+
+
+def _tradier_chain_response(expiration: str, request_id: str) -> ReadOnlyHttpResponse:
+    options = [
+        _tradier_option("CALL_ATM", expiration, "190", "call", "0.50"),
+        _tradier_option("PUT_ATM", expiration, "190", "put", "-0.50"),
+    ]
+    return ReadOnlyHttpResponse(200, {"options": {"option": options}}, (), 12, request_id)
+
+
+def _tradier_daily_bars_response() -> ReadOnlyHttpResponse:
+    days: list[dict[str, object]] = []
+    for day_offset in range(29, -1, -1):
+        day = (date.today() - timedelta(days=day_offset)).isoformat()
+        close = 200 + (day_offset % 5) + (29 - day_offset) * 0.15
+        days.append(
+            {
+                "date": day,
+                "open": str(close - 2),
+                "high": str(close + 2),
+                "low": str(close - 3),
+                "close": str(close),
+                "volume": "50000000",
+            }
+        )
+    return ReadOnlyHttpResponse(200, {"history": {"day": days}}, (), 12, "tradier-request-history")
+
+
+def _finnhub_earnings_response(event_date: str) -> ReadOnlyHttpResponse:
+    return ReadOnlyHttpResponse(
+        200,
+        {"earningsCalendar": [{"symbol": "AAPL", "date": event_date, "hour": "amc"}]},
+        (),
+        12,
+        "finnhub-request-earnings",
+    )
+
+
+def _tradier_responses(front: str, back: str) -> list[ReadOnlyHttpResponse]:
+    return [
+        tradier_quote_response(),
+        _tradier_expirations_response(front, back),
+        _tradier_chain_response(front, "tradier-request-chain-front"),
+        _tradier_chain_response(back, "tradier-request-chain-back"),
+        _tradier_daily_bars_response(),
+    ]
 
 
 class TestEarningsCalendarContract:
@@ -55,14 +186,14 @@ class TestEarningsCalendarContract:
 
 
 class TestEarningsCalendarAdapter:
-    def test_requires_shared_fulfillment(self) -> None:
+    def test_requires_sealed_evidence(self) -> None:
         context = RuntimeContext(
             EARNINGS_CALENDAR_CONTRACT, "AAPL", _FixedClock(datetime.now(UTC)), "run-1"
         )
-        with pytest.raises(RuntimeError, match="requires shared market data access"):
+        with pytest.raises(RuntimeError, match="requires sealed subject-first evidence"):
             earnings_calendar_adapter(context)
 
-    def test_a_non_success_outcome_assigns_no_lifecycle_stage_or_opportunity_id(
+    def test_missing_sealed_evidence_facts_assign_no_lifecycle_stage_or_opportunity_id(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
@@ -70,21 +201,39 @@ class TestEarningsCalendarAdapter:
         monkeypatch.setenv("ASA_FINNHUB_ENABLED", "true")
         monkeypatch.setenv("ASA_FINNHUB_API_KEY", "sandbox-secret-key")
         clock = _FixedClock(datetime.now(UTC))
-        config = load_market_data_config(
-            {
-                "ASA_TRADIER_ENABLED": "true",
-                "ASA_TRADIER_ACCESS_TOKEN": "sandbox-secret-token",
-                "ASA_FINNHUB_ENABLED": "true",
-                "ASA_FINNHUB_API_KEY": "sandbox-secret-key",
-            }
+        config = live_only_config(
+            load_market_data_config(
+                {
+                    "ASA_TRADIER_ENABLED": "true",
+                    "ASA_TRADIER_ACCESS_TOKEN": "sandbox-secret-token",
+                    "ASA_FINNHUB_ENABLED": "true",
+                    "ASA_FINNHUB_API_KEY": "sandbox-secret-key",
+                }
+            )
         )
-        # No scripted responses at all -- the very first acquisition
-        # (the earnings event) fails immediately and deterministically.
-        access = build_shared_market_data_access(
-            config, lambda _provider_id: ScriptedTransport([]), clock, ("AAPL",)
+        # Every endpoint fails cleanly (HTTP 500) -- the very first
+        # acquisition (the earnings event) fails immediately and
+        # deterministically, and every capability after it does too.
+        def transport_factory(_provider_id: str) -> object:
+            return _RoutedTransport({})
+
+        access = build_shared_market_data_access(config, transport_factory, clock, ("AAPL",))
+        plan = SubjectAcquisitionPlan(
+            "AAPL",
+            access["AAPL"].fulfillment,
+            attempt_repository=InMemoryAcquisitionAttemptRepository(),
+            plan_id="test-cycle:AAPL",
+            clock=clock,
+        )
+        sealed_evidence = acquire_sealed_earnings_calendar_evidence(
+            "AAPL",
+            plan,
+            clock,
+            provider_metadata=provider_metadata_for(config, transport_factory, clock),
+            resolution_policy_by_capability=_RESOLUTION_POLICIES,
         )
         context = RuntimeContext(
-            EARNINGS_CALENDAR_CONTRACT, "AAPL", clock, "run-1", access["AAPL"].fulfillment
+            EARNINGS_CALENDAR_CONTRACT, "AAPL", clock, "run-1", sealed_evidence
         )
 
         result = earnings_calendar_adapter(context)
@@ -96,3 +245,107 @@ class TestEarningsCalendarAdapter:
         assert result.lifecycle_stage is None
         assert "sandbox-secret-token" not in str(result)
         assert "sandbox-secret-key" not in str(result)
+
+    def test_full_sealed_acquisition_matches_the_pre_cutover_live_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+        monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+        monkeypatch.setenv("ASA_FINNHUB_ENABLED", "true")
+        monkeypatch.setenv("ASA_FINNHUB_API_KEY", "sandbox-secret-key")
+        clock = _FixedClock(datetime.now(UTC))
+        front = (date.today() + timedelta(days=14)).isoformat()
+        back = (date.today() + timedelta(days=44)).isoformat()
+        earnings_date = (date.today() + timedelta(days=20)).isoformat()
+        config = live_only_config(
+            load_market_data_config(
+                {
+                    "ASA_TRADIER_ENABLED": "true",
+                    "ASA_TRADIER_ACCESS_TOKEN": "sandbox-secret-token",
+                    "ASA_FINNHUB_ENABLED": "true",
+                    "ASA_FINNHUB_API_KEY": "sandbox-secret-key",
+                }
+            )
+        )
+
+        # -- Pre-cutover live path -------------------------------------
+        # Finnhub's own transport is endpoint-routed, not a finite queue:
+        # Finnhub also declares REAL_TIME_QUOTE_V1/HISTORICAL_BARS_V1 (see
+        # market_data/finnhub.py's own FINNHUB_CAPABILITIES) and is tried
+        # before Tradier for both (alphabetical priority ordering,
+        # strategy_runtime/market_data_planning.py) -- a real Finnhub
+        # would never "run out of responses," it would return a real HTTP
+        # response for every request, so a genuine HTTP 500 (falling back
+        # to Tradier) is the faithful fixture, not an exhausted queue.
+        old_transports = {
+            "tradier": ScriptedTransport(_tradier_responses(front, back)),
+            "finnhub": _RoutedTransport(
+                {"earnings_calendar": _finnhub_earnings_response(earnings_date)}
+            ),
+        }
+        old_access = build_shared_market_data_access(
+            config, lambda provider_id: old_transports[provider_id], clock, ("AAPL",)
+        )
+        live_adapter = build_live_earnings_calendar_adapter("AAPL", old_access["AAPL"].fulfillment)
+        (old_result,) = run_screening(
+            TARGET_STRATEGY_REGISTRY,
+            {"earnings_calendar": live_adapter},
+            clock,
+            strategy_ids=("earnings_calendar",),
+        )
+
+        # -- New subject-first path -- fresh transports/access, so
+        # neither path's own fulfillment cache can leak into the other --
+        # each acquires independently against identical scripted inputs.
+        new_transports = {
+            "tradier": ScriptedTransport(_tradier_responses(front, back)),
+            "finnhub": _RoutedTransport(
+                {"earnings_calendar": _finnhub_earnings_response(earnings_date)}
+            ),
+        }
+
+        def new_transport_factory(provider_id: str) -> object:
+            return new_transports[provider_id]
+
+        new_access = build_shared_market_data_access(
+            config, new_transport_factory, clock, ("AAPL",)
+        )
+        plan = SubjectAcquisitionPlan(
+            "AAPL",
+            new_access["AAPL"].fulfillment,
+            attempt_repository=InMemoryAcquisitionAttemptRepository(),
+            plan_id="test-cycle:AAPL",
+            clock=clock,
+        )
+        sealed_evidence = acquire_sealed_earnings_calendar_evidence(
+            "AAPL",
+            plan,
+            clock,
+            provider_metadata=provider_metadata_for(config, new_transport_factory, clock),
+            resolution_policy_by_capability=_RESOLUTION_POLICIES,
+        )
+        context = RuntimeContext(
+            EARNINGS_CALENDAR_CONTRACT, "AAPL", clock, "run-1", sealed_evidence
+        )
+
+        new_result = earnings_calendar_adapter(context)
+
+        # Exact-parity assertions (CUTOVER_PASS): both paths reach the
+        # same success/failure classification and the same numeric score
+        # for identical underlying market data.
+        assert new_result.evaluation_state is not EvaluationState.ADAPTER_EXCEPTION
+        old_success = old_result.outcome_status.value in ("pass", "no_signal")
+        new_success = new_result.evaluation_state in (
+            EvaluationState.PASS,
+            EvaluationState.NO_SIGNAL,
+        )
+        assert old_success == new_success, (
+            f"old={old_result.outcome_status.value!r} new={new_result.evaluation_state!r}"
+        )
+        if old_result.strategy_native_score is not None:
+            new_score = new_result.metrics["strategy_native_score"].native()
+            assert new_score == old_result.strategy_native_score
+        # I-06: every evaluation references one sealed snapshot digest.
+        assert sealed_evidence.snapshot.snapshot_digest
+        assert "sandbox-secret-token" not in str(new_result)
+        assert "sandbox-secret-key" not in str(new_result)

--- a/tests/strategy_runtime/adapters/test_forward_factor.py
+++ b/tests/strategy_runtime/adapters/test_forward_factor.py
@@ -79,7 +79,7 @@ class TestForwardFactorAdapter:
             FORWARD_FACTOR_CONTRACT, "AAPL", _FixedClock(datetime.now(UTC)), "run-1"
         )
         with pytest.raises(RuntimeError, match="requires shared market data access"):
-            forward_factor_adapter(context)
+            forward_factor_adapter(context, None)
 
     def test_full_live_acquisition_produces_a_translated_result(
         self, monkeypatch: pytest.MonkeyPatch
@@ -100,11 +100,9 @@ class TestForwardFactorAdapter:
         access = build_shared_market_data_access(
             config, lambda _provider_id: ScriptedTransport(responses), clock, ("AAPL",)
         )
-        context = RuntimeContext(
-            FORWARD_FACTOR_CONTRACT, "AAPL", clock, "run-1", access["AAPL"].fulfillment
-        )
+        context = RuntimeContext(FORWARD_FACTOR_CONTRACT, "AAPL", clock, "run-1")
 
-        result = forward_factor_adapter(context)
+        result = forward_factor_adapter(context, access["AAPL"].fulfillment)
 
         assert result.strategy_id == "forward_factor"
         assert result.symbol == "AAPL"

--- a/tests/strategy_runtime/adapters/test_registry.py
+++ b/tests/strategy_runtime/adapters/test_registry.py
@@ -5,7 +5,22 @@ strategies execute through one shared runtime" success criterion.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import pytest
+
 from strategy_runtime.adapters import build_migrated_strategy_registry
+from strategy_runtime.adapters.earnings_calendar import EARNINGS_CALENDAR_CONTRACT
+from strategy_runtime.context import RuntimeContext
+
+
+@dataclass
+class _FixedClock:
+    value: datetime
+
+    def now(self) -> datetime:
+        return self.value
 
 
 def test_all_three_migration_targets_are_registered() -> None:
@@ -19,3 +34,35 @@ def test_each_registered_strategy_has_a_contract_and_an_adapter() -> None:
         contract = registry.contract_for(strategy_id)
         assert contract.strategy_id == strategy_id
         assert callable(registry.adapter_for(strategy_id))
+
+
+class TestEarningsCalendarCutoverSwitch:
+    """SPRINT-014 S14-PR-05's own required rollback switch. Each adapter's
+    own missing-dependency guard raises a distinct, existing message
+    (RuntimeContext.sealed_evidence is None -- the new sealed path;
+    fulfillment is None -- the legacy path) -- calling the registered
+    adapter with neither sealed_evidence nor legacy fulfillment supplied
+    and asserting *which* message comes back proves which code path the
+    switch actually selected, deterministically, without needing a full
+    live acquisition fixture for either path.
+    """
+
+    def test_cutover_enabled_by_default_selects_the_sealed_evidence_path(self) -> None:
+        registry = build_migrated_strategy_registry()
+        context = RuntimeContext(
+            EARNINGS_CALENDAR_CONTRACT, "AAPL", _FixedClock(datetime.now(UTC)), "run-1"
+        )
+        with pytest.raises(RuntimeError, match="sealed subject-first evidence"):
+            registry.adapter_for("earnings_calendar")(context)
+
+    def test_cutover_disabled_selects_the_legacy_acquisition_path(self) -> None:
+        registry = build_migrated_strategy_registry(earnings_calendar_cutover_enabled=False)
+        context = RuntimeContext(
+            EARNINGS_CALENDAR_CONTRACT, "AAPL", _FixedClock(datetime.now(UTC)), "run-1"
+        )
+        with pytest.raises(RuntimeError, match="legacy path.*requires shared market data access"):
+            registry.adapter_for("earnings_calendar")(context)
+
+    def test_cutover_disabled_still_registers_all_three_targets(self) -> None:
+        registry = build_migrated_strategy_registry(earnings_calendar_cutover_enabled=False)
+        assert registry.strategy_ids() == ("earnings_calendar", "forward_factor", "skew_momentum")

--- a/tests/strategy_runtime/adapters/test_skew_momentum_vertical.py
+++ b/tests/strategy_runtime/adapters/test_skew_momentum_vertical.py
@@ -136,7 +136,7 @@ class TestSkewMomentumAdapter:
             SKEW_MOMENTUM_VERTICAL_CONTRACT, "AAPL", _FixedClock(datetime.now(UTC)), "run-1"
         )
         with pytest.raises(RuntimeError, match="requires shared market data access"):
-            skew_momentum_adapter(context)
+            skew_momentum_adapter(context, None)
 
     def test_full_live_acquisition_produces_a_translated_result(
         self, monkeypatch: pytest.MonkeyPatch
@@ -165,15 +165,9 @@ class TestSkewMomentumAdapter:
         access = build_shared_market_data_access(
             config, lambda _provider_id: ScriptedTransport(responses), clock, ("AAPL",)
         )
-        context = RuntimeContext(
-            SKEW_MOMENTUM_VERTICAL_CONTRACT,
-            "AAPL",
-            clock,
-            "run-1",
-            access["AAPL"].fulfillment,
-        )
+        context = RuntimeContext(SKEW_MOMENTUM_VERTICAL_CONTRACT, "AAPL", clock, "run-1")
 
-        result = skew_momentum_adapter(context)
+        result = skew_momentum_adapter(context, access["AAPL"].fulfillment)
 
         assert result.strategy_id == "skew_momentum"
         assert result.symbol == "AAPL"

--- a/tests/strategy_runtime/test_market_data_planning.py
+++ b/tests/strategy_runtime/test_market_data_planning.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from analytics.features import DerivedFactSet
 from domain import (
     CanonicalInstrumentIdentity,
     EvidenceKind,
@@ -27,8 +28,23 @@ from domain import (
     MarketDataSubjectType,
     ProviderAddressProjection,
 )
-from market_data import CapabilityRequest, load_market_data_config
+from market_data import (
+    BudgetScope,
+    CapabilityFulfillmentService,
+    CapabilityRegistry,
+    CapabilityRequest,
+    ProviderPriority,
+    ProviderPriorityPolicy,
+    ProviderRegistry,
+    RequestBudgetManager,
+    RequestBudgetPolicy,
+    load_market_data_config,
+)
+from market_data.factory import ProviderDependencies
+from market_data.fixture import FIXTURE_PROVIDER_ID, DeterministicFixtureProvider
+from market_data.resolution import ResolutionPolicy
 from market_data.rolling_window import ProviderRollingWindowTracker, RollingWindowPolicy
+from market_data.subject_snapshot import seal_subject_snapshot
 from strategy_runtime import (
     NO_LIFECYCLE,
     DataRequirement,
@@ -38,12 +54,14 @@ from strategy_runtime import (
     StrategyContract,
     StrategyRegistry,
     StructureKind,
+    SubjectSealedEvidence,
     build_provider_rolling_window_tracker,
     build_shared_market_data_access,
     declared_rolling_window_policies,
     run_strategies,
 )
 from strategy_runtime.market_data_planning import enabled_provider_configs
+from tests.market_data.test_fulfillment import UnusedBudget as _UnusedBudget
 
 NOW = datetime(2026, 1, 1, tzinfo=UTC)
 CAPABILITY = MarketCapability.REAL_TIME_QUOTE_V1
@@ -107,6 +125,44 @@ class TestBuildSharedMarketDataAccess:
         assert first is second  # identical object back -- genuinely not re-fetched
 
 
+def _sealed_evidence_for(symbol: str) -> SubjectSealedEvidence:
+    # SPRINT-014 S14-PR-05: RuntimeContext no longer carries a live
+    # CapabilityFulfillmentService (I-09) -- this fixture proves
+    # run_strategies()'s replacement generic capability, sealed_evidence_by_
+    # subject, the same way the pre-cutover fulfillment_by_subject fixture
+    # once proved EPIC-3's own shared-fulfillment mechanism.
+    base = next(
+        item
+        for item in load_market_data_config({}).providers
+        if item.provider_id == FIXTURE_PROVIDER_ID
+    )
+    source = DeterministicFixtureProvider(
+        base, ProviderDependencies(object(), _FixedClock(), _UnusedBudget())
+    )
+    registry = ProviderRegistry((source,))
+    priority_policy = ProviderPriorityPolicy(
+        "v1", (ProviderPriority(CAPABILITY, (FIXTURE_PROVIDER_ID,)),)
+    )
+    capabilities = CapabilityRegistry(registry, priority_policy)
+    budgets = RequestBudgetManager(
+        (RequestBudgetPolicy(FIXTURE_PROVIDER_ID, BudgetScope.RUNTIME, 4, 4, 0, "v1"),),
+        _FixedClock(),
+    )
+    fulfillment = CapabilityFulfillmentService(registry, capabilities, budgets)
+    result = fulfillment.fulfill(_quote_request())
+    policy = ResolutionPolicy("v1", (FIXTURE_PROVIDER_ID,), 60, ("last",))
+    snapshot = seal_subject_snapshot(
+        (result,),
+        as_of=NOW,
+        required_capabilities=(CAPABILITY,),
+        resolution_policy_by_capability={CAPABILITY: policy},
+        provider_metadata=(source.metadata,),
+    )
+    return SubjectSealedEvidence(
+        snapshot=snapshot, canonical_facts=(), derived_facts=DerivedFactSet(())
+    )
+
+
 class TestRunStrategiesWithSharedMarketData:
     def _contract(self, strategy_id: str) -> StrategyContract:
         return StrategyContract(
@@ -122,43 +178,42 @@ class TestRunStrategiesWithSharedMarketData:
             outputs=(OutputKind.METRICS,),
         )
 
-    def test_two_strategies_sharing_a_subject_get_the_same_fulfillment_result_object(
+    def test_two_strategies_sharing_a_subject_get_the_same_sealed_evidence_object(
         self,
     ) -> None:
-        request = _quote_request()
-
         def _adapter(context: RuntimeContext) -> object:
-            assert context.fulfillment is not None
-            return context.fulfillment.fulfill(request)
+            assert context.sealed_evidence is not None
+            return context.sealed_evidence
 
         registry = StrategyRegistry(
             ((self._contract("alpha"), _adapter), (self._contract("beta"), _adapter))
         )
-        config = load_market_data_config({})
         clock = _FixedClock()
-        access = build_shared_market_data_access(config, _no_transport_needed, clock, ("AAPL",))
-        fulfillment_by_subject = {symbol: item.fulfillment for symbol, item in access.items()}
+        sealed_evidence_by_subject = {"AAPL": _sealed_evidence_for("AAPL")}
 
         results = run_strategies(
-            registry, clock, subjects=("AAPL",), fulfillment_by_subject=fulfillment_by_subject
+            registry,
+            clock,
+            subjects=("AAPL",),
+            sealed_evidence_by_subject=sealed_evidence_by_subject,
         )
 
         assert len(results) == 2
         alpha_result = next(item for item in results if item.strategy_id == "alpha").result
         beta_result = next(item for item in results if item.strategy_id == "beta").result
-        assert alpha_result is beta_result  # both adapters actually shared one fulfillment
+        assert alpha_result is beta_result  # both adapters actually shared one bundle
 
-    def test_no_fulfillment_by_subject_leaves_context_fulfillment_none(self) -> None:
+    def test_no_sealed_evidence_by_subject_leaves_context_sealed_evidence_none(self) -> None:
         seen: list[object] = []
 
         def _adapter(context: RuntimeContext) -> str:
-            seen.append(context.fulfillment)
+            seen.append(context.sealed_evidence)
             return "ok"
 
         registry = StrategyRegistry(((self._contract("alpha"), _adapter),))
         clock = _FixedClock()
 
-        run_strategies(registry, clock, subjects=("AAPL",))  # no fulfillment_by_subject at all
+        run_strategies(registry, clock, subjects=("AAPL",))  # no sealed_evidence_by_subject at all
 
         assert seen == [None]
 


### PR DESCRIPTION
## Summary

Cuts Earnings Calendar over from imperative, strategy-driven acquisition to the subject-first evidence pipeline built by S14-PR-02/03/04 (SubjectAcquisitionPlan → sealed MarketSnapshot → canonical/derived facts → SubjectSealedEvidence). RuntimeContext no longer carries a live fulfillment object (I-09). Forward Factor and Skew Momentum keep working, unchanged financially, via a legacy composition binding built at registry-construction time.

Wires **both** real composition roots: `asa/scheduled_screening.py` and `asa/api/screening_routes.py`'s on-demand refresh endpoint — the second one was not in the original ticket scope but turned out to be a real, necessary consequence of the same I-09 constraint (its previous startup-time registry made every on-demand forward_factor/skew_momentum refresh unconditionally fail; caught only by running the full suite, not the touched-file subset).

Includes a **tested rollback switch** (`earnings_calendar_cutover_enabled=False`) that restores the pre-cutover acquisition path without discarding any sealed evidence.

**Full self-review, the 13 bugs found and fixed (all via running tests, never by reasoning alone), the read-set-expansion rationale, and the CUTOVER_PASS checklist against the Architect's own 5 criteria:**
`project/reports/SPRINT-014-S14-PR-05-shadow-cutover.md`

## Do not merge

Per the Architect's explicit directive for this ticket, this PR is **not** auto-merged on an ordinary architecture PASS — it is held for the Founder's own personal CUTOVER_PASS review of the shadow packet and the final live composition.

## Test plan

- [x] Full suite green: 2895 passed, 45 skipped, 0 failed (`pytest`)
- [x] `ruff check` clean on every touched file
- [x] `mypy` (strict, `asa` package) clean
- [x] Shadow-parity test confirms old/new paths reach identical PASS/NO_SIGNAL classification and identical `strategy_native_score` for the same evidence, verified reaching a real PASS (score 62.5), not a degenerate both-fail case
- [x] Rollback switch proven via 4 dedicated tests (3 unit-level path-selection tests + 1 end-to-end attempt-scoping test)
- [x] New screening↔strategy_runtime/facts architecture-boundary exception is itself boundary-tested for circularity

🤖 Generated with [Claude Code](https://claude.com/claude-code)