### PR TITLE
S15-02: recover malformed and sparse historical bars

### DIFF
--- a/market_data/tradier.py
+++ b/market_data/tradier.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 from collections.abc import Mapping, Sequence
 from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal, InvalidOperation
@@ -72,6 +73,8 @@ TRADIER_CAPABILITIES = (
 # tradier_rolling_window_policy() read from, so the two can never drift.
 _MARKET_DATA_PER_MINUTE_PRODUCTION = 120
 _MARKET_DATA_PER_MINUTE_SANDBOX = 60
+
+LOGGER = logging.getLogger(__name__)
 
 
 def tradier_rolling_window_policy(
@@ -305,10 +308,29 @@ class TradierProvider:
             )
         if request.capability is MarketCapability.HISTORICAL_BARS_V1:
             rows = _rows(_mapping(response.json_body, "history").get("day"))
-            return tuple(
-                self._observation(request, subject, _bar(subject, row), response, row)
-                for row in rows
-            )
+            observations: list[MarketObservation] = []
+            rejected_rows = 0
+            for row in rows:
+                try:
+                    observations.append(
+                        self._observation(request, subject, _bar(subject, row), response, row)
+                    )
+                except (KeyError, TypeError, ValueError, InvalidOperation, DomainInvariantError):
+                    rejected_rows += 1
+            if rejected_rows:
+                LOGGER.warning(
+                    "Tradier rejected %d malformed historical bar row(s)",
+                    rejected_rows,
+                    extra={
+                        "provider": "tradier",
+                        "symbol": subject.canonical_instrument.display_symbol,
+                        "capability": request.capability.value,
+                        "diagnostic_code": ProviderErrorCode.SCHEMA_MISMATCH.value,
+                    },
+                )
+            if not observations:
+                raise DomainInvariantError("Tradier history contained no valid canonical bars")
+            return tuple(observations)
         if "expirations" in request.required_fields and "contracts" not in request.required_fields:
             values = _mapping(response.json_body, "expirations").get("date")
             dates = values if isinstance(values, list) else [values]

--- a/screening/live_adapters.py
+++ b/screening/live_adapters.py
@@ -308,7 +308,11 @@ def _spot_price(quote: Quote) -> Decimal:
 # hardcoded constants (identical for every symbol) since this ticket's
 # original authorship. See project/reports/SPRINT-011.md for the full
 # defect writeup and cited sources for each strategy's own thesis.
-_HISTORICAL_LOOKBACK_DAYS = 45  # calendar days -- ~30 trading days
+# Tradier can return a sparse daily history for otherwise valid symbols
+# (production CVX: 11 rows in 45 calendar days, 57 rows in 180).  The
+# consumer requires 21 observations, so request a bounded horizon proven
+# sufficient for that live provider shape without adding calls or retries.
+_HISTORICAL_LOOKBACK_DAYS = 180
 
 # SPRINT-013 S13-04D: mirrors strategies/stonk_manifests.py's own
 # SKEW_MOMENTUM_VERTICAL_MANIFEST-declared historical_lookback_observations/

--- a/tests/market_data/test_tradier.py
+++ b/tests/market_data/test_tradier.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 import pytest
 
@@ -275,6 +276,77 @@ def test_daily_history_normalizes_decimal_ohlcv() -> None:
     )
     assert result.error is None and isinstance(result.observations[0].value, OHLCVBar)
     assert transport.requests[0].path == "/v1/markets/history"
+
+
+def test_daily_history_rejects_one_incoherent_row_without_discarding_valid_series(
+    caplog,
+) -> None:  # noqa: ANN001
+    transport = Transport(
+        (
+            response(
+                {
+                    "history": {
+                        "day": [
+                            {
+                                "date": "2026-06-29",
+                                "open": "124.00",
+                                "high": "125.00",
+                                "low": "123.00",
+                                "close": "122.99",
+                                "volume": 100,
+                            },
+                            {
+                                "date": "2026-06-30",
+                                "open": "124.00",
+                                "high": "126.00",
+                                "low": "123.00",
+                                "close": "125.00",
+                                "volume": 200,
+                            },
+                        ]
+                    }
+                }
+            ),
+        )
+    )
+
+    result = provider(transport).fetch(
+        request(MarketCapability.HISTORICAL_BARS_V1, ("close",)), authorization()
+    )
+
+    assert result.error is None
+    assert len(result.observations) == 1
+    assert result.observations[0].value.close == Decimal("125.00")
+    assert "rejected 1 malformed historical bar row" in caplog.text
+
+
+def test_daily_history_fails_when_every_row_is_incoherent() -> None:
+    transport = Transport(
+        (
+            response(
+                {
+                    "history": {
+                        "day": {
+                            "date": "2026-06-29",
+                            "open": "124.00",
+                            "high": "125.00",
+                            "low": "123.00",
+                            "close": "122.99",
+                            "volume": 100,
+                        }
+                    }
+                }
+            ),
+        )
+    )
+
+    result = provider(transport).fetch(
+        request(MarketCapability.HISTORICAL_BARS_V1, ("close",)), authorization()
+    )
+
+    assert result.observations == ()
+    assert result.error is not None
+    assert result.error.code is ProviderErrorCode.SCHEMA_MISMATCH
 
 
 def test_option_chain_preserves_greeks_iv_and_liquidity() -> None:

