### PR TITLE
S16-01: restore completed Tradier history normalization

### DIFF
--- a/market_data/tradier.py
+++ b/market_data/tradier.py
@@ -321,11 +321,24 @@ class TradierProvider:
             rows = _rows(_mapping(response.json_body, "history").get("day"))
             bars: list[OHLCVBar] = []
             rejected_rows = 0
+            incomplete_rows = 0
+            received_at = self._dependencies.clock.now()
             for row in rows:
                 try:
-                    bars.append(_bar(subject, row))
+                    bar = _bar(subject, row)
                 except (KeyError, TypeError, ValueError, InvalidOperation, DomainInvariantError):
                     rejected_rows += 1
+                    continue
+                # Tradier includes the current, still-forming daily candle.
+                # Canonical historical bars are completed intervals: admitting
+                # today's midnight-to-midnight row before midnight makes its
+                # end_at later than OHLCVSeries.as_of and invalidates the whole
+                # otherwise-usable response.  Keep completed provider facts and
+                # leave the in-progress candle to real-time capabilities.
+                if bar.end_at > received_at:
+                    incomplete_rows += 1
+                    continue
+                bars.append(bar)
             if rejected_rows:
                 LOGGER.warning(
                     "Tradier rejected %d malformed historical bar row(s)",
@@ -337,12 +350,22 @@ class TradierProvider:
                         "diagnostic_code": ProviderErrorCode.SCHEMA_MISMATCH.value,
                     },
                 )
+            if incomplete_rows:
+                LOGGER.info(
+                    "Tradier excluded %d incomplete historical bar row(s)",
+                    incomplete_rows,
+                    extra={
+                        "provider": "tradier",
+                        "symbol": subject.canonical_instrument.display_symbol,
+                        "capability": request.capability.value,
+                    },
+                )
             if not bars:
                 raise DomainInvariantError("Tradier history contained no valid canonical bars")
             series = OHLCVSeries(
                 subject.canonical_instrument,
                 86400,
-                self._dependencies.clock.now(),
+                received_at,
                 tuple(sorted(bars, key=lambda bar: bar.start_at)),
             )
             return (self._observation(request, subject, series, response, {}),)

--- a/tests/market_data/test_tradier.py
+++ b/tests/market_data/test_tradier.py
@@ -333,6 +333,50 @@ def test_multi_day_history_normalizes_into_one_series_observation() -> None:
     assert series.bars[0].start_at < series.bars[1].start_at
 
 
+def test_daily_history_excludes_current_incomplete_row_without_discarding_completed_history(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    transport = Transport(
+        (
+            response(
+                {
+                    "history": {
+                        "day": [
+                            {
+                                "date": "2026-07-20",
+                                "open": "205.00",
+                                "high": "212",
+                                "low": "204",
+                                "close": "210",
+                                "volume": 50000000,
+                            },
+                            {
+                                "date": "2026-07-21",
+                                "open": "210.00",
+                                "high": "214",
+                                "low": "209",
+                                "close": "213",
+                                "volume": 30000000,
+                            },
+                        ]
+                    }
+                }
+            ),
+        )
+    )
+
+    with caplog.at_level("INFO"):
+        result = provider(transport).fetch(
+            request(MarketCapability.HISTORICAL_BARS_V1, ("close",)), authorization()
+        )
+
+    assert result.error is None
+    series = result.observations[0].value
+    assert isinstance(series, OHLCVSeries)
+    assert [bar.start_at.date() for bar in series.bars] == [date(2026, 7, 20)]
+    assert "excluded 1 incomplete historical bar row" in caplog.text
+
+
 def test_daily_history_rejects_one_incoherent_row_without_discarding_valid_series(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Ticket
S16-01 — Recover Skew Momentum Evaluability

Assigned Worker: Codex Worker  
Manager stop status: CLEAR

## Symptom and root cause
Production persisted evidence showed Skew historical acquisition falling through Alpha Vantage rate limits/staleness and Finnhub entitlement failure because Tradier consistently returned `schema_mismatch`.

A bounded live reproduction proved Tradier returned the correct documented history shape. The adapter then modeled Tradier's current in-progress daily candle as a completed UTC day. Its `end_at` was tomorrow while `OHLCVSeries.as_of` was retrieval time, violating the immutable completed-series invariant and rejecting the entire otherwise-valid history response.

## Correction
Historical normalization now excludes incomplete daily intervals before constructing the canonical completed series. Completed bars remain intact; no retries, provider fallback changes, strategy policy changes, or strategy-owned acquisition are introduced.

## Before / after
- Before: bounded Tradier validation: `historical_bars_v1 fail SCHEMA_MISMATCH`.
- After on this branch: `historical_bars_v1 pass VALID_DATA` with one bounded request; quote and option-chain remain `VALID_DATA`.
- Regression is red on baseline because today's row causes `OHLCVSeries.as_of` failure; green on head because the completed prior row remains usable.

## Production effect
Restores the primary provider's completed history for the same canonical capability used by all 30 Skew subjects. This removes the shared ASA-caused historical failure mechanism without changing Skew thresholds or S14R boundaries. Exact production closure remains S16-03 work after merged-main verification and Founder-authorized deployment.

## Validation
- `tests/market_data/test_tradier.py`: 25 passed
- market-data/runtime/scheduled integration set: 137 passed
- relevant architecture: 18 passed
- Ruff: green
- mypy changed provider: green
- Lean integrity: green
- Lean entrypoints: green
- bounded live Tradier validation: history, option chain, quote all `VALID_DATA`
- `git diff --check`: green

## Self-review
- Correction is at owning normalization layer.
- No public/frozen contract change.
- No strategy-owned acquisition.
- No request-budget widening.
- No scope expansion.
- No secrets or payloads recorded.

Closes #311
