### PR TITLE
CORR-02: record truthful snapshot seal time

### DIFF
--- a/strategy_runtime/service.py
+++ b/strategy_runtime/service.py
@@ -111,7 +111,6 @@ def _temporal_metadata(
     observations: tuple[MarketObservation, ...],
     previous: UniversalSignalRow | None,
 ) -> ResultTemporalMetadata | None:
-    evaluated = evaluated_at.astimezone(UTC)
     if not observations:
         return None
     current_observations = _current_temporal_observations(observations)
@@ -121,6 +120,12 @@ def _temporal_metadata(
     recorded_times = tuple(item.recorded_time.astimezone(UTC) for item in observations)
     observed = max(effective_times)
     received = max(recorded_times)
+    # The cycle clock is deliberately frozen for deterministic orchestration,
+    # but acquisition can finish after that cycle boundary. Temporal audit
+    # truth must never claim that a snapshot was sealed or evaluated before
+    # its last observation was received.
+    subject_snapshot_at = received
+    evaluated = max(evaluated_at.astimezone(UTC), subject_snapshot_at)
     calendar = UsEquitySessionCalendar()
     session_status = calendar.status_at(evaluated)
     session = calendar.session(evaluated.astimezone(NEW_YORK).date())
@@ -149,7 +154,7 @@ def _temporal_metadata(
         else None
     )
     return ResultTemporalMetadata(
-        subject_snapshot_at=evaluated,
+        subject_snapshot_at=subject_snapshot_at,
         observed_at=observed,
         received_at=received,
         evaluated_at=evaluated,

--- a/tests/strategy_runtime/test_refresh_integrity_regressions.py
+++ b/tests/strategy_runtime/test_refresh_integrity_regressions.py
@@ -129,6 +129,26 @@ def test_unchanged_source_advances_evaluation_without_claiming_data_advanced() -
     assert temporal.data_advanced_on_last_refresh is False
 
 
+def test_snapshot_and_evaluation_never_precede_acquisition_completion() -> None:
+    cycle_started = EVALUATED
+    acquired = EVALUATED + timedelta(minutes=2)
+    observation = _observation(
+        capability=MarketCapability.REAL_TIME_QUOTE_V1,
+        effective_time=EVALUATED - timedelta(seconds=1),
+        observation_id="late-acquisition",
+    )
+    observation.recorded_time = acquired
+
+    temporal = _temporal_metadata(
+        _registry(), "alpha", cycle_started, (observation,), previous=None
+    )
+
+    assert temporal is not None
+    assert temporal.subject_snapshot_at == acquired
+    assert temporal.evaluated_at == acquired
+    assert temporal.persisted_at == acquired
+
+
 def test_replayed_older_snapshot_cannot_replace_current_authoritative_evaluation() -> None:
     existing = _row(
         observation_id="aaa",


### PR DESCRIPTION
## Ticket
CORR-02 production-proof correction — SP500-CORRECTNESS-001

## Symptom
Persisted audit on deployed `main@4b150216` showed `subject_snapshot_at` / `evaluated_at` around 18:40:54 while source observations were received through 18:42:29.

## Root cause
The deterministic cycle clock is frozen at orchestration start. Reusing it as snapshot seal/evaluation time made those events precede acquisition completion.

## Correction
At the generic temporal owner, use maximum provider-neutral `recorded_time` as snapshot seal time and clamp evaluation/persistence to no earlier than that seal. Evidence effective time remains unchanged. No strategy/provider policy changes.

## Proof
- red production evidence captured via sanitized aggregate query
- regression proves snapshot/evaluation/persistence never precede acquisition completion
- 12 focused temporal/Skew/all-consumer tests pass
- Ruff, strict mypy, diff check green

## Sprint effect
Makes the new temporal boundary truthful while preserving deterministic cycle orchestration and replay evidence. Worker self-review complete; Manager stop CLEAR.

Merge only after all CI gates complete green.