### PR TITLE
UNI-03: activate staged S&P 500 screening cohorts

### DIFF
--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -58,7 +58,7 @@ from domain import UnknownReason
 from market_data import ReuseDecision, load_market_data_config_from_environment
 from market_data.attempts import AcquisitionAttemptRepository
 from market_data.live_transport import build_live_transport
-from market_data.session_schedule import SessionRefreshSchedule
+from market_data.session_schedule import ScheduledRefreshSlot, SessionRefreshSchedule
 from screening import APPROVED_LIVE_UNIVERSE, EARNINGS_CALENDAR_UNIVERSE
 from screening.cycle_identity import (
     manual_invocation_slot_id,
@@ -69,6 +69,8 @@ from screening.cycle_identity import (
     pair_evaluation_id as compute_pair_evaluation_id,
 )
 from screening.live_acquisition import live_only_config
+from screening.universe_cohorts import UniverseCohort, plan_universe_cohort
+from screening.universe_membership import SP500_MEMBERSHIP
 from strategy_runtime.adapters import (
     build_migrated_cutover_policy,
     build_migrated_shadow_registry,
@@ -111,7 +113,53 @@ PRODUCTION_SCREENING_UNIVERSE: tuple[tuple[str, str], ...] = tuple(
     for signal_id in ("forward_factor", "skew_momentum")
     for symbol in APPROVED_LIVE_UNIVERSE
 ) + tuple(("earnings_calendar", symbol) for symbol in EARNINGS_CALENDAR_UNIVERSE)
+
+# UNI-01's current proven live capacity. Increasing this is a measured
+# capacity decision, never a CLI/environment override.
+SP500_COHORT_MAXIMUM_SUBJECTS = 30
 _LOGGER = logging.getLogger(__name__)
+
+
+def _scheduled_cohort_ordinal(slot: ScheduledRefreshSlot) -> int:
+    """Stable ordinal across every exchange-calendar refresh slot.
+
+    Counting the schedule's actual slots (including holidays and early-close
+    sessions) guarantees complete, gap-free cohort traversal without mutable
+    scheduler state or a database cursor.
+    """
+    if slot.session_date < SP500_MEMBERSHIP.effective_date:
+        raise ValueError("scheduled slot predates the active S&P 500 membership snapshot")
+    schedule = SessionRefreshSchedule()
+    cursor = SP500_MEMBERSHIP.effective_date
+    ordinal = 0
+    while cursor < slot.session_date:
+        ordinal += len(schedule.slots_for(cursor))
+        cursor += timedelta(days=1)
+    session_slots = schedule.slots_for(slot.session_date)
+    try:
+        slot_offset = next(
+            index for index, candidate in enumerate(session_slots) if candidate == slot
+        )
+    except StopIteration:
+        raise ValueError("scheduled slot is not part of its session schedule") from None
+    return ordinal + slot_offset
+
+
+def scheduled_sp500_cohort(slot: ScheduledRefreshSlot) -> UniverseCohort:
+    return plan_universe_cohort(
+        SP500_MEMBERSHIP,
+        maximum_subjects=SP500_COHORT_MAXIMUM_SUBJECTS,
+        cohort_ordinal=_scheduled_cohort_ordinal(slot),
+    )
+
+
+def scheduled_sp500_universe(slot: ScheduledRefreshSlot) -> tuple[tuple[str, str], ...]:
+    cohort = scheduled_sp500_cohort(slot)
+    return tuple(
+        (strategy_id, symbol)
+        for symbol in cohort.symbols
+        for strategy_id in ("forward_factor", "skew_momentum", "earnings_calendar")
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -206,7 +254,7 @@ class RefreshScheduleClaimRepository(Protocol):
 
 
 def run_scheduled_refresh(
-    universe: tuple[tuple[str, str], ...] = PRODUCTION_SCREENING_UNIVERSE,
+    universe: tuple[tuple[str, str], ...] | None = None,
     *,
     repository: LatestResultRepository | None = None,
     history_repository: ObservationHistoryRepository | None = None,
@@ -255,6 +303,7 @@ def run_scheduled_refresh(
     reported complete when it wasn't.
     """
     run_at = now or datetime.now(UTC)
+    resolved_universe = PRODUCTION_SCREENING_UNIVERSE if universe is None else universe
     invocation_type = "manual"
     slot_id = manual_invocation_slot_id(run_at)
     if enforce_schedule:
@@ -268,6 +317,25 @@ def run_scheduled_refresh(
             return ()
         invocation_type = "scheduled"
         slot_id = slot.slot_id
+        if universe is None:
+            cohort = scheduled_sp500_cohort(slot)
+            resolved_universe = tuple(
+                (strategy_id, symbol)
+                for symbol in cohort.symbols
+                for strategy_id in ("forward_factor", "skew_momentum", "earnings_calendar")
+            )
+            _LOGGER.info(
+                "scheduled_universe_cohort_selected",
+                extra={
+                    "universe_id": cohort.universe_id,
+                    "source_revision_id": cohort.source_revision_id,
+                    "cohort_ordinal": cohort.cohort_ordinal,
+                    "cohort_count": cohort.cohort_count,
+                    "subject_count": len(cohort.symbols),
+                },
+            )
+
+    universe = resolved_universe
 
     resolved_repository = repository or PostgresLatestResultRepository(
         create_postgres_engine(Settings().database_url)

--- a/project/reports/UNIVERSE-001-UNI-03.md
+++ b/project/reports/UNIVERSE-001-UNI-03.md
@@ -1,0 +1,33 @@
+# UNIVERSE-001 / UNI-03 — Staged S&P 500 Rollout
+
+## Rollout state
+
+Scheduled production now selects one deterministic S&P 500 cohort from the
+effective-dated membership snapshot. Manual and explicitly supplied universes retain their
+existing behavior, preserving the 30-symbol control and bounded test/diagnostic calls.
+
+- Membership revision: `1369213082` (`2026-08-13T15:09:18Z`).
+- Members: 503.
+- Capacity: at most 30 subjects per scheduled cycle.
+- Sweep: 17 cohorts; five normal-session slots advance five cohorts per trading day.
+- Per cohort: all three production strategies; at most 90 strategy pairs.
+- Selection: actual exchange-calendar slots, including holiday and early-close semantics.
+- State: no database cursor; slot-to-cohort mapping is deterministic and replayable.
+- Operational diagnostic: source revision, cohort ordinal/count, and subject count; no payloads.
+
+The scheduler does not rank, filter, or infer strategy viability. It bounds required work fairly
+and preserves every member exactly once per full sweep. Existing strategy-owned phase expansion
+continues to avoid contract acquisition when declared evidence proves a subject ineligible.
+
+## Pre-merge proof
+
+- One production-composition cohort: 30 subjects / 90 pairs.
+- Deterministic multi-capability fixture transport; real production orchestration unchanged.
+- Result: 90 completed, zero exceptions, zero `missing_data`.
+- Full scheduler, membership, cohort, and screening-boundary selection: 153 tests passed.
+- Ruff, strict mypy, Lean integrity, Lean entrypoints, and diff validation passed.
+
+## Remaining closure gate
+
+After merge, validate the exact main SHA. Production deployment and a real scheduled-cycle proof
+remain Founder-authorized actions. Russell 2000 remains blocked until the S&P 500 rollout passes.

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -9,13 +9,16 @@ import pytest
 
 from asa.scheduled_screening import (
     PRODUCTION_SCREENING_UNIVERSE,
+    SP500_COHORT_MAXIMUM_SUBJECTS,
     run_scheduled_refresh,
+    scheduled_sp500_universe,
 )
 from domain import CanonicalInstrumentIdentity, MarketCapability
 from domain.strategy_evidence import HistoricalSkewObservation
 from market_data import FixtureScenario, ProviderErrorCode
 from market_data.attempts import AttemptQuery, InMemoryAcquisitionAttemptRepository
 from market_data.session_calendar import UsEquitySessionCalendar
+from market_data.session_schedule import SessionRefreshSchedule
 from market_data.transport import ReadOnlyHttpResponse
 from screening import APPROVED_LIVE_UNIVERSE, EARNINGS_CALENDAR_UNIVERSE
 from strategy_runtime.orchestration import ShadowParityDiagnostic
@@ -170,6 +173,65 @@ def test_earnings_calendar_pairs_use_the_single_name_subset_only() -> None:
     }
     assert earnings_symbols == set(EARNINGS_CALENDAR_UNIVERSE)
     assert earnings_symbols.isdisjoint(etfs)
+
+
+def test_scheduled_sp500_rollout_is_bounded_and_all_strategy() -> None:
+    slot = SessionRefreshSchedule().slots_for(date(2026, 8, 17))[0]
+    universe = scheduled_sp500_universe(slot)
+    symbols = {symbol for _strategy_id, symbol in universe}
+
+    assert len(symbols) == SP500_COHORT_MAXIMUM_SUBJECTS
+    assert len(universe) == 3 * SP500_COHORT_MAXIMUM_SUBJECTS
+    assert {strategy_id for strategy_id, _symbol in universe} == {
+        "forward_factor",
+        "skew_momentum",
+        "earnings_calendar",
+    }
+
+
+def test_scheduled_slots_advance_to_the_next_cohort() -> None:
+    first, second = SessionRefreshSchedule().slots_for(date(2026, 8, 17))[:2]
+    first_symbols = {symbol for _strategy_id, symbol in scheduled_sp500_universe(first)}
+    second_symbols = {symbol for _strategy_id, symbol in scheduled_sp500_universe(second)}
+    assert first_symbols.isdisjoint(second_symbols)
+
+
+def test_default_scheduled_cycle_uses_bounded_sp500_cohort(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import asa.scheduled_screening as scheduled_screening_module
+
+    monkeypatch.setattr(
+        scheduled_screening_module,
+        "build_shared_market_data_access",
+        build_fixture_market_data_access_factory(),
+    )
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    caplog.set_level(logging.INFO)
+    slot = SessionRefreshSchedule().slots_for(date(2026, 8, 17))[0]
+    outcomes = run_scheduled_refresh(
+        repository=InMemoryLatestResultRepository(),
+        history_repository=InMemoryObservationHistoryRepository(),
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        historical_skew_repository=_RecordingHistoricalSkewRepository(),
+        claim_repository=_SingleUseClaimRepository(),
+        enforce_schedule=True,
+        now=slot.scheduled_at,
+    )
+
+    assert len(outcomes) == 3 * SP500_COHORT_MAXIMUM_SUBJECTS
+    assert all(item.error is None for item in outcomes)
+    assert all(item.outcome != "missing_data" for item in outcomes)
+    selection = next(
+        record
+        for record in caplog.records
+        if record.message == "scheduled_universe_cohort_selected"
+    )
+    assert selection.source_revision_id == 1369213082
+    assert selection.cohort_count == 17
+    assert selection.subject_count == 30
 
 
 def test_no_enabled_provider_raises(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #339

## Ticket
UNI-03 — Staged Rollout and Production Proof

## Change
Scheduled production now traverses the revision-pinned 503-member S&P 500 snapshot in deterministic cohorts of at most 30 subjects. Every scheduled slot advances one cohort; normal sessions cover five cohorts. A full sweep covers every member exactly once in 17 cohorts.

Manual and explicitly supplied universes preserve existing behavior, including the current 30-symbol regression control.

## Capacity and diagnostics
- at most 30 subjects / 90 strategy pairs per scheduled cycle
- production-equivalent ceiling: 270 provider calls / 150 option calls
- logs universe ID, membership revision, cohort ordinal/count, subject count
- no mutable cursor, strategy ranking, provider heuristic, or threshold change

## Validation
- 153 scheduler/membership/cohort/architecture tests passed
- end-to-end scheduled cohort: 90/90 completed; zero exceptions; zero missing_data with fixture transport
- Ruff passed
- strict mypy passed
- Lean pre-push, governance integrity, entrypoints, and diff check passed

## Boundaries
No Russell 2000, deployment, provider replacement, strategy tuning, UI, or brokerage work. Deployment remains Founder-only.

## Auto-merge
Founder Sprint Delegation active; Manager stop status CLEAR. Merge only after every required CI gate is green.