### PR TITLE
XFACT-03: normalize fallback historical series

### DIFF
--- a/market_data/alpha_vantage.py
+++ b/market_data/alpha_vantage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Mapping
-from datetime import datetime, time, timedelta, timezone
+from datetime import UTC, datetime, time, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import cast
 
@@ -20,6 +20,7 @@ from domain import (
     MarketDataSubject,
     MarketObservation,
     OHLCVBar,
+    OHLCVSeries,
     ProviderProvenance,
     Security,
     SecurityAssetType,
@@ -250,7 +251,7 @@ class AlphaVantageProvider:
             series = response.json_body.get("Time Series (Daily)")
             if not isinstance(series, Mapping):
                 raise _EmptyPayload
-            values: list[MarketObservation] = []
+            bars: list[OHLCVBar] = []
             for raw_date, raw_row in sorted(series.items()):
                 day = datetime.fromisoformat(str(raw_date)).date()
                 if not request.effective_start.date() <= day <= request.effective_end.date():
@@ -258,7 +259,7 @@ class AlphaVantageProvider:
                 if not isinstance(raw_row, Mapping):
                     raise TypeError("daily row must be an object")
                 row = cast(Mapping[str, object], raw_row)
-                start = datetime.combine(day, time.min, tzinfo=timezone.utc)
+                start = datetime.combine(day, time.min, tzinfo=UTC)
                 bar = OHLCVBar(
                     subject.canonical_instrument,
                     86400,
@@ -270,10 +271,24 @@ class AlphaVantageProvider:
                     _decimal(row["4. close"]),
                     _decimal(row["5. volume"]),
                 )
-                values.append(self._observation(request, subject, bar, bar.end_at, response))
-            if not values:
+                bars.append(bar)
+            if not bars:
                 raise _NoData
-            return tuple(values)
+            series_value = OHLCVSeries(
+                subject.canonical_instrument,
+                86400,
+                self._dependencies.clock.now(),
+                tuple(bars),
+            )
+            return (
+                self._observation(
+                    request,
+                    subject,
+                    series_value,
+                    series_value.bars[-1].end_at,
+                    response,
+                ),
+            )
         rows = response.json_body.get("quarterlyEarnings")
         if not isinstance(rows, list) or not rows:
             raise _EmptyPayload
@@ -319,13 +334,9 @@ class AlphaVantageProvider:
         effective: datetime,
         response: ReadOnlyHttpResponse,
     ) -> MarketObservation:
-        received = self._dependencies.clock.now().astimezone(timezone.utc)
+        received = self._dependencies.clock.now().astimezone(UTC)
         age = max(0, int((received - effective).total_seconds()))
-        present = tuple(
-            field
-            for field in request.required_fields
-            if hasattr(value, field) and getattr(value, field) is not None
-        )
+        present = tuple(field for field in request.required_fields if _present(field, value))
         missing = tuple(field for field in request.required_fields if field not in present)
         provenance = ProviderProvenance(
             self.provider_id, response.request_reference, _evidence(response)
@@ -419,6 +430,12 @@ class AlphaVantageProvider:
             ),
             attempts,
         )
+
+
+def _present(field: str, value: object) -> bool:
+    if isinstance(value, OHLCVSeries) and field in {"open", "high", "low", "close", "volume"}:
+        return bool(value.bars) and all(getattr(bar, field) is not None for bar in value.bars)
+    return hasattr(value, field) and getattr(value, field) is not None
 
 
 def _decimal(value: object) -> Decimal:

--- a/market_data/finnhub.py
+++ b/market_data/finnhub.py
@@ -18,6 +18,7 @@ from domain import (
     MarketDataSubject,
     MarketObservation,
     OHLCVBar,
+    OHLCVSeries,
     ProviderProvenance,
     Quote,
     Security,
@@ -324,10 +325,13 @@ class FinnhubProvider:
                 )
                 for index in range(len(arrays[0]))
             )
