### PR TITLE
CORR-01/02: separate snapshot ordering from evidence freshness

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -142,6 +142,7 @@ class ScreeningResultResponse(TimestampedResource):
     structure: str | None = None
     reason_codes: list[str] = Field(default_factory=list)
     assumptions: list[str] = Field(default_factory=list)
+    subject_snapshot_at: datetime
     observed_at: datetime
     received_at: datetime
     evaluated_at: datetime
@@ -165,6 +166,9 @@ class ScreeningResultResponse(TimestampedResource):
         """Build the public response from the canonical universal result."""
         temporal = result.temporal
         observed_at = temporal.observed_at if temporal is not None else result.observed_at
+        subject_snapshot_at = (
+            temporal.subject_snapshot_at if temporal is not None else result.observed_at
+        )
         received_at = temporal.received_at if temporal is not None else result.observed_at
         evaluated_at = temporal.evaluated_at if temporal is not None else result.observed_at
         persisted_at = temporal.persisted_at if temporal is not None else result.observed_at
@@ -235,8 +239,9 @@ class ScreeningResultResponse(TimestampedResource):
             ),
             reason_codes=_decision_sequence(result, "decision.reason_codes"),
             assumptions=_decision_sequence(result, "decision.assumptions"),
-            updated_at=result.observed_at,
+            updated_at=persisted_at,
             age_seconds=canonical_age,
+            subject_snapshot_at=subject_snapshot_at,
             observed_at=observed_at,
             received_at=received_at,
             evaluated_at=evaluated_at,

