### PR TITLE
S14R-M2: converge production strategies on sealed facts

### DIFF
--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -454,6 +454,7 @@ def build_screening_router(
                         subject_access.capability_registry
                     ),
                     capability_reducer_by_capability=migrated_shadow_capability_reducers(),
+                    strategy_ids=(signal,),
                 )
             except Exception:
                 _LOGGER.warning(

--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -411,7 +411,7 @@ def run_scheduled_refresh(
     # A preparation failure is isolated exactly like this module's other
     # best-effort side channels (skew capture, opportunity history) and
     # never aborts or affects any pair's own legacy evaluation.
-    shadow_registry = build_migrated_shadow_registry(clock.now())
+    shadow_registry = build_migrated_shadow_registry(clock.now(), historical_skew_repository)
     shadow_capability_reducers = migrated_shadow_capability_reducers()
     # SPRINT-014 S14-PR-05, Architect checkpoint: nineteenth review, "one
     # shared cutover policy owner used identically by scheduled and API
@@ -440,6 +440,12 @@ def run_scheduled_refresh(
                     access[symbol].capability_registry
                 ),
                 capability_reducer_by_capability=shadow_capability_reducers,
+                strategy_ids=tuple(
+                    sorted(
+                        requested_signal_ids_by_symbol[symbol]
+                        & set(shadow_registry.strategy_ids())
+                    )
+                ),
             )
         except Exception:
             _LOGGER.warning(

--- a/strategies/forward_factor_evaluation.py
+++ b/strategies/forward_factor_evaluation.py
@@ -1,0 +1,56 @@
+"""Read-only Forward Factor graph evaluation over materialized knowledge."""
+
+from __future__ import annotations
+
+from analytics.features import DerivedFactSet
+from domain import ExpirationCollection
+from strategies import (
+    CORE_COMPONENTS,
+    FORWARD_FACTOR_CALENDAR_MANIFEST,
+    STONK_STRATEGY_PLUGINS,
+    compile_strategy_graph,
+    execute_strategy_graph,
+)
+from strategies.forward_factor_knowledge import ForwardFactorPayload
+from strategies.plugins import build_plugin_registry
+from strategies.stonk_components import DATE, EXPIRATION_COLLECTION, OPTION_CHAIN, B, D
+from strategies.type_system import ComponentValues, StrategyTypeReference, TypedValue
+
+_COMPONENT_REGISTRY = build_plugin_registry(CORE_COMPONENTS, STONK_STRATEGY_PLUGINS)
+_INTEGER = StrategyTypeReference("Integer", "1.0.0")
+
+
+def evaluate_forward_factor(
+    derived_facts: DerivedFactSet, payload: ForwardFactorPayload
+) -> ComponentValues:
+    front_iv = derived_facts.get(payload.implied_forward_fact_id)
+    factor = derived_facts.get(payload.forward_factor_fact_id)
+    # Reading both facts proves the graph receives the exact materialized
+    # feature set for this selection. Its frozen graph still derives the same
+    # values from the canonical front/back IV inputs for explainability.
+    assert front_iv.value is not None
+    assert factor.value is not None
+
+    optional_date = StrategyTypeReference("Optional", "1.0.0", (DATE,))
+    values = {
+        "expiration_select.expirations": (
+            EXPIRATION_COLLECTION,
+            ExpirationCollection(payload.as_of, (payload.front_cycle, payload.back_cycle)),
+        ),
+        "double_calendar.chain": (OPTION_CHAIN, payload.chain),
+        "forward_iv.front_iv": (D, payload.front_implied_volatility),
+        "forward_iv.back_iv": (D, payload.back_implied_volatility),
+        "forward_iv.front_dte": (_INTEGER, payload.front_cycle.days_to_expiration),
+        "forward_iv.back_dte": (_INTEGER, payload.back_cycle.days_to_expiration),
+        "factor.front_iv": (D, payload.front_implied_volatility),
+        "eligibility.earnings_eligible": (B, payload.earnings_eligible),
+        "eligibility.confirmed_earnings_date": (
+            optional_date,
+            payload.confirmed_earnings_date,
+        ),
+    }
+    context = ComponentValues(
+        tuple((name, TypedValue(type_ref, value)) for name, (type_ref, value) in values.items())
+    )
+    graph = compile_strategy_graph(FORWARD_FACTOR_CALENDAR_MANIFEST, _COMPONENT_REGISTRY)
+    return execute_strategy_graph(graph, context).outputs

--- a/strategies/forward_factor_knowledge.py
+++ b/strategies/forward_factor_knowledge.py
@@ -1,0 +1,240 @@
+"""Forward Factor mapping from sealed evidence to immutable facts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+from analytics.derived_fact_materialization import derived_fact_id
+from analytics.derived_facts import (
+    FORWARD_FACTOR,
+    IMPLIED_FORWARD_VOLATILITY,
+    NO_CONFIRMED_EARNINGS_THROUGH_EXPIRATION,
+    compute_forward_factor,
+    compute_implied_forward_volatility,
+    compute_no_confirmed_earnings_through_expiration,
+)
+from analytics.features import DerivedFactQualityStatus, DerivedFactRequest, DerivedFactSet
+from domain import (
+    CanonicalFact,
+    EarningsEvent,
+    EvidenceKind,
+    EvidenceReference,
+    ExpirationCycle,
+    MarketCapability,
+    OptionChain,
+)
+from facts.canonical_projection import CanonicalFactRequest, canonical_fact_id
+from strategies.knowledge_contracts import KnowledgeMapping
+
+FACT_SPOT = "spot_price"
+FACT_OPTION_IV = "option_implied_volatility"
+FACT_EARNINGS_DATE = "earnings_date"
+FACT_EARNINGS_CONFIRMED = "earnings_confirmed"
+_FACT_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class ForwardFactorPayload:
+    chain: OptionChain
+    front_cycle: ExpirationCycle
+    back_cycle: ExpirationCycle
+    front_strike: Decimal
+    back_strike: Decimal
+    front_implied_volatility: Decimal
+    back_implied_volatility: Decimal
+    as_of: date
+    earnings_eligible: bool
+    confirmed_earnings_date: date | None
+    front_iv_fact_id: str
+    back_iv_fact_id: str
+    implied_forward_fact_id: str
+    forward_factor_fact_id: str
+
+
+def build_forward_factor_knowledge_mapping(
+    *,
+    subject: str,
+    snapshot_digest: str,
+    quote_observation_id: str,
+    chain_observation_id: str,
+    earnings_observation_id: str | None,
+    spot_price: Decimal,
+    chain: OptionChain,
+    front_cycle: ExpirationCycle,
+    back_cycle: ExpirationCycle,
+    front_strike: Decimal,
+    back_strike: Decimal,
+    front_iv: Decimal,
+    back_iv: Decimal,
+    event: EarningsEvent | None,
+    as_of: date,
+) -> KnowledgeMapping[ForwardFactorPayload]:
+    front_subject = f"{subject}:{front_cycle.expiration_date.isoformat()}:{front_strike}:call"
+    back_subject = f"{subject}:{back_cycle.expiration_date.isoformat()}:{back_strike}:call"
+    requests = [
+        CanonicalFactRequest(
+            MarketCapability.REAL_TIME_QUOTE_V1,
+            quote_observation_id,
+            spot_price,
+            subject,
+            FACT_SPOT,
+        ),
+        CanonicalFactRequest(
+            MarketCapability.OPTION_CHAIN_V1,
+            chain_observation_id,
+            front_iv,
+            front_subject,
+            FACT_OPTION_IV,
+        ),
+        CanonicalFactRequest(
+            MarketCapability.OPTION_CHAIN_V1,
+            chain_observation_id,
+            back_iv,
+            back_subject,
+            FACT_OPTION_IV,
+        ),
+    ]
+    if event is not None and earnings_observation_id is not None:
+        requests.extend(
+            (
+                CanonicalFactRequest(
+                    MarketCapability.EARNINGS_CALENDAR_V1,
+                    earnings_observation_id,
+                    event.earnings_date.isoformat(),
+                    subject,
+                    FACT_EARNINGS_DATE,
+                ),
+                CanonicalFactRequest(
+                    MarketCapability.EARNINGS_CALENDAR_V1,
+                    earnings_observation_id,
+                    event.confirmed,
+                    subject,
+                    FACT_EARNINGS_CONFIRMED,
+                ),
+            )
+        )
+
+    front_fact_id = canonical_fact_id(FACT_OPTION_IV, front_subject, snapshot_digest)
+    back_fact_id = canonical_fact_id(FACT_OPTION_IV, back_subject, snapshot_digest)
+    selection_parameters = (
+        ("front_expiration", front_cycle.expiration_date.isoformat()),
+        ("back_expiration", back_cycle.expiration_date.isoformat()),
+        ("front_strike", str(front_strike)),
+        ("back_strike", str(back_strike)),
+    )
+    implied_id = derived_fact_id(
+        IMPLIED_FORWARD_VOLATILITY,
+        subject,
+        snapshot_digest,
+        parameters=selection_parameters,
+    )
+    factor_id = derived_fact_id(
+        FORWARD_FACTOR, subject, snapshot_digest, parameters=selection_parameters
+    )
+
+    def _compute(facts: tuple[CanonicalFact, ...]) -> tuple[DerivedFactRequest, ...]:
+        front_fact = next(item for item in facts if item.fact_id == front_fact_id)
+        back_fact = next(item for item in facts if item.fact_id == back_fact_id)
+        assert isinstance(front_fact.value, Decimal)
+        assert isinstance(back_fact.value, Decimal)
+        evidence = (
+            EvidenceReference(EvidenceKind.CANONICAL_FACT, front_fact.fact_id, _FACT_VERSION),
+            EvidenceReference(EvidenceKind.CANONICAL_FACT, back_fact.fact_id, _FACT_VERSION),
+        )
+        implied = compute_implied_forward_volatility(
+            front_fact.value,
+            back_fact.value,
+            front_cycle.days_to_expiration,
+            back_cycle.days_to_expiration,
+        )
+        result = [
+            DerivedFactRequest(
+                IMPLIED_FORWARD_VOLATILITY,
+                subject,
+                implied,
+                "decimal",
+                evidence,
+                DerivedFactQualityStatus.VALID,
+                selection_parameters,
+            ),
+            DerivedFactRequest(
+                FORWARD_FACTOR,
+                subject,
+                compute_forward_factor(front_fact.value, implied),
+                "decimal",
+                evidence,
+                DerivedFactQualityStatus.VALID,
+                selection_parameters,
+            ),
+        ]
+        if event is not None:
+            earnings_fact = next(item for item in facts if item.fact_type == FACT_EARNINGS_DATE)
+            confirmed_fact = next(
+                item for item in facts if item.fact_type == FACT_EARNINGS_CONFIRMED
+            )
+            earnings_evidence = (
+                EvidenceReference(
+                    EvidenceKind.CANONICAL_FACT, earnings_fact.fact_id, _FACT_VERSION
+                ),
+                EvidenceReference(
+                    EvidenceKind.CANONICAL_FACT, confirmed_fact.fact_id, _FACT_VERSION
+                ),
+            )
+            assert isinstance(earnings_fact.value, str)
+            assert isinstance(confirmed_fact.value, bool)
+            result.append(
+                DerivedFactRequest(
+                    NO_CONFIRMED_EARNINGS_THROUGH_EXPIRATION,
+                    subject,
+                    compute_no_confirmed_earnings_through_expiration(
+                        confirmed=confirmed_fact.value,
+                        earnings_date=date.fromisoformat(earnings_fact.value),
+                        as_of=as_of,
+                        back_expiration=back_cycle.expiration_date,
+                    ),
+                    "boolean",
+                    earnings_evidence,
+                    DerivedFactQualityStatus.VALID,
+                    (("back_expiration", back_cycle.expiration_date.isoformat()),),
+                )
+            )
+        return tuple(result)
+
+    def _payload(
+        facts: tuple[CanonicalFact, ...], derived: DerivedFactSet
+    ) -> ForwardFactorPayload:
+        front_value = next(item for item in facts if item.fact_id == front_fact_id).value
+        back_value = next(item for item in facts if item.fact_id == back_fact_id).value
+        assert isinstance(front_value, Decimal)
+        assert isinstance(back_value, Decimal)
+        earnings_eligible = True
+        if event is not None:
+            eligibility_id = derived_fact_id(
+                NO_CONFIRMED_EARNINGS_THROUGH_EXPIRATION,
+                subject,
+                snapshot_digest,
+                parameters=(("back_expiration", back_cycle.expiration_date.isoformat()),),
+            )
+            value = derived.get(eligibility_id).value
+            assert isinstance(value, bool)
+            earnings_eligible = value
+        return ForwardFactorPayload(
+            chain,
+            front_cycle,
+            back_cycle,
+            front_strike,
+            back_strike,
+            front_value,
+            back_value,
+            as_of,
+            earnings_eligible,
+            event.earnings_date if event is not None and event.confirmed else None,
+            front_fact_id,
+            back_fact_id,
+            implied_id,
+            factor_id,
+        )
+
+    return KnowledgeMapping(tuple(requests), _compute, _payload)

--- a/strategies/forward_factor_planning.py
+++ b/strategies/forward_factor_planning.py
@@ -1,0 +1,113 @@
+"""Provider-blind subject demands for Forward Factor."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Mapping  # noqa: UP035 -- strategies boundary permits typing only
+
+from analytics.expiration_selection import ExpirationCandidate, rank_expiration_pairs
+from domain import (
+    CapabilityDemand,
+    DemandExpansion,
+    EvidenceUsability,
+    ExpirationCollection,
+    MarketCapability,
+    OptionChain,
+    ResolvedCapabilityEvidence,
+    UnknownReason,
+)
+from strategies import FORWARD_FACTOR_CALENDAR_MANIFEST
+from strategies.earnings_calendar_planning import earnings_demand
+from strategies.manifest import node_parameter_value
+
+MAX_PAIR_ATTEMPTS = 5
+
+
+def _policy() -> dict[str, int]:
+    names = (
+        "front_min_dte",
+        "front_max_dte",
+        "back_min_dte",
+        "back_max_dte",
+        "minimum_gap_days",
+        "maximum_gap_days",
+        "target_front_dte",
+        "target_gap_days",
+    )
+    values: dict[str, int] = {}
+    for name in names:
+        value = node_parameter_value(FORWARD_FACTOR_CALENDAR_MANIFEST, "expiration_select", name)
+        assert isinstance(value, int) and not isinstance(value, bool)
+        values[name] = value
+    return values
+
+
+def quote_demand(now: datetime) -> CapabilityDemand:
+    return CapabilityDemand(MarketCapability.REAL_TIME_QUOTE_V1, ("last",), now, now)
+
+
+def expirations_demand(now: datetime) -> CapabilityDemand:
+    return CapabilityDemand(MarketCapability.OPTION_CHAIN_V1, ("expirations",), now, now)
+
+
+def chain_demand(now: datetime, expiration: date) -> CapabilityDemand:
+    return CapabilityDemand(
+        MarketCapability.OPTION_CHAIN_V1,
+        ("contracts",),
+        now,
+        now,
+        expiration=expiration,
+    )
+
+
+def bootstrap_demands(now: datetime) -> tuple[CapabilityDemand, ...]:
+    return quote_demand(now), expirations_demand(now), earnings_demand(now)
+
+
+def _candidates(
+    evidence: ResolvedCapabilityEvidence | None, as_of: date
+) -> tuple[ExpirationCandidate, ...]:
+    if evidence is None or evidence.usability is not EvidenceUsability.RESOLVED:
+        return ()
+    if isinstance(evidence.value, ExpirationCollection):
+        dates = tuple(cycle.expiration_date for cycle in evidence.value.cycles)
+    elif isinstance(evidence.value, OptionChain):
+        dates = tuple(sorted({contract.expiration for contract in evidence.value.contracts}))
+    else:
+        return ()
+    return tuple(
+        ExpirationCandidate(expiration, (expiration - as_of).days)
+        for expiration in dates
+        if expiration >= as_of
+    )
+
+
+def expand_demands(
+    evidence: Mapping[str, ResolvedCapabilityEvidence], *, now: datetime
+) -> DemandExpansion:
+    discovery = expirations_demand(now)
+    ranked = rank_expiration_pairs(
+        _candidates(evidence.get(discovery.demand_id), now.date()),
+        **_policy(),
+    )[:MAX_PAIR_ATTEMPTS]
+    if not ranked:
+        return DemandExpansion(
+            unknown_reasons=(
+                UnknownReason("no_valid_expiration_pair", (discovery.demand_id,)),
+            )
+        )
+    dates = tuple(sorted({item.expiration_date for pair in ranked for item in pair}))
+    demands = tuple(chain_demand(now, expiration) for expiration in dates)
+    selections = tuple(
+        (f"pair_{index}", f"{front.expiration_date.isoformat()}/{back.expiration_date.isoformat()}")
+        for index, (front, back) in enumerate(ranked)
+    )
+    return DemandExpansion(demands=demands, selections=selections)
+
+
+def resolved_field_requirements() -> dict[MarketCapability, tuple[tuple[str, ...], int]]:
+    return {
+        MarketCapability.REAL_TIME_QUOTE_V1: (("last",), 3600),
+        MarketCapability.OPTION_CHAIN_V1: (("contracts",), 3600),
+        MarketCapability.EARNINGS_CALENDAR_V1: (("earnings_date",), 3600),
+    }

--- a/strategies/skew_momentum_knowledge.py
+++ b/strategies/skew_momentum_knowledge.py
@@ -1,0 +1,258 @@
+"""Skew Momentum mapping from sealed evidence to immutable facts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+from analytics.derived_facts import (
+    ATM_IV_VS_REALIZED,
+    CALL_WING_IV_VS_REALIZED,
+    NAMED_MOMENTUM_DIMENSIONS,
+    NORMALIZED_CALL_SKEW,
+    NORMALIZED_PUT_SKEW,
+    PUT_WING_IV_VS_REALIZED,
+    REALIZED_VOLATILITY,
+    SKEW_HISTORICAL_ZSCORE,
+    compute_atm_iv_vs_realized_volatility,
+    compute_historical_zscore,
+    compute_iv_realized_spread,
+    compute_normalized_skew,
+)
+from analytics.features import DerivedFactQualityStatus, DerivedFactRequest, DerivedFactSet
+from analytics.realized_volatility import compute_realized_volatility, compute_trailing_return
+from domain import (
+    CanonicalFact,
+    EvidenceKind,
+    EvidenceReference,
+    HistoricalSkewObservation,
+    MarketCapability,
+    OptionChain,
+)
+from facts.canonical_projection import CanonicalFactRequest, canonical_fact_id
+from strategies.knowledge_contracts import KnowledgeMapping
+
+FACT_DAILY_CLOSES = "daily_closes"
+FACT_OPTION_IV = "option_implied_volatility"
+_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class SkewMomentumPayload:
+    chain: OptionChain
+    expiration: date
+    normalized_call_skew: Decimal
+    normalized_put_skew: Decimal
+    call_skew_zscore: Decimal | None
+    put_skew_zscore: Decimal | None
+    historical_valid_observations: int
+    call_atm_iv_minus_rv: Decimal
+    put_atm_iv_minus_rv: Decimal
+    call_wing_iv_minus_rv: Decimal
+    put_wing_iv_minus_rv: Decimal
+    call_wing_iv_minus_atm_iv: Decimal
+    put_wing_iv_minus_atm_iv: Decimal
+    time_series_return: Decimal
+
+
+def build_skew_momentum_knowledge_mapping(
+    *,
+    subject: str,
+    snapshot_digest: str,
+    chain_observation_id: str,
+    bars_observation_id: str,
+    chain: OptionChain,
+    expiration: date,
+    closes: tuple[Decimal, ...],
+    call_atm_iv: Decimal,
+    put_atm_iv: Decimal,
+    call_wing_iv: Decimal,
+    put_wing_iv: Decimal,
+    history: tuple[HistoricalSkewObservation, ...],
+) -> KnowledgeMapping[SkewMomentumPayload]:
+    iv_values = (
+        ("call_atm", call_atm_iv),
+        ("put_atm", put_atm_iv),
+        ("call_wing", call_wing_iv),
+        ("put_wing", put_wing_iv),
+    )
+    requests = [
+        CanonicalFactRequest(
+            MarketCapability.HISTORICAL_BARS_V1,
+            bars_observation_id,
+            closes,
+            subject,
+            FACT_DAILY_CLOSES,
+        )
+    ]
+    requests.extend(
+        CanonicalFactRequest(
+            MarketCapability.OPTION_CHAIN_V1,
+            chain_observation_id,
+            value,
+            f"{subject}:{expiration.isoformat()}:{name}",
+            FACT_OPTION_IV,
+        )
+        for name, value in iv_values
+    )
+    close_id = canonical_fact_id(FACT_DAILY_CLOSES, subject, snapshot_digest)
+    iv_ids = {
+        name: canonical_fact_id(
+            FACT_OPTION_IV, f"{subject}:{expiration.isoformat()}:{name}", snapshot_digest
+        )
+        for name, _ in iv_values
+    }
+    params = (("expiration", expiration.isoformat()),)
+
+    def _compute(facts: tuple[CanonicalFact, ...]) -> tuple[DerivedFactRequest, ...]:
+        fact_by_id = {fact.fact_id: fact for fact in facts}
+        close_values = fact_by_id[close_id].value
+        assert isinstance(close_values, tuple)
+        typed_closes = tuple(value for value in close_values if isinstance(value, Decimal))
+        iv = {name: fact_by_id[fact_id].value for name, fact_id in iv_ids.items()}
+        assert all(isinstance(value, Decimal) for value in iv.values())
+        typed_iv = {name: value for name, value in iv.items() if isinstance(value, Decimal)}
+        canonical_evidence = tuple(
+            EvidenceReference(EvidenceKind.CANONICAL_FACT, fact.fact_id, _VERSION) for fact in facts
+        )
+        chain_evidence = tuple(
+            EvidenceReference(EvidenceKind.CANONICAL_FACT, iv_ids[name], _VERSION)
+            for name in sorted(iv_ids)
+        )
+        call_skew = compute_normalized_skew(typed_iv["call_atm"], typed_iv["call_wing"])
+        put_skew = compute_normalized_skew(typed_iv["put_atm"], typed_iv["put_wing"])
+        realized = compute_realized_volatility(typed_closes)
+        result = [
+            DerivedFactRequest(
+                REALIZED_VOLATILITY,
+                subject,
+                realized,
+                "decimal",
+                canonical_evidence,
+                DerivedFactQualityStatus.VALID,
+            ),
+            DerivedFactRequest(
+                NORMALIZED_CALL_SKEW,
+                subject,
+                call_skew,
+                "decimal",
+                chain_evidence,
+                DerivedFactQualityStatus.VALID,
+                params,
+            ),
+            DerivedFactRequest(
+                NORMALIZED_PUT_SKEW,
+                subject,
+                put_skew,
+                "decimal",
+                chain_evidence,
+                DerivedFactQualityStatus.VALID,
+                params,
+            ),
+            DerivedFactRequest(
+                ATM_IV_VS_REALIZED,
+                f"{subject}:call",
+                compute_atm_iv_vs_realized_volatility(typed_iv["call_atm"], typed_closes),
+                "decimal",
+                canonical_evidence,
+                DerivedFactQualityStatus.VALID,
+                params,
+            ),
+            DerivedFactRequest(
+                ATM_IV_VS_REALIZED,
+                f"{subject}:put",
+                compute_atm_iv_vs_realized_volatility(typed_iv["put_atm"], typed_closes),
+                "decimal",
+                canonical_evidence,
+                DerivedFactQualityStatus.VALID,
+                params,
+            ),
+            DerivedFactRequest(
+                CALL_WING_IV_VS_REALIZED,
+                subject,
+                compute_iv_realized_spread(typed_iv["call_wing"], realized),
+                "decimal",
+                canonical_evidence,
+                DerivedFactQualityStatus.VALID,
+                params,
+            ),
+            DerivedFactRequest(
+                PUT_WING_IV_VS_REALIZED,
+                subject,
+                compute_iv_realized_spread(typed_iv["put_wing"], realized),
+                "decimal",
+                canonical_evidence,
+                DerivedFactQualityStatus.VALID,
+                params,
+            ),
+            DerivedFactRequest(
+                NAMED_MOMENTUM_DIMENSIONS,
+                subject,
+                compute_trailing_return(typed_closes[-21:]),
+                "decimal",
+                (EvidenceReference(EvidenceKind.CANONICAL_FACT, close_id, _VERSION),),
+                DerivedFactQualityStatus.VALID,
+                (("lookback_sessions", "20"),),
+            ),
+        ]
+        if len(history) >= 40:
+            history_evidence = tuple(reference for item in history for reference in item.evidence)
+            result.extend(
+                (
+                    DerivedFactRequest(
+                        SKEW_HISTORICAL_ZSCORE,
+                        f"{subject}:call",
+                        compute_historical_zscore(
+                            call_skew, tuple(item.call_skew for item in history)
+                        ),
+                        "decimal",
+                        history_evidence,
+                        DerivedFactQualityStatus.VALID,
+                        (("lookback_observations", "60"),),
+                    ),
+                    DerivedFactRequest(
+                        SKEW_HISTORICAL_ZSCORE,
+                        f"{subject}:put",
+                        compute_historical_zscore(
+                            put_skew, tuple(item.put_skew for item in history)
+                        ),
+                        "decimal",
+                        history_evidence,
+                        DerivedFactQualityStatus.VALID,
+                        (("lookback_observations", "60"),),
+                    ),
+                )
+            )
+        return tuple(result)
+
+    def _payload(facts: tuple[CanonicalFact, ...], derived: DerivedFactSet) -> SkewMomentumPayload:
+        def value(feature: str, subject_part: str = subject) -> Decimal:
+            fact = next(
+                item
+                for item in derived.facts
+                if item.derived_fact_id.startswith(f"{feature}:{subject_part}:")
+            )
+            assert isinstance(fact.value, Decimal)
+            return fact.value
+
+        call_z = value(SKEW_HISTORICAL_ZSCORE, f"{subject}:call") if len(history) >= 40 else None
+        put_z = value(SKEW_HISTORICAL_ZSCORE, f"{subject}:put") if len(history) >= 40 else None
+        return SkewMomentumPayload(
+            chain,
+            expiration,
+            value(NORMALIZED_CALL_SKEW),
+            value(NORMALIZED_PUT_SKEW),
+            call_z,
+            put_z,
+            len(history),
+            value(ATM_IV_VS_REALIZED, f"{subject}:call"),
+            value(ATM_IV_VS_REALIZED, f"{subject}:put"),
+            value(CALL_WING_IV_VS_REALIZED),
+            value(PUT_WING_IV_VS_REALIZED),
+            call_wing_iv - call_atm_iv,
+            put_wing_iv - put_atm_iv,
+            value(NAMED_MOMENTUM_DIMENSIONS),
+        )
+
+    return KnowledgeMapping(tuple(requests), _compute, _payload)

--- a/strategies/skew_momentum_planning.py
+++ b/strategies/skew_momentum_planning.py
@@ -1,0 +1,85 @@
+"""Provider-blind subject demands for Skew Momentum."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Mapping  # noqa: UP035
+
+from domain import (
+    CapabilityDemand,
+    DemandExpansion,
+    EvidenceUsability,
+    ExpirationCollection,
+    MarketCapability,
+    ResolvedCapabilityEvidence,
+    UnknownReason,
+)
+
+HISTORICAL_LOOKBACK_DAYS = 180
+
+
+def quote_demand(now: datetime) -> CapabilityDemand:
+    return CapabilityDemand(MarketCapability.REAL_TIME_QUOTE_V1, ("last",), now, now)
+
+
+def expirations_demand(now: datetime) -> CapabilityDemand:
+    return CapabilityDemand(MarketCapability.OPTION_CHAIN_V1, ("expirations",), now, now)
+
+
+def bars_demand(now: datetime) -> CapabilityDemand:
+    return CapabilityDemand(
+        MarketCapability.HISTORICAL_BARS_V1,
+        ("close",),
+        now - timedelta(days=HISTORICAL_LOOKBACK_DAYS),
+        now,
+    )
+
+
+def chain_demand(now: datetime, expiration: date) -> CapabilityDemand:
+    return CapabilityDemand(
+        MarketCapability.OPTION_CHAIN_V1,
+        ("contracts",),
+        now,
+        now,
+        expiration=expiration,
+    )
+
+
+def bootstrap_demands(now: datetime) -> tuple[CapabilityDemand, ...]:
+    return quote_demand(now), expirations_demand(now), bars_demand(now)
+
+
+def expand_demands(
+    evidence: Mapping[str, ResolvedCapabilityEvidence], *, now: datetime
+) -> DemandExpansion:
+    discovery = expirations_demand(now)
+    resolved = evidence.get(discovery.demand_id)
+    if (
+        resolved is None
+        or resolved.usability is not EvidenceUsability.RESOLVED
+        or not isinstance(resolved.value, ExpirationCollection)
+    ):
+        return DemandExpansion(unknown_reasons=(UnknownReason("no_future_expiration"),))
+    future = tuple(
+        cycle.expiration_date
+        for cycle in resolved.value.cycles
+        if cycle.expiration_date > now.date()
+    )
+    if not future:
+        return DemandExpansion(unknown_reasons=(UnknownReason("no_future_expiration"),))
+    expiration = min(future)
+    return DemandExpansion(
+        demands=(chain_demand(now, expiration),),
+        selections=(("expiration", expiration.isoformat()),),
+    )
+
+
+def resolved_field_requirements() -> dict[MarketCapability, tuple[tuple[str, ...], int]]:
+    return {
+        MarketCapability.REAL_TIME_QUOTE_V1: (("last",), 3600),
+        MarketCapability.OPTION_CHAIN_V1: (("contracts",), 3600),
+        MarketCapability.HISTORICAL_BARS_V1: (
+            ("close",),
+            int(timedelta(days=HISTORICAL_LOOKBACK_DAYS + 1).total_seconds()),
+        ),
+    }

--- a/strategy_runtime/adapters/__init__.py
+++ b/strategy_runtime/adapters/__init__.py
@@ -50,6 +50,12 @@ from strategies import (
     SKEW_MOMENTUM_VERTICAL_MANIFEST,
 )
 from strategies.earnings_calendar_planning import earnings_calendar_resolved_field_requirements
+from strategies.forward_factor_planning import (
+    resolved_field_requirements as forward_factor_resolved_field_requirements,
+)
+from strategies.skew_momentum_planning import (
+    resolved_field_requirements as skew_momentum_resolved_field_requirements,
+)
 from strategy_runtime.adapters.earnings_calendar import (
     EARNINGS_CALENDAR_CONTRACT,
     build_earnings_calendar_adapter,
@@ -61,11 +67,18 @@ from strategy_runtime.adapters.forward_factor import (
     FORWARD_FACTOR_CONTRACT,
     build_forward_factor_adapter,
 )
+from strategy_runtime.adapters.forward_factor_subject_first import (
+    build_forward_factor_subject_preparation_binding,
+)
+from strategy_runtime.adapters.skew_momentum_subject_first import (
+    build_skew_momentum_subject_preparation_binding,
+)
 from strategy_runtime.adapters.skew_momentum_vertical import (
     SKEW_MOMENTUM_VERTICAL_CONTRACT,
     build_skew_momentum_adapter,
 )
 from strategy_runtime.catalog import SignalCatalogEntry
+from strategy_runtime.historical_evidence import HistoricalSkewRepository
 from strategy_runtime.manifest_contract import validate_manifest_contract
 from strategy_runtime.market_data_planning import resolution_policy_for_capabilities
 from strategy_runtime.orchestration import CutoverPolicy
@@ -137,7 +150,9 @@ def build_migrated_strategy_registry(
     )
 
 
-def build_migrated_shadow_registry(now: datetime) -> SubjectPreparationRegistry[object]:
+def build_migrated_shadow_registry(
+    now: datetime, historical_skew_repository: HistoricalSkewRepository | None = None
+) -> SubjectPreparationRegistry[object]:
     """Every migrated strategy with a registered subject-first shadow
     binding, assembled once per invocation/cycle (SPRINT-014 S14-PR-05A,
     Architect checkpoint: sixteenth review, "both roots must use the same
@@ -153,6 +168,16 @@ def build_migrated_shadow_registry(now: datetime) -> SubjectPreparationRegistry[
     """
     return SubjectPreparationRegistry(
         (
+            (
+                FORWARD_FACTOR_CONTRACT.strategy_id,
+                build_forward_factor_subject_preparation_binding(now),
+            ),
+            (
+                SKEW_MOMENTUM_VERTICAL_CONTRACT.strategy_id,
+                build_skew_momentum_subject_preparation_binding(
+                    now, historical_skew_repository
+                ),
+            ),
             (
                 EARNINGS_CALENDAR_CONTRACT.strategy_id,
                 build_earnings_calendar_subject_preparation_binding(now),
@@ -183,9 +208,10 @@ def migrated_shadow_resolution_policy(
     constructed from existing market-data configuration/registry
     ownership").
     """
-    return resolution_policy_for_capabilities(
-        capability_registry, earnings_calendar_resolved_field_requirements()
-    )
+    requirements = earnings_calendar_resolved_field_requirements()
+    requirements.update(forward_factor_resolved_field_requirements())
+    requirements.update(skew_momentum_resolved_field_requirements())
+    return resolution_policy_for_capabilities(capability_registry, requirements)
 
 
 def build_migrated_signal_catalog() -> tuple[SignalCatalogEntry, ...]:
@@ -234,8 +260,10 @@ def build_migrated_cutover_policy(values: Mapping[str, str]) -> CutoverPolicy:
     """
     return CutoverPolicy(
         {
+            FORWARD_FACTOR_CONTRACT.strategy_id: True,
+            SKEW_MOMENTUM_VERTICAL_CONTRACT.strategy_id: True,
             EARNINGS_CALENDAR_CONTRACT.strategy_id: _boolean_flag(
-                values, EARNINGS_CALENDAR_CUTOVER_ENABLED_VAR, default=False
+                values, EARNINGS_CALENDAR_CUTOVER_ENABLED_VAR, default=True
             )
         }
     )

--- a/strategy_runtime/adapters/forward_factor_subject_first.py
+++ b/strategy_runtime/adapters/forward_factor_subject_first.py
@@ -1,0 +1,216 @@
+"""Forward Factor preparation and read-only runtime binding."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date, datetime
+from decimal import Decimal
+from functools import partial
+from types import MappingProxyType
+
+from domain import (
+    EarningsEvent,
+    ExpirationCollection,
+    MarketCapability,
+    OptionChain,
+    OptionType,
+    Quote,
+    UnknownReason,
+)
+from market_data.snapshot import MarketSnapshot
+from screening.explanations import build_graph_explanation
+from screening.subject_fact_projection import resolution_for
+from screening.subject_planning import ResolvedEvidenceView, SubjectPlanConsumer
+from strategies import FORWARD_FACTOR_CALENDAR_MANIFEST
+from strategies.forward_factor_evaluation import evaluate_forward_factor
+from strategies.forward_factor_knowledge import (
+    ForwardFactorPayload,
+    build_forward_factor_knowledge_mapping,
+)
+from strategies.forward_factor_planning import (
+    bootstrap_demands,
+    expand_demands,
+    expirations_demand,
+)
+from strategies.knowledge_contracts import KnowledgeMapping
+from strategy_runtime.adapters._screening_bridge import explanation_metrics
+from strategy_runtime.adapters.forward_factor import FORWARD_FACTOR_CONTRACT
+from strategy_runtime.context import RuntimeContext
+from strategy_runtime.knowledge import ReadOnlyStrategyInput
+from strategy_runtime.registry import StrategyAdapter
+from strategy_runtime.result import (
+    EvaluationState,
+    RowType,
+    UniversalScreeningResult,
+    compute_observation_id,
+)
+from strategy_runtime.subject_preparation import SubjectPreparationBinding
+from strategy_runtime.values import TypedValue
+
+_STRATEGY_ID = "forward_factor"
+_SUCCESSFUL = frozenset({"PASS", "WATCH"})
+
+
+def _spot(quote: Quote) -> Decimal:
+    if quote.last is not None:
+        return quote.last
+    if quote.bid is not None and quote.ask is not None:
+        return (quote.bid + quote.ask) / Decimal(2)
+    raise ValueError("quote has no usable spot price")
+
+
+def _atm_strike(chain: OptionChain, expiration: date, spot: Decimal) -> Decimal:
+    strikes = {
+        contract.strike
+        for contract in chain.contracts
+        if contract.expiration == expiration and contract.option_type is OptionType.CALL
+    }
+    if not strikes:
+        raise ValueError("no call contracts at selected expiration")
+    return min(strikes, key=lambda strike: (abs(strike - spot), strike))
+
+
+def _prepare(
+    snapshot: MarketSnapshot,
+    projected: ResolvedEvidenceView,
+    selections: tuple[tuple[str, object], ...],
+    subject: str,
+) -> KnowledgeMapping[ForwardFactorPayload] | UnknownReason:
+    quote_resolution = resolution_for(snapshot, MarketCapability.REAL_TIME_QUOTE_V1)
+    chain_resolution = resolution_for(snapshot, MarketCapability.OPTION_CHAIN_V1)
+    quote_observation = quote_resolution.selected_observation
+    chain_observation = chain_resolution.selected_observation
+    if quote_observation is None or not isinstance(quote_observation.value, Quote):
+        return UnknownReason("unusable_quote")
+    if chain_observation is None or not isinstance(chain_observation.value, OptionChain):
+        return UnknownReason("unusable_option_chain")
+    discovery = projected.get(expirations_demand(snapshot.as_of).demand_id)
+    if discovery is None or not isinstance(discovery.value, ExpirationCollection):
+        return UnknownReason("unusable_expiration_collection")
+
+    chain = chain_observation.value
+    pair: tuple[date, date] | None = None
+    for key, value in sorted(selections):
+        if not key.startswith("pair_") or not isinstance(value, str):
+            continue
+        front_text, back_text = value.split("/", 1)
+        candidate = date.fromisoformat(front_text), date.fromisoformat(back_text)
+        available = {contract.expiration for contract in chain.contracts}
+        if candidate[0] in available and candidate[1] in available:
+            pair = candidate
+            break
+    if pair is None:
+        return UnknownReason("no_usable_expiration_pair")
+    front_date, back_date = pair
+    cycles = {cycle.expiration_date: cycle for cycle in discovery.value.cycles}
+    if front_date not in cycles or back_date not in cycles:
+        return UnknownReason("selected_expiration_missing")
+    spot = _spot(quote_observation.value)
+    front_strike = _atm_strike(chain, front_date, spot)
+    back_strike = _atm_strike(chain, back_date, spot)
+    (front_contract,) = chain.find(
+        expiration=front_date, strike=front_strike, option_type=OptionType.CALL
+    )
+    (back_contract,) = chain.find(
+        expiration=back_date, strike=back_strike, option_type=OptionType.CALL
+    )
+    if front_contract.implied_volatility is None or back_contract.implied_volatility is None:
+        return UnknownReason("missing_implied_volatility")
+
+    try:
+        earnings_resolution = resolution_for(snapshot, MarketCapability.EARNINGS_CALENDAR_V1)
+    except ValueError:
+        earnings_observation = None
+    else:
+        earnings_observation = earnings_resolution.selected_observation
+    event = (
+        earnings_observation.value
+        if earnings_observation is not None
+        and isinstance(earnings_observation.value, EarningsEvent)
+        else None
+    )
+    return build_forward_factor_knowledge_mapping(
+        subject=subject,
+        snapshot_digest=snapshot.snapshot_digest,
+        quote_observation_id=quote_observation.observation_id,
+        chain_observation_id=chain_observation.observation_id,
+        earnings_observation_id=(
+            earnings_observation.observation_id if earnings_observation is not None else None
+        ),
+        spot_price=spot,
+        chain=chain,
+        front_cycle=cycles[front_date],
+        back_cycle=cycles[back_date],
+        front_strike=front_strike,
+        back_strike=back_strike,
+        front_iv=front_contract.implied_volatility,
+        back_iv=back_contract.implied_volatility,
+        event=event,
+        as_of=snapshot.as_of.date(),
+    )
+
+
+def build_forward_factor_subject_preparation_binding(
+    now: datetime,
+) -> SubjectPreparationBinding[ForwardFactorPayload]:
+    return SubjectPreparationBinding(
+        SubjectPlanConsumer(
+            _STRATEGY_ID,
+            bootstrap_demands(now),
+            partial(expand_demands, now=now),
+        ),
+        _prepare,
+        build_forward_factor_subject_first_adapter,
+    )
+
+
+def _provenance(knowledge: ReadOnlyStrategyInput[ForwardFactorPayload]) -> tuple[str, ...]:
+    return (
+        f"snapshot_id:{knowledge.snapshot_id}",
+        f"snapshot_digest:{knowledge.snapshot_digest}",
+        *(f"canonical_fact:{fact.fact_id}@{fact.version}" for fact in knowledge.canonical_facts),
+        *(
+            f"derived_fact:{fact.derived_fact_id}@{fact.formula_version}"
+            for fact in knowledge.derived_facts.facts
+        ),
+    )
+
+
+def build_forward_factor_subject_first_adapter(
+    knowledge_by_subject: Mapping[str, ReadOnlyStrategyInput[ForwardFactorPayload]],
+) -> StrategyAdapter[UniversalScreeningResult]:
+    frozen = MappingProxyType(dict(knowledge_by_subject))
+
+    def _adapter(context: RuntimeContext) -> UniversalScreeningResult:
+        knowledge = frozen[context.subject]
+        outputs = evaluate_forward_factor(knowledge.derived_facts, knowledge.payload)
+        verdict_text = str(outputs.get("verdict").value)
+        successful = verdict_text in _SUCCESSFUL
+        explanation = build_graph_explanation(FORWARD_FACTOR_CALENDAR_MANIFEST, outputs)
+        metrics = explanation_metrics(explanation)
+        score = outputs.get("forward_factor").value
+        if isinstance(score, Decimal):
+            metrics["strategy_native_score"] = TypedValue.of_decimal(score)
+        return UniversalScreeningResult(
+            strategy_id=_STRATEGY_ID,
+            strategy_version=FORWARD_FACTOR_CONTRACT.version,
+            symbol=context.subject,
+            observation_id=compute_observation_id(
+                context.run_id, _STRATEGY_ID, context.subject
+            ),
+            opportunity_id=None,
+            row_type=RowType.RESULT,
+            verdict=verdict_text,
+            evaluation_state=(EvaluationState.PASS if successful else EvaluationState.NO_SIGNAL),
+            lifecycle_stage=None,
+            recommendation_state=None,
+            data_quality=None,
+            metrics=metrics,
+            economics={},
+            blockers=(),
+            warnings=explanation.warnings,
+            provenance=_provenance(knowledge),
+            observed_at=knowledge.effective_time,
+        )
+
+    return _adapter

--- a/strategy_runtime/adapters/skew_momentum_subject_first.py
+++ b/strategy_runtime/adapters/skew_momentum_subject_first.py
@@ -1,0 +1,215 @@
+"""Skew Momentum preparation and read-only runtime binding."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from decimal import Decimal
+from functools import partial
+from types import MappingProxyType
+from typing import cast
+
+from domain import (
+    CanonicalInstrumentIdentity,
+    MarketCapability,
+    OHLCVSeries,
+    OptionChain,
+    OptionType,
+    Quote,
+    UnknownReason,
+)
+from market_data.snapshot import MarketSnapshot
+from screening.context_builders import build_skew_momentum_context
+from screening.explanations import build_graph_explanation
+from screening.live_context import select_atm_strike_at_expiration, select_nearest_delta_contract
+from screening.subject_fact_projection import resolution_for
+from screening.subject_planning import ResolvedEvidenceView, SubjectPlanConsumer
+from strategies import (
+    CORE_COMPONENTS,
+    SKEW_MOMENTUM_VERTICAL_MANIFEST,
+    STONK_STRATEGY_PLUGINS,
+    compile_strategy_graph,
+    execute_strategy_graph,
+)
+from strategies.knowledge_contracts import KnowledgeMapping
+from strategies.plugins import build_plugin_registry
+from strategies.skew_momentum_knowledge import (
+    SkewMomentumPayload,
+    build_skew_momentum_knowledge_mapping,
+)
+from strategies.skew_momentum_planning import bootstrap_demands, expand_demands
+from strategy_runtime.adapters._screening_bridge import explanation_metrics
+from strategy_runtime.adapters.skew_momentum_vertical import SKEW_MOMENTUM_VERTICAL_CONTRACT
+from strategy_runtime.context import RuntimeContext
+from strategy_runtime.historical_evidence import HistoricalSkewRepository
+from strategy_runtime.knowledge import ReadOnlyStrategyInput
+from strategy_runtime.registry import StrategyAdapter
+from strategy_runtime.result import (
+    EvaluationState,
+    RowType,
+    UniversalScreeningResult,
+    compute_observation_id,
+)
+from strategy_runtime.subject_preparation import SubjectPreparationBinding
+from strategy_runtime.values import TypedValue
+
+_STRATEGY_ID = "skew_momentum"
+_COMPONENTS = build_plugin_registry(CORE_COMPONENTS, STONK_STRATEGY_PLUGINS)
+
+
+def _spot(quote: Quote) -> Decimal:
+    if quote.last is not None:
+        return quote.last
+    if quote.bid is not None and quote.ask is not None:
+        return (quote.bid + quote.ask) / Decimal(2)
+    raise ValueError("quote has no usable spot")
+
+
+def _prepare(
+    historical_repository: HistoricalSkewRepository | None,
+    now: datetime,
+    snapshot: MarketSnapshot,
+    projected: ResolvedEvidenceView,
+    selections: tuple[tuple[str, object], ...],
+    subject: str,
+) -> KnowledgeMapping[SkewMomentumPayload] | UnknownReason:
+    del projected
+    quote_resolution = resolution_for(snapshot, MarketCapability.REAL_TIME_QUOTE_V1)
+    chain_resolution = resolution_for(snapshot, MarketCapability.OPTION_CHAIN_V1)
+    bars_resolution = resolution_for(snapshot, MarketCapability.HISTORICAL_BARS_V1)
+    quote_observation = quote_resolution.selected_observation
+    chain_observation = chain_resolution.selected_observation
+    bars_observation = bars_resolution.selected_observation
+    if quote_observation is None or not isinstance(quote_observation.value, Quote):
+        return UnknownReason("unusable_quote")
+    if chain_observation is None or not isinstance(chain_observation.value, OptionChain):
+        return UnknownReason("unusable_option_chain")
+    if bars_observation is None or not isinstance(bars_observation.value, OHLCVSeries):
+        return UnknownReason("unusable_historical_bars")
+    closes = tuple(bar.close for bar in bars_observation.value.bars)
+    if len(closes) < 21:
+        return UnknownReason("insufficient_historical_bars")
+    expiration_text = dict(selections).get("expiration")
+    if not isinstance(expiration_text, str):
+        return UnknownReason("no_future_expiration")
+    expiration = datetime.fromisoformat(expiration_text).date()
+    chain = chain_observation.value
+    spot = _spot(quote_observation.value)
+    call_strike = select_atm_strike_at_expiration(chain, expiration, spot, OptionType.CALL)
+    put_strike = select_atm_strike_at_expiration(chain, expiration, spot, OptionType.PUT)
+    (call_atm,) = chain.find(expiration=expiration, strike=call_strike, option_type=OptionType.CALL)
+    (put_atm,) = chain.find(expiration=expiration, strike=put_strike, option_type=OptionType.PUT)
+    call_wing = select_nearest_delta_contract(
+        chain, expiration, OptionType.CALL, Decimal("0.25"), exclude_strike=call_strike
+    )
+    put_wing = select_nearest_delta_contract(
+        chain, expiration, OptionType.PUT, Decimal("-0.25"), exclude_strike=put_strike
+    )
+    values = tuple(item.implied_volatility for item in (call_atm, put_atm, call_wing, put_wing))
+    if any(value is None for value in values):
+        return UnknownReason("missing_implied_volatility")
+    history = (
+        ()
+        if historical_repository is None
+        else historical_repository.history_for(
+            CanonicalInstrumentIdentity("symbol", subject),
+            as_of=now,
+            maximum_observations=60,
+        )
+    )
+    return build_skew_momentum_knowledge_mapping(
+        subject=subject,
+        snapshot_digest=snapshot.snapshot_digest,
+        chain_observation_id=chain_observation.observation_id,
+        bars_observation_id=bars_observation.observation_id,
+        chain=chain,
+        expiration=expiration,
+        closes=closes,
+        call_atm_iv=cast(Decimal, values[0]),
+        put_atm_iv=cast(Decimal, values[1]),
+        call_wing_iv=cast(Decimal, values[2]),
+        put_wing_iv=cast(Decimal, values[3]),
+        history=history,
+    )
+
+
+def build_skew_momentum_subject_preparation_binding(
+    now: datetime, historical_repository: HistoricalSkewRepository | None = None
+) -> SubjectPreparationBinding[SkewMomentumPayload]:
+    return SubjectPreparationBinding(
+        SubjectPlanConsumer(_STRATEGY_ID, bootstrap_demands(now), partial(expand_demands, now=now)),
+        partial(_prepare, historical_repository, now),
+        build_skew_momentum_subject_first_adapter,
+    )
+
+
+def build_skew_momentum_subject_first_adapter(
+    knowledge_by_subject: Mapping[str, ReadOnlyStrategyInput[SkewMomentumPayload]],
+) -> StrategyAdapter[UniversalScreeningResult]:
+    frozen = MappingProxyType(dict(knowledge_by_subject))
+
+    def _adapter(context: RuntimeContext) -> UniversalScreeningResult:
+        knowledge = frozen[context.subject]
+        payload = knowledge.payload
+        graph_context = build_skew_momentum_context(
+            payload.chain,
+            payload.expiration,
+            normalized_call_skew=payload.normalized_call_skew,
+            normalized_put_skew=payload.normalized_put_skew,
+            call_skew_zscore=payload.call_skew_zscore,
+            put_skew_zscore=payload.put_skew_zscore,
+            historical_valid_observations=payload.historical_valid_observations,
+            call_atm_iv_minus_rv=payload.call_atm_iv_minus_rv,
+            put_atm_iv_minus_rv=payload.put_atm_iv_minus_rv,
+            call_wing_iv_minus_rv=payload.call_wing_iv_minus_rv,
+            put_wing_iv_minus_rv=payload.put_wing_iv_minus_rv,
+            call_wing_iv_minus_atm_iv=payload.call_wing_iv_minus_atm_iv,
+            put_wing_iv_minus_atm_iv=payload.put_wing_iv_minus_atm_iv,
+            time_series_return=payload.time_series_return,
+            cross_sectional_percentile=None,
+            comparison_peer_count=0,
+            sector_relative_return=None,
+        )
+        outputs = execute_strategy_graph(
+            compile_strategy_graph(SKEW_MOMENTUM_VERTICAL_MANIFEST, _COMPONENTS), graph_context
+        ).outputs
+        verdict = str(outputs.get("verdict").value)
+        explanation = build_graph_explanation(SKEW_MOMENTUM_VERTICAL_MANIFEST, outputs)
+        metrics = explanation_metrics(explanation)
+        score = outputs.get("score").value
+        if isinstance(score, Decimal):
+            metrics["strategy_native_score"] = TypedValue.of_decimal(score)
+        return UniversalScreeningResult(
+            strategy_id=_STRATEGY_ID,
+            strategy_version=SKEW_MOMENTUM_VERTICAL_CONTRACT.version,
+            symbol=context.subject,
+            observation_id=compute_observation_id(context.run_id, _STRATEGY_ID, context.subject),
+            opportunity_id=None,
+            row_type=RowType.RESULT,
+            verdict=verdict,
+            evaluation_state=EvaluationState.PASS
+            if verdict in {"PASS", "WATCH"}
+            else EvaluationState.NO_SIGNAL,
+            lifecycle_stage=None,
+            recommendation_state=None,
+            data_quality=None,
+            metrics=metrics,
+            economics={},
+            blockers=(),
+            warnings=explanation.warnings,
+            provenance=(
+                f"snapshot_id:{knowledge.snapshot_id}",
+                f"snapshot_digest:{knowledge.snapshot_digest}",
+                *(
+                    f"canonical_fact:{fact.fact_id}@{fact.version}"
+                    for fact in knowledge.canonical_facts
+                ),
+                *(
+                    f"derived_fact:{fact.derived_fact_id}@{fact.formula_version}"
+                    for fact in knowledge.derived_facts.facts
+                ),
+            ),
+            observed_at=knowledge.effective_time,
+        )
+
+    return _adapter

--- a/strategy_runtime/orchestration.py
+++ b/strategy_runtime/orchestration.py
@@ -79,7 +79,7 @@ from strategy_runtime.service import refresh
 from strategy_runtime.subject_preparation import (
     SubjectPreparationBinding,
     SubjectPreparationRegistry,
-    prepare_strategy_knowledge,
+    prepare_subject_knowledge,
 )
 from strategy_runtime.validation import validate_result
 
@@ -191,6 +191,7 @@ def prepare_subject_shadow_knowledge(
     resolution_policy_by_capability: dict[MarketCapability, ResolutionPolicy],
     capability_reducer_by_capability: Mapping[MarketCapability, CapabilityResultReducer]
     | None = None,
+    strategy_ids: tuple[str, ...] | None = None,
 ) -> dict[str, ReadOnlyStrategyInput[object] | UnknownReason]:
     """Run subject-first preparation once for every strategy_id
     ``shadow_registry`` declares, against the same ``plan`` every legacy
@@ -208,19 +209,19 @@ def prepare_subject_shadow_knowledge(
     contract acquisition for OPTION_CHAIN_V1. Caller-supplied, generic:
     this module never registers one itself.
     """
-    return {
-        strategy_id: prepare_strategy_knowledge(
-            plan,
-            now,
-            shadow_registry,
-            strategy_id,
-            subject=subject,
-            provider_metadata=provider_metadata,
-            resolution_policy_by_capability=resolution_policy_by_capability,
-            capability_reducer_by_capability=capability_reducer_by_capability,
-        )
-        for strategy_id in shadow_registry.strategy_ids()
-    }
+    return prepare_subject_knowledge(
+        plan,
+        now,
+        (
+            shadow_registry
+            if strategy_ids is None
+            else shadow_registry.restricted_to(strategy_ids)
+        ),
+        subject=subject,
+        provider_metadata=provider_metadata,
+        resolution_policy_by_capability=resolution_policy_by_capability,
+        capability_reducer_by_capability=capability_reducer_by_capability,
+    )
 
 
 # The envelope/pair identity fields plus the semantic fields two

--- a/strategy_runtime/subject_preparation.py
+++ b/strategy_runtime/subject_preparation.py
@@ -126,6 +126,14 @@ class SubjectPreparationRegistry(Generic[TPayload]):
         except KeyError:
             raise UnknownSubjectPreparationBindingError(strategy_id) from None
 
+    def restricted_to(
+        self, strategy_ids: tuple[str, ...]
+    ) -> SubjectPreparationRegistry[TPayload]:
+        """Immutable view containing only explicitly requested consumers."""
+        return SubjectPreparationRegistry(
+            tuple((strategy_id, self.binding_for(strategy_id)) for strategy_id in strategy_ids)
+        )
+
 
 def prepare_strategy_knowledge(
     plan: SubjectAcquisitionPlan,
@@ -179,3 +187,61 @@ def prepare_strategy_knowledge(
     return compose_strategy_knowledge(
         plan_result.snapshot, knowledge_registry, strategy_id, subject=subject
     )
+
+
+def prepare_subject_knowledge(
+    plan: SubjectAcquisitionPlan,
+    now: datetime,
+    registry: SubjectPreparationRegistry[object],
+    *,
+    subject: str,
+    provider_metadata: tuple[ProviderMetadata, ...],
+    resolution_policy_by_capability: dict[MarketCapability, ResolutionPolicy],
+    capability_reducer_by_capability: Mapping[MarketCapability, CapabilityResultReducer]
+    | None = None,
+) -> dict[str, ReadOnlyStrategyInput[object] | UnknownReason]:
+    """Prepare every registered consumer from one sealed subject snapshot.
+
+    Demand collection and both acquisition phases run once across the whole
+    registry.  Each strategy-owned binding then maps the same immutable
+    snapshot into its own read-only payload.  Adding another consumer changes
+    declarations only; it cannot create a second evidence boundary.
+    """
+    strategy_ids = registry.strategy_ids()
+    if not strategy_ids:
+        return {}
+    bindings = {strategy_id: registry.binding_for(strategy_id) for strategy_id in strategy_ids}
+    plan_result = run_subject_plan(
+        plan,
+        now,
+        tuple(bindings[strategy_id].consumer for strategy_id in strategy_ids),
+        provider_metadata=provider_metadata,
+        resolution_policy_by_capability=resolution_policy_by_capability,
+        capability_reducer_by_capability=capability_reducer_by_capability,
+    )
+    prepared: dict[str, ReadOnlyStrategyInput[object] | UnknownReason] = {}
+    for strategy_id in strategy_ids:
+        binding = bindings[strategy_id]
+        expansion = plan_result.expansions_by_consumer[binding.consumer.consumer_id]
+        if expansion.unknown_reasons:
+            prepared[strategy_id] = expansion.unknown_reasons[0]
+            continue
+        mapping = binding.prepare_knowledge_mapping(
+            plan_result.snapshot,
+            plan_result.projected_evidence,
+            expansion.selections,
+            subject,
+        )
+        if isinstance(mapping, UnknownReason):
+            prepared[strategy_id] = mapping
+            continue
+        knowledge_registry: KnowledgeCompositionRegistry[object] = (
+            KnowledgeCompositionRegistry(((strategy_id, mapping),))
+        )
+        prepared[strategy_id] = compose_strategy_knowledge(
+            plan_result.snapshot,
+            knowledge_registry,
+            strategy_id,
+            subject=subject,
+        )
+    return prepared

--- a/tests/architecture/test_migrated_strategy_acquisition_blindness.py
+++ b/tests/architecture/test_migrated_strategy_acquisition_blindness.py
@@ -1,0 +1,45 @@
+"""S14R: migrated read-only adapters cannot regain acquisition authority."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ADAPTERS = (
+    ROOT / "strategy_runtime/adapters/earnings_calendar_subject_first.py",
+    ROOT / "strategy_runtime/adapters/forward_factor_subject_first.py",
+    ROOT / "strategy_runtime/adapters/skew_momentum_subject_first.py",
+)
+FORBIDDEN = {
+    "CapabilityFulfiller",
+    "CapabilityFulfillmentService",
+    "BudgetManager",
+    "Provider",
+    "CapabilityRequest",
+}
+
+
+def test_migrated_read_only_adapters_import_no_acquisition_authority() -> None:
+    for path in ADAPTERS:
+        tree = ast.parse(path.read_text())
+        imported = {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+            for alias in node.names
+        }
+        assert imported.isdisjoint(FORBIDDEN), path
+
+
+def test_all_production_strategies_have_subject_first_bindings() -> None:
+    from datetime import UTC, datetime
+
+    from strategy_runtime.adapters import build_migrated_shadow_registry
+
+    registry = build_migrated_shadow_registry(datetime(2026, 8, 11, tzinfo=UTC))
+    assert registry.strategy_ids() == (
+        "earnings_calendar",
+        "forward_factor",
+        "skew_momentum",
+    )

--- a/tests/asa/_fixture_market_data_access.py
+++ b/tests/asa/_fixture_market_data_access.py
@@ -290,5 +290,6 @@ def shadow_alone_call_count(
         provider_metadata=access.provider_metadata,
         resolution_policy_by_capability=migrated_shadow_resolution_policy(capability_registry),
         capability_reducer_by_capability=migrated_shadow_capability_reducers(),
+        strategy_ids=("earnings_calendar",),
     )
     return len(access.budget_manager.accounting)

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -1411,6 +1411,8 @@ def test_scheduled_earnings_pass_shadow_diagnostic_matches_and_legacy_persists(
     """
     import asa.scheduled_screening as scheduled_screening_module
 
+    monkeypatch.setenv("ASA_EARNINGS_CALENDAR_CUTOVER_ENABLED", "false")
+
     monkeypatch.setattr(
         scheduled_screening_module,
         "build_shared_market_data_access",
@@ -1459,6 +1461,8 @@ def test_scheduled_earnings_watch_shadow_diagnostic_matches_and_legacy_persists(
     real scheduled root instead of a hand-built snapshot.
     """
     import asa.scheduled_screening as scheduled_screening_module
+
+    monkeypatch.setenv("ASA_EARNINGS_CALENDAR_CUTOVER_ENABLED", "false")
 
     monkeypatch.setattr(
         scheduled_screening_module,
@@ -1510,6 +1514,7 @@ def test_scheduled_earnings_outage_shadow_unknown_and_bounded_once_not_doubled(
     proving the plan's own bounded retry is shared once, never doubled
     by legacy independently retrying the same already-exhausted failure.
     """
+    monkeypatch.setenv("ASA_EARNINGS_CALENDAR_CUTOVER_ENABLED", "false")
     import asa.scheduled_screening as scheduled_screening_module
 
     scenario = FixtureScenario(

--- a/tests/asa/test_screening_refresh_route.py
+++ b/tests/asa/test_screening_refresh_route.py
@@ -444,6 +444,7 @@ class TestRealEarningsShadowAgainstFixtureProvider:
         request's own total must equal it exactly, never more.
         """
 
+        monkeypatch.setenv("ASA_EARNINGS_CALENDAR_CUTOVER_ENABLED", "false")
         client = self._client(monkeypatch, build_fixture_market_data_access_factory())
         caplog.set_level(logging.INFO)
         logging.getLogger().addHandler(caplog.handler)
@@ -503,6 +504,7 @@ class TestRealEarningsShadowAgainstFixtureProvider:
         real route -> plan -> subject-first shadow preparation -> legacy
         Earnings -> comparator, end to end.
         """
+        monkeypatch.setenv("ASA_EARNINGS_CALENDAR_CUTOVER_ENABLED", "false")
         factory = build_fixture_market_data_access_factory(
             provider_cls_by_symbol={"AAPL": WatchEarningsFixtureProvider}
         )

--- a/tests/strategy_runtime/adapters/test_cutover_policy.py
+++ b/tests/strategy_runtime/adapters/test_cutover_policy.py
@@ -17,9 +17,9 @@ from strategy_runtime.adapters import (
 from strategy_runtime.adapters.earnings_calendar import EARNINGS_CALENDAR_CONTRACT
 
 
-def test_absent_flag_defaults_to_not_cut_over() -> None:
+def test_absent_flag_defaults_to_subject_first_authority() -> None:
     policy = build_migrated_cutover_policy({})
-    assert policy.is_cut_over(EARNINGS_CALENDAR_CONTRACT.strategy_id) is False
+    assert policy.is_cut_over(EARNINGS_CALENDAR_CONTRACT.strategy_id) is True
 
 
 @pytest.mark.parametrize("raw", ["1", "true", "TRUE", "yes", "on"])
@@ -39,19 +39,19 @@ def test_malformed_value_raises_rather_than_silently_defaulting() -> None:
         build_migrated_cutover_policy({EARNINGS_CALENDAR_CUTOVER_ENABLED_VAR: "maybe"})
 
 
-def test_only_earnings_calendar_is_ever_eligible() -> None:
+def test_migrated_strategies_are_cut_over_to_subject_first_execution() -> None:
     """Architect checkpoint: nineteenth review, "Scope it only to the
     migrated earnings_calendar strategy. FF/Skew stay on their existing
     legacy evaluation path." -- no flag exists that could register any
     other strategy_id.
     """
     policy = build_migrated_cutover_policy({EARNINGS_CALENDAR_CUTOVER_ENABLED_VAR: "true"})
-    assert policy.is_cut_over("forward_factor") is False
-    assert policy.is_cut_over("skew_momentum") is False
+    assert policy.is_cut_over("forward_factor") is True
+    assert policy.is_cut_over("skew_momentum") is True
 
 
 def test_unrelated_environment_keys_are_ignored() -> None:
     policy = build_migrated_cutover_policy(
         {"ASA_TRADIER_ENABLED": "true", "PATH": "/usr/bin"}
     )
-    assert policy.is_cut_over(EARNINGS_CALENDAR_CONTRACT.strategy_id) is False
+    assert policy.is_cut_over(EARNINGS_CALENDAR_CONTRACT.strategy_id) is True

--- a/tests/strategy_runtime/test_orchestration.py
+++ b/tests/strategy_runtime/test_orchestration.py
@@ -486,6 +486,45 @@ class TestPrepareSubjectShadowKnowledge:
         # the real plan/fulfillment, not a stub.
         assert len(budgets.accounting) == 1
 
+    def test_consumers_share_one_snapshot_and_one_equivalent_request(self) -> None:
+        def adapter_builder(
+            _knowledge: Mapping[str, ReadOnlyStrategyInput[object]],
+        ) -> Callable[[RuntimeContext], UniversalScreeningResult]:
+            raise AssertionError("not evaluated during preparation")
+
+        entries = tuple(
+            (
+                strategy_id,
+                SubjectPreparationBinding(
+                    SubjectPlanConsumer(
+                        strategy_id,
+                        (_synthetic_demand(),),
+                        lambda _evidence: DemandExpansion(),
+                    ),
+                    _synthetic_prepare_knowledge_mapping,
+                    adapter_builder,
+                ),
+            )
+            for strategy_id in ("consumer-a", "consumer-b")
+        )
+        fulfillment, budgets = service(provider("primary"))
+        result = prepare_subject_shadow_knowledge(
+            _plan(fulfillment),
+            NOW,
+            SubjectPreparationRegistry(entries),
+            subject="AAPL",
+            provider_metadata=(provider("primary").metadata,),
+            resolution_policy_by_capability=_SYNTHETIC_RESOLUTION_POLICY,
+        )
+
+        first = result["consumer-a"]
+        second = result["consumer-b"]
+        assert isinstance(first, ReadOnlyStrategyInput)
+        assert isinstance(second, ReadOnlyStrategyInput)
+        assert first.snapshot_id == second.snapshot_id
+        assert first.snapshot_digest == second.snapshot_digest
+        assert len(budgets.accounting) == 1
+
 
 def _synthetic_knowledge_input(symbol: str) -> ReadOnlyStrategyInput[object]:
     return ReadOnlyStrategyInput(


### PR DESCRIPTION
## Milestone\nS14R-M2 / closes #303\n\n## Outcome\n- moves Forward Factor and Skew Momentum onto provider-blind subject planning and immutable read-only knowledge\n- prepares requested production strategies from one sealed subject snapshot\n- materializes named/versioned canonical and derived facts before strategy evaluation\n- makes subject-first execution authoritative by default for all three production strategies\n- preserves an explicit Earnings rollback flag until M3 legacy deletion\n\n## Invariants\n- migrated read-only adapters import no provider, fulfillment, budget, or request authority\n- equivalent demands share one request and one snapshot identity\n- strategy graphs retain thesis-owned gates and thresholds\n- no deployment or product policy change\n\n## Validation\n- full pytest: 3,227 passed, 45 skipped\n- architecture: 556 passed\n- targeted ruff and mypy: passed\n- Lean entrypoints/integrity: passed\n- git diff check: passed\n\n## Self-review\nCLEAR. No known sprint invariant violation. Manager stop status CLEAR. Delegated merge authority: SPRINT-014R Amendment 013.