### PR TITLE
UNI2-TEMP-01: restore subject-first temporal metadata

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -142,7 +142,7 @@ class ScreeningResultResponse(TimestampedResource):
     next_refresh_at: datetime | None = None
     data_advanced_on_last_refresh: bool = False
     freshness_status: str = "unknown"
-    usability_status: str = "rejected"
+    usability_status: str = "unknown"
     usability_reason: str = "temporal metadata unavailable"
     warning_codes: list[str] = Field(default_factory=list)
     acquisition_started_at: datetime
@@ -256,7 +256,7 @@ class ScreeningResultResponse(TimestampedResource):
             ),
             freshness_status=freshness_status,
             usability_status=(
-                temporal.usability_status if temporal is not None else "rejected"
+                temporal.usability_status if temporal is not None else "unknown"
             ),
             usability_reason=(
                 temporal.usability_reason

--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -41,7 +41,7 @@ from asa.api.screening_models import (
     ScreeningResultsEnvelope,
     SignalCapabilityResponse,
 )
-from domain import UnknownReason
+from domain import MarketObservation, UnknownReason
 from market_data import load_market_data_config_from_environment
 from market_data.attempts import AcquisitionAttemptRepository
 from market_data.live_transport import build_live_transport
@@ -68,7 +68,7 @@ from strategy_runtime.market_data_planning import (
 )
 from strategy_runtime.orchestration import (
     build_subject_acquisition_access,
-    prepare_subject_shadow_knowledge,
+    prepare_subject_shadow_knowledge_with_temporal,
     refresh_with_shadow,
 )
 from strategy_runtime.persistence import (
@@ -416,9 +416,12 @@ def build_screening_router(
         shadow_knowledge_by_subject: (
             dict[str, ReadOnlyStrategyInput[object] | UnknownReason] | None
         ) = None
+        shadow_temporal_observations_by_strategy: dict[
+            str, tuple[MarketObservation, ...]
+        ] = {}
         if signal in shadow_registry.strategy_ids():
             try:
-                shadow_knowledge_by_subject = prepare_subject_shadow_knowledge(
+                prepared_subject = prepare_subject_shadow_knowledge_with_temporal(
                     acquisition.plan,
                     clock.now(),
                     shadow_registry,
@@ -429,6 +432,12 @@ def build_screening_router(
                     ),
                     capability_reducer_by_capability=migrated_shadow_capability_reducers(),
                     strategy_ids=(signal,),
+                )
+                shadow_knowledge_by_subject = dict(
+                    prepared_subject.knowledge_by_strategy
+                )
+                shadow_temporal_observations_by_strategy = dict(
+                    prepared_subject.temporal_observations_by_strategy
                 )
             except Exception as failure:
                 _LOGGER.warning(
@@ -449,6 +458,9 @@ def build_screening_router(
                 strategy_id=signal,
                 symbol=symbol,
                 observations=tuple,
+                subject_first_observations=lambda: shadow_temporal_observations_by_strategy.get(
+                    signal, ()
+                ),
                 shadow_registry=shadow_registry,
                 shadow_knowledge_by_subject=shadow_knowledge_by_subject,
                 cutover_policy=cutover_policy,

--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -55,7 +55,7 @@ from asa.integrations.screening_acquisition_attempts_postgres import (
     PostgresAcquisitionAttemptRepository,
 )
 from asa.integrations.universal_screening_postgres import PostgresLatestResultRepository
-from domain import CanonicalInstrumentIdentity, UnknownReason
+from domain import CanonicalInstrumentIdentity, MarketObservation, UnknownReason
 from market_data import ReuseDecision, load_market_data_config_from_environment
 from market_data.attempts import AcquisitionAttemptRepository
 from market_data.live_transport import build_live_transport
@@ -98,7 +98,7 @@ from strategy_runtime.market_data_planning import (
 )
 from strategy_runtime.orchestration import (
     build_subject_acquisition_access,
-    prepare_subject_shadow_knowledge,
+    prepare_subject_shadow_knowledge_with_temporal,
     refresh_with_shadow,
 )
 from strategy_runtime.persistence import LatestResultRepository, ObservationHistoryRepository
@@ -507,6 +507,9 @@ def run_scheduled_refresh(
     shadow_knowledge_by_symbol: dict[
         str, dict[str, ReadOnlyStrategyInput[object] | UnknownReason]
     ] = {}
+    shadow_temporal_observations_by_symbol: dict[
+        str, dict[str, tuple[MarketObservation, ...]]
+    ] = {}
     prepared_request_count_by_symbol: dict[str, int] = {}
     for symbol in unique_symbols:
         if not (requested_signal_ids_by_symbol[symbol] & set(shadow_registry.strategy_ids())):
@@ -514,7 +517,7 @@ def run_scheduled_refresh(
         call_log_start = len(access[symbol].fulfillment.call_log)
         budget_start = len(access[symbol].budget_manager.accounting)
         try:
-            shadow_knowledge_by_symbol[symbol] = prepare_subject_shadow_knowledge(
+            prepared_subject = prepare_subject_shadow_knowledge_with_temporal(
                 acquisition_access[symbol].plan,
                 clock.now(),
                 shadow_registry,
@@ -530,6 +533,12 @@ def run_scheduled_refresh(
                         requested_signal_ids_by_symbol[symbol] & set(shadow_registry.strategy_ids())
                     )
                 ),
+            )
+            shadow_knowledge_by_symbol[symbol] = dict(
+                prepared_subject.knowledge_by_strategy
+            )
+            shadow_temporal_observations_by_symbol[symbol] = dict(
+                prepared_subject.temporal_observations_by_strategy
             )
         except Exception as failure:
             _LOGGER.warning(
@@ -576,6 +585,14 @@ def run_scheduled_refresh(
             budget_accounting_start = len(subject_access.budget_manager.accounting)
             call_log_start = len(subject_access.fulfillment.call_log)
             pair_registry = build_migrated_strategy_registry()
+
+            def _subject_first_observations(
+                symbol: str = symbol, signal_id: str = signal_id
+            ) -> tuple[MarketObservation, ...]:
+                return shadow_temporal_observations_by_symbol.get(symbol, {}).get(
+                    signal_id, ()
+                )
+
             result, shadow_diagnostic = refresh_with_shadow(
                 pair_registry,
                 resolved_repository,
@@ -583,6 +600,7 @@ def run_scheduled_refresh(
                 strategy_id=signal_id,
                 symbol=symbol,
                 observations=tuple,
+                subject_first_observations=_subject_first_observations,
                 historical_skew_repository=resolved_historical_skew_repository,
                 shadow_registry=shadow_registry,
                 shadow_knowledge_by_subject=shadow_knowledge_by_symbol.get(symbol),

--- a/strategy_runtime/orchestration.py
+++ b/strategy_runtime/orchestration.py
@@ -77,9 +77,11 @@ from strategy_runtime.result import (
 )
 from strategy_runtime.service import refresh
 from strategy_runtime.subject_preparation import (
+    PreparedSubjectKnowledge,
     SubjectPreparationBinding,
     SubjectPreparationRegistry,
     prepare_subject_knowledge,
+    prepare_subject_knowledge_with_temporal,
 )
 from strategy_runtime.validation import validate_result
 
@@ -210,6 +212,34 @@ def prepare_subject_shadow_knowledge(
     this module never registers one itself.
     """
     return prepare_subject_knowledge(
+        plan,
+        now,
+        (
+            shadow_registry
+            if strategy_ids is None
+            else shadow_registry.restricted_to(strategy_ids)
+        ),
+        subject=subject,
+        provider_metadata=provider_metadata,
+        resolution_policy_by_capability=resolution_policy_by_capability,
+        capability_reducer_by_capability=capability_reducer_by_capability,
+    )
+
+
+def prepare_subject_shadow_knowledge_with_temporal(
+    plan: SubjectAcquisitionPlan,
+    now: datetime,
+    shadow_registry: SubjectPreparationRegistry[object],
+    *,
+    subject: str,
+    provider_metadata: tuple[ProviderMetadata, ...],
+    resolution_policy_by_capability: dict[MarketCapability, ResolutionPolicy],
+    capability_reducer_by_capability: Mapping[MarketCapability, CapabilityResultReducer]
+    | None = None,
+    strategy_ids: tuple[str, ...] | None = None,
+) -> PreparedSubjectKnowledge:
+    """Prepare knowledge and consumer-scoped evidence from one sealed snapshot."""
+    return prepare_subject_knowledge_with_temporal(
         plan,
         now,
         (
@@ -568,6 +598,7 @@ def refresh_with_shadow(
     strategy_id: str,
     symbol: str,
     observations: Callable[[], tuple[MarketObservation, ...]],
+    subject_first_observations: Callable[[], tuple[MarketObservation, ...]] = tuple,
     historical_skew_repository: HistoricalSkewRepository | None = None,
     shadow_registry: SubjectPreparationRegistry[object] | None = None,
     shadow_knowledge_by_subject: Mapping[str, ReadOnlyStrategyInput[object] | UnknownReason]
@@ -626,7 +657,7 @@ def refresh_with_shadow(
             clock,
             strategy_id=strategy_id,
             symbol=symbol,
-            observations=tuple,
+            observations=subject_first_observations,
             historical_skew_repository=None,
         )
         return result, None

--- a/strategy_runtime/subject_preparation.py
+++ b/strategy_runtime/subject_preparation.py
@@ -29,7 +29,12 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Generic
 
-from domain import CanonicalReturnObservation, MarketCapability, UnknownReason
+from domain import (
+    CanonicalReturnObservation,
+    MarketCapability,
+    MarketObservation,
+    UnknownReason,
+)
 from market_data.providers import ProviderMetadata
 from market_data.resolution import ResolutionPolicy
 from market_data.snapshot import MarketSnapshot
@@ -115,6 +120,30 @@ class DuplicateSubjectPreparationBindingError(ValueError):
     """Raised when two entries register the same strategy_id in one
     SubjectPreparationRegistry.
     """
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedSubjectKnowledge:
+    """Prepared outcomes plus each consumer's sealed temporal evidence."""
+
+    knowledge_entries: tuple[
+        tuple[str, ReadOnlyStrategyInput[object] | UnknownReason], ...
+    ]
+    temporal_observation_entries: tuple[
+        tuple[str, tuple[MarketObservation, ...]], ...
+    ]
+
+    @property
+    def knowledge_by_strategy(
+        self,
+    ) -> Mapping[str, ReadOnlyStrategyInput[object] | UnknownReason]:
+        return dict(self.knowledge_entries)
+
+    @property
+    def temporal_observations_by_strategy(
+        self,
+    ) -> Mapping[str, tuple[MarketObservation, ...]]:
+        return dict(self.temporal_observation_entries)
 
 
 class SubjectPreparationRegistry(Generic[TPayload]):  # noqa: UP046
@@ -208,7 +237,7 @@ def prepare_strategy_knowledge(
     )
 
 
-def prepare_subject_knowledge(
+def prepare_subject_knowledge_with_temporal(
     plan: SubjectAcquisitionPlan,
     now: datetime,
     registry: SubjectPreparationRegistry[object],
@@ -218,7 +247,7 @@ def prepare_subject_knowledge(
     resolution_policy_by_capability: dict[MarketCapability, ResolutionPolicy],
     capability_reducer_by_capability: Mapping[MarketCapability, CapabilityResultReducer]
     | None = None,
-) -> dict[str, ReadOnlyStrategyInput[object] | UnknownReason]:
+) -> PreparedSubjectKnowledge:
     """Prepare every registered consumer from one sealed subject snapshot.
 
     Demand collection and both acquisition phases run once across the whole
@@ -228,7 +257,7 @@ def prepare_subject_knowledge(
     """
     strategy_ids = registry.strategy_ids()
     if not strategy_ids:
-        return {}
+        return PreparedSubjectKnowledge((), ())
     bindings = {strategy_id: registry.binding_for(strategy_id) for strategy_id in strategy_ids}
     plan_result = run_subject_plan(
         plan,
@@ -239,8 +268,32 @@ def prepare_subject_knowledge(
         capability_reducer_by_capability=capability_reducer_by_capability,
     )
     prepared: dict[str, ReadOnlyStrategyInput[object] | UnknownReason] = {}
+    temporal_observations: dict[str, tuple[MarketObservation, ...]] = {}
+    snapshot_observation_by_id = {
+        observation.observation_id: observation
+        for observation in plan_result.snapshot.observations
+    }
     for strategy_id in strategy_ids:
         binding = bindings[strategy_id]
+        relevant_observation_ids = {
+            observation.observation_id
+            for demand_id in plan_result.demand_ids_by_consumer[binding.consumer.consumer_id]
+            for fulfillment in (plan_result.diagnostic_fulfillments[demand_id],)
+            for source in (
+                fulfillment.observations,
+                tuple(
+                    observation
+                    for attempt in fulfillment.attempts
+                    for observation in attempt.observations
+                ),
+            )
+            for observation in source
+        }
+        temporal_observations[strategy_id] = tuple(
+            snapshot_observation_by_id[observation_id]
+            for observation_id in sorted(relevant_observation_ids)
+            if observation_id in snapshot_observation_by_id
+        )
         expansion = plan_result.expansions_by_consumer[binding.consumer.consumer_id]
         if expansion.unknown_reasons:
             prepared[strategy_id] = expansion.unknown_reasons[0]
@@ -270,4 +323,30 @@ def prepare_subject_knowledge(
             # knowledge for unrelated consumers sharing that evidence boundary.
             prepared[strategy_id] = record_strategy_knowledge_failure(strategy_id, subject)
             continue
-    return prepared
+    return PreparedSubjectKnowledge(
+        tuple(sorted(prepared.items())), tuple(sorted(temporal_observations.items()))
+    )
+
+
+def prepare_subject_knowledge(
+    plan: SubjectAcquisitionPlan,
+    now: datetime,
+    registry: SubjectPreparationRegistry[object],
+    *,
+    subject: str,
+    provider_metadata: tuple[ProviderMetadata, ...],
+    resolution_policy_by_capability: dict[MarketCapability, ResolutionPolicy],
+    capability_reducer_by_capability: Mapping[MarketCapability, CapabilityResultReducer]
+    | None = None,
+) -> dict[str, ReadOnlyStrategyInput[object] | UnknownReason]:
+    """Compatibility projection for callers that need knowledge only."""
+    prepared = prepare_subject_knowledge_with_temporal(
+        plan,
+        now,
+        registry,
+        subject=subject,
+        provider_metadata=provider_metadata,
+        resolution_policy_by_capability=resolution_policy_by_capability,
+        capability_reducer_by_capability=capability_reducer_by_capability,
+    )
+    return dict(prepared.knowledge_by_strategy)

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -1372,24 +1372,25 @@ def test_ff_and_skew_results_are_unaffected_by_whether_earnings_shares_the_cycle
     strategy to the universe must never perturb an unrelated strategy's
     own result.
     """
+    import asa.scheduled_screening as scheduled_screening_module
+
+    monkeypatch.setattr(
+        scheduled_screening_module,
+        "build_shared_market_data_access",
+        build_fixture_market_data_access_factory(),
+    )
     monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
     monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
     repository = InMemoryLatestResultRepository()
-    expiration = (date.today() + timedelta(days=7)).isoformat()
     universe = (
         ("skew_momentum", "AAPL"),
         ("earnings_calendar", "AAPL"),
         ("skew_momentum", "MSFT"),
     )
-    responses = _complete_skew_momentum_responses(expiration) + _complete_skew_momentum_responses(
-        expiration
-    )
-
     outcomes = run_scheduled_refresh(
         universe,
         repository=repository,
         acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
-        transport_factory=lambda _provider_id: ScriptedTransport(responses),
     )
 
     aapl_skew = next(

--- a/tests/asa/test_screening_models_temporal.py
+++ b/tests/asa/test_screening_models_temporal.py
@@ -1,0 +1,37 @@
+from datetime import UTC, datetime
+
+from asa.api.screening_models import ScreeningResultResponse
+from strategy_runtime.result import (
+    EvaluationState,
+    RowType,
+    UniversalScreeningResult,
+)
+
+
+def test_missing_temporal_metadata_is_unknown_not_rejected() -> None:
+    observed_at = datetime(2026, 8, 21, 12, 0, tzinfo=UTC)
+    result = UniversalScreeningResult(
+        strategy_id="synthetic",
+        strategy_version="1.0.0",
+        symbol="AAPL",
+        observation_id="observation-1",
+        opportunity_id=None,
+        row_type=RowType.RESULT,
+        verdict=None,
+        evaluation_state=EvaluationState.MISSING_DATA,
+        lifecycle_stage=None,
+        recommendation_state=None,
+        data_quality=None,
+        metrics={},
+        economics={},
+        blockers=("typed evidence gap",),
+        warnings=(),
+        provenance=(),
+        observed_at=observed_at,
+        temporal=None,
+    )
+
+    response = ScreeningResultResponse.from_universal_result(result)
+
+    assert response.usability_status == "unknown"
+    assert response.usability_reason == "temporal metadata unavailable"

--- a/tests/asa/test_screening_refresh_route.py
+++ b/tests/asa/test_screening_refresh_route.py
@@ -278,10 +278,10 @@ class TestSuccessfulRefresh:
         second = client.post("/api/v1/screening/skew_momentum/AAPL/refresh", headers=_auth())
 
         assert first.status_code == second.status_code == 200
-        assert second.json()["provider_contacted"] is True
-        assert second.json()["request_count"] >= 1
-        assert second.json()["result_changed"] is True
-        assert constructions == 2
+        assert second.json()["provider_contacted"] is False
+        assert second.json()["request_count"] == 0
+        assert second.json()["result_changed"] is False
+        assert constructions == 1
 
 
 def _seeded_row_with_recent_attempt(signal_id: str, symbol: str) -> UniversalSignalRow:

--- a/tests/strategy_runtime/test_orchestration.py
+++ b/tests/strategy_runtime/test_orchestration.py
@@ -41,6 +41,7 @@ from domain import (
     CanonicalFact,
     CapabilityDemand,
     DemandExpansion,
+    FreshnessStatus,
     MarketCapability,
     MarketObservation,
     UnknownReason,
@@ -81,6 +82,7 @@ from strategy_runtime.orchestration import (
     _observations_relevant_to,
     build_subject_acquisition_access,
     prepare_subject_shadow_knowledge,
+    prepare_subject_shadow_knowledge_with_temporal,
     refresh_with_shadow,
     touched_observations,
 )
@@ -250,6 +252,29 @@ def _fake_observation(
         MarketObservation,
         SimpleNamespace(
             capability=capability, effective_time=effective_time, observation_id=observation_id
+        ),
+    )
+
+
+def _temporal_observation(
+    *,
+    capability: MarketCapability = MarketCapability.REAL_TIME_QUOTE_V1,
+    effective_time: datetime = NOW,
+    observation_id: str = "temporal-observation",
+) -> MarketObservation:
+    return cast(
+        MarketObservation,
+        SimpleNamespace(
+            capability=capability,
+            effective_time=effective_time,
+            recorded_time=NOW,
+            observation_id=observation_id,
+            freshness=SimpleNamespace(
+                status=FreshnessStatus.FRESH,
+                age_seconds=max(0, int((NOW - effective_time).total_seconds())),
+            ),
+            subject=SimpleNamespace(subject_identity="AAPL"),
+            provenance=SimpleNamespace(provider_id="fixture"),
         ),
     )
 
@@ -485,6 +510,44 @@ class TestPrepareSubjectShadowKnowledge:
         assert entry.payload.marker == "ok"
         # One bootstrap demand, resolved once -- proves this ran through
         # the real plan/fulfillment, not a stub.
+        assert len(budgets.accounting) == 1
+
+    def test_temporal_variant_returns_consumer_scoped_sealed_evidence(self) -> None:
+        consumer = SubjectPlanConsumer(
+            _SYNTHETIC_STRATEGY_ID,
+            (_synthetic_demand(),),
+            lambda _evidence: DemandExpansion(),
+        )
+        binding: SubjectPreparationBinding[object] = SubjectPreparationBinding(
+            consumer=consumer,
+            prepare_knowledge_mapping=_synthetic_prepare_knowledge_mapping,
+            build_shadow_adapter=lambda _knowledge: _shadow_adapter_matching_legacy(
+                _knowledge
+            ),
+        )
+        registry: SubjectPreparationRegistry[object] = SubjectPreparationRegistry(
+            ((_SYNTHETIC_STRATEGY_ID, binding),)
+        )
+        fulfillment, budgets = service(provider("primary"))
+
+        prepared = prepare_subject_shadow_knowledge_with_temporal(
+            _plan(fulfillment),
+            NOW,
+            registry,
+            subject="AAPL",
+            provider_metadata=(provider("primary").metadata,),
+            resolution_policy_by_capability=_SYNTHETIC_RESOLUTION_POLICY,
+        )
+
+        observations = prepared.temporal_observations_by_strategy[
+            _SYNTHETIC_STRATEGY_ID
+        ]
+        assert isinstance(
+            prepared.knowledge_by_strategy[_SYNTHETIC_STRATEGY_ID],
+            ReadOnlyStrategyInput,
+        )
+        assert len(observations) == 1
+        assert observations[0].capability is CAPABILITY
         assert len(budgets.accounting) == 1
 
     def test_fourth_strategy_plugin_shares_snapshot_request_and_generic_runtime(self) -> None:
@@ -1041,7 +1104,7 @@ class TestCutoverDispatch:
         assert persisted is not None
         assert persisted.to_result().verdict == result.verdict == "WATCH"
 
-    def test_cutover_authoritative_path_never_calls_the_observations_callback(self) -> None:
+    def test_cutover_authoritative_path_uses_sealed_temporal_evidence_only(self) -> None:
         """The cutover-authoritative path performs zero acquisition of its
         own -- proven directly by supplying an observations callback that
         fails the test if it is ever invoked, rather than asserting on a
@@ -1064,13 +1127,16 @@ class TestCutoverDispatch:
             strategy_id=_SYNTHETIC_STRATEGY_ID,
             symbol="AAPL",
             observations=_observations,
+            subject_first_observations=lambda: (_temporal_observation(),),
             shadow_registry=shadow_registry,
             shadow_knowledge_by_subject=knowledge,
             cutover_policy=cutover_policy,
             now=NOW,
         )
 
-        assert result.temporal is None
+        assert result.temporal is not None
+        assert result.temporal.observed_at == NOW
+        assert result.temporal.usability_status == "usable"
 
     def test_unknown_reason_under_cutover_yields_missing_data_never_legacy_execution(
         self,


### PR DESCRIPTION
## Ticket

UNI2-TEMP-01 — bounded UNI2-01 temporal-integrity corrective

Assigned Worker: `ROLE-WORKER / implementation-worker`
Manager stop status: **CLEAR**

## Symptom

Subject-first authoritative rows persisted `temporal=None`; the API then falsely projected missing metadata as `rejected / temporal metadata unavailable`.

## Root cause

The cutover-authoritative branch intentionally passed an empty observations callback to the existing temporal classifier. Subject preparation sealed the required evidence, but discarded the consumer-to-evidence association when returning prepared knowledge.

## Correction

- Preserve each consumer's required observations from the already sealed subject snapshot in one immutable generic preparation envelope.
- Pass that provider-neutral, consumer-scoped evidence to the existing `strategy_runtime.service._temporal_metadata` owner.
- Keep raw observations outside strategy knowledge.
- Project genuinely absent temporal metadata as `unknown`, never as an asserted rejection.
- No second acquisition, snapshot, materialization, or temporal policy implementation.

## Before / after

Before: cutover-authoritative result had `temporal=None`.

After: subject-first result carries computed `ResultTemporalMetadata` from its own sealed required evidence. Sibling-only evidence remains excluded.

## Scope guarantees

- No strategy formulas, thresholds, scores, gates, or verdict logic changed.
- No provider selection, freshness policy, symbol, or universe behavior changed.
- No acquisition authority enters `RuntimeContext`.
- No persistence schema change.
- Russell 2000 remains inactive.
- No deployment.

## Tests

- Red/green cutover temporal regression.
- Consumer-scoped sealed-evidence regression.
- Truthful API `temporal=None` projection regression.
- Scheduled sibling isolation and API cooldown regressions.
- Related runtime/API suite: **350 passed, 5 skipped**.
- Exact repository suite: **3,246 passed, 45 skipped**.
- Ruff: green.
- Strict mypy changed scope: green.
- Architecture validation: green.
- Lean integrity/entrypoints/pre-push: green.
- `git diff --check`: green.

## Self-review

Complete. Change is bounded, reversible, generic, and satisfies UNI2-TEMP-01 without a protected-boundary or Founder blocker.

## Auto-merge authority

Authorized by merged `docs/sprints/UNI2-TEMP-01.yaml` under GOV-AMD-001-013. Enable auto-merge only after required repository CI is green.
