### PR TITLE
S14R P0: restore production subject preparation

### DIFF
--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -76,6 +76,7 @@ from strategy_runtime.persistence import (
     ObservationHistoryRepository,
     replay_opportunity_history,
 )
+from strategy_runtime.preparation_diagnostics import classify_subject_preparation_exception
 from strategy_runtime.registry import StrategyRegistry
 from strategy_runtime.result import EvaluationState, UniversalScreeningResult
 from strategy_runtime.service import get_state, record_opportunity_observation
@@ -429,10 +430,15 @@ def build_screening_router(
                     capability_reducer_by_capability=migrated_shadow_capability_reducers(),
                     strategy_ids=(signal,),
                 )
-            except Exception:
+            except Exception as failure:
                 _LOGGER.warning(
                     "shadow_subject_preparation_failed",
-                    extra={"signal_id": signal, "symbol": symbol},
+                    extra={
+                        "signal_id": signal,
+                        "symbol": symbol,
+                        "failure_class": classify_subject_preparation_exception(failure),
+                        "exception_type": type(failure).__name__,
+                    },
                     exc_info=True,
                 )
         try:

--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -90,6 +90,7 @@ from strategy_runtime.orchestration import (
     refresh_with_shadow,
 )
 from strategy_runtime.persistence import LatestResultRepository, ObservationHistoryRepository
+from strategy_runtime.preparation_diagnostics import classify_subject_preparation_exception
 from strategy_runtime.service import record_opportunity_observation
 
 # The production screening universe (project/reports/SPRINT-008D-SCREENING-
@@ -425,10 +426,17 @@ def run_scheduled_refresh(
                     )
                 ),
             )
-        except Exception:
+        except Exception as failure:
             _LOGGER.warning(
                 "shadow_subject_preparation_failed",
-                extra={"symbol": symbol, "screening_cycle_id": screening_cycle_id},
+                extra={
+                    "symbol": symbol,
+                    "screening_cycle_id": screening_cycle_id,
+                    "failure_class": (
+                        classify_subject_preparation_exception(failure)
+                    ),
+                    "exception_type": type(failure).__name__,
+                },
                 exc_info=True,
             )
         finally:

--- a/market_data/capability_coalescing.py
+++ b/market_data/capability_coalescing.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import dataclasses
 from datetime import datetime
 
