### PR TITLE
CORR-02: repair temporal validation fixtures

### DIFF
--- a/tests/asa/market_data_ops/test_market_data_validate.py
+++ b/tests/asa/market_data_ops/test_market_data_validate.py
@@ -111,10 +111,12 @@ def test_tradier_option_chain_live_run_completes_instead_of_crashing(
     """
     monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
     monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    expiration = (datetime.now(UTC) + timedelta(days=30)).date()
+    option_symbol = f"AAPL{expiration:%y%m%d}C00210000"
     option_row = {
-        "symbol": "AAPL260821C00210000",
+        "symbol": option_symbol,
         "underlying": "AAPL",
-        "expiration_date": "2026-08-21",
+        "expiration_date": expiration.isoformat(),
         "strike": "210",
         "option_type": "call",
         "bid": "4.9",
@@ -131,7 +133,9 @@ def test_tradier_option_chain_live_run_completes_instead_of_crashing(
                 "history": {
                     "day": [
                         {
-                            "date": "2026-07-20",
+                            "date": (
+                                datetime.now(UTC) - timedelta(days=1)
+                            ).date().isoformat(),
                             "open": "205.00",
                             "high": "212",
                             "low": "204",

--- a/tests/fixtures/ui-screening-result.json
+++ b/tests/fixtures/ui-screening-result.json
@@ -44,6 +44,7 @@
   "assumptions": ["research policy 2.0.1-research"],
   "updated_at": "2026-07-29T13:45:00Z",
   "age_seconds": 120,
+  "subject_snapshot_at": "2026-07-29T13:44:00Z",
   "observed_at": "2026-07-29T13:40:00Z",
   "received_at": "2026-07-29T13:41:00Z",
   "evaluated_at": "2026-07-29T13:44:00Z",


### PR DESCRIPTION
## Ticket
CORR-02 corrective PR — SP500-CORRECTNESS-001

## Failed acceptance
PR #361 merged before pending checks because repository protection did not hold the merge. Backend then exposed two fixture defects.

## Root cause / correction
- public UI fixture lacked the new `subject_snapshot_at` field
- Tradier validation fixture used a hard-coded option expiration that had become past-dated; it now derives current, valid temporal evidence

## Validation
The two red CI cases pass locally; Ruff and diff checks pass. This PR will not merge until every repository check is completed and green.

## Authority
In-scope CORR-02 correction. Worker self-review complete; Manager stop status CLEAR.