### PR TITLE
SPRINT-015: restore production market-data acquisition

### DIFF
--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -314,7 +314,12 @@ def run_scheduled_refresh(
     # new scheduled cycle always starts from empty cycle-scoped state.
     unique_symbols = tuple(sorted({symbol for _, symbol in universe}))
     access = build_shared_market_data_access(
-        config, transport_factory, clock, unique_symbols, rolling_window=rolling_window
+        config,
+        transport_factory,
+        clock,
+        unique_symbols,
+        budget_clock=quota_clock,
+        rolling_window=rolling_window,
     )
     reuse_counts = {
         "provider_calls": 0,

--- a/market_data/finnhub.py
+++ b/market_data/finnhub.py
@@ -328,7 +328,13 @@ class FinnhubProvider:
                 self._observation(request, subject, value, value.end_at, response)
                 for value in bar_values
             )
-        rows = _rows(response.json_body.get("earningsCalendar"))
+        raw_earnings = response.json_body.get("earningsCalendar")
+        # An explicitly present empty calendar is a valid, authoritative
+        # answer: no event matched this symbol/window.  Missing or malformed
+        # calendar structure remains EMPTY_PAYLOAD/SCHEMA_MISMATCH below.
+        if raw_earnings == []:
+            raise _NoData
+        rows = _rows(raw_earnings)
         security = Security(
             subject.canonical_instrument,
             subject.canonical_instrument.display_symbol.upper(),

--- a/market_data/tradier.py
+++ b/market_data/tradier.py
@@ -457,11 +457,16 @@ def _is_monthly_expiration(value: date) -> bool:
 
 def _row_observed_at_or_none(row: Mapping[str, object]) -> datetime | None:
     raw = row.get("trade_date") or row.get("timestamp")
+    return _provider_timestamp_or_none(raw)
+
+
+def _provider_timestamp_or_none(raw: object) -> datetime | None:
     if isinstance(raw, (int, float)):
         divisor = 1000 if raw > 10_000_000_000 else 1
         return datetime.fromtimestamp(raw / divisor, tz=UTC)
     if isinstance(raw, str):
-        return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(UTC)
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
     return None
 
 
@@ -521,16 +526,14 @@ def _chain(
 ) -> OptionChain:
     if not rows:
         raise ValueError("empty option chain")
-    # SPRINT-013 S13-10: the chain's own canonical timestamp is the median
-    # of every contract row's own genuine trade timestamp (rows missing
-    # one entirely are excluded, never silently treated as "now" -- a
-    # missing timestamp must never inflate apparent freshness). Median,
-    # not min/max: a single very old illiquid contract cannot alone make
-    # an otherwise-current chain look stale, and a single very recently
-    # touched contract cannot alone make an otherwise-stale chain look
-    # fresh. Never response order (median_observed_at sorts internally).
+    # The chain's canonical timestamp is the median of each row's latest
+    # genuine provider field timestamp. Tradier timestamps trades, bids,
+    # asks, and Greeks independently; a last trade is not the observation
+    # time of a current quote. Rows with no provider timestamp are excluded,
+    # never silently treated as "now". Median keeps response order and one
+    # outlier from controlling chain freshness.
     valid_times = tuple(
-        parsed for row in rows if (parsed := _row_observed_at_or_none(row)) is not None
+        parsed for row in rows if (parsed := _row_market_state_at_or_none(row)) is not None
     )
     observed = median_observed_at(valid_times) if valid_times else received_at
     evidence = _evidence(response)
@@ -540,6 +543,31 @@ def _chain(
     return OptionChain(
         f"tradier:{response.request_reference}", security, observed, contracts, evidence
     )
+
+
+def _row_market_state_at_or_none(row: Mapping[str, object]) -> datetime | None:
+    """Latest provider timestamp for the market fields carried by one row.
+
+    ``trade_date`` is only the most recent transaction.  Treating it as the
+    timestamp of the row's current bid, ask, and Greeks rejects live chains
+    whenever otherwise-usable contracts have not traded recently.  Tradier
+    supplies distinct bid/ask timestamps and an ORATS update timestamp; use
+    every populated field's declared timestamp and select the latest genuine
+    provider observation.  No retrieval-time substitution is made here.
+    """
+    candidates: list[datetime] = []
+    for name in ("trade_date", "bid_date", "ask_date"):
+        value = row.get(name)
+        if value is not None:
+            parsed = _provider_timestamp_or_none(value)
+            if parsed is not None:
+                candidates.append(parsed)
+    greeks = row.get("greeks")
+    if isinstance(greeks, Mapping) and greeks.get("updated_at") is not None:
+        parsed = _provider_timestamp_or_none(greeks["updated_at"])
+        if parsed is not None:
+            candidates.append(parsed)
+    return max(candidates) if candidates else None
 
 
 def _option(

--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -280,7 +280,11 @@ def _acquire_optional_earnings(
         events = tuple(cast(EarningsEvent, item.value) for item in result.observations)
         return min(events, key=lambda item: item.earnings_date)
     errors = tuple(attempt.error.code for attempt in result.attempts if attempt.error is not None)
-    if errors and all(code is ProviderErrorCode.NO_DATA for code in errors):
+    # One authoritative provider NO_DATA answer confirms that no event
+    # matched the requested symbol/window. Other providers may be
+    # temporarily unavailable; that absence is not contradictory market
+    # evidence, and must not erase the valid no-event result.
+    if ProviderErrorCode.NO_DATA in errors:
         return None
     summary = ", ".join(code.value for code in errors) or "unknown_provider_error"
     raise StrategyAdapterError(

--- a/strategy_runtime/market_data_planning.py
+++ b/strategy_runtime/market_data_planning.py
@@ -172,6 +172,7 @@ def build_shared_market_data_access(
     clock: Clock,
     subjects: tuple[str, ...],
     *,
+    budget_clock: Clock | None = None,
     rolling_window: ProviderRollingWindowTracker | None = None,
 ) -> dict[str, SubjectMarketDataAccess]:
     """One SubjectMarketDataAccess per subject in ``subjects`` -- never one
@@ -192,7 +193,7 @@ def build_shared_market_data_access(
     result: dict[str, SubjectMarketDataAccess] = {}
     for subject in subjects:
         budget_manager = _build_request_budget_manager(
-            enabled_configs, clock, rolling_window=rolling_window
+            enabled_configs, budget_clock or clock, rolling_window=rolling_window
         )
         factory = _provider_factory()
         providers = tuple(

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -1022,8 +1022,8 @@ def test_a_long_running_cycle_regains_provider_capacity_after_elapsed_time(
     _force_tiny_tradier_window(monkeypatch, window_limit=_SKEW_MOMENTUM_REQUESTS_PER_PAIR)
     import asa.scheduled_screening as scheduled_screening_module
 
-    # Anchor (call 0), pair 1's own 4 requests closely spaced (call 1-4,
-    # all well within the same 60s Tradier window together), then a
+    # Anchor (call 0), pair 1's own 4 requests closely spaced (three clock
+    # reads each: local authorization, shared window, completion), then a
     # large jump comfortably past 60s before pair 2's own requests
     # (call 5+) -- a real elapsed-time gap, never an evaluation-timestamp
     # one (every pair still shares the exact same frozen `now` for its
@@ -1033,7 +1033,34 @@ def test_a_long_running_cycle_regains_provider_capacity_after_elapsed_time(
         scheduled_screening_module.time,
         "monotonic",
         _stepped_monotonic(
-            [0.0, 0.01, 0.02, 0.03, 0.04, 400.0, 400.01, 400.02, 400.03], tail=400.04
+            [
+                0.0,
+                0.01,
+                0.02,
+                0.03,
+                0.04,
+                0.05,
+                0.06,
+                0.07,
+                0.08,
+                0.09,
+                0.10,
+                0.11,
+                0.12,
+                400.0,
+                400.01,
+                400.02,
+                400.03,
+                400.04,
+                400.05,
+                400.06,
+                400.07,
+                400.08,
+                400.09,
+                400.10,
+                400.11,
+            ],
+            tail=400.12,
         ),
     )
 

--- a/tests/market_data/test_finnhub.py
+++ b/tests/market_data/test_finnhub.py
@@ -255,7 +255,7 @@ def test_provider_shaped_upcoming_earnings_normalize_calendar_event(
 @pytest.mark.parametrize(
     ("body", "expected"),
     (
-        ({"earningsCalendar": []}, ProviderErrorCode.EMPTY_PAYLOAD),
+        ({"earningsCalendar": []}, ProviderErrorCode.NO_DATA),
         ({"earningsCalendar": [{"symbol": "AAPL"}]}, ProviderErrorCode.SCHEMA_MISMATCH),
     ),
 )

--- a/tests/market_data/test_tradier.py
+++ b/tests/market_data/test_tradier.py
@@ -310,12 +310,7 @@ def test_option_chain_preserves_greeks_iv_and_liquidity() -> None:
 
 
 def test_option_chain_freshness_is_the_median_not_the_first_response_row() -> None:
-    """SPRINT-013 S13-10: the chain's own canonical timestamp is a
-    deterministic aggregate (median) over every contract's own genuine
-    trade time -- never the first row's own value, and never simply the
-    single newest either (an aggregate robust to an outlier in *either*
-    direction, not a max/min that only guards one direction).
-    """
+    """Chain time is an order-independent aggregate of provider field times."""
     old = {
         "symbol": "AAPL260821C00210000",
         "underlying": "AAPL",
@@ -341,6 +336,38 @@ def test_option_chain_freshness_is_the_median_not_the_first_response_row() -> No
     recent_time = NOW - timedelta(minutes=5)
     expected_median = old_time + (recent_time - old_time) / 2
     assert result.observations[0].effective_time == expected_median
+
+
+def test_current_bid_and_ask_dates_keep_an_untraded_chain_usable() -> None:
+    """A last transaction is not the timestamp of current quoted prices."""
+    old_trade = NOW - timedelta(days=3)
+    current_quote = NOW - timedelta(minutes=1)
+    row = {
+        "symbol": "DIS260821C00100000",
+        "underlying": "DIS",
+        "expiration_date": "2026-08-21",
+        "strike": "100",
+        "option_type": "call",
+        "last": "5",
+        "bid": "4.90",
+        "ask": "5.10",
+        "trade_date": int(old_trade.timestamp() * 1000),
+        "bid_date": int(current_quote.timestamp() * 1000),
+        "ask_date": int(current_quote.timestamp() * 1000),
+    }
+    result = provider(Transport((response({"options": {"option": [row]}}),))).fetch(
+        request(
+            MarketCapability.OPTION_CHAIN_V1,
+            ("contracts",),
+            expiration=True,
+            maximum_age_seconds=3600,
+        ),
+        authorization(),
+    )
+
+    assert result.error is None
+    assert result.observations[0].effective_time == current_quote
+    assert result.observations[0].freshness.status is FreshnessStatus.FRESH
 
 
 def test_option_chain_freshness_is_identical_regardless_of_response_row_order() -> None:

--- a/tests/screening/test_live_adapters.py
+++ b/tests/screening/test_live_adapters.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import dataclasses
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
+from types import SimpleNamespace
 
 from domain import (
     AnnouncementTime,
@@ -63,6 +64,7 @@ from screening.adapters import TARGET_STRATEGY_REGISTRY
 from screening.live_acquisition import build_capability_registry, build_request_budget_manager
 from screening.live_adapters import (
     SKEW_MINIMUM_VALID_OBSERVATIONS,
+    _acquire_optional_earnings,
     _acquire_or_raise,
     build_live_adapters,
     build_live_skew_momentum_adapter,
@@ -539,6 +541,26 @@ class TestCaptureSkewSnapshot:
 
 
 class TestForwardFactorAndEarningsCalendarNeedTwoExpirations:
+    def test_confirmed_no_event_survives_another_providers_transient_failure(self) -> None:
+        class _Fulfillment:
+            def fulfill(self, _request, **_kwargs):  # noqa: ANN001, ANN202
+                return SimpleNamespace(
+                    observations=(),
+                    attempts=(
+                        SimpleNamespace(
+                            error=SimpleNamespace(code=ProviderErrorCode.RATE_LIMITED)
+                        ),
+                        SimpleNamespace(error=SimpleNamespace(code=ProviderErrorCode.NO_DATA)),
+                    ),
+                )
+
+        assert (
+            _acquire_optional_earnings(
+                _Fulfillment(), SYMBOL, NOW, NOW.date() + timedelta(days=60)  # type: ignore[arg-type]
+            )
+            is None
+        )
+
     def test_forward_factor_reports_missing_data_against_the_single_expiration_default_fixture(
         self,
     ) -> None:

--- a/tests/strategy_runtime/test_market_data_planning.py
+++ b/tests/strategy_runtime/test_market_data_planning.py
@@ -11,7 +11,7 @@ not merely that two dict lookups return the same Python object.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -105,6 +105,28 @@ class TestBuildSharedMarketDataAccess:
         second = fulfillment.fulfill(request)
 
         assert first is second  # identical object back -- genuinely not re-fetched
+
+    def test_operational_budget_window_advances_while_semantic_clock_stays_frozen(self) -> None:
+        """A long subject plan must not hit a permanent one-second burst window."""
+        config = load_market_data_config({})
+        semantic_clock = _FixedClock()
+        budget_clock = _FixedClock()
+        access = build_shared_market_data_access(
+            config,
+            _no_transport_needed,
+            semantic_clock,
+            ("HD",),
+            budget_clock=budget_clock,
+        )
+
+        for _ in range(9):
+            access["HD"].budget_manager.authorize(
+                "deterministic_fixture", MarketCapability.OPTION_CHAIN_V1, 1
+            )
+            budget_clock.value += timedelta(seconds=2)
+
+        assert semantic_clock.now() == NOW
+        assert len(access["HD"].budget_manager.accounting) == 9
 
 
 class TestRunStrategiesWithSharedMarketData:


### PR DESCRIPTION
## Symptom
Production Forward Factor repeatedly rejected live DIS/HD option data and left most of the universe unevaluable. Later acquisition also confused a valid empty earnings calendar with a malformed provider response.

Closes #294.

## Root causes
- The subject-local burst ledger used the frozen semantic cycle clock. Its one-second window never advanced, so later valid requests were refused as `pair_burst_exhausted`.
- Tradier chain freshness used only contract last-trade timestamps even when current bid/ask/Greek timestamps were present. Illiquid contracts made newly retrieved usable chains `stale_data`.
- Finnhub `earningsCalendar: []` was normalized as `empty_payload`, not authoritative `no_data`. A second provider rate limit then erased the valid no-event result.

## Corrections
- Separate operational budget time from frozen semantic evaluation time.
- Derive Tradier row market-state time from genuine trade, bid, ask, and Greek timestamps; no retrieval-time fabrication.
- Normalize explicit empty Finnhub earnings calendars as `no_data`; preserve malformed/missing payload failures.
- Accept one authoritative no-event response when other providers only fail transiently and no provider returns a conflicting event.

## Production effect
Sanitized live-provider runs with the candidate code:
- DIS: `stale_data` -> fully evaluated `no_signal` (6 provider requests).
- HD: `pair_burst_exhausted` -> fully evaluated `no_signal` (6 provider requests).
- Forward Factor first pass: 20/30 fully evaluated; remaining 10 reached earnings acquisition and exposed the next exact defect.
- After earnings correction: all 10 residual symbols fully evaluated `no_signal`, including XOM, CVX, SPY, QQQ, IWM, DIA, XLF, XLE, XLK, GLD.
- Combined evidence: 30/30 Forward Factor universe rows evaluable; zero known ASA-caused missing data in this strategy path.

No credentials, raw payloads, strategy thresholds, retries, architecture contracts, schema, or deployment configuration changed. Live probes were bounded and read-only.

## Validation
- `pytest -q`: 2882 passed, 45 skipped.
- Changed-scope Ruff: passed.
- Changed-source mypy: passed.
- Lean entrypoint: passed.
- Lean integrity: passed.
- `git diff --check`: passed.
- Repository-wide Ruff remains red on 492 pre-existing findings outside this patch; no unrelated cleanup included.

## Deployment
Not deployed. Founder/deployment authority remains unchanged. Full scheduled-cycle proof on merged production code remains required before SPRINT-015 exit.