--- a/asa/integrations/universal_screening_postgres.py
+++ b/asa/integrations/universal_screening_postgres.py
@@ -73,17 +73,29 @@ class PostgresLatestResultRepository:
                     WHERE
                         (
                             COALESCE(
-                                EXCLUDED.source_observed_at,
+                                (EXCLUDED.temporal ->> 'subject_snapshot_at')::timestamptz,
                                 EXCLUDED.observed_at
                             ),
-                            EXCLUDED.observed_at,
+                            COALESCE(
+                                (EXCLUDED.temporal ->> 'evaluated_at')::timestamptz,
+                                EXCLUDED.observed_at
+                            ),
                             EXCLUDED.observation_id
                         ) >= (
                             COALESCE(
-                                universal_screening_state.source_observed_at,
+                                (
+                                    universal_screening_state.temporal
+                                    ->> 'subject_snapshot_at'
+                                )::timestamptz,
                                 universal_screening_state.observed_at
                             ),
-                            universal_screening_state.observed_at,
+                            COALESCE(
+                                (
+                                    universal_screening_state.temporal
+                                    ->> 'evaluated_at'
+                                )::timestamptz,
+                                universal_screening_state.observed_at
+                            ),
                             universal_screening_state.observation_id
                         )
                 """),
@@ -153,6 +165,7 @@ def _to_params(row: UniversalSignalRow) -> dict[str, object]:
             if row.temporal is None
             else json.dumps(
                 {
+                    "subject_snapshot_at": row.temporal.subject_snapshot_at.isoformat(),
                     "observed_at": row.temporal.observed_at.isoformat(),
                     "received_at": row.temporal.received_at.isoformat(),
                     "evaluated_at": row.temporal.evaluated_at.isoformat(),
@@ -198,6 +211,9 @@ def _to_row(mapping: RowMapping) -> UniversalSignalRow:
         None
         if temporal_data is None
         else ResultTemporalMetadata(
+            subject_snapshot_at=datetime.fromisoformat(
+                temporal_data.get("subject_snapshot_at", temporal_data["evaluated_at"])
+            ),
             observed_at=datetime.fromisoformat(temporal_data["observed_at"]),
             received_at=datetime.fromisoformat(temporal_data["received_at"]),
             evaluated_at=datetime.fromisoformat(temporal_data["evaluated_at"]),

--- a/strategy_runtime/persistence.py
+++ b/strategy_runtime/persistence.py
@@ -139,12 +139,13 @@ class UniversalSignalRow:
 
 class LatestResultRepository(Protocol):
     """Stores only the latest UniversalSignalRow per (signal_id,
-    symbol). upsert() advances that row only when the candidate's source
-    observation ordering key is not older; late arrivals never regress
-    latest state. Same-source candidates are ordered by evaluation time,
-    then observation identity as the final deterministic tie-breaker. It
-    never accumulates history (ObservationHistoryRepository's own job). A
-    symbol a given run never touches is never removed by that run.
+    symbol). upsert() advances that row only when the candidate's sealed
+    subject snapshot is not older; replayed late arrivals never regress
+    latest state. Source observation time remains freshness evidence, not
+    a persistence veto. Same-snapshot candidates are ordered by evaluation
+    time, then observation identity as the final deterministic tie-breaker.
+    It never accumulates history (ObservationHistoryRepository's own job).
+    A symbol a given run never touches is never removed by that run.
     """
 
     def upsert(self, row: UniversalSignalRow) -> None: ...
@@ -157,19 +158,23 @@ class LatestResultRepository(Protocol):
 
 
 def latest_ordering_key(row: UniversalSignalRow) -> tuple[datetime, datetime, str]:
-    """Canonical monotonic order: source time, evaluation time, stable identity.
+    """Canonical monotonic order: snapshot time, evaluation time, stable identity.
 
-    The former two-part key used a SHA-derived observation identity as the
-    second element. SHA lexical order is deterministic but not chronological,
-    so a later scheduled evaluation using unchanged source data could be
-    rejected and leave its refresh metadata stuck on an older slot. Evaluation
-    time is the truthful same-source ordering dimension; identity remains only
-    the final idempotent tie-breaker.
+    Source evidence chronology controls freshness and usability but may stay
+    equal or move backward as a current sealed snapshot selects different
+    legitimate evidence. Snapshot chronology is the authoritative latest-state
+    boundary. Evaluation time orders repeated projections of the same snapshot;
+    identity remains only the final idempotent tie-breaker.
     """
-    source_time = (
-        row.temporal.observed_at if row.temporal is not None else row.observed_at
+    snapshot_time = (
+        row.temporal.subject_snapshot_at
+        if row.temporal is not None
+        else row.observed_at
     )
-    return source_time, row.observed_at, row.observation_id
+    evaluated_time = (
+        row.temporal.evaluated_at if row.temporal is not None else row.observed_at
+    )
+    return snapshot_time, evaluated_time, row.observation_id
 
 
 def should_replace_latest(

--- a/strategy_runtime/result.py
+++ b/strategy_runtime/result.py
@@ -86,6 +86,7 @@ SUCCESS_EVALUATION_STATES = frozenset({EvaluationState.PASS, EvaluationState.NO_
 class ResultTemporalMetadata:
     """Provider-neutral temporal audit data for one computed result."""
 
+    subject_snapshot_at: datetime
     observed_at: datetime
     received_at: datetime
     evaluated_at: datetime
@@ -107,6 +108,7 @@ class ResultTemporalMetadata:
 
     def __post_init__(self) -> None:
         for name in (
+            "subject_snapshot_at",
             "observed_at",
             "received_at",
             "evaluated_at",

--- a/strategy_runtime/service.py
+++ b/strategy_runtime/service.py
@@ -149,6 +149,7 @@ def _temporal_metadata(
         else None
     )
     return ResultTemporalMetadata(
+        subject_snapshot_at=evaluated,
         observed_at=observed,
         received_at=received,
         evaluated_at=evaluated,

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -1459,6 +1459,60 @@ def test_production_root_prepares_all_three_strategies_from_one_subject_snapshot
     )
 
 
+def test_current_subject_refresh_persists_all_consumers_coherently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SP500-CORRECTNESS-001: one current snapshot advances all consumers."""
+    import asa.scheduled_screening as scheduled_screening_module
+
+    monkeypatch.setattr(
+        scheduled_screening_module,
+        "build_shared_market_data_access",
+        build_fixture_market_data_access_factory(),
+    )
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    repository = InMemoryLatestResultRepository()
+    universe = (
+        ("forward_factor", "AAPL"),
+        ("skew_momentum", "AAPL"),
+        ("earnings_calendar", "AAPL"),
+    )
+    run_scheduled_refresh(
+        universe,
+        repository=repository,
+        history_repository=InMemoryObservationHistoryRepository(),
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        historical_skew_repository=_RecordingHistoricalSkewRepository(),
+    )
+    first = {row.signal_id: row for row in repository.get_all()}
+    run_scheduled_refresh(
+        universe,
+        repository=repository,
+        history_repository=InMemoryObservationHistoryRepository(),
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        historical_skew_repository=_RecordingHistoricalSkewRepository(),
+    )
+    second = {row.signal_id: row for row in repository.get_all()}
+
+    assert set(second) == {item[0] for item in universe}
+    for signal_id in second:
+        assert first[signal_id].temporal is not None
+        assert second[signal_id].temporal is not None
+        assert (
+            second[signal_id].temporal.evaluated_at
+            > first[signal_id].temporal.evaluated_at
+        )
+        assert (
+            second[signal_id].temporal.persisted_at
+            == second[signal_id].temporal.evaluated_at
+        )
+        assert (
+            second[signal_id].temporal.subject_snapshot_at
+            == second[signal_id].temporal.evaluated_at
+        )
+
+
 def test_production_universe_topology_has_no_universal_preparation_failure(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/asa/test_screening_refresh_route.py
+++ b/tests/asa/test_screening_refresh_route.py
@@ -221,9 +221,11 @@ class TestSuccessfulRefresh:
         assert body["updated_at"] is not None
         assert body["age_seconds"] >= 0
         assert body["observed_at"] is not None
+        assert body["subject_snapshot_at"] is not None
         assert body["received_at"] is not None
         assert body["evaluated_at"] is not None
         assert body["persisted_at"] is not None
+        assert body["updated_at"] == body["persisted_at"]
         # The request completed and persisted even when strategy evidence is
         # insufficient for a verdict; temporal fields are optional then.
         assert body["market_session_status"] in {
@@ -290,6 +292,7 @@ def _seeded_row_with_recent_attempt(signal_id: str, symbol: str) -> UniversalSig
     """
     now = datetime.now(UTC)
     temporal = ResultTemporalMetadata(
+        subject_snapshot_at=now,
         observed_at=now,
         received_at=now,
         evaluated_at=now,

--- a/tests/asa/test_universal_screening_service_postgres_integration.py
+++ b/tests/asa/test_universal_screening_service_postgres_integration.py
@@ -160,8 +160,11 @@ def test_get_state_never_triggers_a_provider_request(
     assert first == second
 
 
-def _temporal(*, source: datetime, evaluated: datetime) -> ResultTemporalMetadata:
+def _temporal(
+    *, source: datetime, evaluated: datetime, snapshot: datetime | None = None
+) -> ResultTemporalMetadata:
     return ResultTemporalMetadata(
+        subject_snapshot_at=snapshot or evaluated,
         observed_at=source,
         received_at=evaluated,
         evaluated_at=evaluated,
@@ -184,7 +187,11 @@ def _temporal(*, source: datetime, evaluated: datetime) -> ResultTemporalMetadat
 
 
 def _signal_row(
-    *, observation_id: str, source: datetime, evaluated: datetime
+    *,
+    observation_id: str,
+    source: datetime,
+    evaluated: datetime,
+    snapshot: datetime | None = None,
 ) -> UniversalSignalRow:
     return UniversalSignalRow.from_result(
         UniversalScreeningResult(
@@ -205,7 +212,7 @@ def _signal_row(
             warnings=(),
             provenance=(),
             observed_at=evaluated,
-            temporal=_temporal(source=source, evaluated=evaluated),
+            temporal=_temporal(source=source, evaluated=evaluated, snapshot=snapshot),
         )
     )
 
@@ -240,19 +247,44 @@ def test_postgres_write_guard_matches_the_in_memory_should_replace_latest_decisi
     assert stored.observation_id == "aaa"
 
 
-def test_postgres_write_guard_rejects_an_older_source_even_with_a_higher_hash(
+def test_postgres_write_guard_accepts_current_snapshot_with_older_source_evidence(
     repository: PostgresLatestResultRepository,
 ) -> None:
-    same_evaluated = datetime(2026, 7, 27, 18, 0, tzinfo=UTC)
-    existing = _signal_row(observation_id="aaa", source=same_evaluated, evaluated=same_evaluated)
-    older_source_higher_hash = _signal_row(
-        observation_id="zzz", source=same_evaluated - timedelta(days=1), evaluated=same_evaluated
+    initial = datetime(2026, 7, 27, 18, 0, tzinfo=UTC)
+    existing = _signal_row(observation_id="aaa", source=initial, evaluated=initial)
+    current_snapshot = _signal_row(
+        observation_id="zzz",
+        source=initial - timedelta(days=1),
+        evaluated=initial + timedelta(hours=1),
     )
-    assert should_replace_latest(existing, older_source_higher_hash) is False
+    assert should_replace_latest(existing, current_snapshot) is True
 
     repository.upsert(existing)
-    repository.upsert(older_source_higher_hash)
+    repository.upsert(current_snapshot)
 
     stored = repository.get_one(STRATEGY_ID, SYMBOL)
     assert stored is not None
-    assert stored.observation_id == "aaa"  # older source never regressed the stored row
+    assert stored.observation_id == "zzz"
+
+
+def test_postgres_write_guard_rejects_replayed_older_subject_snapshot(
+    repository: PostgresLatestResultRepository,
+) -> None:
+    current = datetime(2026, 7, 27, 18, 0, tzinfo=UTC)
+    existing = _signal_row(
+        observation_id="aaa", source=current, evaluated=current, snapshot=current
+    )
+    replay = _signal_row(
+        observation_id="zzz",
+        source=current - timedelta(days=1),
+        evaluated=current + timedelta(hours=1),
+        snapshot=current - timedelta(days=1),
+    )
+    assert should_replace_latest(existing, replay) is False
+
+    repository.upsert(existing)
+    repository.upsert(replay)
+
+    stored = repository.get_one(STRATEGY_ID, SYMBOL)
+    assert stored is not None
+    assert stored.observation_id == "aaa"

--- a/tests/strategy_runtime/test_refresh_integrity_regressions.py
+++ b/tests/strategy_runtime/test_refresh_integrity_regressions.py
@@ -20,8 +20,11 @@ from strategy_runtime.service import _temporal_metadata
 EVALUATED = datetime(2026, 7, 27, 18, 0, tzinfo=UTC)
 
 
-def _temporal(*, source: datetime, evaluated: datetime) -> ResultTemporalMetadata:
+def _temporal(
+    *, source: datetime, evaluated: datetime, snapshot: datetime | None = None
+) -> ResultTemporalMetadata:
     return ResultTemporalMetadata(
+        subject_snapshot_at=snapshot or evaluated,
         observed_at=source,
         received_at=evaluated,
         evaluated_at=evaluated,
@@ -44,7 +47,11 @@ def _temporal(*, source: datetime, evaluated: datetime) -> ResultTemporalMetadat
 
 
 def _row(
-    *, observation_id: str, source: datetime, evaluated: datetime
+    *,
+    observation_id: str,
+    source: datetime,
+    evaluated: datetime,
+    snapshot: datetime | None = None,
 ) -> UniversalSignalRow:
     return UniversalSignalRow.from_result(
         UniversalScreeningResult(
@@ -65,7 +72,7 @@ def _row(
             warnings=(),
             provenance=(),
             observed_at=evaluated,
-            temporal=_temporal(source=source, evaluated=evaluated),
+            temporal=_temporal(source=source, evaluated=evaluated, snapshot=snapshot),
         )
     )
 
@@ -83,7 +90,7 @@ def test_later_same_source_evaluation_wins_even_with_lower_hash_identity() -> No
     assert should_replace_latest(later, existing) is False
 
 
-def test_later_evaluation_cannot_regress_an_older_source_observation() -> None:
+def test_current_snapshot_recomputation_is_not_vetoed_by_older_source_evidence() -> None:
     existing = _row(
         observation_id="aaa",
         source=EVALUATED,
@@ -95,7 +102,48 @@ def test_later_evaluation_cannot_regress_an_older_source_observation() -> None:
         evaluated=EVALUATED + timedelta(hours=1),
     )
 
-    assert should_replace_latest(existing, older_source) is False
+    assert should_replace_latest(existing, older_source) is True
+
+
+def test_unchanged_source_advances_evaluation_without_claiming_data_advanced() -> None:
+    source = EVALUATED - timedelta(minutes=1)
+    previous = _row(observation_id="old", source=source, evaluated=EVALUATED)
+    temporal = _temporal_metadata(
+        _registry(),
+        "alpha",
+        EVALUATED + timedelta(hours=1),
+        (
+            _observation(
+                capability=MarketCapability.REAL_TIME_QUOTE_V1,
+                effective_time=source,
+                observation_id="same",
+            ),
+        ),
+        previous=previous,
+    )
+
+    assert temporal is not None
+    assert temporal.observed_at == source
+    assert temporal.evaluated_at == EVALUATED + timedelta(hours=1)
+    assert temporal.persisted_at == temporal.evaluated_at
+    assert temporal.data_advanced_on_last_refresh is False
+
+
+def test_replayed_older_snapshot_cannot_replace_current_authoritative_evaluation() -> None:
+    existing = _row(
+        observation_id="aaa",
+        source=EVALUATED,
+        evaluated=EVALUATED,
+        snapshot=EVALUATED,
+    )
+    replay = _row(
+        observation_id="zzz",
+        source=EVALUATED - timedelta(days=1),
+        evaluated=EVALUATED + timedelta(hours=1),
+        snapshot=EVALUATED - timedelta(days=1),
+    )
+
+    assert should_replace_latest(existing, replay) is False
 
 
 def _observation(


### PR DESCRIPTION
## Tickets
CORR-01, CORR-02 — SP500-CORRECTNESS-001

## Root cause
Latest-result replacement ordered first by `source_observed_at`. A newly sealed authoritative subject snapshot could therefore recompute all consumers successfully yet have rows silently rejected when selected evidence time was unchanged or older. API `updated_at` also exposed the result observation/evaluation field without explicitly representing snapshot time.

## Correction
- add immutable `subject_snapshot_at` temporal truth
- order latest state by `(subject_snapshot_at, evaluated_at, observation_id)`
- retain `observed_at`/`source_observed_at` solely for evidence freshness and usability
- preserve backward reads for temporal JSON written before this field
- expose snapshot time and make API `updated_at` equal persisted update time

## Before / after
Before: current recomputation with older evidence was rejected at the generic latest-state owner.
After: current snapshot advances; unchanged evidence reports `data_advanced_on_last_refresh=false`; replayed older snapshots remain rejected.

## Proof
- targeted temporal/API/current-three-consumer tests: 24 passed
- broader runtime/scheduled/API persistence tests: 386 passed, 6 skipped
- architecture: 576 passed
- strict mypy changed scope: green
- Ruff changed scope: green
- Lean integrity + entrypoints: green
- git diff check: green

## Self-review
Worker self-review complete. Manager stop status CLEAR. No strategy policy, provider policy, acquisition count, Russell, governance, deployment, or production changes.

## Auto-merge authority
Founder-activated SP500-CORRECTNESS-001 delegates merge authority for CORR-01/CORR-02 after required gates pass.