### PR TITLE
FRESH-02: screening liveness and batch proof

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -100,6 +100,17 @@ class CapabilitiesResponse(BaseModel):
     signals: list[SignalCapabilityResponse]
 
 
+class ScreeningOperationalHealthResponse(BaseModel):
+    last_attempted_batch_at: datetime | None
+    last_successful_batch_at: datetime | None
+    oldest_subject_age: int | None
+    overdue_subject_count: int
+    last_batch_subject_count: int
+    last_batch_pair_count: int
+    last_batch_failure_count: int
+    last_batch_incomplete_diagnostic_count: int
+
+
 class ScreeningResultResponse(TimestampedResource):
     signal_id: str
     signal_version: str

--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -37,6 +37,7 @@ from asa.api.screening_models import (
     CapabilitiesResponse,
     OpportunityHistoryResponse,
     RefreshResultResponse,
+    ScreeningOperationalHealthResponse,
     ScreeningResultResponse,
     ScreeningResultsEnvelope,
     SignalCapabilityResponse,
@@ -236,6 +237,7 @@ def build_screening_router(
     capabilities_catalog: tuple[SignalCatalogEntry, ...],
     history_repository: ObservationHistoryRepository,
     acquisition_attempt_repository: AcquisitionAttemptRepository,
+    operational_health: Callable[[], dict[str, object]],
 ) -> APIRouter:
     router = APIRouter(prefix="/api/v1", dependencies=[Depends(authorize)])
 
@@ -251,6 +253,13 @@ def build_screening_router(
                 for definition in capabilities_catalog
             ]
         )
