### PR TITLE
UNI-02: bound broad-universe acquisition cohorts

### DIFF
--- a/project/reports/UNIVERSE-001-UNI-02.md
+++ b/project/reports/UNIVERSE-001-UNI-02.md
@@ -1,0 +1,36 @@
+# UNIVERSE-001 / UNI-02 — Root-Cause Scale Correction
+
+## Failed scale gate
+
+UNI-01 measured 2,515 option-chain calls for a naive 503-subject, all-three-strategy
+cycle. The established 30-subject control uses 150 option calls.
+
+## Root cause and owner
+
+Forward Factor and Skew Momentum legitimately require option evidence to evaluate.
+Removing those requests with a generic prefilter would alter strategy semantics; no
+declared cheap eligibility rule can prove those subjects ineligible. Earnings Calendar
+already avoids phase-two contract acquisition when its declared earnings/expiration
+requirements reject a subject.
+
+The defect is therefore a cycle-capacity/fairness problem owned by generic screening
+scheduling, not a strategy, provider, or option normalizer.
+
+## Correction
+
+`screening.universe_cohorts.plan_universe_cohort` deterministically partitions the
+effective-dated membership into bounded, symbol-sorted cohorts. A full sweep covers each
+member exactly once. Cohort selection carries the membership source revision and is replay
+stable; it contains no strategy identity, score, threshold, provider, or heuristic ranking.
+
+At the current proven capacity of 30 subjects:
+
+- 503 members become 17 cohorts (16 × 30, 1 × 23);
+- a cycle remains bounded at at most 270 provider calls / 150 option calls under the
+  UNI-01 production-equivalent topology;
+- naive one-cycle acquisition is avoided without fabricating evaluations or changing
+  strategy policy;
+- total full-sweep work is preserved honestly rather than hidden.
+
+Production activation is deliberately deferred to UNI-03. The existing 30-symbol
+production universe remains unchanged in this ticket.

--- a/screening/universe_cohorts.py
+++ b/screening/universe_cohorts.py
@@ -1,0 +1,49 @@
+"""Deterministic bounded traversal of effective-dated universe membership.
+
+This is capacity/fairness planning only. It never ranks symbols, inspects
+strategy policy, or changes membership. Every member appears exactly once in
+one full sweep; callers choose which cohort ordinal a cycle processes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from screening.universe_membership import EquityUniverseMembershipSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class UniverseCohort:
+    universe_id: str
+    source_revision_id: int
+    cohort_ordinal: int
+    cohort_count: int
+    symbols: tuple[str, ...]
+
+
+def plan_universe_cohort(
+    snapshot: EquityUniverseMembershipSnapshot,
+    *,
+    maximum_subjects: int,
+    cohort_ordinal: int,
+) -> UniverseCohort:
+    """Return one deterministic slice of symbol-sorted membership.
+
+    ``cohort_ordinal`` may increase indefinitely; modulo traversal makes the
+    plan replayable while guaranteeing a complete sweep every ``cohort_count``
+    cycles. The final cohort may be smaller and is never padded or duplicated.
+    """
+    if maximum_subjects < 1:
+        raise ValueError("maximum_subjects must be positive")
+    if cohort_ordinal < 0:
+        raise ValueError("cohort_ordinal must be non-negative")
+    cohort_count = (len(snapshot.symbols) + maximum_subjects - 1) // maximum_subjects
+    normalized_ordinal = cohort_ordinal % cohort_count
+    start = normalized_ordinal * maximum_subjects
+    return UniverseCohort(
+        universe_id=snapshot.universe_id,
+        source_revision_id=snapshot.source_revision_id,
+        cohort_ordinal=normalized_ordinal,
+        cohort_count=cohort_count,
+        symbols=snapshot.symbols[start : start + maximum_subjects],
+    )

--- a/tests/screening/test_universe_cohorts.py
+++ b/tests/screening/test_universe_cohorts.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from screening.universe_cohorts import plan_universe_cohort
+from screening.universe_membership import SP500_MEMBERSHIP
+
+
+def test_sp500_is_covered_once_across_a_complete_bounded_sweep() -> None:
+    cohorts = tuple(
+        plan_universe_cohort(SP500_MEMBERSHIP, maximum_subjects=30, cohort_ordinal=ordinal)
+        for ordinal in range(17)
+    )
+    symbols = tuple(symbol for cohort in cohorts for symbol in cohort.symbols)
+
+    assert all(len(cohort.symbols) == 30 for cohort in cohorts[:-1])
+    assert len(cohorts[-1].symbols) == 23
+    assert symbols == SP500_MEMBERSHIP.symbols
+    assert len(set(symbols)) == 503
+
+
+def test_cohort_selection_is_replay_stable_and_wraps_by_sweep() -> None:
+    first = plan_universe_cohort(SP500_MEMBERSHIP, maximum_subjects=30, cohort_ordinal=3)
+    replay = plan_universe_cohort(SP500_MEMBERSHIP, maximum_subjects=30, cohort_ordinal=20)
+    assert first == replay
+
+
+@pytest.mark.parametrize("maximum_subjects", (0, -1))
+def test_non_positive_capacity_is_rejected(maximum_subjects: int) -> None:
+    with pytest.raises(ValueError, match="maximum_subjects"):
+        plan_universe_cohort(
+            SP500_MEMBERSHIP,
+            maximum_subjects=maximum_subjects,
+            cohort_ordinal=0,
+        )
+
+
+def test_negative_ordinal_is_rejected() -> None:
+    with pytest.raises(ValueError, match="cohort_ordinal"):
+        plan_universe_cohort(SP500_MEMBERSHIP, maximum_subjects=30, cohort_ordinal=-1)


### PR DESCRIPTION
Closes #337

## Ticket
UNI-02 — Root-Cause Scale Correction

## Root cause
UNI-01 proved naive 503-subject preparation generates 4,527 provider calls, including 2,515 option calls. FF and Skew legitimately require option evidence, so generic filtering would change strategy semantics. This is a scheduler capacity/fairness problem.

## Correction
Adds deterministic, strategy-neutral bounded cohorts over the effective-dated membership snapshot. At the currently proven 30-subject capacity, S&P 500 is covered in 17 cohorts (16×30 + 23), each member exactly once per sweep. Maximum production-equivalent cycle cost remains 270 calls / 150 option calls instead of one 4,527 / 2,515 burst.

No production activation in this PR; UNI-03 owns rollout.

## Architecture
- no strategy identity, thresholds, providers, or rankings
- no membership mutation
- replay-stable modulo traversal
- source revision retained
- existing production 30-symbol universe unchanged

## Validation
- 117 targeted/integration/architecture tests passed
- Ruff passed
- strict mypy passed
- Lean governance integrity passed
- Lean entrypoints passed
- diff check passed

## Auto-merge
Founder Sprint Delegation active; Manager stop status CLEAR. Merge only after required CI green.