### PR TITLE
FRESH-01: oldest-first bounded subject scheduler

### DIFF
--- a/asa/integrations/refresh_schedule_postgres.py
+++ b/asa/integrations/refresh_schedule_postgres.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from collections.abc import Sequence
+from datetime import datetime, timedelta
 
 from sqlalchemy import Engine, text
 
@@ -23,3 +24,94 @@ class PostgresRefreshScheduleClaimRepository:
                 {"slot_id": slot_id, "claimed_at": claimed_at},
             )
             return result.first() is not None
+
+
+class PostgresSubjectRefreshRepository:
+    """Atomic oldest-first subject claims shared by separate cron processes."""
+
+    def __init__(self, engine: Engine) -> None:
+        self._engine = engine
+
+    def claim_oldest(
+        self,
+        subject_ids: Sequence[str],
+        *,
+        claimed_at: datetime,
+        maximum_subjects: int,
+        lease: timedelta,
+    ) -> tuple[str, ...]:
+        if maximum_subjects < 1:
+            raise ValueError("maximum_subjects must be positive")
+        normalized = tuple(sorted(set(subject_ids)))
+        if not normalized:
+            return ()
+        with self._engine.begin() as connection:
+            connection.execute(
+                text("""
+                    INSERT INTO screening_subject_refresh_state (subject_id)
+                    SELECT unnest(CAST(:subject_ids AS text[]))
+                    ON CONFLICT (subject_id) DO NOTHING
+                """),
+                {"subject_ids": list(normalized)},
+            )
+            rows = connection.execute(
+                text("""
+                    WITH eligible AS (
+                        SELECT subject_id
+                        FROM screening_subject_refresh_state
+                        WHERE subject_id = ANY(CAST(:subject_ids AS text[]))
+                          AND (eligible_after IS NULL OR eligible_after <= :claimed_at)
+                          AND (claim_expires_at IS NULL OR claim_expires_at <= :claimed_at)
+                        ORDER BY last_completed_at ASC NULLS FIRST, subject_id ASC
+                        FOR UPDATE SKIP LOCKED
+                        LIMIT :maximum_subjects
+                    )
+                    UPDATE screening_subject_refresh_state AS state
+                    SET claimed_at = :claimed_at,
+                        claim_expires_at = :claim_expires_at
+                    FROM eligible
+                    WHERE state.subject_id = eligible.subject_id
+                    RETURNING state.subject_id
+                """),
+                {
+                    "subject_ids": list(normalized),
+                    "claimed_at": claimed_at,
+                    "claim_expires_at": claimed_at + lease,
+                    "maximum_subjects": maximum_subjects,
+                },
+            ).scalars()
+            return tuple(sorted(rows))
+
+    def complete(self, subject_id: str, *, completed_at: datetime, succeeded: bool) -> None:
+        with self._engine.begin() as connection:
+            if succeeded:
+                connection.execute(
+                    text("""
+                        UPDATE screening_subject_refresh_state
+                        SET last_completed_at = :completed_at,
+                            claimed_at = NULL,
+                            claim_expires_at = NULL,
+                            eligible_after = NULL,
+                            consecutive_failures = 0
+                        WHERE subject_id = :subject_id
+                    """),
+                    {"subject_id": subject_id, "completed_at": completed_at},
+                )
+                return
+            connection.execute(
+                text("""
+                    UPDATE screening_subject_refresh_state
+                    SET claimed_at = NULL,
+                        claim_expires_at = NULL,
+                        consecutive_failures = consecutive_failures + 1,
+                        eligible_after = :completed_at + (
+                            CASE
+                                WHEN consecutive_failures = 0 THEN INTERVAL '5 minutes'
+                                WHEN consecutive_failures = 1 THEN INTERVAL '15 minutes'
+                                ELSE INTERVAL '30 minutes'
+                            END
+                        )
+                    WHERE subject_id = :subject_id
+                """),
+                {"subject_id": subject_id, "completed_at": completed_at},
+            )

