### PR TITLE
UNI-01: restore screening import boundary

### DIFF
--- a/screening/universe_membership.py
+++ b/screening/universe_membership.py
@@ -11,7 +11,6 @@ import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
-from pathlib import Path
 from types import MappingProxyType
 
 
@@ -64,8 +63,9 @@ class EquityUniverseMembershipSnapshot:
         return MappingProxyType({member.symbol: member for member in self.members})
 
 
-def load_membership_snapshot(path: Path) -> EquityUniverseMembershipSnapshot:
-    payload = json.loads(path.read_text())
+def load_membership_snapshot(path: str) -> EquityUniverseMembershipSnapshot:
+    with open(path, encoding="utf-8") as snapshot_file:
+        payload = json.load(snapshot_file)
     members = tuple(
         sorted(
             (
@@ -94,5 +94,5 @@ def load_membership_snapshot(path: Path) -> EquityUniverseMembershipSnapshot:
 
 
 SP500_MEMBERSHIP = load_membership_snapshot(
-    Path(__file__).with_name("universe_snapshots") / "sp500-2026-08-13.json"
+    f"{__file__.rsplit('/', 1)[0]}/universe_snapshots/sp500-2026-08-13.json"
 )


### PR DESCRIPTION
Corrective PR for UNI-01 / #334 after PR #335 merged before its Architecture Validation failure was available.

Root cause: `screening/universe_membership.py` imported `pathlib`, outside the frozen screening import allowlist.

Correction: load the committed snapshot through built-in file I/O and a module-relative string path. No allowlist change, contract change, or behavior expansion.

Validation:
- `tests/architecture/test_screening_boundaries.py`
- `tests/screening/test_universe_membership.py`
- 106 passed
- Ruff and strict mypy passed on the correction before publishing

Manager stop status: CLEAR. Do not merge until all required CI is green.