### PR TITLE
XFACT-03: integrate reusable cross-sectional facts

### DIFF
--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -76,6 +76,7 @@ from strategy_runtime.adapters import (
     migrated_shadow_capability_reducers,
     migrated_shadow_resolution_policy,
 )
+from strategy_runtime.cross_subject_knowledge import compose_cross_subject_knowledge
 from strategy_runtime.historical_evidence import HistoricalSkewRepository
 from strategy_runtime.knowledge import ReadOnlyStrategyInput
 from strategy_runtime.lifecycle import RecommendedAction
@@ -439,9 +440,7 @@ def run_scheduled_refresh(
                 extra={
                     "symbol": symbol,
                     "screening_cycle_id": screening_cycle_id,
-                    "failure_class": (
-                        classify_subject_preparation_exception(failure)
-                    ),
+                    "failure_class": (classify_subject_preparation_exception(failure)),
                     "exception_type": type(failure).__name__,
                 },
                 exc_info=True,
@@ -451,6 +450,13 @@ def run_scheduled_refresh(
             prepared_request_count_by_symbol[symbol] = (
                 len(access[symbol].budget_manager.accounting) - budget_start
             )
+    # Provider-free cycle stage: all subject snapshots are sealed before
+    # registered cross-subject families are materialized once and rebound to
+    # their declaring consumers. This adds no acquisition and contains no
+    # strategy identity branch.
+    shadow_knowledge_by_symbol = compose_cross_subject_knowledge(
+        shadow_knowledge_by_symbol, shadow_registry
+    ).knowledge_by_subject
     outcomes: list[PairOutcome] = []
     for signal_id, symbol in universe:
         subject_access = access[symbol]

--- a/strategies/skew_momentum_knowledge.py
+++ b/strategies/skew_momentum_knowledge.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 
 from analytics.derived_facts import (
@@ -54,6 +54,13 @@ class SkewMomentumPayload:
     call_wing_iv_minus_atm_iv: Decimal
     put_wing_iv_minus_atm_iv: Decimal
     time_series_return: Decimal
+    momentum_period_start: datetime
+    momentum_period_end: datetime
+    cross_sectional_percentile: Decimal | None = None
+    comparison_peer_count: int = 0
+    sector_relative_return: Decimal | None = None
+    comparison_unknown_reason: str | None = "cross_sectional_not_materialized"
+    sector_unknown_reason: str | None = "cross_sectional_not_materialized"
 
 
 def build_skew_momentum_knowledge_mapping(
@@ -70,6 +77,8 @@ def build_skew_momentum_knowledge_mapping(
     call_wing_iv: Decimal,
     put_wing_iv: Decimal,
     history: tuple[HistoricalSkewObservation, ...],
+    momentum_period_start: datetime,
+    momentum_period_end: datetime,
 ) -> KnowledgeMapping[SkewMomentumPayload]:
     iv_values = (
         ("call_atm", call_atm_iv),
@@ -253,6 +262,8 @@ def build_skew_momentum_knowledge_mapping(
             call_wing_iv - call_atm_iv,
             put_wing_iv - put_atm_iv,
             value(NAMED_MOMENTUM_DIMENSIONS),
+            momentum_period_start,
+            momentum_period_end,
         )
 
     return KnowledgeMapping(tuple(requests), _compute, _payload)

--- a/strategy_runtime/adapters/skew_momentum_subject_first.py
+++ b/strategy_runtime/adapters/skew_momentum_subject_first.py
@@ -3,14 +3,21 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import replace
 from datetime import datetime
 from decimal import Decimal
 from functools import partial
 from types import MappingProxyType
 from typing import cast
 
+from analytics.cross_sectional_materialization import SubjectCrossSectionalFacts
+from analytics.derived_facts import CROSS_SECTIONAL_MOMENTUM, SECTOR_RELATIVE_MOMENTUM
+from analytics.features import DerivedFactSet
 from domain import (
     CanonicalInstrumentIdentity,
+    CanonicalReturnObservation,
+    EvidenceKind,
+    EvidenceReference,
     MarketCapability,
     OHLCVSeries,
     OptionChain,
@@ -139,6 +146,63 @@ def _prepare(
         call_wing_iv=cast(Decimal, values[2]),
         put_wing_iv=cast(Decimal, values[3]),
         history=history,
+        momentum_period_start=bars_observation.value.bars[-21].start_at,
+        momentum_period_end=bars_observation.value.bars[-1].end_at,
+    )
+
+
+def _extract_cross_subject_return(
+    knowledge: ReadOnlyStrategyInput[SkewMomentumPayload],
+) -> CanonicalReturnObservation:
+    closes_fact = next(
+        fact for fact in knowledge.canonical_facts if fact.fact_type == "daily_closes"
+    )
+    return CanonicalReturnObservation(
+        CanonicalInstrumentIdentity("symbol", knowledge.payload.chain.underlying.symbol),
+        knowledge.payload.time_series_return,
+        knowledge.payload.momentum_period_start,
+        knowledge.payload.momentum_period_end,
+        knowledge.effective_time,
+        (EvidenceReference(EvidenceKind.CANONICAL_FACT, closes_fact.fact_id, closes_fact.version),),
+    )
+
+
+def _bind_cross_subject_facts(
+    knowledge: ReadOnlyStrategyInput[SkewMomentumPayload],
+    cross_subject_value: object,
+) -> ReadOnlyStrategyInput[SkewMomentumPayload]:
+    if not isinstance(cross_subject_value, SubjectCrossSectionalFacts):
+        raise TypeError("Skew cross-subject binding requires SubjectCrossSectionalFacts")
+    cross_subject = cross_subject_value
+
+    def value(feature_id: str) -> Decimal | None:
+        fact = next(
+            (
+                item
+                for item in cross_subject.derived_facts.facts
+                if item.derived_fact_id.startswith(f"{feature_id}:")
+            ),
+            None,
+        )
+        if fact is None:
+            return None
+        assert isinstance(fact.value, Decimal)
+        return fact.value
+
+    payload = replace(
+        knowledge.payload,
+        cross_sectional_percentile=value(CROSS_SECTIONAL_MOMENTUM),
+        comparison_peer_count=cross_subject.comparison_peer_count,
+        sector_relative_return=value(SECTOR_RELATIVE_MOMENTUM),
+        comparison_unknown_reason=cross_subject.comparison_unknown_reason,
+        sector_unknown_reason=cross_subject.sector_unknown_reason,
+    )
+    return replace(
+        knowledge,
+        derived_facts=DerivedFactSet(
+            (*knowledge.derived_facts.facts, *cross_subject.derived_facts.facts)
+        ),
+        payload=payload,
     )
 
 
@@ -149,6 +213,9 @@ def build_skew_momentum_subject_preparation_binding(
         SubjectPlanConsumer(_STRATEGY_ID, bootstrap_demands(now), partial(expand_demands, now=now)),
         partial(_prepare, historical_repository, now),
         build_skew_momentum_subject_first_adapter,
+        "twenty_session_return_v1",
+        _extract_cross_subject_return,
+        _bind_cross_subject_facts,
     )
 
 
@@ -175,9 +242,9 @@ def build_skew_momentum_subject_first_adapter(
             call_wing_iv_minus_atm_iv=payload.call_wing_iv_minus_atm_iv,
             put_wing_iv_minus_atm_iv=payload.put_wing_iv_minus_atm_iv,
             time_series_return=payload.time_series_return,
-            cross_sectional_percentile=None,
-            comparison_peer_count=0,
-            sector_relative_return=None,
+            cross_sectional_percentile=payload.cross_sectional_percentile,
+            comparison_peer_count=payload.comparison_peer_count,
+            sector_relative_return=payload.sector_relative_return,
         )
         outputs = execute_strategy_graph(
             compile_strategy_graph(SKEW_MOMENTUM_VERTICAL_MANIFEST, _COMPONENTS), graph_context
@@ -205,7 +272,19 @@ def build_skew_momentum_subject_first_adapter(
             metrics=metrics,
             economics={},
             blockers=(),
-            warnings=explanation.warnings,
+            warnings=(
+                *explanation.warnings,
+                *(
+                    ()
+                    if payload.comparison_unknown_reason is None
+                    else (payload.comparison_unknown_reason,)
+                ),
+                *(
+                    ()
+                    if payload.sector_unknown_reason is None
+                    else (payload.sector_unknown_reason,)
+                ),
+            ),
             provenance=(
                 f"snapshot_id:{knowledge.snapshot_id}",
                 f"snapshot_digest:{knowledge.snapshot_digest}",

--- a/strategy_runtime/cross_subject_knowledge.py
+++ b/strategy_runtime/cross_subject_knowledge.py
@@ -1,0 +1,118 @@
+"""Registry-driven cross-subject knowledge composition over sealed inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from analytics.cross_sectional_materialization import (
+    CrossSectionalFactInputs,
+    SubjectCrossSectionalFacts,
+    materialize_cross_sectional_facts,
+)
+from domain import CanonicalInstrumentIdentity, CanonicalReturnObservation, UnknownReason
+from strategy_runtime.comparison_universe import (
+    ASSET_TYPE_BY_INSTRUMENT,
+    SECTOR_BY_INSTRUMENT,
+    approved_sector_id,
+    select_comparison_universe_returns,
+    select_sector_reference_returns,
+)
+from strategy_runtime.knowledge import ReadOnlyStrategyInput
+from strategy_runtime.subject_preparation import SubjectPreparationRegistry
+
+
+@dataclass(frozen=True, slots=True)
+class CrossSubjectKnowledgeResult:
+    knowledge_by_subject: dict[str, dict[str, ReadOnlyStrategyInput[object] | UnknownReason]]
+    materialization_count_by_family: tuple[tuple[str, int], ...]
+
+
+def _instrument(symbol: str) -> CanonicalInstrumentIdentity:
+    return CanonicalInstrumentIdentity("symbol", symbol)
+
+
+def _selected_inputs(
+    returns: tuple[CanonicalReturnObservation, ...],
+) -> tuple[CrossSectionalFactInputs, ...]:
+    selected: list[CrossSectionalFactInputs] = []
+    for item in returns:
+        subject = item.instrument
+        period = (item.period_start, item.period_end)
+        comparison = select_comparison_universe_returns(
+            subject, period, returns, ASSET_TYPE_BY_INSTRUMENT
+        )
+        sector = select_sector_reference_returns(subject, period, SECTOR_BY_INSTRUMENT, returns)
+        if subject not in ASSET_TYPE_BY_INSTRUMENT:
+            comparison_reason = "missing_instrument_class"
+        else:
+            comparison_reason = "insufficient_comparison_cohort"
+        subject_sector = SECTOR_BY_INSTRUMENT.get(subject)
+        if subject_sector is None:
+            sector_reason = "missing_sector_membership"
+        elif approved_sector_id(subject_sector) is None:
+            sector_reason = "unsupported_sector_membership"
+        else:
+            sector_reason = "missing_sector_benchmark_return"
+        selected.append(
+            CrossSectionalFactInputs(
+                item,
+                comparison,
+                sector,
+                comparison_reason,
+                sector_reason,
+            )
+        )
+    return tuple(selected)
+
+
+def compose_cross_subject_knowledge(
+    knowledge_by_subject: dict[str, dict[str, ReadOnlyStrategyInput[object] | UnknownReason]],
+    registry: SubjectPreparationRegistry[object],
+) -> CrossSubjectKnowledgeResult:
+    """Materialize each declared evidence family once, then bind by callback."""
+
+    result = {subject: dict(values) for subject, values in knowledge_by_subject.items()}
+    family_entries: dict[str, list[tuple[str, str, ReadOnlyStrategyInput[object]]]] = {}
+    for strategy_id in registry.strategy_ids():
+        binding = registry.binding_for(strategy_id)
+        family_id = binding.cross_subject_family_id
+        extractor = binding.extract_cross_subject_return
+        binder = binding.bind_cross_subject_facts
+        if family_id is None or extractor is None or binder is None:
+            continue
+        for subject, by_strategy in result.items():
+            knowledge = by_strategy.get(strategy_id)
+            if knowledge is None or isinstance(knowledge, UnknownReason):
+                continue
+            family_entries.setdefault(family_id, []).append((strategy_id, subject, knowledge))
+
+    counts: list[tuple[str, int]] = []
+    for family_id in sorted(family_entries):
+        entries = family_entries[family_id]
+        returns_by_subject: dict[str, CanonicalReturnObservation] = {}
+        for strategy_id, subject, knowledge in entries:
+            extractor = registry.binding_for(strategy_id).extract_cross_subject_return
+            assert extractor is not None
+            extracted = extractor(knowledge)
+            existing = returns_by_subject.get(subject)
+            if existing is not None and existing != extracted:
+                raise ValueError(
+                    f"cross-subject family {family_id!r} produced conflicting "
+                    f"returns for {subject!r}"
+                )
+            returns_by_subject[subject] = extracted
+        returns = tuple(returns_by_subject[subject] for subject in sorted(returns_by_subject))
+        if not returns:
+            continue
+        materialized = materialize_cross_sectional_facts(
+            _selected_inputs(returns),
+            effective_time=max(item.effective_time for item in returns),
+        )
+        by_subject = {item.subject: item for item in materialized}
+        counts.append((family_id, 1))
+        for strategy_id, subject, knowledge in entries:
+            binder = registry.binding_for(strategy_id).bind_cross_subject_facts
+            assert binder is not None
+            facts: SubjectCrossSectionalFacts = by_subject[_instrument(subject)]
+            result[subject][strategy_id] = binder(knowledge, facts)
+    return CrossSubjectKnowledgeResult(result, tuple(counts))

--- a/strategy_runtime/subject_preparation.py
+++ b/strategy_runtime/subject_preparation.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Generic
 
-from domain import MarketCapability, UnknownReason
+from domain import CanonicalReturnObservation, MarketCapability, UnknownReason
 from market_data.providers import ProviderMetadata
 from market_data.resolution import ResolutionPolicy
 from market_data.snapshot import MarketSnapshot
@@ -71,6 +71,13 @@ PrepareKnowledgeMapping = Callable[
 BuildShadowAdapter = Callable[
     [Mapping[str, "ReadOnlyStrategyInput[TPayload]"]], StrategyAdapter[UniversalScreeningResult]
 ]
+ExtractCrossSubjectReturn = Callable[
+    ["ReadOnlyStrategyInput[TPayload]"], CanonicalReturnObservation
+]
+BindCrossSubjectFacts = Callable[
+    ["ReadOnlyStrategyInput[TPayload]", object],
+    "ReadOnlyStrategyInput[TPayload]",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,6 +92,19 @@ class SubjectPreparationBinding(Generic[TPayload]):  # noqa: UP046
     consumer: SubjectPlanConsumer
     prepare_knowledge_mapping: PrepareKnowledgeMapping[TPayload]
     build_shadow_adapter: BuildShadowAdapter[TPayload]
+    cross_subject_family_id: str | None = None
+    extract_cross_subject_return: ExtractCrossSubjectReturn[TPayload] | None = None
+    bind_cross_subject_facts: BindCrossSubjectFacts[TPayload] | None = None
+
+    def __post_init__(self) -> None:
+        callbacks = (
+            self.extract_cross_subject_return,
+            self.bind_cross_subject_facts,
+        )
+        if self.cross_subject_family_id is None and any(item is not None for item in callbacks):
+            raise ValueError("cross-subject callbacks require a family id")
+        if self.cross_subject_family_id is not None and any(item is None for item in callbacks):
+            raise ValueError("cross-subject family requires extraction and binding callbacks")
 
 
 class UnknownSubjectPreparationBindingError(KeyError):
@@ -127,9 +147,7 @@ class SubjectPreparationRegistry(Generic[TPayload]):  # noqa: UP046
         except KeyError:
             raise UnknownSubjectPreparationBindingError(strategy_id) from None
 
-    def restricted_to(
-        self, strategy_ids: tuple[str, ...]
-    ) -> SubjectPreparationRegistry[TPayload]:
+    def restricted_to(self, strategy_ids: tuple[str, ...]) -> SubjectPreparationRegistry[TPayload]:
         """Immutable view containing only explicitly requested consumers."""
         return SubjectPreparationRegistry(
             tuple((strategy_id, self.binding_for(strategy_id)) for strategy_id in strategy_ids)
@@ -243,8 +261,8 @@ def prepare_subject_knowledge(
         if isinstance(mapping, UnknownReason):
             prepared[strategy_id] = mapping
             continue
-        knowledge_registry: KnowledgeCompositionRegistry[object] = (
-            KnowledgeCompositionRegistry(((strategy_id, mapping),))
+        knowledge_registry: KnowledgeCompositionRegistry[object] = KnowledgeCompositionRegistry(
+            ((strategy_id, mapping),)
         )
         prepared[strategy_id] = compose_strategy_knowledge(
             plan_result.snapshot,

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -55,9 +55,9 @@ def _tradier_option(
 
 def _tradier_daily_bars_response() -> ReadOnlyHttpResponse:
     days: list[dict[str, object]] = []
-    latest_completed_day = UsEquitySessionCalendar().latest_completed_session(
-        datetime.now(UTC)
-    ).closes_at.date()
+    latest_completed_day = (
+        UsEquitySessionCalendar().latest_completed_session(datetime.now(UTC)).closes_at.date()
+    )
     for day_offset in range(59, -1, -1):
         day = (latest_completed_day - timedelta(days=day_offset)).isoformat()
         close = 200 + (day_offset % 5) + (59 - day_offset) * 0.15
@@ -71,9 +71,7 @@ def _tradier_daily_bars_response() -> ReadOnlyHttpResponse:
                 "volume": "50000000",
             }
         )
-    return ReadOnlyHttpResponse(
-        200, {"history": {"day": days}}, (), 12, "tradier-request-history"
-    )
+    return ReadOnlyHttpResponse(200, {"history": {"day": days}}, (), 12, "tradier-request-history")
 
 
 def _tradier_skew_capable_chain_responses(expiration: str) -> list[ReadOnlyHttpResponse]:
@@ -520,9 +518,7 @@ def test_non_skew_momentum_pairs_never_touch_the_historical_skew_repository(
         universe,
         repository=repository,
         historical_skew_repository=historical_skew_repository,
-        transport_factory=lambda _provider_id: ScriptedTransport(
-            [tradier_quote_response()]
-        ),
+        transport_factory=lambda _provider_id: ScriptedTransport([tradier_quote_response()]),
     )
 
     assert outcomes[0].signal_id == "earnings_calendar"
@@ -1186,9 +1182,7 @@ def test_shadow_subject_preparation_failure_never_aborts_the_cycle(
     assert len(outcomes) == 2
     assert all(item.error is None for item in outcomes)
     failures = [
-        record
-        for record in caplog.records
-        if record.message == "shadow_subject_preparation_failed"
+        record for record in caplog.records if record.message == "shadow_subject_preparation_failed"
     ]
     assert len(failures) == 1
     assert failures[0].symbol == "AAPL"
@@ -1263,6 +1257,16 @@ def test_production_universe_topology_has_no_universal_preparation_failure(
     assert all(item.outcome != "missing_data" for item in outcomes)
     assert not any(
         record.message == "shadow_subject_preparation_failed" for record in caplog.records
+    )
+    skew = repository.get_one("skew_momentum", "AAPL")
+    assert skew is not None
+    assert skew.metrics["derived_fact.cross_sectional_percentile"].native() != "UNKNOWN"
+    assert skew.metrics["derived_fact.sector_relative_return"].native() != "UNKNOWN"
+    assert any(
+        item.startswith("derived_fact:cross_sectional_momentum:") for item in skew.provenance
+    )
+    assert any(
+        item.startswith("derived_fact:sector_relative_momentum:") for item in skew.provenance
     )
 
 
@@ -1406,9 +1410,7 @@ def test_shadow_parity_diagnostic_is_logged_with_sanitized_fields(
     )
 
     assert outcomes[0].error is None
-    entries = [
-        record for record in caplog.records if record.message == "shadow_parity_diagnostic"
-    ]
+    entries = [record for record in caplog.records if record.message == "shadow_parity_diagnostic"]
     assert len(entries) == 1
     entry = entries[0]
     assert entry.signal_id == "forward_factor"
@@ -1538,9 +1540,7 @@ def _removed_scheduled_earnings_pass_shadow_diagnostic_matches_and_legacy_persis
     assert len(outcomes) == 1
     assert outcomes[0].error is None
     assert outcomes[0].outcome == "pass"
-    entries = [
-        record for record in caplog.records if record.message == "shadow_parity_diagnostic"
-    ]
+    entries = [record for record in caplog.records if record.message == "shadow_parity_diagnostic"]
     assert len(entries) == 1
     entry = entries[0]
     assert entry.shadow_status == "match"
@@ -1591,9 +1591,7 @@ def _removed_scheduled_earnings_watch_shadow_diagnostic_matches_and_legacy_persi
     assert len(outcomes) == 1
     assert outcomes[0].error is None
     assert outcomes[0].outcome == "pass"  # WATCH's own evaluation_state
-    entries = [
-        record for record in caplog.records if record.message == "shadow_parity_diagnostic"
-    ]
+    entries = [record for record in caplog.records if record.message == "shadow_parity_diagnostic"]
     assert len(entries) == 1
     entry = entries[0]
     assert entry.shadow_status == "match"
@@ -1645,9 +1643,7 @@ def _removed_scheduled_earnings_outage_shadow_unknown_and_bounded_once_not_doubl
     assert len(outcomes) == 1
     assert outcomes[0].error is None
     assert outcomes[0].outcome == "missing_data"
-    entries = [
-        record for record in caplog.records if record.message == "shadow_parity_diagnostic"
-    ]
+    entries = [record for record in caplog.records if record.message == "shadow_parity_diagnostic"]
     assert len(entries) == 1
     entry = entries[0]
     assert entry.shadow_status == "shadow_unknown"
@@ -1700,9 +1696,7 @@ def test_scheduled_earnings_cutover_pass_is_authoritative_with_zero_legacy_calls
     assert len(outcomes) == 1
     assert outcomes[0].error is None
     assert outcomes[0].outcome == "pass"
-    entries = [
-        record for record in caplog.records if record.message == "shadow_parity_diagnostic"
-    ]
+    entries = [record for record in caplog.records if record.message == "shadow_parity_diagnostic"]
     assert entries == []
     persisted = repository.get_one("earnings_calendar", "AAPL")
     assert persisted is not None
@@ -1738,9 +1732,7 @@ def test_scheduled_earnings_cutover_watch_is_authoritative(
     assert len(outcomes) == 1
     assert outcomes[0].error is None
     assert outcomes[0].outcome == "pass"  # WATCH's own evaluation_state
-    entries = [
-        record for record in caplog.records if record.message == "shadow_parity_diagnostic"
-    ]
+    entries = [record for record in caplog.records if record.message == "shadow_parity_diagnostic"]
     assert entries == []
     persisted = repository.get_one("earnings_calendar", "AAPL")
     assert persisted is not None
@@ -1786,9 +1778,7 @@ def test_scheduled_earnings_cutover_outage_is_authoritative_missing_data_and_bou
     assert len(outcomes) == 1
     assert outcomes[0].error is None
     assert outcomes[0].outcome == "missing_data"
-    entries = [
-        record for record in caplog.records if record.message == "shadow_parity_diagnostic"
-    ]
+    entries = [record for record in caplog.records if record.message == "shadow_parity_diagnostic"]
     assert entries == []
     persisted = repository.get_one("earnings_calendar", "AAPL")
     assert persisted is not None
@@ -1828,9 +1818,7 @@ def _removed_scheduled_earnings_cutover_explicitly_disabled_keeps_legacy_authori
     assert len(outcomes) == 1
     assert outcomes[0].error is None
     assert outcomes[0].outcome == "pass"
-    entries = [
-        record for record in caplog.records if record.message == "shadow_parity_diagnostic"
-    ]
+    entries = [record for record in caplog.records if record.message == "shadow_parity_diagnostic"]
     assert len(entries) == 1
     assert entries[0].shadow_status == "match"
     persisted = repository.get_one("earnings_calendar", "AAPL")
@@ -1875,9 +1863,7 @@ def test_scheduled_forward_factor_unaffected_by_earnings_cutover(
     assert earnings_outcome.error is None
     # forward_factor is never shadow-registered/cutover-eligible: no
     # shadow_parity_diagnostic entry is ever logged for it, cut over or not.
-    entries = [
-        record for record in caplog.records if record.message == "shadow_parity_diagnostic"
-    ]
+    entries = [record for record in caplog.records if record.message == "shadow_parity_diagnostic"]
     assert all(entry.signal_id != "forward_factor" for entry in entries)
     forward_factor_persisted = repository.get_one("forward_factor", "AAPL")
     assert forward_factor_persisted is not None

--- a/tests/strategy_runtime/test_cross_subject_knowledge.py
+++ b/tests/strategy_runtime/test_cross_subject_knowledge.py
@@ -1,0 +1,104 @@
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from analytics.features import DerivedFactSet
+from domain import (
+    CanonicalInstrumentIdentity,
+    CanonicalReturnObservation,
+    EvidenceKind,
+    EvidenceReference,
+)
+from screening.subject_planning import SubjectPlanConsumer
+from strategy_runtime.cross_subject_knowledge import compose_cross_subject_knowledge
+from strategy_runtime.knowledge import ReadOnlyStrategyInput
+from strategy_runtime.subject_preparation import (
+    SubjectPreparationBinding,
+    SubjectPreparationRegistry,
+)
+
+START = datetime(2026, 7, 1, tzinfo=UTC)
+END = datetime(2026, 8, 1, tzinfo=UTC)
+
+
+@dataclass(frozen=True, slots=True)
+class _Payload:
+    observation: CanonicalReturnObservation
+
+
+def _observation(symbol: str, value: str) -> CanonicalReturnObservation:
+    return CanonicalReturnObservation(
+        CanonicalInstrumentIdentity("symbol", symbol),
+        Decimal(value),
+        START,
+        END,
+        END,
+        (EvidenceReference(EvidenceKind.CANONICAL_FACT, f"closes:{symbol}", 1),),
+    )
+
+
+def _knowledge(observation: CanonicalReturnObservation) -> ReadOnlyStrategyInput[object]:
+    return ReadOnlyStrategyInput(
+        "snapshot",
+        "digest",
+        END,
+        (),
+        DerivedFactSet(()),
+        _Payload(observation),
+    )
+
+
+def _extract(knowledge: ReadOnlyStrategyInput[object]) -> CanonicalReturnObservation:
+    payload = knowledge.payload
+    assert isinstance(payload, _Payload)
+    return payload.observation
+
+
+def _bind(knowledge: ReadOnlyStrategyInput[object], facts: object) -> ReadOnlyStrategyInput[object]:
+    from analytics.cross_sectional_materialization import SubjectCrossSectionalFacts
+
+    assert isinstance(facts, SubjectCrossSectionalFacts)
+    return replace(knowledge, derived_facts=facts.derived_facts)
+
+
+def _binding(consumer_id: str) -> SubjectPreparationBinding[object]:
+    return SubjectPreparationBinding(
+        SubjectPlanConsumer(consumer_id, (), lambda _evidence: None),  # type: ignore[arg-type]
+        lambda *_args: None,  # type: ignore[arg-type]
+        lambda _knowledge: lambda _context: None,  # type: ignore[arg-type,return-value]
+        "twenty_session_return_v1",
+        _extract,
+        _bind,
+    )
+
+
+def test_two_consumers_share_one_order_independent_materialization() -> None:
+    returns = {
+        "AAPL": "0.06",
+        "MSFT": "0.05",
+        "NVDA": "0.04",
+        "AMD": "0.03",
+        "AVGO": "0.02",
+        "MU": "0.01",
+        "XLK": "0.025",
+    }
+    registry = SubjectPreparationRegistry(
+        (("consumer_a", _binding("consumer_a")), ("consumer_b", _binding("consumer_b")))
+    )
+    knowledge = {
+        symbol: {
+            "consumer_a": _knowledge(_observation(symbol, value)),
+            "consumer_b": _knowledge(_observation(symbol, value)),
+        }
+        for symbol, value in reversed(tuple(returns.items()))
+    }
+
+    result = compose_cross_subject_knowledge(knowledge, registry)
+
+    assert result.materialization_count_by_family == (("twenty_session_return_v1", 1),)
+    first = result.knowledge_by_subject["AAPL"]["consumer_a"]
+    second = result.knowledge_by_subject["AAPL"]["consumer_b"]
+    assert isinstance(first, ReadOnlyStrategyInput)
+    assert isinstance(second, ReadOnlyStrategyInput)
+    assert first.derived_facts == second.derived_facts
+    assert len(first.derived_facts.facts) == 2


### PR DESCRIPTION
## Ticket / Worker
XFACT-03 / implementation-worker

Closes #322. Depends on merged XFACT-02.

## Outcome
- registry bindings may declaratively expose one cross-subject return family and bind its immutable facts
- generic cycle composition groups equivalent families and materializes each once
- Skew binds cross-sectional percentile and sector-relative return without provider authority or runtime strategy-ID branches
- specific missing cohort/membership/benchmark reasons remain visible
- production scheduled root runs this stage only after all subject snapshots seal

## Reuse / modularity
A synthetic second consumer declares the same family. Both consumers receive identical fact identity/value from one materialization, independent of subject/registration order and without generic changes.

## Architecture review
- invariant: strategy remains provider-blind
- reachable path: sealed ReadOnlyStrategyInput -> registered extraction -> explicit domain evidence selection -> analytics materialization -> registered binding
- consequence: reusable facts reach consumers without duplicate acquisition/calculation
- owner: runtime orchestration selects; analytics materializes; strategy binding interprets
- no protected domain/evidence contract changed

## Production-equivalent proof
The mechanically identical 82-pair scheduled topology passes. Forward Factor and Earnings remain evaluable. AAPL Skew exposes non-UNKNOWN cross-sectional and sector-relative metrics plus pinned derived-fact provenance.

## Validation
- relevant analytics/runtime/strategies/ASA/architecture: 1,284 passed
- final focused architecture + scheduled: 596 passed
- Ruff changed scope: PASS
- mypy changed scope: PASS
- Lean integrity/entrypoints: PASS
- diff check: PASS

## Known legitimate UNKNOWN
ETF sector membership and absent aligned configured sector benchmark returns remain specifically typed; no proxy is invented. Historical z-scores use the corrected authoritative repository from XFACT-01.

## Self-review / stop status
Complete / CLEAR. No provider calls, universe expansion, threshold changes, or strategy-owned acquisition.