-            return tuple(
-                self._observation(request, subject, value, value.end_at, response)
-                for value in bar_values
+            series = OHLCVSeries(
+                subject.canonical_instrument,
+                86400,
+                self._dependencies.clock.now(),
+                bar_values,
             )
+            return (self._observation(request, subject, series, series.bars[-1].end_at, response),)
         raw_earnings = response.json_body.get("earningsCalendar")
         # An explicitly present empty calendar is a valid, authoritative
         # answer: no event matched this symbol/window.  Missing or malformed
@@ -505,6 +509,8 @@ def _evidence(response: ReadOnlyHttpResponse) -> tuple[EvidenceReference, ...]:
 
 
 def _present(field: str, value: object) -> bool:
+    if isinstance(value, OHLCVSeries) and field in {"open", "high", "low", "close", "volume"}:
+        return bool(value.bars) and all(getattr(bar, field) is not None for bar in value.bars)
     aliases = {"earnings_date": "earnings_date", "last": "last"}
     return (
         hasattr(value, aliases.get(field, field))

--- a/tests/market_data/test_alpha_vantage.py
+++ b/tests/market_data/test_alpha_vantage.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 import pytest
 
@@ -16,7 +17,7 @@ from domain import (
     MarketDataRequestContext,
     MarketDataSubject,
     MarketDataSubjectType,
-    OHLCVBar,
+    OHLCVSeries,
     ProviderAddressProjection,
 )
 from market_data import (
@@ -32,7 +33,7 @@ from market_data.alpha_vantage import AlphaVantageProvider, alpha_vantage_provid
 from market_data.providers import ProviderErrorCode
 from market_data.transport import ReadOnlyHttpRequest, ReadOnlyHttpResponse
 
-NOW = datetime(2026, 7, 21, 16, 0, tzinfo=timezone.utc)
+NOW = datetime(2026, 7, 21, 16, 0, tzinfo=UTC)
 EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "instrument-reference:AAPL"),)
 INSTRUMENT = Instrument(
     CanonicalInstrumentIdentity("figi", "BBG000B9XRY4"), InstrumentKind.EQUITY, "AAPL", "USD"
@@ -134,7 +135,9 @@ def test_daily_bars_use_compact_raw_documented_endpoint_and_decimal_values() -> 
         request(MarketCapability.HISTORICAL_BARS_V1, ("open", "high", "low", "close", "volume")),
         authorization(),
     )
-    assert result.error is None and isinstance(result.observations[0].value, OHLCVBar)
+    assert result.error is None and isinstance(result.observations[0].value, OHLCVSeries)
+    assert len(result.observations) == 1
+    assert result.observations[0].value.bars[0].close == Decimal("210")
     query = dict(transport.requests[0].query)
     assert query["function"] == "TIME_SERIES_DAILY" and query["outputsize"] == "compact"
     assert "test-key" not in repr(transport.requests[0])

--- a/tests/market_data/test_finnhub.py
+++ b/tests/market_data/test_finnhub.py
@@ -16,7 +16,7 @@ from domain import (
     MarketDataRequestContext,
     MarketDataSubject,
     MarketDataSubjectType,
-    OHLCVBar,
+    OHLCVSeries,
     ProviderAddressProjection,
     Quote,
 )
@@ -93,14 +93,10 @@ def subject(
         "finnhub", "v1", "symbol", symbol, NOW - timedelta(days=30), None, EVIDENCE
     )
     semantic_start = (
-        NOW
-        if capability is MarketCapability.EARNINGS_CALENDAR_V1
-        else NOW - timedelta(days=5)
+        NOW if capability is MarketCapability.EARNINGS_CALENDAR_V1 else NOW - timedelta(days=5)
     )
     semantic_end = (
-        NOW + timedelta(days=75)
-        if capability is MarketCapability.EARNINGS_CALENDAR_V1
-        else NOW
+        NOW + timedelta(days=75) if capability is MarketCapability.EARNINGS_CALENDAR_V1 else NOW
     )
     return MarketDataSubject(
         INSTRUMENT
@@ -113,9 +109,7 @@ def subject(
         ),
         kind,
         capability,
-        MarketDataRequestContext(
-            semantic_start, semantic_end, fields, (projection,), EVIDENCE
-        ),
+        MarketDataRequestContext(semantic_start, semantic_end, fields, (projection,), EVIDENCE),
     )
 
 
@@ -144,9 +138,7 @@ def provider(
     selected = next(item for item in config.providers if item.provider_id == "finnhub")
     authorizer = budget or Budget()
     return (
-        FinnhubProvider(
-            selected, ProviderDependencies(transport, clock or Clock(), authorizer)
-        ),
+        FinnhubProvider(selected, ProviderDependencies(transport, clock or Clock(), authorizer)),
         authorizer,
     )
 
@@ -168,9 +160,7 @@ def test_quote_success_requires_semantic_price_and_timestamp() -> None:
 def test_weekend_quote_from_friday_session_is_prior_session() -> None:
     friday_close = datetime(2026, 7, 24, 20, tzinfo=UTC)
     saturday = datetime(2026, 7, 25, 16, tzinfo=UTC)
-    transport = Transport(
-        (response({"c": 620.5, "t": int(friday_close.timestamp())}),)
-    )
+    transport = Transport((response({"c": 620.5, "t": int(friday_close.timestamp())}),))
     adapter, _ = provider(transport, clock=Clock(saturday))
     requested = replace(
         request(MarketCapability.REAL_TIME_QUOTE_V1, ("last",)),
@@ -198,8 +188,9 @@ def test_candle_success_validates_status_arrays_and_utc_timestamps() -> None:
         request(MarketCapability.HISTORICAL_BARS_V1, ("open", "high", "low", "close", "volume")),
         authorization(),
     )
-    assert result.error is None and isinstance(result.observations[0].value, OHLCVBar)
-    assert result.observations[0].value.start_at.tzinfo is UTC
+    assert result.error is None and isinstance(result.observations[0].value, OHLCVSeries)
+    assert len(result.observations) == 1
+    assert result.observations[0].value.bars[0].start_at.tzinfo is UTC
     assert dict(transport.requests[0].query)["resolution"] == "D"
 
 


### PR DESCRIPTION
## Ticket / Worker
XFACT-03 corrective pass / implementation-worker

Closes #324.

## Production symptom
Authorized cycle on `main@28ca9e2`: 11 shared subject-preparation failures, causing Forward Factor 11 missing, Skew 11 missing, Earnings 20 missing.

## Root cause
Finnhub and Alpha Vantage still emitted one `OHLCVBar` observation per candle. The frozen historical capability contract and shared reducer require one `OHLCVSeries` observation per request. Tradier already complied. Fallback activation therefore failed during capability reduction.

## Correction
Both fallback adapters now bundle ordered canonical bars into one `OHLCVSeries`, with series-aware completeness and latest-bar effective time. No retry, threshold, provider priority, strategy, runtime, or universe change.

## Before / after
Baseline provider compliance reaches the reducer with invalid scalar bar observations. Head emits the canonical series shape and passes shared provider compliance/coalescing tests.

## Validation
- provider/reducer focused: 59 passed
- market data + runtime + scheduled production + architecture: 1,191 passed / 1 skipped
- Ruff/mypy: PASS
- Lean pre-push: PASS
- diff check: PASS

## Self-review / stop status
Complete / CLEAR. Permanent correction at provider normalization owner; no workaround or architecture expansion.