+
+    @router.get(
+        "/screening/operations",
+        response_model=ScreeningOperationalHealthResponse,
+    )
+    def screening_operations() -> ScreeningOperationalHealthResponse:
+        return ScreeningOperationalHealthResponse.model_validate(operational_health())
 
     @router.get("/screening", response_model=ScreeningResultsEnvelope)
     def list_screening(

--- a/asa/bootstrap.py
+++ b/asa/bootstrap.py
@@ -1,6 +1,6 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 from fastapi import FastAPI, Request, Response
@@ -28,6 +28,7 @@ from asa.integrations.providers.deterministic_fake_broker import (
     DeterministicFakeBrokerPortfolioProvider,
 )
 from asa.integrations.providers.robinhood import RobinhoodPortfolioProvider
+from asa.integrations.refresh_schedule_postgres import PostgresSubjectRefreshRepository
 from asa.integrations.runs_postgres import PostgresRunPublicationRepository
 from asa.integrations.screening_acquisition_attempts_postgres import (
     PostgresAcquisitionAttemptRepository,
@@ -58,6 +59,7 @@ class DependencyOverrides:
     latest_result_repository: LatestResultRepository | None = None
     observation_history_repository: ObservationHistoryRepository | None = None
     acquisition_attempt_repository: AcquisitionAttemptRepository | None = None
+    screening_operational_health: Callable[[], dict[str, object]] | None = None
 
 
 def build_application(
@@ -89,6 +91,28 @@ def build_application(
     acquisition_attempt_repository = (
         selected.acquisition_attempt_repository
         or PostgresAcquisitionAttemptRepository(engine_factory(settings.database_url))
+    )
+    subject_refresh_repository = PostgresSubjectRefreshRepository(
+        engine_factory(settings.database_url)
+    )
+
+    def postgres_screening_operational_health() -> dict[str, object]:
+        health = subject_refresh_repository.operational_health(as_of=datetime.now(UTC))
+        return {
+            "last_attempted_batch_at": health.last_attempted_batch_at,
+            "last_successful_batch_at": health.last_successful_batch_at,
+            "oldest_subject_age": health.oldest_subject_age_seconds,
+            "overdue_subject_count": health.overdue_subject_count,
+            "last_batch_subject_count": health.last_batch_subject_count,
+            "last_batch_pair_count": health.last_batch_pair_count,
+            "last_batch_failure_count": health.last_batch_failure_count,
+            "last_batch_incomplete_diagnostic_count": (
+                health.last_batch_incomplete_diagnostic_count
+            ),
+        }
+
+    screening_operational_health = (
+        selected.screening_operational_health or postgres_screening_operational_health
     )
     agent_authorize = build_agent_authorizer(settings.agent_api_token)
     quote_service = MarketQuoteService(
@@ -140,6 +164,7 @@ def build_application(
             capabilities_catalog=build_migrated_signal_catalog(),
             history_repository=observation_history_repository,
             acquisition_attempt_repository=acquisition_attempt_repository,
+            operational_health=screening_operational_health,
         )
     )
     mount_ui(app)

--- a/asa/integrations/refresh_schedule_postgres.py
+++ b/asa/integrations/refresh_schedule_postgres.py
@@ -3,9 +3,22 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from sqlalchemy import Engine, text
+
+
+@dataclass(frozen=True, slots=True)
+class ScreeningOperationalHealth:
+    last_attempted_batch_at: datetime | None
+    last_successful_batch_at: datetime | None
+    oldest_subject_age_seconds: int | None
+    overdue_subject_count: int
+    last_batch_subject_count: int
+    last_batch_pair_count: int
+    last_batch_failure_count: int
+    last_batch_incomplete_diagnostic_count: int
 
 
 class PostgresRefreshScheduleClaimRepository:
@@ -115,3 +128,95 @@ class PostgresSubjectRefreshRepository:
                 """),
                 {"subject_id": subject_id, "completed_at": completed_at},
             )
+
+    def batch_started(self, *, attempted_at: datetime, subject_count: int) -> None:
+        with self._engine.begin() as connection:
+            connection.execute(
+                text("""
+                    UPDATE screening_operational_state
+                    SET last_attempted_batch_at = :attempted_at,
+                        last_batch_subject_count = :subject_count,
+                        last_batch_pair_count = 0,
+                        last_batch_failure_count = 0,
+                        last_batch_incomplete_diagnostic_count = 0
+                    WHERE singleton_id = 1
+                """),
+                {"attempted_at": attempted_at, "subject_count": subject_count},
+            )
+
+    def batch_completed(
+        self,
+        *,
+        completed_at: datetime,
+        pair_count: int,
+        failure_count: int,
+        incomplete_diagnostic_count: int,
+    ) -> None:
+        with self._engine.begin() as connection:
+            connection.execute(
+                text("""
+                    UPDATE screening_operational_state
+                    SET last_successful_batch_at = CASE
+                            WHEN :failure_count = 0 AND :incomplete_count = 0
+                                THEN :completed_at
+                            ELSE last_successful_batch_at
+                        END,
+                        last_batch_pair_count = :pair_count,
+                        last_batch_failure_count = :failure_count,
+                        last_batch_incomplete_diagnostic_count = :incomplete_count
+                    WHERE singleton_id = 1
+                """),
+                {
+                    "completed_at": completed_at,
+                    "pair_count": pair_count,
+                    "failure_count": failure_count,
+                    "incomplete_count": incomplete_diagnostic_count,
+                },
+            )
+
+    def operational_health(self, *, as_of: datetime) -> ScreeningOperationalHealth:
+        with self._engine.connect() as connection:
+            row = connection.execute(
+                text("""
+                    SELECT
+                        operational.last_attempted_batch_at,
+                        operational.last_successful_batch_at,
+                        CASE
+                            WHEN COUNT(subject.subject_id) FILTER (
+                                WHERE subject.last_completed_at IS NULL
+                            ) > 0 THEN NULL
+                            ELSE GREATEST(
+                                0,
+                                EXTRACT(EPOCH FROM (
+                                    :as_of - MIN(subject.last_completed_at)
+                                ))::bigint
+                            )
+                        END AS oldest_subject_age_seconds,
+                        COUNT(subject.subject_id) FILTER (
+                            WHERE subject.last_completed_at IS NULL
+                               OR operational.last_successful_batch_at IS NULL
+                               OR subject.last_completed_at < operational.last_successful_batch_at
+                        ) AS overdue_subject_count,
+                        operational.last_batch_subject_count,
+                        operational.last_batch_pair_count,
+                        operational.last_batch_failure_count,
+                        operational.last_batch_incomplete_diagnostic_count
+                    FROM screening_operational_state AS operational
+                    LEFT JOIN screening_subject_refresh_state AS subject ON TRUE
+                    WHERE operational.singleton_id = 1
+                    GROUP BY operational.singleton_id
+                """),
+                {"as_of": as_of},
+            ).mappings().one()
+        return ScreeningOperationalHealth(
+            last_attempted_batch_at=row["last_attempted_batch_at"],
+            last_successful_batch_at=row["last_successful_batch_at"],
+            oldest_subject_age_seconds=row["oldest_subject_age_seconds"],
+            overdue_subject_count=row["overdue_subject_count"],
+            last_batch_subject_count=row["last_batch_subject_count"],
+            last_batch_pair_count=row["last_batch_pair_count"],
+            last_batch_failure_count=row["last_batch_failure_count"],
+            last_batch_incomplete_diagnostic_count=row[
+                "last_batch_incomplete_diagnostic_count"
+            ],
+        )

--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -295,6 +295,17 @@ class SubjectRefreshRepository(Protocol):
 
     def complete(self, subject_id: str, *, completed_at: datetime, succeeded: bool) -> None: ...
 
+    def batch_started(self, *, attempted_at: datetime, subject_count: int) -> None: ...
+
+    def batch_completed(
+        self,
+        *,
+        completed_at: datetime,
+        pair_count: int,
+        failure_count: int,
+        incomplete_diagnostic_count: int,
+    ) -> None: ...
+
 
 def run_scheduled_refresh(
     universe: tuple[tuple[str, str], ...] | None = None,
@@ -368,6 +379,9 @@ def run_scheduled_refresh(
             )
             if not claimed_symbols:
                 return ()
+            resolved_subject_repository.batch_started(
+                attempted_at=run_at, subject_count=len(claimed_symbols)
+            )
             resolved_universe = tuple(
                 (strategy_id, symbol)
                 for symbol in claimed_symbols
@@ -745,6 +759,14 @@ def run_scheduled_refresh(
                 succeeded=bool(subject_outcomes)
                 and all(item.error is None for item in subject_outcomes),
             )
+        resolved_subject_repository.batch_completed(
+            completed_at=completed_at,
+            pair_count=len(outcomes),
+            failure_count=sum(item.error is not None for item in outcomes),
+            incomplete_diagnostic_count=sum(
+                not item.attempts_recorded for item in outcomes
+            ),
+        )
     return tuple(outcomes)
 
 

--- a/migrations/versions/0014_screening_operational_state.py
+++ b/migrations/versions/0014_screening_operational_state.py
@@ -1,0 +1,39 @@
+"""Add singleton screening batch-operability state.
+
+Revision ID: 0014
+Revises: 0013
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0014"
+down_revision: str | None = "0013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "screening_operational_state",
+        sa.Column("singleton_id", sa.Integer(), primary_key=True),
+        sa.Column("last_attempted_batch_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_successful_batch_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_batch_subject_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_batch_pair_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_batch_failure_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "last_batch_incomplete_diagnostic_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.CheckConstraint("singleton_id = 1", name="ck_screening_operational_singleton"),
+    )
+    op.execute("INSERT INTO screening_operational_state (singleton_id) VALUES (1)")
+
+
+def downgrade() -> None:
+    op.drop_table("screening_operational_state")

--- a/tests/asa/test_refresh_schedule_postgres_integration.py
+++ b/tests/asa/test_refresh_schedule_postgres_integration.py
@@ -1,0 +1,108 @@
+"""Real-Postgres proofs for atomic oldest-first subject refresh state."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from asa.integrations.refresh_schedule_postgres import PostgresSubjectRefreshRepository
+
+pytestmark = [
+    pytest.mark.postgres,
+    pytest.mark.skipif(
+        not os.getenv("ASA_TEST_DATABASE_URL"),
+        reason="ASA_TEST_DATABASE_URL not set",
+    ),
+]
+
+NOW = datetime(2026, 8, 21, 16, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def repository() -> PostgresSubjectRefreshRepository:
+    database_url = os.environ["ASA_TEST_DATABASE_URL"]
+    os.environ["ASA_DATABASE_URL"] = database_url
+    command.upgrade(Config("alembic.ini"), "head")
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE screening_subject_refresh_state"))
+        connection.execute(
+            text("""
+                UPDATE screening_operational_state
+                SET last_attempted_batch_at = NULL,
+                    last_successful_batch_at = NULL,
+                    last_batch_subject_count = 0,
+                    last_batch_pair_count = 0,
+                    last_batch_failure_count = 0,
+                    last_batch_incomplete_diagnostic_count = 0
+                WHERE singleton_id = 1
+            """)
+        )
+    return PostgresSubjectRefreshRepository(engine)
+
+
+def test_atomic_claims_are_disjoint_and_abandoned_claims_recover(
+    repository: PostgresSubjectRefreshRepository,
+) -> None:
+    first = repository.claim_oldest(
+        ("MSFT", "AAPL", "NVDA"),
+        claimed_at=NOW,
+        maximum_subjects=2,
+        lease=timedelta(minutes=30),
+    )
+    second = repository.claim_oldest(
+        ("MSFT", "AAPL", "NVDA"),
+        claimed_at=NOW,
+        maximum_subjects=2,
+        lease=timedelta(minutes=30),
+    )
+
+    assert first == ("AAPL", "MSFT")
+    assert second == ("NVDA",)
+    assert repository.claim_oldest(
+        ("MSFT", "AAPL", "NVDA"),
+        claimed_at=NOW + timedelta(minutes=31),
+        maximum_subjects=2,
+        lease=timedelta(minutes=30),
+    ) == ("AAPL", "MSFT")
+
+
+def test_completion_backoff_and_operational_health(
+    repository: PostgresSubjectRefreshRepository,
+) -> None:
+    assert repository.claim_oldest(
+        ("AAPL", "MSFT"),
+        claimed_at=NOW,
+        maximum_subjects=2,
+        lease=timedelta(minutes=30),
+    ) == ("AAPL", "MSFT")
+    repository.batch_started(attempted_at=NOW, subject_count=2)
+    repository.complete("AAPL", completed_at=NOW + timedelta(minutes=1), succeeded=True)
+    repository.complete("MSFT", completed_at=NOW + timedelta(minutes=1), succeeded=False)
+    repository.batch_completed(
+        completed_at=NOW + timedelta(minutes=1),
+        pair_count=6,
+        failure_count=1,
+        incomplete_diagnostic_count=0,
+    )
+
+    health = repository.operational_health(as_of=NOW + timedelta(minutes=2))
+    assert health.last_attempted_batch_at == NOW
+    assert health.last_successful_batch_at is None
+    assert health.oldest_subject_age_seconds is None
+    assert health.overdue_subject_count == 2
+    assert health.last_batch_subject_count == 2
+    assert health.last_batch_pair_count == 6
+    assert health.last_batch_failure_count == 1
+    assert health.last_batch_incomplete_diagnostic_count == 0
+    assert repository.claim_oldest(
+        ("AAPL", "MSFT"),
+        claimed_at=NOW + timedelta(minutes=2),
+        maximum_subjects=2,
+        lease=timedelta(minutes=30),
+    ) == ("AAPL",)

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -234,6 +234,8 @@ def test_default_scheduled_cycle_uses_bounded_sp500_cohort(
     )
     assert selection.source_revision_id == 1369213082
     assert selection.subject_count == 30
+    assert subject_claims.batch_attempted_at == slot.scheduled_at
+    assert subject_claims.batch_result == (90, 0, 0)
     expanded_symbol = next(
         symbol for symbol in subject_claims.last_claimed
         if symbol not in APPROVED_LIVE_UNIVERSE
@@ -352,6 +354,8 @@ class _InMemorySubjectRefreshRepository:
         self.eligible_after: dict[str, datetime] = {}
         self.failures: dict[str, int] = {}
         self.last_claimed: tuple[str, ...] = ()
+        self.batch_attempted_at: datetime | None = None
+        self.batch_result: tuple[int, int, int] | None = None
 
     def claim_oldest(
         self,
@@ -391,6 +395,21 @@ class _InMemorySubjectRefreshRepository:
         self.failures[subject_id] = count
         delay = (5, 15, 30)[min(count - 1, 2)]
         self.eligible_after[subject_id] = completed_at + timedelta(minutes=delay)
+
+    def batch_started(self, *, attempted_at: datetime, subject_count: int) -> None:
+        self.batch_attempted_at = attempted_at
+        assert subject_count == len(self.last_claimed)
+
+    def batch_completed(
+        self,
+        *,
+        completed_at: datetime,
+        pair_count: int,
+        failure_count: int,
+        incomplete_diagnostic_count: int,
+    ) -> None:
+        del completed_at
+        self.batch_result = (pair_count, failure_count, incomplete_diagnostic_count)
 
 
 def test_subject_claims_are_never_refreshed_then_oldest_with_canonical_tie_break() -> None:

--- a/tests/asa/test_screening_routes.py
+++ b/tests/asa/test_screening_routes.py
@@ -61,7 +61,17 @@ def _client(
         build_application(
             Settings(agent_api_token=SecretStr(token) if token else None, _env_file=None),
             DependencyOverrides(
-                latest_result_repository=repository or InMemoryLatestResultRepository()
+                latest_result_repository=repository or InMemoryLatestResultRepository(),
+                screening_operational_health=lambda: {
+                    "last_attempted_batch_at": NOW,
+                    "last_successful_batch_at": NOW,
+                    "oldest_subject_age": 600,
+                    "overdue_subject_count": 473,
+                    "last_batch_subject_count": 30,
+                    "last_batch_pair_count": 90,
+                    "last_batch_failure_count": 0,
+                    "last_batch_incomplete_diagnostic_count": 0,
+                },
             ),
         )
     )
@@ -108,6 +118,26 @@ class TestCapabilities:
         response = _client().get("/api/v1/capabilities", headers=_auth())
         for item in response.json()["signals"]:
             assert item["required_capabilities"]
+
+
+class TestScreeningOperations:
+    def test_exposes_distinct_authenticated_screening_liveness(self) -> None:
+        response = _client().get("/api/v1/screening/operations", headers=_auth())
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "last_attempted_batch_at": NOW.isoformat().replace("+00:00", "Z"),
+            "last_successful_batch_at": NOW.isoformat().replace("+00:00", "Z"),
+            "oldest_subject_age": 600,
+            "overdue_subject_count": 473,
+            "last_batch_subject_count": 30,
+            "last_batch_pair_count": 90,
+            "last_batch_failure_count": 0,
+            "last_batch_incomplete_diagnostic_count": 0,
+        }
+
+    def test_screening_liveness_requires_authorization(self) -> None:
+        assert _client().get("/api/v1/screening/operations").status_code == 404
 
 
 class TestListScreening:


### PR DESCRIPTION
## Ticket

FRESH-02 — Minimal screening liveness plus production proof

Assigned Worker: `implementation-worker`
Manager stop status: CLEAR
Worker self-review: COMPLETE

## Outcome

Adds the minimum distinct screening-operability seam without changing generic `/health` or `/readiness`. The scheduled owner records batch attempt/completion state and the authenticated API exposes:

- last attempted/successful batch times
- oldest subject age
- overdue subject count relative to the last successful frontier
- last batch subject/pair/failure/incomplete-diagnostic counts

Successful batch state requires zero runner failures and zero incomplete diagnostics. Subject freshness remains advanced only by completed all-strategy subject work from FRESH-01.

## Architecture / safety

- Existing subject scheduler and Postgres persistence owners only.
- No strategy/provider policy changes.
- No acquisition for observability.
- No generic health/readiness semantic changes.
- No Russell activation or deployment.

## Validation

- Scheduler/API tests: 71 passed
- Real-Postgres integration tests: collected; 2 skipped locally because `ASA_TEST_DATABASE_URL` is absent; required CI DB gate must pass before merge
- Architecture suite: 576 passed
- Strict mypy changed scope: PASS
- Ruff changed scope: PASS
- Lean pre-push/integrity/entrypoints: PASS
- `git diff --check`: PASS

## Deployment / production proof

Deployment remains Founder-only. After exact-main validation, Founder deployment authority is required for the production acceptance cycle.

## Auto-merge authority

Qualifying FRESH-02 PR under Founder-activated SCREENING-FRESHNESS-001 delegation. Enable auto-merge after all required CI is green.