-from domain import MarketCapability
+from domain import MarketCapability, OHLCVSeries
 from domain.financial import ExpirationCollection, OptionChain, OptionContract
 from domain.market_data import (
     MarketDataSubject,
@@ -282,3 +282,120 @@ def reduce_option_chain_results(
         observed_at=front_request.effective_end,
     )
     return dataclasses.replace(combined, attempts=combined.attempts + discovery_attempts)
+
+
+def reduce_historical_bar_results(
+    results: tuple[CapabilityFulfillmentResult, ...],
+) -> CapabilityFulfillmentResult:
+    """Coalesce distinct historical-bar windows for one sealed subject.
+
+    Consumers legitimately request different lookbacks.  The sealed snapshot
+    still owns one capability resolution, so combine the normalized series
+    while retaining every request attempt.  Overlapping bars are selected
+    deterministically from the newest source observation.
+    """
+    if not results:
+        raise ValueError("reduce_historical_bar_results requires at least one result")
+    if any(item.request.capability is not MarketCapability.HISTORICAL_BARS_V1 for item in results):
+        raise ValueError("reduce_historical_bar_results requires HISTORICAL_BARS_V1 results")
+
+    attempts = tuple(attempt for item in results for attempt in item.attempts)
+    observations = tuple(observation for item in results for observation in item.observations)
+    if not observations:
+        primary = min(
+            results,
+            key=lambda item: (
+                item.request.effective_start,
+                item.request.effective_end,
+                item.request.maximum_age_seconds,
+                tuple(subject.subject_identity for subject in item.request.subjects),
+            ),
+        )
+        return dataclasses.replace(primary, attempts=attempts)
+
+    series_by_observation: list[tuple[MarketObservation, OHLCVSeries]] = []
+    for observation in observations:
+        if not isinstance(observation.value, OHLCVSeries):
+            raise DomainInvariantError(
+                "reduce_historical_bar_results received a nominally successful "
+                f"HISTORICAL_BARS_V1 observation whose value is "
+                f"{type(observation.value).__name__}, not OHLCVSeries"
+            )
+        series_by_observation.append((observation, observation.value))
+    instrument = series_by_observation[0][1].instrument
+    interval_seconds = series_by_observation[0][1].interval_seconds
+    if any(
+        series.instrument.identity != instrument.identity
+        or series.interval_seconds != interval_seconds
+        for _, series in series_by_observation
+    ):
+        raise DomainInvariantError(
+            "reduce_historical_bar_results requires one instrument and interval"
+        )
+
+    bars_by_start = {}
+    for _observation, series in sorted(
+        series_by_observation,
+        key=lambda item: (item[0].effective_time, item[0].observation_id),
+    ):
+        for bar in series.bars:
+            bars_by_start[bar.start_at] = bar
+    primary_observation, _ = max(
+        series_by_observation,
+        key=lambda item: (item[0].effective_time, item[0].observation_id),
+    )
+    combined_series = OHLCVSeries(
+        instrument,
+        interval_seconds,
+        max(series.as_of for _, series in series_by_observation),
+        tuple(bars_by_start.values()),
+    )
+    effective_start = min(item.request.effective_start for item in results)
+    effective_end = max(item.request.effective_end for item in results)
+    combined_subject = dataclasses.replace(
+        primary_observation.subject,
+        request_context=dataclasses.replace(
+            primary_observation.subject.request_context,
+            semantic_start=effective_start,
+            semantic_end=effective_end,
+        ),
+    )
+    combined_request = CapabilityRequest(
+        MarketCapability.HISTORICAL_BARS_V1,
+        (combined_subject,),
+        effective_start,
+        effective_end,
+        primary_observation.subject.request_context.required_fields,
+        max(item.request.maximum_age_seconds for item in results),
+    )
+    evidence = tuple(
+        EvidenceReference(EvidenceKind.OBSERVATION, observation.observation_id)
+        for observation in sorted(observations, key=lambda item: item.observation_id)
+    )
+    combined_observation = dataclasses.replace(
+        primary_observation,
+        subject=combined_subject,
+        value=combined_series,
+        observation_id=market_observation_identity(
+            primary_observation.provenance.provider_id,
+            MarketCapability.HISTORICAL_BARS_V1,
+            combined_subject,
+            primary_observation.effective_time,
+            combined_series,
+            primary_observation.schema_version,
+        ),
+        provenance=dataclasses.replace(primary_observation.provenance, evidence=evidence),
+    )
+    status = (
+        FulfillmentStatus.FULFILLED
+        if all(item.status is FulfillmentStatus.FULFILLED for item in results)
+        else FulfillmentStatus.DEGRADED
+    )
+    return CapabilityFulfillmentResult(
+        combined_request,
+        status,
+        combined_observation.provenance.provider_id,
+        (combined_observation,),
+        attempts,
+        True,
+    )

--- a/strategy_runtime/adapters/__init__.py
+++ b/strategy_runtime/adapters/__init__.py
@@ -12,7 +12,10 @@ from datetime import datetime
 
 from domain import MarketCapability
 from market_data import CapabilityRegistry
-from market_data.capability_coalescing import reduce_option_chain_results
+from market_data.capability_coalescing import (
+    reduce_historical_bar_results,
+    reduce_option_chain_results,
+)
 from market_data.resolution import ResolutionPolicy
 from screening.subject_planning import CapabilityResultReducer
 from strategies import (
@@ -122,14 +125,18 @@ def build_migrated_shadow_registry(
 
 
 def migrated_shadow_capability_reducers() -> dict[MarketCapability, CapabilityResultReducer]:
-    """Generic multi-result capability reducers any registered shadow
-    binding's own subject plan might need while sealing -- currently just
-    OPTION_CHAIN_V1 (Earnings Calendar's own discovery-then-per-expiration-
-    contract acquisition shape), forwarded unchanged into
+    """Generic multi-result capability reducers registered bindings need.
+
+    OPTION_CHAIN_V1 combines discovery/per-expiration requests. Historical
+    bars combine the distinct lookback windows declared by Skew Momentum
+    and Earnings Calendar. Both are forwarded unchanged into
     strategy_runtime.orchestration.prepare_subject_shadow_knowledge by
     both production roots.
     """
-    return {MarketCapability.OPTION_CHAIN_V1: reduce_option_chain_results}
+    return {
+        MarketCapability.HISTORICAL_BARS_V1: reduce_historical_bar_results,
+        MarketCapability.OPTION_CHAIN_V1: reduce_option_chain_results,
+    }
 
 
 def migrated_shadow_resolution_policy(

--- a/strategy_runtime/adapters/skew_momentum_subject_first.py
+++ b/strategy_runtime/adapters/skew_momentum_subject_first.py
@@ -74,9 +74,18 @@ def _prepare(
     subject: str,
 ) -> KnowledgeMapping[SkewMomentumPayload] | UnknownReason:
     del projected
-    quote_resolution = resolution_for(snapshot, MarketCapability.REAL_TIME_QUOTE_V1)
-    chain_resolution = resolution_for(snapshot, MarketCapability.OPTION_CHAIN_V1)
-    bars_resolution = resolution_for(snapshot, MarketCapability.HISTORICAL_BARS_V1)
+    try:
+        quote_resolution = resolution_for(snapshot, MarketCapability.REAL_TIME_QUOTE_V1)
+    except ValueError:
+        return UnknownReason("unusable_quote")
+    try:
+        chain_resolution = resolution_for(snapshot, MarketCapability.OPTION_CHAIN_V1)
+    except ValueError:
+        return UnknownReason("unusable_option_chain")
+    try:
+        bars_resolution = resolution_for(snapshot, MarketCapability.HISTORICAL_BARS_V1)
+    except ValueError:
+        return UnknownReason("unusable_historical_bars")
     quote_observation = quote_resolution.selected_observation
     chain_observation = chain_resolution.selected_observation
     bars_observation = bars_resolution.selected_observation

--- a/strategy_runtime/preparation_diagnostics.py
+++ b/strategy_runtime/preparation_diagnostics.py
@@ -1,0 +1,42 @@
+"""Secret-free operational classification for subject preparation failures."""
+
+from __future__ import annotations
+
+import logging
+
+from domain import UnknownReason
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def classify_subject_preparation_exception(exc: BaseException) -> str:
+    message = str(exc).lower()
+    if "capability_reducer" in message or "demands resolved to" in message:
+        return "capability_reduction_failure"
+    if "resolution policy" in message or "priority policy" in message:
+        return "resolution_policy_construction_failure"
+    if "snapshot" in message or "seal" in message:
+        return "snapshot_sealing_failure"
+    if "provenance" in message:
+        return "provenance_mismatch"
+    if "fact" in message and ("identity" in message or "version" in message):
+        return "fact_identity_version_failure"
+    if "demand" in message:
+        return "demand_construction_failure"
+    if "provider" in message and ("config" in message or "enabled" in message):
+        return "provider_config_construction_failure"
+    return "unexpected_runtime_exception"
+
+
+def record_strategy_knowledge_failure(
+    strategy_id: str, subject: str
+) -> UnknownReason:
+    _LOGGER.exception(
+        "strategy_knowledge_construction_failed",
+        extra={
+            "failure_class": "strategy_knowledge_construction_failure",
+            "strategy_id": strategy_id,
+            "subject": subject,
+        },
+    )
+    return UnknownReason("strategy_knowledge_construction_failed")

--- a/strategy_runtime/subject_preparation.py
+++ b/strategy_runtime/subject_preparation.py
@@ -43,6 +43,7 @@ from screening.subject_planning import (
 from strategy_runtime.knowledge import ReadOnlyStrategyInput, TPayload
 from strategy_runtime.knowledge_composition import compose_strategy_knowledge
 from strategy_runtime.knowledge_registry import KnowledgeBinding, KnowledgeCompositionRegistry
+from strategy_runtime.preparation_diagnostics import record_strategy_knowledge_failure
 from strategy_runtime.registry import StrategyAdapter
 from strategy_runtime.result import UniversalScreeningResult
 
@@ -73,7 +74,7 @@ BuildShadowAdapter = Callable[
 
 
 @dataclass(frozen=True, slots=True)
-class SubjectPreparationBinding(Generic[TPayload]):
+class SubjectPreparationBinding(Generic[TPayload]):  # noqa: UP046
     """One strategy's own subject-first preparation declaration: what to
     plan/demand (a SubjectPlanConsumer, screening-owned but built from
     this strategy's own pure demand/expansion functions), what to do with
@@ -96,7 +97,7 @@ class DuplicateSubjectPreparationBindingError(ValueError):
     """
 
 
-class SubjectPreparationRegistry(Generic[TPayload]):
+class SubjectPreparationRegistry(Generic[TPayload]):  # noqa: UP046
     """Mirrors strategy_runtime.knowledge_registry.KnowledgeCompositionRegistry's
     own established immutable-constructor shape exactly -- no dynamic
     discovery, no ``.register()`` mutator.
@@ -226,12 +227,19 @@ def prepare_subject_knowledge(
         if expansion.unknown_reasons:
             prepared[strategy_id] = expansion.unknown_reasons[0]
             continue
-        mapping = binding.prepare_knowledge_mapping(
-            plan_result.snapshot,
-            plan_result.projected_evidence,
-            expansion.selections,
-            subject,
-        )
+        try:
+            mapping = binding.prepare_knowledge_mapping(
+                plan_result.snapshot,
+                plan_result.projected_evidence,
+                expansion.selections,
+                subject,
+            )
+        except Exception:
+            # The subject snapshot is already sealed. A defect in one
+            # strategy-owned projection must not erase valid knowledge for
+            # unrelated consumers sharing that evidence boundary.
+            prepared[strategy_id] = record_strategy_knowledge_failure(strategy_id, subject)
+            continue
         if isinstance(mapping, UnknownReason):
             prepared[strategy_id] = mapping
             continue

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -25,7 +25,7 @@ from tests.asa._fixture_market_data_access import (
     capturing_market_data_access_factory,
     shadow_alone_call_count,
 )
-from tests.asa.fakes import InMemoryLatestResultRepository
+from tests.asa.fakes import InMemoryLatestResultRepository, InMemoryObservationHistoryRepository
 from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
 
 
@@ -1164,6 +1164,76 @@ def test_shadow_subject_preparation_failure_never_aborts_the_cycle(
     ]
     assert len(failures) == 1
     assert failures[0].symbol == "AAPL"
+    assert failures[0].failure_class == "resolution_policy_construction_failure"
+
+
+def test_production_root_prepares_all_three_strategies_from_one_subject_snapshot(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Regression for #307: the real production composition root must
+    coalesce Skew's 180-day and Earnings' 45-day historical-bar demands.
+    Before the fix this exact topology raised during snapshot sealing and
+    every authoritative result became subject_preparation_failed.
+    """
+    import asa.scheduled_screening as scheduled_screening_module
+
+    monkeypatch.setattr(
+        scheduled_screening_module,
+        "build_shared_market_data_access",
+        build_fixture_market_data_access_factory(),
+    )
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    repository = InMemoryLatestResultRepository()
+    caplog.set_level(logging.WARNING)
+
+    outcomes = run_scheduled_refresh(
+        (
+            ("forward_factor", "AAPL"),
+            ("skew_momentum", "AAPL"),
+            ("earnings_calendar", "AAPL"),
+        ),
+        repository=repository,
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+    )
+
+    assert len(outcomes) == 3
+    assert all(item.error is None for item in outcomes)
+    assert all(item.outcome != "missing_data" for item in outcomes)
+    assert not any(
+        record.message == "shadow_subject_preparation_failed" for record in caplog.records
+    )
+
+
+def test_production_universe_topology_has_no_universal_preparation_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Mechanically identical 82-pair topology using deterministic providers."""
+    import asa.scheduled_screening as scheduled_screening_module
+
+    monkeypatch.setattr(
+        scheduled_screening_module,
+        "build_shared_market_data_access",
+        build_fixture_market_data_access_factory(),
+    )
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    repository = InMemoryLatestResultRepository()
+    caplog.set_level(logging.WARNING)
+
+    outcomes = run_scheduled_refresh(
+        PRODUCTION_SCREENING_UNIVERSE,
+        repository=repository,
+        history_repository=InMemoryObservationHistoryRepository(),
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+    )
+
+    assert len(outcomes) == 82
+    assert all(item.error is None for item in outcomes)
+    assert all(item.outcome != "missing_data" for item in outcomes)
+    assert not any(
+        record.message == "shadow_subject_preparation_failed" for record in caplog.records
+    )
 
 
 def test_ff_and_skew_results_are_unaffected_by_whether_earnings_shares_the_cycle(

--- a/tests/strategy_runtime/adapters/test_earnings_calendar_subject_first.py
+++ b/tests/strategy_runtime/adapters/test_earnings_calendar_subject_first.py
@@ -82,6 +82,7 @@ from strategy_runtime.subject_preparation import (
     SubjectPreparationRegistry,
     UnknownSubjectPreparationBindingError,
     prepare_strategy_knowledge,
+    prepare_subject_knowledge,
 )
 from tests.market_data.test_fulfillment import CAPABILITY, provider, service
 from tests.strategy_runtime.test_earnings_calendar_generic_composition import (
@@ -488,6 +489,43 @@ class TestPrepareStrategyKnowledgeGenericMechanics:
         assert isinstance(result, UnknownReason)
         assert result.code == "synthetic_gap"
         assert called is False
+
+    def test_one_binding_failure_does_not_destroy_other_prepared_knowledge(self) -> None:
+        consumer_a = SubjectPlanConsumer(
+            "broken-strategy", (_synthetic_demand(),), lambda _evidence: DemandExpansion()
+        )
+        consumer_b = SubjectPlanConsumer(
+            "healthy-strategy", (_synthetic_demand(),), lambda _evidence: DemandExpansion()
+        )
+
+        def _broken(*_args: object) -> KnowledgeMapping[_SyntheticPayload]:
+            raise RuntimeError("synthetic binding defect")
+
+        broken: SubjectPreparationBinding[_SyntheticPayload] = SubjectPreparationBinding(
+            consumer_a, _broken, _synthetic_build_shadow_adapter
+        )
+        healthy: SubjectPreparationBinding[_SyntheticPayload] = SubjectPreparationBinding(
+            consumer_b, _synthetic_prepare_knowledge_mapping, _synthetic_build_shadow_adapter
+        )
+        registry: SubjectPreparationRegistry[object] = SubjectPreparationRegistry(
+            (("broken-strategy", broken), ("healthy-strategy", healthy))
+        )
+        fulfillment, budgets = service(provider("primary"))
+
+        result = prepare_subject_knowledge(
+            _plan(fulfillment),
+            NOW,
+            registry,
+            subject="AAPL",
+            provider_metadata=(provider("primary").metadata,),
+            resolution_policy_by_capability=_SYNTHETIC_RESOLUTION_POLICY,
+        )
+
+        broken_result = result["broken-strategy"]
+        assert isinstance(broken_result, UnknownReason)
+        assert broken_result.code == "strategy_knowledge_construction_failed"
+        assert isinstance(result["healthy-strategy"], ReadOnlyStrategyInput)
+        assert len(budgets.accounting) == 1
 
 
 class TestEarningsCalendarSubjectFirstAdapter:


### PR DESCRIPTION
## Ticket
S14R-M3 correction / closes #307

## Symptom
`main@1dc75c39` deployed successfully, but the real scheduled cycle returned `missing_data` / `subject_preparation_failed` for all 82 production strategy-symbol pairs.

## Reproduction
Railway production logs show the real composition root failing at snapshot sealing:

- `2 demands resolved to historical_bars_v1 ... no capability_reducer_by_capability entry`
- when bars were unavailable, Skew knowledge construction raised `snapshot has no resolution for historical_bars_v1`

## Owning layer and root cause
The subject plan correctly unioned Skew Momentum's 180-day and Earnings Calendar's 45-day bar demands, but market-data registered no historical-series reducer. The strategy binding also treated an expected absent resolution as an invariant exception. Any binding exception escaped the shared preparation loop and erased otherwise-valid knowledge for every strategy on the subject.

## Correction
- Add capability-owned deterministic historical-series coalescing with complete attempt/provenance retention.
- Register it for `HISTORICAL_BARS_V1`.
- Convert expected absent Skew evidence into typed unavailable knowledge.
- Contain post-seal strategy-binding defects per strategy; shared acquisition remains intact.
- Add secret-free preparation failure classes to scheduled and API composition roots.

## Frozen architecture compliance
Preserves provider-blind strategies, one sealed subject boundary, strategy-neutral facts, provider-free replay, generic orchestration, and the deleted legacy acquisition path. No public contract, governance, strategy threshold, provider, or universe change.

## Before / after
Before: 82/82 production pairs collapsed to generic missing data.

After (production-equivalent): the mechanically identical 82-pair topology completes with no `subject_preparation_failed` and no missing-data result using deterministic provider transport. One subject runs all three production strategies over one shared snapshot. A synthetic broken strategy binding no longer destroys healthy sibling knowledge.

## Validation
- `pytest -q`: 3,197 passed, 45 skipped
- focused production/replay/orchestration regressions: 141 passed
- ruff changed files: pass
- mypy `asa market_data screening strategy_runtime`: pass
- architecture boundary tests: pass
- Lean integrity: pass
- Lean entrypoints: pass
- Lean pre-push: 5/5 pass
- `git diff --check`: pass

## Deployment
Not performed. Separate Founder authorization remains required after exact-main verification.

## Auto-merge authority
In-scope correction under active SPRINT-014R Founder Sprint Delegation. Branch protection and all required checks remain mandatory.
