### PR TITLE
Inject canonical classifications into cross-subject facts

### DIFF
--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -41,6 +41,7 @@ import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from types import MappingProxyType
 from typing import Protocol
 
 from asa.config import Settings
@@ -54,7 +55,7 @@ from asa.integrations.screening_acquisition_attempts_postgres import (
     PostgresAcquisitionAttemptRepository,
 )
 from asa.integrations.universal_screening_postgres import PostgresLatestResultRepository
-from domain import UnknownReason
+from domain import CanonicalInstrumentIdentity, UnknownReason
 from market_data import ReuseDecision, load_market_data_config_from_environment
 from market_data.attempts import AcquisitionAttemptRepository
 from market_data.live_transport import build_live_transport
@@ -70,13 +71,21 @@ from screening.cycle_identity import (
 )
 from screening.live_acquisition import live_only_config
 from screening.universe_cohorts import UniverseCohort, plan_universe_cohort
-from screening.universe_membership import SP500_MEMBERSHIP
+from screening.universe_membership import (
+    SP500_MEMBERSHIP,
+    EquityUniverseClassifications,
+    canonical_equity_classifications,
+)
 from strategy_runtime.adapters import (
     build_migrated_cutover_policy,
     build_migrated_shadow_registry,
     build_migrated_strategy_registry,
     migrated_shadow_capability_reducers,
     migrated_shadow_resolution_policy,
+)
+from strategy_runtime.comparison_universe import (
+    ASSET_TYPE_BY_INSTRUMENT,
+    SECTOR_BY_INSTRUMENT,
 )
 from strategy_runtime.cross_subject_knowledge import compose_cross_subject_knowledge
 from strategy_runtime.historical_evidence import HistoricalSkewRepository
