### PR TITLE
XFACT-01: root cause and cross-subject boundary

### DIFF
--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -388,7 +388,14 @@ def run_scheduled_refresh(
     # A preparation failure is isolated exactly like this module's other
     # best-effort side channels (skew capture, opportunity history) and
     # never aborts or affects any pair's own legacy evaluation.
-    shadow_registry = build_migrated_shadow_registry(clock.now(), historical_skew_repository)
+    # Use the resolved repository, not only the optional injection argument.
+    # In production the argument is normally ``None`` and the Postgres-backed
+    # default above is the authoritative historical-evidence owner. Passing the
+    # unresolved argument silently disabled Skew's historical z-score facts in
+    # every default scheduled cycle.
+    shadow_registry = build_migrated_shadow_registry(
+        clock.now(), resolved_historical_skew_repository
+    )
     shadow_capability_reducers = migrated_shadow_capability_reducers()
     # SPRINT-014 S14-PR-05, Architect checkpoint: nineteenth review, "one
     # shared cutover policy owner used identically by scheduled and API

--- a/project/reports/XFACT-01-root-cause.md
+++ b/project/reports/XFACT-01-root-cause.md
@@ -1,0 +1,37 @@
+# XFACT-01 — Root Cause and Cross-Subject Boundary
+
+## Root causes
+
+- `call_skew_zscore` and `put_skew_zscore`: the scheduled production root
+  resolved the default Postgres historical-skew repository, then passed the
+  unresolved optional injection argument to the subject-first registry. With
+  normal production construction that argument is `None`, so the Skew binding
+  received no historical observations and could not materialize either fact.
+- `cross_sectional_percentile` and `sector_relative_return`: subject-first
+  preparation correctly seals one subject at a time, but no provider-free
+  post-preparation owner materializes facts across the cycle's already-sealed
+  subject knowledge. The Skew adapter therefore explicitly supplies `None`.
+
+## Existing owners
+
+- Cross-subject evidence contracts: `domain/strategy_evidence.py`.
+- Registered formulas and versions: `analytics/derived_facts.py`.
+- Immutable fact identity/materialization: `analytics/features.py` and
+  `analytics/derived_fact_materialization.py`.
+- Configured-universe asset and authoritative GICS/Select Sector SPDR mappings:
+  `strategy_runtime/comparison_universe.py`.
+- Subject-local read-only knowledge: `strategy_runtime/knowledge.py`.
+
+Existing evidence references can pin every contributing canonical fact; no new
+evidence kind is needed. Cross-subject identity must additionally bind the
+ordered cohort/member identities and relevant input fact identities through
+materialization parameters/digest.
+
+## Correct boundary
+
+Correct the historical-repository dependency at the production composition
+root. Materialize comparison and sector facts in a provider-free,
+strategy-neutral post-preparation stage over the cycle's sealed read-only
+knowledge. Consumers bind those immutable facts declaratively. Missing cohort
+coverage or authoritative sector/reference membership remains a specific typed
+UNKNOWN; no peer, sector, or proxy is invented.

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -473,6 +473,40 @@ def test_skew_momentum_pair_reads_the_injected_historical_skew_repository(
     ]
 
 
+def test_skew_momentum_pair_reads_the_default_historical_skew_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: production construction must not discard its resolved default."""
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    repository = InMemoryLatestResultRepository()
+    historical_skew_repository = _RecordingHistoricalSkewRepository()
+    monkeypatch.setattr(
+        "asa.scheduled_screening.PostgresHistoricalSkewRepository",
+        lambda _engine: historical_skew_repository,
+    )
+    monkeypatch.setattr(
+        "asa.scheduled_screening.create_postgres_engine",
+        lambda _url: object(),
+    )
+    expiration = (date.today() + timedelta(days=7)).isoformat()
+
+    outcomes = run_scheduled_refresh(
+        (("skew_momentum", "AAPL"),),
+        repository=repository,
+        history_repository=InMemoryObservationHistoryRepository(),
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        transport_factory=lambda _provider_id: ScriptedTransport(
+            _tradier_skew_capable_chain_responses(expiration)
+        ),
+    )
+
+    assert outcomes[0].error is None
+    assert historical_skew_repository.history_for_calls == [
+        CanonicalInstrumentIdentity("symbol", "AAPL")
+    ]
+
+
 def test_non_skew_momentum_pairs_never_touch_the_historical_skew_repository(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1189,6 +1223,7 @@ def test_production_root_prepares_all_three_strategies_from_one_subject_snapshot
         ),
         repository=repository,
         acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        historical_skew_repository=_RecordingHistoricalSkewRepository(),
     )
 
     assert len(outcomes) == 3
@@ -1220,6 +1255,7 @@ def test_production_universe_topology_has_no_universal_preparation_failure(
         repository=repository,
         history_repository=InMemoryObservationHistoryRepository(),
         acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        historical_skew_repository=_RecordingHistoricalSkewRepository(),
     )
 
     assert len(outcomes) == 82


### PR DESCRIPTION
## Ticket / Worker
XFACT-01 / implementation-worker

Closes #318.

## Root cause
1. Default scheduled production constructed the Postgres skew-history repository, then passed the unresolved optional argument (`None`) into subject-first Skew preparation.
2. Comparison and sector facts have registered domain/analytics owners, but no provider-free cycle-level materialization stage; the adapter explicitly binds `None`.

## Correction
- Pass the resolved historical repository at the production composition root.
- Record the bounded root-cause and owner analysis for XFACT-02.

## Before / after
Default production could never read historical skew facts. It now uses the authoritative configured repository; regression fails on baseline and passes on head.

## Validation
- scheduled production tests: 34 passed
- strategy runtime + analytics + architecture: 944 passed
- Ruff: PASS
- mypy changed production scope: PASS
- Lean integrity/entrypoints: PASS
- diff check: PASS

## Self-review / stop status
Worker self-review complete. Manager stop status CLEAR. No contract, scope, provider, universe, or governance change.