### PR TITLE
UNI-03: handle canonical option coordinate collisions

### DIFF
--- a/strategy_runtime/adapters/forward_factor_subject_first.py
+++ b/strategy_runtime/adapters/forward_factor_subject_first.py
@@ -13,6 +13,7 @@ from domain import (
     ExpirationCollection,
     MarketCapability,
     OptionChain,
+    OptionContract,
     OptionType,
     Quote,
     UnknownReason,
@@ -70,6 +71,23 @@ def _atm_strike(chain: OptionChain, expiration: date, spot: Decimal) -> Decimal:
     return min(strikes, key=lambda strike: (abs(strike - spot), strike))
 
 
+def _contract_at(
+    chain: OptionChain, expiration: date, strike: Decimal
+) -> OptionContract:
+    """Select the first canonically ordered contract at economic coordinates.
+
+    Distinct canonical contract identities may legally share an expiration,
+    strike, and option type (for example standard and adjusted series).
+    ``OptionChain`` already orders those identities deterministically.
+    """
+    matches = chain.find(
+        expiration=expiration, strike=strike, option_type=OptionType.CALL
+    )
+    if not matches:
+        raise ValueError("no call contract at selected expiration and strike")
+    return matches[0]
+
+
 def _prepare(
     snapshot: MarketSnapshot,
     projected: ResolvedEvidenceView,
@@ -108,12 +126,8 @@ def _prepare(
     spot = _spot(quote_observation.value)
     front_strike = _atm_strike(chain, front_date, spot)
     back_strike = _atm_strike(chain, back_date, spot)
-    (front_contract,) = chain.find(
-        expiration=front_date, strike=front_strike, option_type=OptionType.CALL
-    )
-    (back_contract,) = chain.find(
-        expiration=back_date, strike=back_strike, option_type=OptionType.CALL
-    )
+    front_contract = _contract_at(chain, front_date, front_strike)
+    back_contract = _contract_at(chain, back_date, back_strike)
     if front_contract.implied_volatility is None or back_contract.implied_volatility is None:
         return UnknownReason("missing_implied_volatility")
 

--- a/tests/strategy_runtime/adapters/test_forward_factor_subject_first.py
+++ b/tests/strategy_runtime/adapters/test_forward_factor_subject_first.py
@@ -1,0 +1,73 @@
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from domain import (
+    CanonicalInstrumentIdentity,
+    EvidenceKind,
+    EvidenceReference,
+    Instrument,
+    InstrumentKind,
+    OptionChain,
+    OptionContract,
+    OptionType,
+    Security,
+    SecurityAssetType,
+)
+from strategy_runtime.adapters.forward_factor_subject_first import _contract_at
+
+OBSERVED_AT = datetime(2026, 8, 17, 19, 0, tzinfo=UTC)
+EXPIRATION = date(2026, 9, 18)
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "uni-03-regression"),)
+
+
+def _security() -> Security:
+    return Security(
+        Instrument(
+            CanonicalInstrumentIdentity("figi", "figi-SPGI"),
+            InstrumentKind.EQUITY,
+            "SPGI",
+            "USD",
+        ),
+        "SPGI",
+        SecurityAssetType.EQUITY,
+        "XNYS",
+    )
+
+
+def _contract(contract_id: str, implied_volatility: str) -> OptionContract:
+    return OptionContract(
+        CanonicalInstrumentIdentity("asa-option-v1", contract_id),
+        _security(),
+        EXPIRATION,
+        Decimal("550"),
+        OptionType.CALL,
+        Decimal("9"),
+        Decimal("11"),
+        Decimal("10"),
+        10,
+        100,
+        Decimal("0.5"),
+        None,
+        None,
+        None,
+        None,
+        Decimal(implied_volatility),
+        OBSERVED_AT,
+        EVIDENCE,
+    )
+
+
+def test_contract_selection_accepts_multiple_canonical_identities_deterministically() -> None:
+    later = _contract("SPGI-adjusted", "0.31")
+    canonical_first = _contract("SPGI-standard", "0.29")
+    chain = OptionChain(
+        "spgi-chain",
+        _security(),
+        OBSERVED_AT,
+        (canonical_first, later),
+        EVIDENCE,
+    )
+
+    selected = _contract_at(chain, EXPIRATION, Decimal("550"))
+
+    assert selected is chain.contracts[0]


### PR DESCRIPTION
## Ticket
UNI-03 corrective; closes #341. Assigned Worker: implementation-worker. Manager stop status: CLEAR.

## Symptom / production evidence
`main@7c7fcbf` processed the staged 30-subject S&P 500 cohort (90 strategy pairs) with zero runner failures, but Forward Factor / SPGI returned ASA-caused `strategy_knowledge_construction_failed`. Exact exception: `ValueError: too many values to unpack (expected 1)` in the subject-first knowledge binding.

## Root cause and owner
`OptionChain` permits distinct canonical option identities at identical expiration/strike/type coordinates. The Forward Factor binding incorrectly treated those economic coordinates as unique. Owner: `strategy_runtime/adapters/forward_factor_subject_first.py`.

## Correction
Select the first match from `OptionChain` canonical deterministic ordering, matching the established `analytics.forward_factor.compute_option_implied_volatility` behavior. No acquisition, provider, strategy policy, architecture, or public contract change.

## Before / after
Before: 1/30 Forward Factor cohort rows was ASA-caused missing_data.
After: multiple canonical identities at one ATM coordinate select deterministically and knowledge construction proceeds. Production rerun follows merge/deploy.

## Validation
- Regression + Forward Factor/orchestration: 47 passed
- Rollout/runtime/architecture scope: 351 passed
- Ruff: green
- strict mypy: green
- Lean integrity/entrypoints/pre-push: green
- Worker self-review: complete

## Sprint effect
Removes the demonstrated UNI-03 ASA-caused failure while preserving provider-blind acquisition, deterministic selection, and staged cohort bounds.

## Auto-merge authority
Qualifying in-scope UNI-03 corrective under active UNIVERSE-001 delegation. Branch protection will not be bypassed.