@@ -118,6 +127,26 @@ PRODUCTION_SCREENING_UNIVERSE: tuple[tuple[str, str], ...] = tuple(
 # capacity decision, never a CLI/environment override.
 SP500_COHORT_MAXIMUM_SUBJECTS = 30
 _LOGGER = logging.getLogger(__name__)
+
+
+def _cross_subject_classifications(symbols: tuple[str, ...]) -> EquityUniverseClassifications:
+    """Authoritative S&P classifications plus explicit legacy-topology compatibility."""
+    active = canonical_equity_classifications(SP500_MEMBERSHIP)
+    asset_types = dict(active.asset_types)
+    sectors = dict(active.sectors)
+    for symbol in symbols:
+        instrument = CanonicalInstrumentIdentity("symbol", symbol)
+        if instrument in active.asset_types:
+            continue
+        legacy_asset_type = ASSET_TYPE_BY_INSTRUMENT.get(instrument)
+        if legacy_asset_type is not None:
+            asset_types[instrument] = legacy_asset_type
+        legacy_sector = SECTOR_BY_INSTRUMENT.get(instrument)
+        if legacy_sector is not None:
+            sectors[instrument] = legacy_sector
+    return EquityUniverseClassifications(
+        MappingProxyType(asset_types), MappingProxyType(sectors)
+    )
 
 
 def _scheduled_cohort_ordinal(slot: ScheduledRefreshSlot) -> int:
@@ -522,8 +551,12 @@ def run_scheduled_refresh(
     # registered cross-subject families are materialized once and rebound to
     # their declaring consumers. This adds no acquisition and contains no
     # strategy identity branch.
+    classifications = _cross_subject_classifications(unique_symbols)
     shadow_knowledge_by_symbol = compose_cross_subject_knowledge(
-        shadow_knowledge_by_symbol, shadow_registry
+        shadow_knowledge_by_symbol,
+        shadow_registry,
+        asset_types=classifications.asset_types,
+        sectors=classifications.sectors,
     ).knowledge_by_subject
     outcomes: list[PairOutcome] = []
     for signal_id, symbol in universe:

--- a/screening/universe_membership.py
+++ b/screening/universe_membership.py
@@ -13,6 +13,30 @@ from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from types import MappingProxyType
 
+from domain import CanonicalInstrumentIdentity, SectorClassification, SecurityAssetType
+
+GICS_TAXONOMY = "GICS"
+GICS_TAXONOMY_VERSION = "2023"
+
+# Taxonomy-level reference data at the boundary where the authoritative
+# membership source's sector names become canonical domain classifications.
+# This is deliberately not keyed by symbol or universe.
+GICS_SECTOR_NAME_TO_CODE: Mapping[str, str] = MappingProxyType(
+    {
+        "Energy": "10",
+        "Materials": "15",
+        "Industrials": "20",
+        "Consumer Discretionary": "25",
+        "Consumer Staples": "30",
+        "Health Care": "35",
+        "Financials": "40",
+        "Information Technology": "45",
+        "Communication Services": "50",
+        "Utilities": "55",
+        "Real Estate": "60",
+    }
+)
+
 
 @dataclass(frozen=True, slots=True)
 class EquityUniverseMember:
@@ -61,6 +85,36 @@ class EquityUniverseMembershipSnapshot:
     @property
     def by_symbol(self) -> Mapping[str, EquityUniverseMember]:
         return MappingProxyType({member.symbol: member for member in self.members})
+
+
+@dataclass(frozen=True, slots=True)
+class EquityUniverseClassifications:
+    asset_types: Mapping[CanonicalInstrumentIdentity, SecurityAssetType]
+    sectors: Mapping[CanonicalInstrumentIdentity, SectorClassification]
+
+
+def canonical_equity_classifications(
+    snapshot: EquityUniverseMembershipSnapshot,
+) -> EquityUniverseClassifications:
+    """Project typed equity membership metadata into canonical classifications."""
+    asset_types: dict[CanonicalInstrumentIdentity, SecurityAssetType] = {}
+    sectors: dict[CanonicalInstrumentIdentity, SectorClassification] = {}
+    for member in snapshot.members:
+        instrument = CanonicalInstrumentIdentity("symbol", member.symbol)
+        asset_types[instrument] = SecurityAssetType.EQUITY
+        try:
+            sector_code = GICS_SECTOR_NAME_TO_CODE[member.gics_sector]
+        except KeyError:
+            raise ValueError(
+                f"unsupported GICS sector name in {snapshot.universe_id}: "
+                f"{member.gics_sector!r}"
+            ) from None
+        sectors[instrument] = SectorClassification(
+            GICS_TAXONOMY, GICS_TAXONOMY_VERSION, sector_code
+        )
+    return EquityUniverseClassifications(
+        MappingProxyType(asset_types), MappingProxyType(sectors)
+    )
 
 
 def load_membership_snapshot(path: str) -> EquityUniverseMembershipSnapshot:

--- a/strategy_runtime/cross_subject_knowledge.py
+++ b/strategy_runtime/cross_subject_knowledge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 from analytics.cross_sectional_materialization import (
@@ -9,10 +10,14 @@ from analytics.cross_sectional_materialization import (
     SubjectCrossSectionalFacts,
     materialize_cross_sectional_facts,
 )
-from domain import CanonicalInstrumentIdentity, CanonicalReturnObservation, UnknownReason
+from domain import (
+    CanonicalInstrumentIdentity,
+    CanonicalReturnObservation,
+    SectorClassification,
+    SecurityAssetType,
+    UnknownReason,
+)
 from strategy_runtime.comparison_universe import (
-    ASSET_TYPE_BY_INSTRUMENT,
-    SECTOR_BY_INSTRUMENT,
     approved_sector_id,
     select_comparison_universe_returns,
     select_sector_reference_returns,
@@ -33,20 +38,22 @@ def _instrument(symbol: str) -> CanonicalInstrumentIdentity:
 
 def _selected_inputs(
     returns: tuple[CanonicalReturnObservation, ...],
+    asset_types: Mapping[CanonicalInstrumentIdentity, SecurityAssetType],
+    sectors: Mapping[CanonicalInstrumentIdentity, SectorClassification],
 ) -> tuple[CrossSectionalFactInputs, ...]:
     selected: list[CrossSectionalFactInputs] = []
     for item in returns:
         subject = item.instrument
         period = (item.period_start, item.period_end)
         comparison = select_comparison_universe_returns(
-            subject, period, returns, ASSET_TYPE_BY_INSTRUMENT
+            subject, period, returns, asset_types
         )
-        sector = select_sector_reference_returns(subject, period, SECTOR_BY_INSTRUMENT, returns)
-        if subject not in ASSET_TYPE_BY_INSTRUMENT:
+        sector = select_sector_reference_returns(subject, period, sectors, returns)
+        if subject not in asset_types:
             comparison_reason = "missing_instrument_class"
         else:
             comparison_reason = "insufficient_comparison_cohort"
-        subject_sector = SECTOR_BY_INSTRUMENT.get(subject)
+        subject_sector = sectors.get(subject)
         if subject_sector is None:
             sector_reason = "missing_sector_membership"
         elif approved_sector_id(subject_sector) is None:
@@ -68,8 +75,11 @@ def _selected_inputs(
 def compose_cross_subject_knowledge(
     knowledge_by_subject: dict[str, dict[str, ReadOnlyStrategyInput[object] | UnknownReason]],
     registry: SubjectPreparationRegistry[object],
+    *,
+    asset_types: Mapping[CanonicalInstrumentIdentity, SecurityAssetType],
+    sectors: Mapping[CanonicalInstrumentIdentity, SectorClassification],
 ) -> CrossSubjectKnowledgeResult:
-    """Materialize each declared evidence family once, then bind by callback."""
+    """Materialize each declared family once from injected canonical classifications."""
 
     result = {subject: dict(values) for subject, values in knowledge_by_subject.items()}
     family_entries: dict[str, list[tuple[str, str, ReadOnlyStrategyInput[object]]]] = {}
@@ -105,7 +115,7 @@ def compose_cross_subject_knowledge(
         if not returns:
             continue
         materialized = materialize_cross_sectional_facts(
-            _selected_inputs(returns),
+            _selected_inputs(returns, asset_types, sectors),
             effective_time=max(item.effective_time for item in returns),
         )
         by_subject = {item.subject: item for item in materialized}

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -211,8 +211,9 @@ def test_default_scheduled_cycle_uses_bounded_sp500_cohort(
     monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
     caplog.set_level(logging.INFO)
     slot = SessionRefreshSchedule().slots_for(date(2026, 8, 17))[0]
+    repository = InMemoryLatestResultRepository()
     outcomes = run_scheduled_refresh(
-        repository=InMemoryLatestResultRepository(),
+        repository=repository,
         history_repository=InMemoryObservationHistoryRepository(),
         acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
         historical_skew_repository=_RecordingHistoricalSkewRepository(),
@@ -232,6 +233,14 @@ def test_default_scheduled_cycle_uses_bounded_sp500_cohort(
     assert selection.source_revision_id == 1369213082
     assert selection.cohort_count == 17
     assert selection.subject_count == 30
+    expanded_symbol = next(
+        symbol
+        for _strategy_id, symbol in scheduled_sp500_universe(slot)
+        if symbol not in APPROVED_LIVE_UNIVERSE
+    )
+    skew = repository.get_one("skew_momentum", expanded_symbol)
+    assert skew is not None
+    assert skew.metrics["derived_fact.cross_sectional_percentile"].native() != "UNKNOWN"
 
 
 def test_no_enabled_provider_raises(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1330,6 +1339,9 @@ def test_production_universe_topology_has_no_universal_preparation_failure(
     assert any(
         item.startswith("derived_fact:sector_relative_momentum:") for item in skew.provenance
     )
+    legacy_etf = repository.get_one("skew_momentum", "SPY")
+    assert legacy_etf is not None
+    assert legacy_etf.metrics["derived_fact.cross_sectional_percentile"].native() != "UNKNOWN"
 
 
 def test_ff_and_skew_results_are_unaffected_by_whether_earnings_shares_the_cycle(

--- a/tests/screening/test_universe_membership.py
+++ b/tests/screening/test_universe_membership.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from datetime import date
 
-from screening.universe_membership import SP500_MEMBERSHIP
+import pytest
+
+from domain import CanonicalInstrumentIdentity, SecurityAssetType
+from screening.universe_membership import (
+    SP500_MEMBERSHIP,
+    canonical_equity_classifications,
+)
 
 
 def test_sp500_snapshot_is_effective_dated_and_source_pinned() -> None:
@@ -24,3 +30,15 @@ def test_existing_canonical_symbol_identity_is_sufficient() -> None:
     # Membership needs no parallel security identity. Even multi-class/dotted
     # symbols remain opaque normalized values under the existing symbol scheme.
     assert SP500_MEMBERSHIP.by_symbol["BRK.B"].security_name == "Berkshire Hathaway"
+
+
+def test_snapshot_projects_every_member_to_immutable_canonical_classification() -> None:
+    classifications = canonical_equity_classifications(SP500_MEMBERSHIP)
+    spgi = CanonicalInstrumentIdentity("symbol", "SPGI")
+
+    assert len(classifications.asset_types) == 503
+    assert len(classifications.sectors) == 503
+    assert classifications.asset_types[spgi] is SecurityAssetType.EQUITY
+    assert classifications.sectors[spgi].code == "40"
+    with pytest.raises(TypeError):
+        classifications.asset_types[spgi] = SecurityAssetType.ETF  # type: ignore[index]

--- a/tests/strategy_runtime/test_cross_subject_knowledge.py
+++ b/tests/strategy_runtime/test_cross_subject_knowledge.py
@@ -8,8 +8,14 @@ from domain import (
     CanonicalReturnObservation,
     EvidenceKind,
     EvidenceReference,
+    UnknownReason,
 )
 from screening.subject_planning import SubjectPlanConsumer
+from screening.universe_membership import SP500_MEMBERSHIP, canonical_equity_classifications
+from strategy_runtime.comparison_universe import (
+    ASSET_TYPE_BY_INSTRUMENT,
+    SECTOR_BY_INSTRUMENT,
+)
 from strategy_runtime.cross_subject_knowledge import compose_cross_subject_knowledge
 from strategy_runtime.knowledge import ReadOnlyStrategyInput
 from strategy_runtime.subject_preparation import (
@@ -63,7 +69,7 @@ def _bind(knowledge: ReadOnlyStrategyInput[object], facts: object) -> ReadOnlySt
 
 def _binding(consumer_id: str) -> SubjectPreparationBinding[object]:
     return SubjectPreparationBinding(
-        SubjectPlanConsumer(consumer_id, (), lambda _evidence: None),  # type: ignore[arg-type]
+        SubjectPlanConsumer(consumer_id, (), lambda _evidence: None),  # type: ignore[arg-type,return-value]
         lambda *_args: None,  # type: ignore[arg-type]
         lambda _knowledge: lambda _context: None,  # type: ignore[arg-type,return-value]
         "twenty_session_return_v1",
@@ -85,7 +91,9 @@ def test_two_consumers_share_one_order_independent_materialization() -> None:
     registry = SubjectPreparationRegistry(
         (("consumer_a", _binding("consumer_a")), ("consumer_b", _binding("consumer_b")))
     )
-    knowledge = {
+    knowledge: dict[
+        str, dict[str, ReadOnlyStrategyInput[object] | UnknownReason]
+    ] = {
         symbol: {
             "consumer_a": _knowledge(_observation(symbol, value)),
             "consumer_b": _knowledge(_observation(symbol, value)),
@@ -93,7 +101,12 @@ def test_two_consumers_share_one_order_independent_materialization() -> None:
         for symbol, value in reversed(tuple(returns.items()))
     }
 
-    result = compose_cross_subject_knowledge(knowledge, registry)
+    result = compose_cross_subject_knowledge(
+        knowledge,
+        registry,
+        asset_types=ASSET_TYPE_BY_INSTRUMENT,
+        sectors=SECTOR_BY_INSTRUMENT,
+    )
 
     assert result.materialization_count_by_family == (("twenty_session_return_v1", 1),)
     first = result.knowledge_by_subject["AAPL"]["consumer_a"]
@@ -102,3 +115,43 @@ def test_two_consumers_share_one_order_independent_materialization() -> None:
     assert isinstance(second, ReadOnlyStrategyInput)
     assert first.derived_facts == second.derived_facts
     assert len(first.derived_facts.facts) == 2
+
+
+def test_new_membership_subject_needs_no_runtime_symbol_table_or_consumer_change() -> None:
+    returns = {
+        "SPGI": "0.06",
+        "AAPL": "0.05",
+        "MSFT": "0.04",
+        "NVDA": "0.03",
+        "AVGO": "0.02",
+        "MU": "0.01",
+        "XLF": "0.025",
+    }
+    registry = SubjectPreparationRegistry(
+        (("consumer_a", _binding("consumer_a")), ("consumer_b", _binding("consumer_b")))
+    )
+    knowledge: dict[
+        str, dict[str, ReadOnlyStrategyInput[object] | UnknownReason]
+    ] = {
+        symbol: {
+            "consumer_a": _knowledge(_observation(symbol, value)),
+            "consumer_b": _knowledge(_observation(symbol, value)),
+        }
+        for symbol, value in reversed(tuple(returns.items()))
+    }
+    classifications = canonical_equity_classifications(SP500_MEMBERSHIP)
+
+    result = compose_cross_subject_knowledge(
+        knowledge,
+        registry,
+        asset_types=classifications.asset_types,
+        sectors=classifications.sectors,
+    )
+
+    first = result.knowledge_by_subject["SPGI"]["consumer_a"]
+    second = result.knowledge_by_subject["SPGI"]["consumer_b"]
+    assert isinstance(first, ReadOnlyStrategyInput)
+    assert isinstance(second, ReadOnlyStrategyInput)
+    assert first.derived_facts == second.derived_facts
+    assert len(first.derived_facts.facts) == 2
+    assert result.materialization_count_by_family == (("twenty_session_return_v1", 1),)

--- a/tests/strategy_runtime/test_strat_proof_001.py
+++ b/tests/strategy_runtime/test_strat_proof_001.py
@@ -26,6 +26,10 @@ from domain import (
 )
 from market_data.snapshot import MarketSnapshot
 from screening.subject_planning import ResolvedEvidenceView, SubjectPlanConsumer
+from strategy_runtime.comparison_universe import (
+    ASSET_TYPE_BY_INSTRUMENT,
+    SECTOR_BY_INSTRUMENT,
+)
 from strategy_runtime.context import RuntimeContext
 from strategy_runtime.cross_subject_knowledge import compose_cross_subject_knowledge
 from strategy_runtime.execution import ExecutionStatus, run_strategies
@@ -151,6 +155,8 @@ def _compose(
     result = compose_cross_subject_knowledge(
         knowledge,
         SubjectPreparationRegistry(entries),
+        asset_types=ASSET_TYPE_BY_INSTRUMENT,
+        sectors=SECTOR_BY_INSTRUMENT,
     )
     return (
         {


### PR DESCRIPTION
## Ticket
UNI-03-XFACT-CORRECTIVE; assigned Worker: implementation-worker. Manager stop status: CLEAR. Continues #344 under Architect-approved dependency injection.

## Symptom / A-B trace
Known-good AAPL and affected SPGI both exist in the effective-dated S&P membership snapshot. AAPL existed in legacy strategy-runtime classification maps; SPGI did not. Classification lookup was the first divergence, before materialization, causing peer count 0 and typed UNKNOWN.

## Root cause
`compose_cross_subject_knowledge()` silently owned legacy 30-symbol classification maps instead of receiving canonical active-universe classifications.

## Correction
- Project typed equity membership into immutable canonical asset-type and GICS-sector mappings.
- Use one taxonomy-level GICS sector-name-to-code translation at the membership boundary; no symbol-sector table or inference.
- Require generic cross-subject composition callers to inject classifications.
- Production S&P membership is authoritative. Explicit root-level compatibility remains only for non-member legacy topology symbols; no generic fallback.
- Existing formulas, fact IDs/versions, typed UNKNOWN semantics, provider behavior, staged bounds, and strategies remain unchanged.

## Acceptance proof
- Expanded scheduled subject receives numeric cross-sectional fact.
- SPGI plus aligned XLF benchmark receives cross-sectional and sector-relative facts.
- Two consumers receive identical facts with one family materialization.
- New canonical members require no strategy-runtime symbol-table or strategy edits.
- Registration-order, fourth-strategy, replay, old 30-symbol, and ETF compatibility regressions remain green.

## UDR
Separate root proven: non-positive Forward Factor forward variance aborts shared preparation. Tracked in #345; not folded into this corrective.

## Validation
- Focused/broad scope: 1,020 passed
- Full suite: 3,242 passed, 45 skipped, 3 existing deprecation warnings
- Product-CI Ruff scope: green
- Changed-scope Ruff: green
- Product-CI mypy scope: green
- Changed-scope strict mypy: green
- Lean pre-push: green
- `git diff --check`: green
- Worker self-review: complete

## Auto-merge authority
In-scope UNI-03 corrective under active UNIVERSE-001 delegation and explicit Architect approval on #344. No branch protection bypass. Production re-verification remains required after merge.
