### PR TITLE
S16-02: classify Earnings evidence and stop futile retries

### DIFF
--- a/market_data/subject_plan.py
+++ b/market_data/subject_plan.py
@@ -148,6 +148,7 @@ class SubjectAcquisitionPlan:
         attempts_made = 1
         while (
             result.status is FulfillmentStatus.FAILED
+            and _failure_is_retryable(result)
             and attempts_made < self._maximum_attempts_per_request
         ):
             result = self._fulfillment.fulfill(request, required=required)
@@ -180,6 +181,20 @@ class SubjectAcquisitionPlan:
                 extra={"plan_id": self._plan_id, "subject": self._subject},
                 exc_info=True,
             )
+
+
+def _failure_is_retryable(result: CapabilityFulfillmentResult) -> bool:
+    """Retry only a wholly transient provider failure set.
+
+    A failed fulfillment can contain several provider attempts.  Repeating
+    the complete request immediately when any provider returned a definitive
+    result (for example NO_DATA, authorization failure, or schema mismatch)
+    cannot change that result and only consumes scarce fallback quota.  The
+    normalized error policy already owns retryability; the subject plan obeys
+    it instead of maintaining a second error-code list.
+    """
+    errors = tuple(attempt.error for attempt in result.attempts)
+    return bool(errors) and all(error is not None and error.retryable for error in errors)
 
 
 class CapabilityFulfiller(Protocol):

--- a/strategies/earnings_calendar_planning.py
+++ b/strategies/earnings_calendar_planning.py
@@ -291,6 +291,76 @@ def _expiration_candidates(
     return ()
 
 
+def _expiration_rejection_detail(
+    candidates: tuple[ExpirationCandidate, ...],
+    earnings_date: date,
+    requirement: EarningsCalendarRequirement,
+) -> str:
+    """Provider-neutral evidence showing why the frozen pair gate rejected.
+
+    This is diagnostic only: selection remains owned by
+    ``select_earnings_relative_expiration_pair`` above.  Keeping the raw
+    listed dates/DTEs and each gate's eligible subset makes a production
+    ``no_valid_expiration_pair`` independently classifiable without payload
+    access or policy relaxation.
+    """
+    policy = requirement.expiration_policy
+    fronts = tuple(
+        item
+        for item in candidates
+        if policy.front_min_dte <= item.days_to_expiration <= policy.front_max_dte
+        and item.expiration_date < earnings_date
+    )
+    backs = tuple(
+        item
+        for item in candidates
+        if policy.back_min_dte <= item.days_to_expiration <= policy.back_max_dte
+        and item.expiration_date > earnings_date
+    )
+    nearest = min(
+        (
+            (
+                abs(
+                    (back.expiration_date - front.expiration_date).days
+                    - policy.target_gap_days
+                ),
+                front,
+                back,
+            )
+            for front in fronts
+            for back in backs
+            if back.expiration_date > front.expiration_date
+        ),
+        default=None,
+        key=lambda item: (item[0], item[1].expiration_date, item[2].expiration_date),
+    )
+
+    def render(items: tuple[ExpirationCandidate, ...]) -> str:
+        rendered = ",".join(
+            f"{item.expiration_date.isoformat()}({item.days_to_expiration})" for item in items
+        )
+        return rendered or "none"
+
+    nearest_text = (
+        "none"
+        if nearest is None
+        else (
+            f"{nearest[1].expiration_date.isoformat()}/"
+            f"{nearest[2].expiration_date.isoformat()}"
+            f"(gap={(nearest[2].expiration_date - nearest[1].expiration_date).days},"
+            f"deviation={nearest[0]})"
+        )
+    )
+    return (
+        f"earnings_date={earnings_date.isoformat()};"
+        f"listed={render(candidates)};"
+        f"eligible_fronts={render(fronts)};"
+        f"eligible_backs={render(backs)};"
+        f"nearest_pair={nearest_text};"
+        f"target_gap={policy.target_gap_days};tolerance={policy.gap_tolerance_days}"
+    )
+
+
 def expand_earnings_calendar_demands(
     evidence: Mapping[str, ResolvedCapabilityEvidence],
     *,
@@ -345,6 +415,7 @@ def expand_earnings_calendar_demands(
                         the_earnings_demand.demand_id,
                         the_expirations_demand.demand_id,
                     ),
+                    detail=_expiration_rejection_detail(candidates, earnings_date, requirement),
                 ),
             )
         )