--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -50,6 +50,7 @@ from asa.integrations.observation_history_postgres import PostgresObservationHis
 from asa.integrations.postgres import create_postgres_engine
 from asa.integrations.refresh_schedule_postgres import (
     PostgresRefreshScheduleClaimRepository,
+    PostgresSubjectRefreshRepository,
 )
 from asa.integrations.screening_acquisition_attempts_postgres import (
     PostgresAcquisitionAttemptRepository,
@@ -282,6 +283,19 @@ class RefreshScheduleClaimRepository(Protocol):
     def claim(self, slot_id: str, claimed_at: datetime) -> bool: ...
 
 
+class SubjectRefreshRepository(Protocol):
+    def claim_oldest(
+        self,
+        subject_ids: Sequence[str],
+        *,
+        claimed_at: datetime,
+        maximum_subjects: int,
+        lease: timedelta,
+    ) -> tuple[str, ...]: ...
+
+    def complete(self, subject_id: str, *, completed_at: datetime, succeeded: bool) -> None: ...
+
+
 def run_scheduled_refresh(
     universe: tuple[tuple[str, str], ...] | None = None,
     *,
@@ -291,6 +305,7 @@ def run_scheduled_refresh(
     historical_skew_repository: HistoricalSkewRepository | None = None,
     transport_factory: Callable[[str], object] = build_live_transport,
     claim_repository: RefreshScheduleClaimRepository | None = None,
+    subject_refresh_repository: SubjectRefreshRepository | None = None,
     enforce_schedule: bool = False,
     now: datetime | None = None,
 ) -> tuple[PairOutcome, ...]:
@@ -339,30 +354,48 @@ def run_scheduled_refresh(
         slot = SessionRefreshSchedule().due_slot(run_at)
         if slot is None:
             return ()
-        resolved_claim_repository = claim_repository or (
-            PostgresRefreshScheduleClaimRepository(create_postgres_engine(Settings().database_url))
-        )
-        if not resolved_claim_repository.claim(slot.slot_id, run_at):
-            return ()
         invocation_type = "scheduled"
         slot_id = slot.slot_id
         if universe is None:
-            cohort = scheduled_sp500_cohort(slot)
+            resolved_subject_repository = subject_refresh_repository or (
+                PostgresSubjectRefreshRepository(create_postgres_engine(Settings().database_url))
+            )
+            claimed_symbols = resolved_subject_repository.claim_oldest(
+                SP500_MEMBERSHIP.symbols,
+                claimed_at=run_at,
+                maximum_subjects=SP500_COHORT_MAXIMUM_SUBJECTS,
+                lease=timedelta(minutes=30),
+            )
+            if not claimed_symbols:
+                return ()
             resolved_universe = tuple(
                 (strategy_id, symbol)
-                for symbol in cohort.symbols
+                for symbol in claimed_symbols
                 for strategy_id in ("forward_factor", "skew_momentum", "earnings_calendar")
             )
             _LOGGER.info(
-                "scheduled_universe_cohort_selected",
+                "scheduled_oldest_subjects_selected",
                 extra={
-                    "universe_id": cohort.universe_id,
-                    "source_revision_id": cohort.source_revision_id,
-                    "cohort_ordinal": cohort.cohort_ordinal,
-                    "cohort_count": cohort.cohort_count,
-                    "subject_count": len(cohort.symbols),
+                    "universe_id": SP500_MEMBERSHIP.universe_id,
+                    "source_revision_id": SP500_MEMBERSHIP.source_revision_id,
+                    "subject_count": len(claimed_symbols),
                 },
             )
+        else:
+            # Explicit/custom scheduled scopes retain delivery idempotency.
+            # Production default scheduling uses atomic per-subject claims
+            # instead, allowing overlapping cron processes to safely advance
+            # disjoint portions of the stale backlog.
+            resolved_claim_repository = claim_repository or (
+                PostgresRefreshScheduleClaimRepository(
+                    create_postgres_engine(Settings().database_url)
+                )
+            )
+            if not resolved_claim_repository.claim(slot.slot_id, run_at):
+                return ()
+            resolved_subject_repository = None
+    else:
+        resolved_subject_repository = None
 
     universe = resolved_universe
 
@@ -699,6 +732,19 @@ def run_scheduled_refresh(
             **reuse_counts,
         },
     )
+    if resolved_subject_repository is not None:
+        completed_at = datetime.now(UTC)
+        outcomes_by_subject = {
+            symbol: tuple(item for item in outcomes if item.symbol == symbol)
+            for symbol in unique_symbols
+        }
+        for symbol, subject_outcomes in outcomes_by_subject.items():
+            resolved_subject_repository.complete(
+                symbol,
+                completed_at=completed_at,
+                succeeded=bool(subject_outcomes)
+                and all(item.error is None for item in subject_outcomes),
+            )
     return tuple(outcomes)
 
 

--- a/market_data/session_schedule.py
+++ b/market_data/session_schedule.py
@@ -38,23 +38,12 @@ class SessionRefreshSchedule:
         session = self._calendar.session(session_date)
         if session is None:
             return ()
-        instants: tuple[datetime, ...]
-        if session.early_close:
-            duration = session.closes_at - session.opens_at
-            instants = (
-                session.opens_at + timedelta(minutes=10),
-                session.opens_at + duration / 3,
-                session.opens_at + duration * 2 / 3,
-                session.closes_at - timedelta(minutes=10),
-            )
-        else:
-            instants = (
-                session.opens_at + timedelta(minutes=10),
-                session.opens_at + timedelta(hours=1, minutes=30),
-                session.opens_at + timedelta(hours=3, minutes=30),
-                session.opens_at + timedelta(hours=5, minutes=30),
-                session.closes_at - timedelta(minutes=10),
-            )
+        first = session.opens_at + timedelta(minutes=10)
+        last = session.closes_at - timedelta(minutes=10)
+        instants = tuple(
+            first + timedelta(minutes=10 * offset)
+            for offset in range(int((last - first) / timedelta(minutes=10)) + 1)
+        )
         return tuple(
             ScheduledRefreshSlot(instant.astimezone(UTC), session_date, index)
             for index, instant in enumerate(instants, start=1)

--- a/migrations/versions/0013_screening_subject_refresh_state.py
+++ b/migrations/versions/0013_screening_subject_refresh_state.py
@@ -1,0 +1,38 @@
+"""Add durable oldest-first screening subject refresh state.
+
+Revision ID: 0013
+Revises: 0012
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0013"
+down_revision: str | None = "0012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "screening_subject_refresh_state",
+        sa.Column("subject_id", sa.String(length=64), primary_key=True),
+        sa.Column("last_completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("claim_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("eligible_after", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("consecutive_failures", sa.Integer(), nullable=False, server_default="0"),
+        sa.CheckConstraint("consecutive_failures >= 0", name="ck_subject_refresh_failures"),
+    )
+    op.create_index(
+        "ix_subject_refresh_oldest",
+        "screening_subject_refresh_state",
+        ["last_completed_at", "subject_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_subject_refresh_oldest", table_name="screening_subject_refresh_state")
+    op.drop_table("screening_subject_refresh_state")

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -212,12 +212,14 @@ def test_default_scheduled_cycle_uses_bounded_sp500_cohort(
     caplog.set_level(logging.INFO)
     slot = SessionRefreshSchedule().slots_for(date(2026, 8, 17))[0]
     repository = InMemoryLatestResultRepository()
+    subject_claims = _InMemorySubjectRefreshRepository()
     outcomes = run_scheduled_refresh(
         repository=repository,
         history_repository=InMemoryObservationHistoryRepository(),
         acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
         historical_skew_repository=_RecordingHistoricalSkewRepository(),
         claim_repository=_SingleUseClaimRepository(),
+        subject_refresh_repository=subject_claims,
         enforce_schedule=True,
         now=slot.scheduled_at,
     )
@@ -228,14 +230,12 @@ def test_default_scheduled_cycle_uses_bounded_sp500_cohort(
     selection = next(
         record
         for record in caplog.records
-        if record.message == "scheduled_universe_cohort_selected"
+        if record.message == "scheduled_oldest_subjects_selected"
     )
     assert selection.source_revision_id == 1369213082
-    assert selection.cohort_count == 17
     assert selection.subject_count == 30
     expanded_symbol = next(
-        symbol
-        for _strategy_id, symbol in scheduled_sp500_universe(slot)
+        symbol for symbol in subject_claims.last_claimed
         if symbol not in APPROVED_LIVE_UNIVERSE
     )
     skew = repository.get_one("skew_momentum", expanded_symbol)
@@ -343,6 +343,147 @@ class _SingleUseClaimRepository:
             return False
         self.claimed.add(slot_id)
         return True
+
+
+class _InMemorySubjectRefreshRepository:
+    def __init__(self) -> None:
+        self.last_completed: dict[str, datetime] = {}
+        self.claimed_until: dict[str, datetime] = {}
+        self.eligible_after: dict[str, datetime] = {}
+        self.failures: dict[str, int] = {}
+        self.last_claimed: tuple[str, ...] = ()
+
+    def claim_oldest(
+        self,
+        subject_ids: tuple[str, ...],
+        *,
+        claimed_at: datetime,
+        maximum_subjects: int,
+        lease: timedelta,
+    ) -> tuple[str, ...]:
+        eligible = (
+            subject
+            for subject in set(subject_ids)
+            if self.claimed_until.get(subject, claimed_at) <= claimed_at
+            and self.eligible_after.get(subject, claimed_at) <= claimed_at
+        )
+        self.last_claimed = tuple(
+            sorted(
+                eligible,
+                key=lambda subject: (
+                    self.last_completed.get(subject, datetime.min.replace(tzinfo=UTC)),
+                    subject,
+                ),
+            )[:maximum_subjects]
+        )
+        for subject in self.last_claimed:
+            self.claimed_until[subject] = claimed_at + lease
+        return self.last_claimed
+
+    def complete(self, subject_id: str, *, completed_at: datetime, succeeded: bool) -> None:
+        self.claimed_until.pop(subject_id, None)
+        if succeeded:
+            self.last_completed[subject_id] = completed_at
+            self.eligible_after.pop(subject_id, None)
+            self.failures[subject_id] = 0
+            return
+        count = self.failures.get(subject_id, 0) + 1
+        self.failures[subject_id] = count
+        delay = (5, 15, 30)[min(count - 1, 2)]
+        self.eligible_after[subject_id] = completed_at + timedelta(minutes=delay)
+
+
+def test_subject_claims_are_never_refreshed_then_oldest_with_canonical_tie_break() -> None:
+    claims = _InMemorySubjectRefreshRepository()
+    now = datetime(2026, 8, 21, 16, 0, tzinfo=UTC)
+    claims.last_completed = {
+        "MSFT": now - timedelta(hours=1),
+        "AAPL": now - timedelta(hours=2),
+    }
+
+    selected = claims.claim_oldest(
+        ("MSFT", "NVDA", "AAPL", "AMD"),
+        claimed_at=now,
+        maximum_subjects=3,
+        lease=timedelta(minutes=30),
+    )
+
+    assert selected == ("AMD", "NVDA", "AAPL")
+
+
+def test_subject_claim_admission_may_be_lower_than_safety_ceiling() -> None:
+    claims = _InMemorySubjectRefreshRepository()
+    selected = claims.claim_oldest(
+        ("AAPL", "MSFT", "NVDA"),
+        claimed_at=datetime(2026, 8, 21, 16, 0, tzinfo=UTC),
+        maximum_subjects=2,
+        lease=timedelta(minutes=30),
+    )
+
+    assert selected == ("AAPL", "MSFT")
+
+
+def test_subject_claims_are_disjoint_until_completion_or_lease_expiry() -> None:
+    claims = _InMemorySubjectRefreshRepository()
+    now = datetime(2026, 8, 21, 16, 0, tzinfo=UTC)
+    first = claims.claim_oldest(
+        ("AAPL", "MSFT", "NVDA"),
+        claimed_at=now,
+        maximum_subjects=2,
+        lease=timedelta(minutes=30),
+    )
+    second = claims.claim_oldest(
+        ("AAPL", "MSFT", "NVDA"),
+        claimed_at=now,
+        maximum_subjects=2,
+        lease=timedelta(minutes=30),
+    )
+
+    assert first == ("AAPL", "MSFT")
+    assert second == ("NVDA",)
+    recovered = claims.claim_oldest(
+        ("AAPL", "MSFT", "NVDA"),
+        claimed_at=now + timedelta(minutes=31),
+        maximum_subjects=2,
+        lease=timedelta(minutes=30),
+    )
+    assert recovered == ("AAPL", "MSFT")
+
+
+def test_failed_subject_backs_off_without_starving_other_stale_subjects() -> None:
+    claims = _InMemorySubjectRefreshRepository()
+    now = datetime(2026, 8, 21, 16, 0, tzinfo=UTC)
+    selected = claims.claim_oldest(
+        ("AAPL", "MSFT"),
+        claimed_at=now,
+        maximum_subjects=1,
+        lease=timedelta(minutes=30),
+    )
+    assert selected == ("AAPL",)
+    claims.complete("AAPL", completed_at=now, succeeded=False)
+
+    assert claims.claim_oldest(
+        ("AAPL", "MSFT"),
+        claimed_at=now + timedelta(minutes=1),
+        maximum_subjects=1,
+        lease=timedelta(minutes=30),
+    ) == ("MSFT",)
+
+
+def test_typed_non_evaluation_completion_advances_subject_freshness() -> None:
+    claims = _InMemorySubjectRefreshRepository()
+    now = datetime(2026, 8, 21, 16, 0, tzinfo=UTC)
+    assert claims.claim_oldest(
+        ("AAPL",),
+        claimed_at=now,
+        maximum_subjects=1,
+        lease=timedelta(minutes=30),
+    ) == ("AAPL",)
+
+    # Scheduler completion is based on infrastructure success, not verdict.
+    claims.complete("AAPL", completed_at=now + timedelta(minutes=1), succeeded=True)
+
+    assert claims.last_completed["AAPL"] == now + timedelta(minutes=1)
 
 
 def test_duplicate_cron_delivery_executes_slot_once(

--- a/tests/market_data/test_session_schedule.py
+++ b/tests/market_data/test_session_schedule.py
@@ -8,17 +8,22 @@ from market_data.session_schedule import (
 )
 
 
-def test_normal_session_has_five_exchange_relative_slots() -> None:
+def test_normal_session_has_ten_minute_exchange_relative_slots() -> None:
     slots = SessionRefreshSchedule().slots_for(date(2026, 7, 27))
 
-    assert [item.scheduled_at.hour for item in slots] == [13, 15, 17, 19, 19]
-    assert [item.scheduled_at.minute for item in slots] == [40, 0, 0, 0, 50]
+    assert len(slots) == 38
+    assert slots[0].scheduled_at == datetime(2026, 7, 27, 13, 40, tzinfo=UTC)
+    assert slots[-1].scheduled_at == datetime(2026, 7, 27, 19, 50, tzinfo=UTC)
+    assert all(
+        right.scheduled_at - left.scheduled_at == timedelta(minutes=10)
+        for left, right in zip(slots, slots[1:], strict=False)
+    )
 
 
 def test_early_close_uses_actual_close_minus_ten_minutes() -> None:
     slots = SessionRefreshSchedule().slots_for(date(2026, 11, 27))
 
-    assert len(slots) == 4
+    assert len(slots) == 20
     assert slots[-1].scheduled_at == datetime(2026, 11, 27, 17, 50, tzinfo=UTC)
 
 
@@ -44,11 +49,12 @@ def test_dst_changes_utc_time_but_not_exchange_local_time() -> None:
     } == {40}
 
 
-def test_missed_run_catches_up_only_inside_twenty_minutes() -> None:
+def test_due_slot_advances_every_ten_minutes_and_stops_after_market_window() -> None:
     schedule = SessionRefreshSchedule()
 
     assert schedule.due_slot(datetime(2026, 7, 27, 13, 59, tzinfo=UTC)) is not None
-    assert schedule.due_slot(datetime(2026, 7, 27, 14, 1, tzinfo=UTC)) is None
+    assert schedule.due_slot(datetime(2026, 7, 27, 14, 1, tzinfo=UTC)) is not None
+    assert schedule.due_slot(datetime(2026, 7, 27, 20, 11, tzinfo=UTC)) is None
 
 
 def test_retry_backoff_is_bounded() -> None:


### PR DESCRIPTION
## Ticket

FRESH-01 — Oldest-first bounded subject scheduler

Assigned Worker: `implementation-worker`
Manager stop status: CLEAR
Worker self-review: COMPLETE

## Symptom / baseline

Five fixed exchange-session slots selected deterministic rotating cohorts. With 503 subjects and 30-subject cohorts, refresh completion required multiple market days. Slot-level claims could not represent subject freshness or safely distribute overlapping work.

## Root cause and correction

The scheduler selected by slot ordinal rather than persisted subject completion. This PR changes the existing owners only:

- exchange-calendar eligibility now exposes each 10-minute market-hours opportunity;
- durable subject refresh state atomically claims never-refreshed, then oldest-completed subjects with canonical ID tie-breaks;
- the 30-subject safety ceiling remains fixed;
- successful typed outcomes advance subject completion;
- failures receive bounded 5/15/30-minute backoff;
- claims expire after 30 minutes, so abandoned work recovers;
- overlapping processes use `FOR UPDATE SKIP LOCKED` and claim disjoint subjects.

## Architecture / exclusions

- Subject-scoped scheduling; one sealed snapshot still serves all three strategies.
- Existing provider request-budget and rolling-window enforcement remains authoritative.
- No strategy thresholds, provider policy, universe authority, Russell activation, or deployment changes.

## Validation

- Scheduler/provider/runtime targeted suite: 90 passed
- Architecture suite plus scheduler regressions: 624 passed
- Strict mypy changed scope: PASS
- Ruff changed scope: PASS
- Lean pre-push/integrity/entrypoints: PASS
- `git diff --check`: PASS

## Auto-merge authority

Qualifying FRESH-01 PR under Founder-activated SCREENING-FRESHNESS-001 delegation. Enable auto-merge after required CI is green.