--- a/tests/screening/test_live_adapters.py
+++ b/tests/screening/test_live_adapters.py
@@ -428,6 +428,25 @@ class TestSkewMomentumLiveNeedsMultipleStrikes:
         )
         assert result.subject_identity == f"symbol:{SYMBOL}"
 
+    def test_requests_bounded_history_horizon_proven_for_sparse_live_series(self) -> None:
+        CapturingMultiExpirationFixtureProvider.requests.clear()
+        fulfillment, clock = _fulfillment(CapturingMultiExpirationFixtureProvider)
+        adapters = build_live_adapters(SYMBOL, fulfillment)
+
+        run_screening(
+            TARGET_STRATEGY_REGISTRY,
+            adapters,
+            clock,
+            strategy_ids=("skew_momentum",),
+        )
+
+        request = next(
+            item
+            for item in CapturingMultiExpirationFixtureProvider.requests
+            if item.capability is MarketCapability.HISTORICAL_BARS_V1  # type: ignore[attr-defined]
+        )
+        assert request.effective_end - request.effective_start == timedelta(days=180)  # type: ignore[attr-defined]
+
 
 class _StubHistoricalSkewRepository:
     """Structurally satisfies screening.live_adapters.

--- a/tests/strategy_runtime/adapters/test_skew_momentum_vertical.py
+++ b/tests/strategy_runtime/adapters/test_skew_momentum_vertical.py
@@ -76,8 +76,8 @@ def _option_row(strike: int, expiration: str, option_type: str, call_delta: str)
 
 def _history_response() -> ReadOnlyHttpResponse:
     # Skew Momentum's realized-volatility input needs ~30 trading days
-    # (screening/live_adapters.py's _HISTORICAL_LOOKBACK_DAYS=45 calendar
-    # days), ending recently enough to satisfy the freshness requirement --
+    # (screening/live_adapters.py requests a bounded 180-calendar-day
+    # horizon), ending recently enough to satisfy the freshness requirement --
     # ending 15+ days ago (an earlier draft's mistake) reads as STALE_DATA.
     days = []
     cursor = date.today() - timedelta(days=1)


### PR DESCRIPTION
## Ticket
Closes #296.

## Summary
- Preserve valid Tradier historical bars when isolated rows violate canonical OHLC invariants.
- Emit bounded structured warning for rejected rows; fail closed when no valid rows remain.
- Expand historical request horizon from 45 to 180 calendar days, based on measured live CVX coverage.

## Root cause
DIS returned 31 bars, but one bar (`2026-06-29`) had `low > close`; all-or-nothing normalization discarded the full usable series. CVX returned only 11 valid bars in 45 days while Skew Momentum requires 21; the same documented endpoint returned 57 valid bars over 180 days.

## Before / expected after
- DIS: `schema_mismatch` -> 30 valid canonical bars.
- CVX: 11 closes -> 57 closes.
- Skew Momentum: 28/30 evaluable -> expected 30/30, pending deployment proof.

## Safety
- No raw payload, credentials, prices, strategy thresholds, provider ordering, retries, or SPRINT-014 changes.
- Malformed rows never become canonical observations.
- All-malformed payloads remain `schema_mismatch`.
- No extra provider calls.

## Validation
- Full suite: 2,885 passed, 45 skipped.
- Target regressions: 50 passed.
- Ruff: changed files and Product CI targets pass.
- mypy: `market_data`, `screening`, and `asa` pass.
- Product backend tests: 170 passed, 43 skipped.
- Lean entrypoint, integrity, validator, merge-conflict probe, and `git diff --check`: pass.
- Whole-repository Ruff remains non-green from 492 pre-existing baseline findings outside this patch.

## Live validation
Bounded sanitized Tradier reads confirmed:
- DIS: 31 rows / 31 unique dates; one canonical OHLC violation.
- CVX: 11 rows over 45 days; 57 rows over 180 days.
No deployment performed. Production-cycle proof required after merge and Founder deployment authorization.
