### PR TITLE
UNI-03: centralize canonical option selection

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -58,6 +58,7 @@ from analytics.forward_factor import (
     compute_days_to_expiration,
     compute_option_implied_volatility,
 )
+from analytics.option_selection import select_canonical_contract
 from analytics.realized_volatility import (
     InsufficientPriceHistoryError,
     compute_log_returns,
@@ -111,6 +112,7 @@ __all__ = [
     "compute_normalized_skew",
     "compute_no_confirmed_earnings_through_expiration",
     "select_atm_strike",
+    "select_canonical_contract",
     "select_earnings_relative_expiration_pair",
     "select_expiration_pair",
 ]

--- a/analytics/forward_factor.py
+++ b/analytics/forward_factor.py
@@ -23,7 +23,8 @@ from decimal import Decimal
 from typing import cast
 
 from analytics.engine import FeatureComputation
-from analytics.errors import MissingImpliedVolatilityError, NoMatchingContractError
+from analytics.errors import MissingImpliedVolatilityError
+from analytics.option_selection import select_canonical_contract
 from analytics.registry import AnalyticsFeatureDefinition, AnalyticsRegistry
 from domain import MarketCapability, OptionChain, OptionType
 
@@ -44,10 +45,7 @@ def compute_option_implied_volatility(inputs: Mapping[str, object]) -> Decimal:
     expiration = cast(date, inputs["expiration"])
     strike = cast(Decimal, inputs["strike"])
     option_type = cast(OptionType, inputs["option_type"])
-    matches = chain.find(expiration=expiration, strike=strike, option_type=option_type)
-    if not matches:
-        raise NoMatchingContractError(expiration.isoformat(), str(strike))
-    contract = matches[0]
+    contract = select_canonical_contract(chain, expiration, strike, option_type)
     if contract.implied_volatility is None:
         raise MissingImpliedVolatilityError(expiration.isoformat(), str(strike))
     return contract.implied_volatility

--- a/analytics/option_selection.py
+++ b/analytics/option_selection.py
@@ -1,0 +1,32 @@
+"""Deterministic selection over canonical option-chain coordinates."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from analytics.errors import NoMatchingContractError
+from domain import OptionChain, OptionContract, OptionType
+
+
+def select_canonical_contract(
+    chain: OptionChain,
+    expiration: date,
+    strike: Decimal,
+    option_type: OptionType,
+) -> OptionContract:
+    """Return the first canonical match at shared economic coordinates.
+
+    Standard and adjusted contracts can have distinct canonical identities
+    while sharing expiration, strike, and type. ``OptionChain`` already
+    sorts those identities deterministically; no strategy may assume the
+    economic coordinates themselves are unique.
+    """
+    matches = chain.find(
+        expiration=expiration,
+        strike=strike,
+        option_type=option_type,
+    )
+    if not matches:
+        raise NoMatchingContractError(expiration.isoformat(), str(strike))
+    return matches[0]

--- a/strategies/earnings_calendar_structure.py
+++ b/strategies/earnings_calendar_structure.py
@@ -29,6 +29,7 @@ from datetime import date
 from decimal import Decimal
 
 from analytics.atm_selection import select_atm_strike
+from analytics.option_selection import select_canonical_contract
 from domain import (
     EarningsEvent,
     ExpirationCycle,
@@ -113,12 +114,10 @@ def select_earnings_calendar_structure(
     spot_price = quote.last
 
     front_strikes = tuple(
-        item.strike
-        for item in chain.find(expiration=front_expiration, option_type=OptionType.CALL)
+        item.strike for item in chain.find(expiration=front_expiration, option_type=OptionType.CALL)
     )
     back_strikes = tuple(
-        item.strike
-        for item in chain.find(expiration=back_expiration, option_type=OptionType.CALL)
+        item.strike for item in chain.find(expiration=back_expiration, option_type=OptionType.CALL)
     )
     if not front_strikes or not back_strikes:
         no_calls_demand_ids = tuple(
@@ -134,12 +133,10 @@ def select_earnings_calendar_structure(
         )
     front_strike = select_atm_strike(front_strikes, spot_price)
     back_strike = select_atm_strike(back_strikes, spot_price)
-    (front_contract,) = chain.find(
-        expiration=front_expiration, strike=front_strike, option_type=OptionType.CALL
+    front_contract = select_canonical_contract(
+        chain, front_expiration, front_strike, OptionType.CALL
     )
-    (back_contract,) = chain.find(
-        expiration=back_expiration, strike=back_strike, option_type=OptionType.CALL
-    )
+    back_contract = select_canonical_contract(chain, back_expiration, back_strike, OptionType.CALL)
     if front_contract.implied_volatility is None or back_contract.implied_volatility is None:
         missing_iv_demand_ids = tuple(
             demand_id

--- a/strategies/skew_momentum_planning.py
+++ b/strategies/skew_momentum_planning.py
@@ -32,6 +32,7 @@ def bars_demand(now: datetime) -> CapabilityDemand:
         ("close",),
         now - timedelta(days=HISTORICAL_LOOKBACK_DAYS),
         now,
+        maximum_age_seconds=int(timedelta(days=HISTORICAL_LOOKBACK_DAYS + 1).total_seconds()),
     )
 
 

--- a/strategy_runtime/adapters/forward_factor_subject_first.py
+++ b/strategy_runtime/adapters/forward_factor_subject_first.py
@@ -8,12 +8,12 @@ from decimal import Decimal
 from functools import partial
 from types import MappingProxyType
 
+from analytics.option_selection import select_canonical_contract
 from domain import (
     EarningsEvent,
     ExpirationCollection,
     MarketCapability,
     OptionChain,
-    OptionContract,
     OptionType,
     Quote,
     UnknownReason,
@@ -71,23 +71,6 @@ def _atm_strike(chain: OptionChain, expiration: date, spot: Decimal) -> Decimal:
     return min(strikes, key=lambda strike: (abs(strike - spot), strike))
 
 
-def _contract_at(
-    chain: OptionChain, expiration: date, strike: Decimal
-) -> OptionContract:
-    """Select the first canonically ordered contract at economic coordinates.
-
-    Distinct canonical contract identities may legally share an expiration,
-    strike, and option type (for example standard and adjusted series).
-    ``OptionChain`` already orders those identities deterministically.
-    """
-    matches = chain.find(
-        expiration=expiration, strike=strike, option_type=OptionType.CALL
-    )
-    if not matches:
-        raise ValueError("no call contract at selected expiration and strike")
-    return matches[0]
-
-
 def _prepare(
     snapshot: MarketSnapshot,
     projected: ResolvedEvidenceView,
@@ -126,8 +109,8 @@ def _prepare(
     spot = _spot(quote_observation.value)
     front_strike = _atm_strike(chain, front_date, spot)
     back_strike = _atm_strike(chain, back_date, spot)
-    front_contract = _contract_at(chain, front_date, front_strike)
-    back_contract = _contract_at(chain, back_date, back_strike)
+    front_contract = select_canonical_contract(chain, front_date, front_strike, OptionType.CALL)
+    back_contract = select_canonical_contract(chain, back_date, back_strike, OptionType.CALL)
     if front_contract.implied_volatility is None or back_contract.implied_volatility is None:
         return UnknownReason("missing_implied_volatility")
 
@@ -209,9 +192,7 @@ def build_forward_factor_subject_first_adapter(
             strategy_id=_STRATEGY_ID,
             strategy_version=FORWARD_FACTOR_CONTRACT.version,
             symbol=context.subject,
-            observation_id=compute_observation_id(
-                context.run_id, _STRATEGY_ID, context.subject
-            ),
+            observation_id=compute_observation_id(context.run_id, _STRATEGY_ID, context.subject),
             opportunity_id=None,
             row_type=RowType.RESULT,
             verdict=verdict_text,

--- a/strategy_runtime/adapters/skew_momentum_subject_first.py
+++ b/strategy_runtime/adapters/skew_momentum_subject_first.py
@@ -13,6 +13,7 @@ from typing import cast
 from analytics.cross_sectional_materialization import SubjectCrossSectionalFacts
 from analytics.derived_facts import CROSS_SECTIONAL_MOMENTUM, SECTOR_RELATIVE_MOMENTUM
 from analytics.features import DerivedFactSet
+from analytics.option_selection import select_canonical_contract
 from domain import (
     CanonicalInstrumentIdentity,
     CanonicalReturnObservation,
@@ -113,8 +114,8 @@ def _prepare(
     spot = _spot(quote_observation.value)
     call_strike = select_atm_strike_at_expiration(chain, expiration, spot, OptionType.CALL)
     put_strike = select_atm_strike_at_expiration(chain, expiration, spot, OptionType.PUT)
-    (call_atm,) = chain.find(expiration=expiration, strike=call_strike, option_type=OptionType.CALL)
-    (put_atm,) = chain.find(expiration=expiration, strike=put_strike, option_type=OptionType.PUT)
+    call_atm = select_canonical_contract(chain, expiration, call_strike, OptionType.CALL)
+    put_atm = select_canonical_contract(chain, expiration, put_strike, OptionType.PUT)
     call_wing = select_nearest_delta_contract(
         chain, expiration, OptionType.CALL, Decimal("0.25"), exclude_strike=call_strike
     )

--- a/tests/analytics/test_option_selection.py
+++ b/tests/analytics/test_option_selection.py
@@ -1,6 +1,7 @@
 from datetime import UTC, date, datetime
 from decimal import Decimal
 
+from analytics.option_selection import select_canonical_contract
 from domain import (
     CanonicalInstrumentIdentity,
     EvidenceKind,
@@ -13,7 +14,6 @@ from domain import (
     Security,
     SecurityAssetType,
 )
-from strategy_runtime.adapters.forward_factor_subject_first import _contract_at
 
 OBSERVED_AT = datetime(2026, 8, 17, 19, 0, tzinfo=UTC)
 EXPIRATION = date(2026, 9, 18)
@@ -34,7 +34,7 @@ def _security() -> Security:
     )
 
 
-def _contract(contract_id: str, implied_volatility: str) -> OptionContract:
+def _contract(contract_id: str) -> OptionContract:
     return OptionContract(
         CanonicalInstrumentIdentity("asa-option-v1", contract_id),
         _security(),
@@ -51,23 +51,21 @@ def _contract(contract_id: str, implied_volatility: str) -> OptionContract:
         None,
         None,
         None,
-        Decimal(implied_volatility),
+        Decimal("0.30"),
         OBSERVED_AT,
         EVIDENCE,
     )
 
 
-def test_contract_selection_accepts_multiple_canonical_identities_deterministically() -> None:
-    later = _contract("SPGI-adjusted", "0.31")
-    canonical_first = _contract("SPGI-standard", "0.29")
+def test_multiple_canonical_identities_select_by_chain_order() -> None:
     chain = OptionChain(
         "spgi-chain",
         _security(),
         OBSERVED_AT,
-        (canonical_first, later),
+        (_contract("SPGI-standard"), _contract("SPGI-adjusted")),
         EVIDENCE,
     )
 
-    selected = _contract_at(chain, EXPIRATION, Decimal("550"))
+    selected = select_canonical_contract(chain, EXPIRATION, Decimal("550"), OptionType.CALL)
 
     assert selected is chain.contracts[0]

--- a/tests/strategies/test_skew_momentum_planning.py
+++ b/tests/strategies/test_skew_momentum_planning.py
@@ -1,0 +1,13 @@
+from datetime import UTC, datetime
+
+from domain import MarketCapability
+from strategies.skew_momentum_planning import bars_demand, resolved_field_requirements
+
+
+def test_historical_bars_demand_matches_resolution_freshness_policy() -> None:
+    demand = bars_demand(datetime(2026, 8, 17, 20, 30, tzinfo=UTC))
+    _fields, maximum_age_seconds = resolved_field_requirements()[
+        MarketCapability.HISTORICAL_BARS_V1
+    ]
+
+    assert demand.maximum_age_seconds == maximum_age_seconds


### PR DESCRIPTION
## Ticket
UNI-03 loop-breaker corrective; continues #341. Assigned Worker: implementation-worker. Manager stop status: CLEAR.

## Repeated production failure
First production run: Forward Factor / SPGI failed knowledge construction because multiple canonical option identities shared ATM economic coordinates. PR #342 fixed only Forward Factor. Authorized re-verification then reproduced the same exception in Skew Momentum / SPGI.

## Root cause re-analysis
The implementation assumption—not the canonical chain—was wrong: expiration/strike/type are not a unique contract identity. Multiple migrated bindings independently destructured `OptionChain.find()` as a singleton. The local Forward Factor helper was therefore superseded.

The re-verification also exposed Skew historical bars becoming `STALE_DATA` after close: `bars_demand()` defaulted to one-hour freshness while its declared resolution policy already specified the 181-day historical lookback tolerance.

## Owner correction
- Add one provider-neutral `analytics.option_selection.select_canonical_contract()` using `OptionChain` deterministic canonical ordering.
- Use it in Forward Factor, Skew Momentum, Earnings Calendar, and the existing Forward Factor analytics calculation.
- Remove the superseded adapter-local helper/test.
- Align Skew historical-bars demand freshness with its already-declared resolution policy.

No provider, acquisition, threshold, strategy verdict, architecture, or public domain contract change.

## Before / after
Before: SPGI produced ASA-caused knowledge-construction missing_data first in Forward Factor, then Skew; after close Skew could reject otherwise valid daily history as stale.
After: all three migrated knowledge paths deterministically support multiple canonical identities at shared coordinates; Skew request and resolution temporal identities agree.

## Validation
- Focused root regressions: 75 passed
- Scheduled rollout/runtime/analytics/architecture scope: 453 passed
- Ruff changed scope: green
- strict mypy changed scope: green
- Lean pre-push: green
- Worker self-review: complete

## Sprint effect
Satisfies UNI-03 loop-breaker by correcting the shared owner assumption, prevents the demonstrated repeated failure across all migrated strategies, and preserves staged S&P bounds and provider blindness. Production re-verification required after merge.

## Auto-merge authority
Qualifying in-scope UNI-03 corrective under active UNIVERSE-001 delegation. Branch protection will not be bypassed.