@@ -395,13 +466,16 @@ def select_earnings_calendar_phase_two_evidence(
     the_earnings_demand_id = earnings_demand(now, requirement=requirement).demand_id
     the_historical_bars_demand_id = historical_bars_demand(now).demand_id
     the_expirations_demand_id = expirations_demand(now).demand_id
+    evidence_roles = (
+        ("spot_price", the_quote_demand_id),
+        ("earnings_event", the_earnings_demand_id),
+        ("historical_bars", the_historical_bars_demand_id),
+        ("expiration_discovery", the_expirations_demand_id),
+        ("front_chain", front_demand_id),
+        ("back_chain", back_demand_id),
+    )
     by_demand_id = {
-        the_quote_demand_id: projected_evidence.get(the_quote_demand_id),
-        the_earnings_demand_id: projected_evidence.get(the_earnings_demand_id),
-        the_historical_bars_demand_id: projected_evidence.get(the_historical_bars_demand_id),
-        the_expirations_demand_id: projected_evidence.get(the_expirations_demand_id),
-        front_demand_id: projected_evidence.get(front_demand_id),
-        back_demand_id: projected_evidence.get(back_demand_id),
+        demand_id: projected_evidence.get(demand_id) for _role, demand_id in evidence_roles
     }
     unusable = tuple(
         demand_id
@@ -409,7 +483,14 @@ def select_earnings_calendar_phase_two_evidence(
         if item is None or item.usability is not EvidenceUsability.RESOLVED
     )
     if unusable:
-        return UnknownReason("unusable_phase_two_evidence", demand_ids=unusable)
+        unusable_roles = tuple(
+            role for role, demand_id in evidence_roles if demand_id in unusable
+        )
+        return UnknownReason(
+            "unusable_phase_two_evidence",
+            demand_ids=unusable,
+            detail=f"unusable_roles={','.join(unusable_roles)}",
+        )
 
     return EarningsCalendarPhaseTwoEvidence(
         spot_price_evidence=by_demand_id[the_quote_demand_id],  # type: ignore[arg-type]

--- a/strategy_runtime/orchestration.py
+++ b/strategy_runtime/orchestration.py
@@ -498,7 +498,10 @@ def _missing_data_result(
         data_quality=None,
         metrics={},
         economics={},
-        blockers=(f"typed unknown evidence gap: {reason.code}",),
+        blockers=(
+            f"typed unknown evidence gap: {reason.code}"
+            + (f" ({reason.detail})" if reason.detail else ""),
+        ),
         warnings=(),
         provenance=(
             f"unknown:{reason.code}",

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -596,7 +596,7 @@ def _force_tiny_tradier_window(monkeypatch: pytest.MonkeyPatch, window_limit: in
 # that already use it, but these two tests need a genuinely complete
 # fixture so their pass/refusal assertions are unambiguous rather than
 # "some outcome, who knows which."
-_SKEW_MOMENTUM_REQUESTS_PER_PAIR = 5
+_SKEW_MOMENTUM_REQUESTS_PER_PAIR = 4
 _STRIKE_DELTA_LADDER = (
     (-15, "0.80"),
     (-10, "0.70"),
@@ -809,8 +809,8 @@ def test_a_failed_shared_capability_becomes_a_durably_shared_known_failure(
     deliberately never reuses a cached *failed* result on its own (see
     test_fulfillment.py's own
     test_a_failed_result_is_never_reused_and_gets_its_own_independent_retry)
-    -- correct for failure *isolation* within one bare service instance,
-    but it used to also mean there was no durable, shared "this datum is
+        -- correct for failure *isolation* within one bare service instance,
+        but it used to also mean there was no durable, shared "this datum is
     UNKNOWN this cycle" fact a second pair sharing the same symbol could
     consult: it paid its own full provider round-trip for the identical
     failure, even though both pairs ran under the same frozen cycle clock.
@@ -818,12 +818,11 @@ def test_a_failed_shared_capability_becomes_a_durably_shared_known_failure(
     root-cause statement: "Failed cache entries may be removed and
     repeated by later strategies."
 
-    Now that skew_momentum's own legacy adapter is registered against this
+        Now that skew_momentum's own legacy adapter is registered against this
     symbol's shared PlanBackedFulfillment (not the raw fulfillment service
     directly), SubjectAcquisitionPlan itself provides that durable shared
-    fact: the plan's own bounded retry (market_data/subject_plan.py,
-    maximum_attempts_per_request=2 by default) makes one extra attempt at
-    the failing request before freezing it, and every later resolve() for
+        fact: the plan freezes a definitive non-retryable failure after its
+        first provider round trip, and every later resolve() for
     that exact same (request, required) key -- from any pair sharing this
     symbol, including this test's own second, identical
     ("skew_momentum", "AAPL") pair -- returns that frozen result with zero
@@ -845,11 +844,6 @@ def test_a_failed_shared_capability_becomes_a_durably_shared_known_failure(
 
     responses = _complete_skew_momentum_responses(expiration)
     responses[3] = _empty_history_response("tradier-request-4-empty-attempt-1")
-    # The plan's own bounded retry means exactly one more scripted response
-    # is consumed for the SAME failing request -- never a second full
-    # 4-request burst for the second, identical pair.
-    responses.append(_empty_history_response("tradier-request-4-empty-attempt-2"))
-
     outcomes = run_scheduled_refresh(
         universe,
         repository=repository,
@@ -860,9 +854,9 @@ def test_a_failed_shared_capability_becomes_a_durably_shared_known_failure(
     assert len(outcomes) == 2
     assert outcomes[0].error is None
     assert outcomes[1].error is None
-    # First pair: 3 fresh successes (quote/expirations/chain) plus the
-    # plan's own 2 bounded-retry attempts at the one failing capability.
-    assert outcomes[0].request_count == _SKEW_MOMENTUM_REQUESTS_PER_PAIR + 1
+    # First pair: 3 fresh successes (quote/expirations/chain) plus one
+    # definitive non-retryable failure for historical bars.
+    assert outcomes[0].request_count == _SKEW_MOMENTUM_REQUESTS_PER_PAIR
     # Second pair: every one of its four capability requests -- including
     # the now-exhausted, durably shared failure -- is served entirely from
     # this symbol's shared plan. Zero new provider calls.

--- a/tests/market_data/test_subject_plan.py
+++ b/tests/market_data/test_subject_plan.py
@@ -117,11 +117,7 @@ class TestResolveSharesFailure:
         # failure.
         assert len(budgets.accounting) == 1
 
-    def test_the_plans_own_bounded_retry_gets_a_second_chance_before_freezing(self) -> None:
-        # FixtureScenario's own outcome is fixed for the provider's whole
-        # lifetime (unlike the _FailsOnceProvider used elsewhere), so this
-        # proves the *number* of attempts the plan itself makes before
-        # giving up, not that a later attempt happens to succeed.
+    def test_non_retryable_no_data_is_frozen_without_wasting_a_second_request(self) -> None:
         always_fails = FixtureScenario(
             failures=((request().capability, ProviderErrorCode.NO_DATA),)
         )
@@ -131,7 +127,7 @@ class TestResolveSharesFailure:
         result = plan.resolve(request(), required=False)
 
         assert result.status.value == "failed"
-        assert len(budgets.accounting) == 2  # the bounded retry actually ran
+        assert len(budgets.accounting) == 1
 
 
 class TestConsumerOrderIndependence:
@@ -166,7 +162,7 @@ class TestAttemptPersistence:
         plan.resolve(request(), required=False)
 
         rows = repository.query(AttemptQuery(screening_cycle_id="cycle-1:AAPL", limit=10))
-        assert len(rows) == 2  # both bounded-retry attempts persisted
+        assert len(rows) == 1
         assert all(item.outcome is AcquisitionOutcome.NO_MATCHING_DATA for item in rows)
 
     def test_a_reused_result_does_not_duplicate_attempt_rows(self) -> None:

--- a/tests/strategies/test_earnings_calendar_planning.py
+++ b/tests/strategies/test_earnings_calendar_planning.py
@@ -284,6 +284,9 @@ class TestExpandEarningsCalendarDemands:
         assert expansion.demands == ()
         assert len(expansion.unknown_reasons) == 1
         assert expansion.unknown_reasons[0].code == "no_valid_expiration_pair"
+        assert "listed=" in expansion.unknown_reasons[0].detail
+        assert "eligible_fronts=none" in expansion.unknown_reasons[0].detail
+        assert "target_gap=30;tolerance=5" in expansion.unknown_reasons[0].detail
 
     def test_no_listed_expirations_is_no_valid_pair_unknown(self) -> None:
         evidence = _phase_one_evidence(expirations=())
@@ -391,6 +394,7 @@ class TestSelectEarningsCalendarPhaseTwoEvidence:
         assert isinstance(result, UnknownReason)
         assert result.code == "unusable_phase_two_evidence"
         assert the_bars_id in result.demand_ids
+        assert result.detail == "unusable_roles=historical_bars"
 
     def test_unusable_expiration_discovery_evidence_is_unknown(self) -> None:
         selections = self._selections()

--- a/tests/strategy_runtime/test_orchestration.py
+++ b/tests/strategy_runtime/test_orchestration.py
@@ -1077,7 +1077,9 @@ class TestCutoverDispatch:
     ) -> None:
         shadow_registry = _synthetic_shadow_registry(_shadow_adapter_matching_legacy)
         knowledge: dict[str, ReadOnlyStrategyInput[object] | UnknownReason] = {
-            _SYNTHETIC_STRATEGY_ID: UnknownReason("synthetic_gap", demand_ids=("demand-a",))
+            _SYNTHETIC_STRATEGY_ID: UnknownReason(
+                "synthetic_gap", demand_ids=("demand-a",), detail="failed_role=history"
+            )
         }
         cutover_policy = CutoverPolicy({_SYNTHETIC_STRATEGY_ID: True})
 
@@ -1100,6 +1102,7 @@ class TestCutoverDispatch:
         assert result.opportunity_id is None
         assert result.lifecycle_stage is None
         assert any("synthetic_gap" in blocker for blocker in result.blockers)
+        assert any("failed_role=history" in blocker for blocker in result.blockers)
 
     def test_rollback_false_entry_keeps_legacy_authoritative_and_shadow_comparison(
         self,


### PR DESCRIPTION
## Ticket
S16-02 — Classify and Recover Earnings Evaluability

Assigned Worker: Codex Worker  
Manager stop status: CLEAR

## Root causes
1. S16-01's completed-history defect explains the controlling baseline's three `unusable_phase_two_evidence` rows (AVGO/MU/NVDA): their earnings and option-chain attempts succeeded, while historical evidence was unusable.
2. `SubjectAcquisitionPlan` repeated every failed request regardless of the normalized provider errors' retryability. Production therefore doubled definitive `no_data`, authorization, stale, and schema failures and consumed Alpha Vantage quota without any mechanism for a different result.
3. The result projection discarded `UnknownReason.detail`, so a declared expiration-policy rejection or phase-two binding gap could not be independently classified from operational output.

## Correction
- Retry only when the entire terminal provider failure set is explicitly retryable under the existing normalized error policy.
- Preserve typed safe diagnostic detail in missing-data blockers.
- Record the resolved earnings date, listed expiration/DTE set, eligible front/back sets, nearest pair/gap deviation, and frozen target/tolerance for `no_valid_expiration_pair`.
- Record exact evidence roles for `unusable_phase_two_evidence`.

No strategy policy, thresholds, provider selection, public contract, acquisition boundary, or universe changed.

## 22-row classification
- `no_valid_expiration_pair` (13 controlling baseline): emitted only after both earnings and expiration discovery resolve and the frozen strategy selector rejects every listed pair. The new diagnostic makes each symbol's exact policy proof visible.
- `missing_earnings_date` (6 controlling baseline): persisted provider attempts classify upstream `no_data` separately from rate-limit/provider unavailability. Five current recurring symbols have repeated `NO_DATA` from both Finnhub and Alpha when quota allowed; remaining unavailable cases stay typed upstream limitation rather than fabricated no-event.
- `unusable_phase_two_evidence` (AVGO/MU/NVDA): successful earnings and option inventory; historical role was the ASA defect fixed by S16-01.

## Before / after
- Before: non-retryable failures execute twice and opaque terminal codes require source reconstruction.
- After: one definitive attempt set is frozen/reused; transient-only failures retain bounded retry; policy and binding output is self-classifying.

## Validation
- targeted correction suite: 115 passed
- market-data + strategy runtime + scheduled + architecture integration: 687 passed, 1 skipped
- Ruff changed scope: green
- mypy changed source: green
- Lean integrity/entrypoints: green
- git diff check: green

## Self-review
- Existing owners and normalized retry policy reused.
- No new subsystem or contract.
- No strategy-owned acquisition.
- Forward Factor semantics untouched; request use only decreases for definitive failures.
- No secrets/provider payloads persisted.

Closes #313
