### PR TITLE
XFACT-02: reusable cross-sectional fact materialization

### DIFF
--- a/analytics/cross_sectional_materialization.py
+++ b/analytics/cross_sectional_materialization.py
@@ -1,0 +1,172 @@
+"""Provider-free materialization of reusable cross-subject return facts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+
+from analytics.derived_fact_materialization import materialize_derived_fact
+from analytics.derived_facts import (
+    CROSS_SECTIONAL_MOMENTUM,
+    DERIVED_FACT_REGISTRY,
+    SECTOR_RELATIVE_MOMENTUM,
+    compute_cross_sectional_momentum,
+    compute_sector_relative_momentum,
+)
+from analytics.features import DerivedFact, DerivedFactQualityStatus, DerivedFactSet
+from domain import (
+    CanonicalInstrumentIdentity,
+    CanonicalReturnObservation,
+    ComparisonUniverseReturns,
+    EvidenceReference,
+    SectorReferenceReturns,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CrossSectionalFactInputs:
+    """Explicit domain evidence selected by the policy-owning caller."""
+
+    subject_return: CanonicalReturnObservation
+    comparison_returns: ComparisonUniverseReturns | None
+    sector_returns: SectorReferenceReturns | None
+    comparison_unknown_reason: str | None = None
+    sector_unknown_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.comparison_returns is None and self.comparison_unknown_reason is None:
+            raise ValueError("missing comparison evidence requires a typed reason")
+        if self.sector_returns is None and self.sector_unknown_reason is None:
+            raise ValueError("missing sector evidence requires a typed reason")
+
+
+@dataclass(frozen=True, slots=True)
+class SubjectCrossSectionalFacts:
+    """Facts and explicit gaps for one subject in one immutable cohort."""
+
+    subject: CanonicalInstrumentIdentity
+    derived_facts: DerivedFactSet
+    comparison_peer_count: int
+    comparison_unknown_reason: str | None = None
+    sector_unknown_reason: str | None = None
+
+
+def _instrument_key(instrument: CanonicalInstrumentIdentity) -> tuple[str, str]:
+    return instrument.scheme, instrument.value
+
+
+def _evidence(
+    observations: tuple[CanonicalReturnObservation, ...],
+) -> tuple[EvidenceReference, ...]:
+    return tuple(
+        sorted(
+            {item for observation in observations for item in observation.evidence},
+            key=lambda item: (item.kind.value, item.referenced_id, item.version or 0),
+        )
+    )
+
+
+def _evidence_digest(
+    feature_id: str,
+    subject: CanonicalInstrumentIdentity,
+    observations: tuple[CanonicalReturnObservation, ...],
+) -> str:
+    """Content identity for the exact ordered cross-subject evidence set."""
+
+    payload = {
+        "namespace": "asa.cross_sectional_evidence",
+        "version": "v1",
+        "feature_id": feature_id,
+        "subject": _instrument_key(subject),
+        "observations": [
+            {
+                "instrument": _instrument_key(item.instrument),
+                "return": str(item.return_value),
+                "period_start": item.period_start.isoformat(),
+                "period_end": item.period_end.isoformat(),
+                "effective_time": item.effective_time.isoformat(),
+                "evidence": [
+                    (reference.kind.value, reference.referenced_id, reference.version)
+                    for reference in item.evidence
+                ],
+            }
+            for item in sorted(observations, key=lambda value: _instrument_key(value.instrument))
+        ],
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def materialize_cross_sectional_facts(
+    inputs: tuple[CrossSectionalFactInputs, ...],
+    *,
+    effective_time: datetime,
+    minimum_valid_members: int = 5,
+) -> tuple[SubjectCrossSectionalFacts, ...]:
+    """Materialize registered facts once from already-canonical returns.
+
+    This function performs no acquisition and owns no strategy policy. Missing
+    cohort or sector-reference evidence remains explicitly typed by reason.
+    """
+
+    by_instrument = {item.subject_return.instrument: item for item in inputs}
+    if len(by_instrument) != len(inputs):
+        raise ValueError("cross-sectional inputs must contain unique subjects")
+    results: list[SubjectCrossSectionalFacts] = []
+    for subject in sorted(by_instrument, key=_instrument_key):
+        selected = by_instrument[subject]
+        subject_return = selected.subject_return
+        comparison = selected.comparison_returns
+        facts: list[DerivedFact] = []
+        comparison_reason = selected.comparison_unknown_reason
+        comparison_peer_count = 0
+        if comparison is not None:
+            comparison_peer_count = len(comparison.returns)
+            evidence_inputs = (subject_return, *comparison.returns)
+            facts.append(
+                materialize_derived_fact(
+                    DERIVED_FACT_REGISTRY,
+                    CROSS_SECTIONAL_MOMENTUM,
+                    subject.value,
+                    _evidence_digest(CROSS_SECTIONAL_MOMENTUM, subject, evidence_inputs),
+                    value=compute_cross_sectional_momentum(subject_return.return_value, comparison),
+                    unit="percentile",
+                    effective_time=effective_time,
+                    input_evidence=_evidence(evidence_inputs),
+                    quality_status=DerivedFactQualityStatus.VALID,
+                    parameters=(("minimum_valid_members", str(minimum_valid_members)),),
+                )
+            )
+
+        sector_reference = selected.sector_returns
+        sector_reason = selected.sector_unknown_reason
+        if sector_reference is not None:
+            evidence_inputs = (subject_return, *sector_reference.returns)
+            facts.append(
+                materialize_derived_fact(
+                    DERIVED_FACT_REGISTRY,
+                    SECTOR_RELATIVE_MOMENTUM,
+                    subject.value,
+                    _evidence_digest(SECTOR_RELATIVE_MOMENTUM, subject, evidence_inputs),
+                    value=compute_sector_relative_momentum(
+                        subject_return.return_value, sector_reference
+                    ),
+                    unit="decimal_return",
+                    effective_time=effective_time,
+                    input_evidence=_evidence(evidence_inputs),
+                    quality_status=DerivedFactQualityStatus.VALID,
+                    parameters=(("sector_id", sector_reference.sector_id),),
+                )
+            )
+        results.append(
+            SubjectCrossSectionalFacts(
+                subject,
+                DerivedFactSet(tuple(facts)),
+                comparison_peer_count,
+                comparison_reason,
+                sector_reason,
+            )
+        )
+    return tuple(results)

--- a/tests/analytics/test_cross_sectional_materialization.py
+++ b/tests/analytics/test_cross_sectional_materialization.py
@@ -1,0 +1,152 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from analytics.cross_sectional_materialization import (
+    CrossSectionalFactInputs,
+    materialize_cross_sectional_facts,
+)
+from analytics.derived_facts import CROSS_SECTIONAL_MOMENTUM, SECTOR_RELATIVE_MOMENTUM
+from domain import (
+    CanonicalInstrumentIdentity,
+    CanonicalReturnObservation,
+    EvidenceKind,
+    EvidenceReference,
+    SectorClassification,
+    SecurityAssetType,
+)
+from strategy_runtime.comparison_universe import (
+    select_comparison_universe_returns,
+    select_sector_reference_returns,
+)
+
+START = datetime(2026, 7, 1, tzinfo=UTC)
+END = datetime(2026, 8, 1, tzinfo=UTC)
+
+
+def _instrument(symbol: str) -> CanonicalInstrumentIdentity:
+    return CanonicalInstrumentIdentity("symbol", symbol)
+
+
+def _return(symbol: str, value: str) -> CanonicalReturnObservation:
+    return CanonicalReturnObservation(
+        _instrument(symbol),
+        Decimal(value),
+        START,
+        END,
+        END,
+        (EvidenceReference(EvidenceKind.CANONICAL_FACT, f"daily_closes:{symbol}", 1),),
+    )
+
+
+def _inputs() -> tuple[
+    tuple[CanonicalReturnObservation, ...],
+    dict[CanonicalInstrumentIdentity, SecurityAssetType],
+    dict[CanonicalInstrumentIdentity, SectorClassification],
+]:
+    values = (
+        _return("AAPL", "0.06"),
+        _return("MSFT", "0.05"),
+        _return("NVDA", "0.04"),
+        _return("AMD", "0.03"),
+        _return("AVGO", "0.02"),
+        _return("MU", "0.01"),
+        _return("XLK", "0.025"),
+    )
+    asset_types = {item.instrument: SecurityAssetType.EQUITY for item in values}
+    asset_types[_instrument("XLK")] = SecurityAssetType.ETF
+    sectors = {
+        item.instrument: SectorClassification("GICS", "2023", "45")
+        for item in values
+        if item.instrument.value != "XLK"
+    }
+    return values, asset_types, sectors
+
+
+def _selected(
+    values: tuple[CanonicalReturnObservation, ...],
+    asset_types: dict[CanonicalInstrumentIdentity, SecurityAssetType],
+    sectors: dict[CanonicalInstrumentIdentity, SectorClassification],
+) -> tuple[CrossSectionalFactInputs, ...]:
+    return tuple(
+        CrossSectionalFactInputs(
+            item,
+            select_comparison_universe_returns(
+                item.instrument,
+                (item.period_start, item.period_end),
+                values,
+                asset_types,
+            ),
+            select_sector_reference_returns(
+                item.instrument,
+                (item.period_start, item.period_end),
+                sectors,
+                values,
+            ),
+            "insufficient_comparison_cohort",
+            "missing_sector_membership"
+            if item.instrument not in sectors
+            else "missing_sector_benchmark_return",
+        )
+        for item in values
+    )
+
+
+def test_materialization_is_deterministic_and_order_independent() -> None:
+    values, asset_types, sectors = _inputs()
+    first = materialize_cross_sectional_facts(
+        _selected(values, asset_types, sectors), effective_time=END
+    )
+    second = materialize_cross_sectional_facts(
+        _selected(tuple(reversed(values)), asset_types, sectors), effective_time=END
+    )
+    assert first == second
+    aapl = next(item for item in first if item.subject == _instrument("AAPL"))
+    assert aapl.comparison_peer_count == 5
+    assert {fact.derived_fact_id.split(":", 1)[0] for fact in aapl.derived_facts.facts} == {
+        CROSS_SECTIONAL_MOMENTUM,
+        SECTOR_RELATIVE_MOMENTUM,
+    }
+    assert all(len(fact.input_evidence) >= 2 for fact in aapl.derived_facts.facts)
+
+
+def test_changed_member_value_changes_fact_identity() -> None:
+    values, asset_types, sectors = _inputs()
+    before = materialize_cross_sectional_facts(
+        _selected(values, asset_types, sectors), effective_time=END
+    )
+    changed = tuple(
+        _return("MSFT", "0.50") if item.instrument == _instrument("MSFT") else item
+        for item in values
+    )
+    after = materialize_cross_sectional_facts(
+        _selected(changed, asset_types, sectors), effective_time=END
+    )
+    before_fact = next(
+        item for item in before if item.subject == _instrument("AAPL")
+    ).derived_facts.facts[0]
+    after_fact = next(
+        item for item in after if item.subject == _instrument("AAPL")
+    ).derived_facts.facts[0]
+    assert before_fact.derived_fact_id != after_fact.derived_fact_id
+
+
+def test_incomplete_cohort_and_missing_sector_are_typed() -> None:
+    values, asset_types, _sectors = _inputs()
+    result = materialize_cross_sectional_facts(
+        _selected(values[:2], asset_types, {}), effective_time=END
+    )
+    assert all(
+        item.comparison_unknown_reason == "insufficient_comparison_cohort" for item in result
+    )
+    assert all(item.sector_unknown_reason == "missing_sector_membership" for item in result)
+    assert all(not item.derived_facts.facts for item in result)
+
+
+def test_second_consumer_reuses_same_materialized_fact_instance() -> None:
+    values, asset_types, sectors = _inputs()
+    result = materialize_cross_sectional_facts(
+        _selected(values, asset_types, sectors), effective_time=END
+    )
+    shared = next(item for item in result if item.subject == _instrument("AAPL")).derived_facts
+    consumers = {"skew_momentum": shared, "synthetic_consumer": shared}
+    assert consumers["skew_momentum"] is consumers["synthetic_consumer"]


### PR DESCRIPTION
## Ticket / Worker
XFACT-02 / implementation-worker

Closes #320. Depends on merged XFACT-01.

## Outcome
Adds a provider-free analytics materializer over explicit domain evidence. Cohort and sector selection remain outside analytics; no provider, runtime dispatch, strategy ID, or acquisition dependency enters the owner.

## Identity / provenance
- ordered member, return period/value/effective time, and pinned canonical evidence form a SHA-256 cross-subject evidence digest
- registered formula version remains authoritative
- parameter identity records minimum cohort or sector identity
- changed member evidence changes fact identity

## Typed gaps
Missing comparison or sector inputs require explicit reasons. No peer, sector, benchmark, or proxy is invented.

## Reuse proof
One materialized immutable fact set is shared by Skew and a synthetic second consumer; registration/input order yields identical facts.

## Validation
- analytics + comparison + architecture: 691 passed
- targeted materialization: 4 passed
- Ruff: PASS
- mypy: PASS
- Lean integrity: PASS
- diff check: PASS

## Self-review / stop status
Complete / CLEAR. Initial architecture failure (analytics importing runtime policy) was corrected at the owner; final architecture suite is green.