### PR TITLE
PL1-02 Gate 3: track and reconcile exact evidence

### DIFF
--- a/asa/api/portfolio_lifecycle_routes.py
+++ b/asa/api/portfolio_lifecycle_routes.py
@@ -1,0 +1,70 @@
+from collections.abc import Callable
+from datetime import UTC, datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from asa.application.portfolio_lifecycle import CandidateNotFoundError, TrackCandidateService
+from asa.contracts.portfolio_lifecycle import TrackedCandidate
+
+
+class TrackCandidateRequest(BaseModel):
+    strategy_id: str = Field(min_length=1, max_length=64)
+    symbol: str = Field(min_length=1, max_length=32)
+    observation_id: str = Field(min_length=1, max_length=128)
+
+
+class TrackedCandidateResponse(BaseModel):
+    id: UUID
+    originating_observation_id: str
+    opportunity_id: str | None
+    strategy_id: str
+    strategy_version: str
+    symbol: str
+    tracked_at: datetime
+    originating_observed_at: datetime
+    exact_option_symbols: list[str]
+
+    @classmethod
+    def from_domain(cls, candidate: TrackedCandidate) -> "TrackedCandidateResponse":
+        return cls(
+            id=candidate.id,
+            originating_observation_id=candidate.originating_observation_id,
+            opportunity_id=candidate.opportunity_id,
+            strategy_id=candidate.strategy_id,
+            strategy_version=candidate.strategy_version,
+            symbol=candidate.symbol,
+            tracked_at=candidate.tracked_at,
+            originating_observed_at=candidate.originating_observed_at,
+            exact_option_symbols=list(candidate.exact_option_symbols),
+        )
+
+
+def build_portfolio_lifecycle_router(
+    service: TrackCandidateService,
+    authorize: Callable[[Request], None],
+) -> APIRouter:
+    router = APIRouter(prefix="/api/v1", dependencies=[Depends(authorize)])
+
+    @router.post(
+        "/portfolio/tracked-candidates",
+        response_model=TrackedCandidateResponse,
+        operation_id="trackCandidate",
+    )
+    def track_candidate(payload: TrackCandidateRequest) -> TrackedCandidateResponse:
+        try:
+            candidate = service.track(
+                payload.strategy_id,
+                payload.symbol,
+                payload.observation_id,
+                datetime.now(UTC),
+            )
+        except CandidateNotFoundError:
+            raise HTTPException(
+                status_code=404,
+                detail="originating screening observation is unavailable",
+            ) from None
+        return TrackedCandidateResponse.from_domain(candidate)
+
+    return router

--- a/asa/application/portfolio_lifecycle.py
+++ b/asa/application/portfolio_lifecycle.py
@@ -1,0 +1,103 @@
+from datetime import UTC, datetime
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from asa.application.ports.portfolio_lifecycle import PortfolioLifecycleRepository
+from asa.contracts.portfolio import PortfolioSnapshot
+from asa.contracts.portfolio_lifecycle import (
+    PositionAssociation,
+    ReconciliationState,
+    TrackedCandidate,
+)
+from strategy_runtime.persistence import LatestResultRepository, UniversalSignalRow
+
+
+class CandidateNotFoundError(LookupError):
+    pass
+
+
+class TrackCandidateService:
+    def __init__(
+        self,
+        results: LatestResultRepository,
+        lifecycle: PortfolioLifecycleRepository,
+    ) -> None:
+        self._results = results
+        self._lifecycle = lifecycle
+
+    def track(
+        self, strategy_id: str, symbol: str, observation_id: str, tracked_at: datetime
+    ) -> TrackedCandidate:
+        row = self._results.get_one(strategy_id, symbol.upper())
+        if row is None or row.observation_id != observation_id:
+            raise CandidateNotFoundError("originating screening observation is unavailable")
+        candidate = _candidate_from_row(row, tracked_at)
+        return self._lifecycle.add_candidate(candidate)
+
+
+class PortfolioReconciliationService:
+    def reconcile_and_record(
+        self,
+        snapshot: PortfolioSnapshot,
+        repository: PortfolioLifecycleRepository,
+    ) -> tuple[PositionAssociation, ...]:
+        associations = self.reconcile(snapshot, repository.candidates())
+        for association in associations:
+            repository.append_association(association)
+        return associations
+
+    def reconcile(
+        self,
+        snapshot: PortfolioSnapshot,
+        candidates: tuple[TrackedCandidate, ...],
+    ) -> tuple[PositionAssociation, ...]:
+        observed_at = snapshot.observed_at
+        by_symbol: dict[str, list[TrackedCandidate]] = {}
+        for candidate in candidates:
+            if candidate.exact_option_symbols:
+                key = "|".join(sorted(candidate.exact_option_symbols))
+                by_symbol.setdefault(key, []).append(candidate)
+        held_by_account: dict[UUID, set[str]] = {}
+        for leg in snapshot.option_legs:
+            held_by_account.setdefault(leg.account_id, set()).add(leg.option_symbol)
+        associations: list[PositionAssociation] = []
+        for account_id, held in held_by_account.items():
+            for instrument_key, eligible in by_symbol.items():
+                required = set(instrument_key.split("|"))
+                if not required.issubset(held):
+                    continue
+                state = (
+                    ReconciliationState.MATCHED
+                    if len(eligible) == 1
+                    else ReconciliationState.AMBIGUOUS
+                )
+                for candidate in eligible:
+                    associations.append(
+                        PositionAssociation(
+                            tracked_candidate_id=candidate.id,
+                            broker_position_key=f"{account_id}:{instrument_key}",
+                            state=state,
+                            observed_at=observed_at,
+                        )
+                    )
+        return tuple(associations)
+
+
+def _candidate_from_row(row: UniversalSignalRow, tracked_at: datetime) -> TrackedCandidate:
+    option_symbols = row.metrics.get("decision.option_symbols")
+    native = None if option_symbols is None else option_symbols.native()
+    exact_symbols = (
+        tuple(sorted(str(item).upper() for item in native))
+        if isinstance(native, list)
+        else ()
+    )
+    return TrackedCandidate(
+        id=uuid5(NAMESPACE_URL, f"asa:tracked:{row.observation_id}"),
+        originating_observation_id=row.observation_id,
+        opportunity_id=row.opportunity_id,
+        strategy_id=row.signal_id,
+        strategy_version=row.signal_version,
+        symbol=row.symbol,
+        tracked_at=tracked_at.astimezone(UTC),
+        originating_observed_at=row.observed_at.astimezone(UTC),
+        exact_option_symbols=exact_symbols,
+    )

--- a/asa/application/portfolio_use_cases.py
+++ b/asa/application/portfolio_use_cases.py
@@ -5,12 +5,14 @@ from datetime import UTC, datetime, timedelta
 from typing import TypeVar
 from uuid import UUID, uuid4
 
+from asa.application.portfolio_lifecycle import PortfolioReconciliationService
 from asa.application.ports.brokers import (
     BrokerAccountsResult,
     BrokerPortfolioProvider,
     BrokerPortfolioProviderError,
     BrokerPositionsResult,
 )
+from asa.application.ports.portfolio_lifecycle import PortfolioLifecycleRepository
 from asa.application.ports.runs import RunPublicationRepository
 from asa.contracts.market import FreshnessStatus
 from asa.contracts.portfolio import (
@@ -54,9 +56,12 @@ class RunPortfolioIntelligence:
         provider: BrokerPortfolioProvider,
         repository: RunPublicationRepository,
         clock: Clock = lambda: datetime.now(UTC),
+        *,
+        lifecycle_repository: PortfolioLifecycleRepository | None = None,
     ) -> None:
         self._provider = provider
         self._repository = repository
+        self._lifecycle_repository = lifecycle_repository
         self._clock = clock
         self._logger = logging.getLogger("asa.portfolio_run")
 
@@ -89,6 +94,10 @@ class RunPortfolioIntelligence:
                 provider_name,
                 lambda: validate_snapshot(snapshot),
             )
+            if self._lifecycle_repository is not None:
+                PortfolioReconciliationService().reconcile_and_record(
+                    snapshot, self._lifecycle_repository
+                )
             current_step = RunStepName.PUBLISH
             publication = self._repository.publish_portfolio(run.id, snapshot, self._clock())
             self._log_step(run.id, current_step, snapshot.provider, None)

--- a/asa/application/ports/portfolio_lifecycle.py
+++ b/asa/application/ports/portfolio_lifecycle.py
@@ -1,0 +1,15 @@
+from typing import Protocol
+from uuid import UUID
+
+from asa.contracts.portfolio_lifecycle import PositionAssociation, TrackedCandidate
+
+
+class PortfolioLifecycleRepository(Protocol):
+    def add_candidate(self, candidate: TrackedCandidate) -> TrackedCandidate: ...
+
+    def candidates(self) -> tuple[TrackedCandidate, ...]: ...
+
+    def candidate(self, candidate_id: UUID) -> TrackedCandidate | None: ...
+
+    def append_association(self, association: PositionAssociation) -> None: ...
+

--- a/asa/bootstrap.py
+++ b/asa/bootstrap.py
@@ -8,20 +8,26 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import Engine
 
 from asa.api.agent_auth import build_agent_authorizer
+from asa.api.portfolio_lifecycle_routes import build_portfolio_lifecycle_router
 from asa.api.routes import build_router
 from asa.api.screening_routes import build_screening_router
+from asa.application.portfolio_lifecycle import TrackCandidateService
 from asa.application.portfolio_use_cases import (
     PublishedPortfolioQuery,
     RunPortfolioIntelligence,
     RunQueryService,
 )
 from asa.application.ports.brokers import BrokerPortfolioProvider
+from asa.application.ports.portfolio_lifecycle import PortfolioLifecycleRepository
 from asa.application.ports.quotes import QuoteProvider
 from asa.application.ports.repositories import MarketObservationRepository
 from asa.application.ports.runs import RunPublicationRepository
 from asa.application.use_cases import MarketQuoteService
 from asa.config import Settings
 from asa.integrations.observation_history_postgres import PostgresObservationHistoryRepository
+from asa.integrations.portfolio_lifecycle_postgres import (
+    PostgresPortfolioLifecycleRepository,
+)
 from asa.integrations.postgres import PostgresMarketObservationRepository, create_postgres_engine
 from asa.integrations.providers.deterministic_fake import DeterministicFakeQuoteProvider
 from asa.integrations.providers.deterministic_fake_broker import (
@@ -59,6 +65,7 @@ class DependencyOverrides:
     latest_result_repository: LatestResultRepository | None = None
     observation_history_repository: ObservationHistoryRepository | None = None
     acquisition_attempt_repository: AcquisitionAttemptRepository | None = None
+    portfolio_lifecycle_repository: PortfolioLifecycleRepository | None = None
     screening_operational_health: Callable[[], dict[str, object]] | None = None
 
 
@@ -76,6 +83,10 @@ def build_application(
     provider = selected.quote_provider or _build_provider(settings)
     run_repository = selected.run_repository or PostgresRunPublicationRepository(
         engine_factory(settings.database_url)
+    )
+    portfolio_lifecycle_repository = (
+        selected.portfolio_lifecycle_repository
+        or PostgresPortfolioLifecycleRepository(engine_factory(settings.database_url))
     )
     broker_provider = selected.broker_provider or _build_broker_provider(settings)
     latest_result_repository = selected.latest_result_repository or PostgresLatestResultRepository(
@@ -120,7 +131,11 @@ def build_application(
         repository=repository,
         fresh_for=timedelta(seconds=settings.fresh_for_seconds),
     )
-    portfolio_runner = RunPortfolioIntelligence(broker_provider, run_repository)
+    portfolio_runner = RunPortfolioIntelligence(
+        broker_provider,
+        run_repository,
+        lifecycle_repository=portfolio_lifecycle_repository,
+    )
     portfolio_query = PublishedPortfolioQuery(
         run_repository,
         timedelta(seconds=settings.portfolio_fresh_for_seconds),
@@ -167,6 +182,14 @@ def build_application(
             operational_health=screening_operational_health,
         )
     )
+    app.include_router(
+        build_portfolio_lifecycle_router(
+            TrackCandidateService(
+                latest_result_repository, portfolio_lifecycle_repository
+            ),
+            agent_authorize,
+        )
+    )
     mount_ui(app)
 
     @app.middleware("http")
@@ -199,6 +222,7 @@ def build_application(
         "portfolio_query": portfolio_query,
         "latest_result_repository": latest_result_repository,
         "observation_history_repository": observation_history_repository,
+        "portfolio_lifecycle_repository": portfolio_lifecycle_repository,
         "agent_authorize": agent_authorize,
     }
     return app

--- a/asa/contracts/portfolio_lifecycle.py
+++ b/asa/contracts/portfolio_lifecycle.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+
+class ReconciliationState(StrEnum):
+    TRACKED = "tracked"
+    MATCHED = "matched"
+    AMBIGUOUS = "ambiguous"
+    NO_MATCH = "no_match"
+
+
+@dataclass(frozen=True, slots=True)
+class TrackedCandidate:
+    id: UUID
+    originating_observation_id: str
+    opportunity_id: str | None
+    strategy_id: str
+    strategy_version: str
+    symbol: str
+    tracked_at: datetime
+    originating_observed_at: datetime
+    exact_option_symbols: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PositionAssociation:
+    tracked_candidate_id: UUID
+    broker_position_key: str
+    state: ReconciliationState
+    observed_at: datetime
+

--- a/asa/integrations/portfolio_lifecycle_postgres.py
+++ b/asa/integrations/portfolio_lifecycle_postgres.py
@@ -1,0 +1,92 @@
+from uuid import UUID
+
+from sqlalchemy import Engine, text
+from sqlalchemy.engine import RowMapping
+
+from asa.contracts.portfolio_lifecycle import (
+    PositionAssociation,
+    TrackedCandidate,
+)
+
+
+class PostgresPortfolioLifecycleRepository:
+    def __init__(self, engine: Engine) -> None:
+        self._engine = engine
+
+    def add_candidate(self, candidate: TrackedCandidate) -> TrackedCandidate:
+        with self._engine.begin() as connection:
+            connection.execute(
+                text("""
+                    INSERT INTO tracked_candidates (
+                        id, originating_observation_id, opportunity_id, signal_id,
+                        signal_version, symbol, tracked_at, originating_observed_at,
+                        exact_option_symbols
+                    ) VALUES (
+                        :id, :originating_observation_id, :opportunity_id, :signal_id,
+                        :signal_version, :symbol, :tracked_at, :originating_observed_at,
+                        :exact_option_symbols
+                    ) ON CONFLICT (originating_observation_id) DO NOTHING
+                """),
+                {
+                    "id": candidate.id,
+                    "originating_observation_id": candidate.originating_observation_id,
+                    "opportunity_id": candidate.opportunity_id,
+                    "signal_id": candidate.strategy_id,
+                    "signal_version": candidate.strategy_version,
+                    "symbol": candidate.symbol,
+                    "tracked_at": candidate.tracked_at,
+                    "originating_observed_at": candidate.originating_observed_at,
+                    "exact_option_symbols": list(candidate.exact_option_symbols),
+                },
+            )
+        stored = self.candidate(candidate.id)
+        if stored is None:
+            raise RuntimeError("tracked candidate could not be read after insertion")
+        return stored
+
+    def candidates(self) -> tuple[TrackedCandidate, ...]:
+        with self._engine.connect() as connection:
+            rows = connection.execute(
+                text("SELECT * FROM tracked_candidates ORDER BY tracked_at, id")
+            ).mappings()
+            return tuple(_candidate(row) for row in rows)
+
+    def candidate(self, candidate_id: UUID) -> TrackedCandidate | None:
+        with self._engine.connect() as connection:
+            row = connection.execute(
+                text("SELECT * FROM tracked_candidates WHERE id = :id"),
+                {"id": candidate_id},
+            ).mappings().first()
+            return None if row is None else _candidate(row)
+
+    def append_association(self, association: PositionAssociation) -> None:
+        with self._engine.begin() as connection:
+            connection.execute(
+                text("""
+                    INSERT INTO portfolio_position_associations (
+                        tracked_candidate_id, broker_position_key, state, observed_at
+                    ) VALUES (
+                        :tracked_candidate_id, :broker_position_key, :state, :observed_at
+                    ) ON CONFLICT DO NOTHING
+                """),
+                {
+                    "tracked_candidate_id": association.tracked_candidate_id,
+                    "broker_position_key": association.broker_position_key,
+                    "state": association.state.value,
+                    "observed_at": association.observed_at,
+                },
+            )
+
+
+def _candidate(row: RowMapping) -> TrackedCandidate:
+    return TrackedCandidate(
+        id=row["id"],
+        originating_observation_id=row["originating_observation_id"],
+        opportunity_id=row["opportunity_id"],
+        strategy_id=row["signal_id"],
+        strategy_version=row["signal_version"],
+        symbol=row["symbol"],
+        tracked_at=row["tracked_at"],
+        originating_observed_at=row["originating_observed_at"],
+        exact_option_symbols=tuple(row["exact_option_symbols"]),
+    )

--- a/migrations/versions/0016_portfolio_lifecycle_tracking.py
+++ b/migrations/versions/0016_portfolio_lifecycle_tracking.py
@@ -1,0 +1,56 @@
+"""Create tracked candidates and append-only position associations.
+
+Revision ID: 0016
+Revises: 0015
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0016"
+down_revision: str | None = "0015"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tracked_candidates",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("originating_observation_id", sa.String(128), nullable=False, unique=True),
+        sa.Column("opportunity_id", sa.String(128), nullable=True),
+        sa.Column("signal_id", sa.String(64), nullable=False),
+        sa.Column("signal_version", sa.String(64), nullable=False),
+        sa.Column("symbol", sa.String(32), nullable=False),
+        sa.Column("tracked_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("originating_observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("exact_option_symbols", sa.JSON(), nullable=False),
+    )
+    op.create_table(
+        "portfolio_position_associations",
+        sa.Column("id", sa.BigInteger(), sa.Identity(), primary_key=True),
+        sa.Column(
+            "tracked_candidate_id",
+            sa.Uuid(),
+            sa.ForeignKey("tracked_candidates.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("broker_position_key", sa.String(512), nullable=False),
+        sa.Column("state", sa.String(16), nullable=False),
+        sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint(
+            "tracked_candidate_id", "broker_position_key", "state", "observed_at",
+            name="uq_portfolio_position_association_observation",
+        ),
+        sa.CheckConstraint(
+            "state IN ('tracked', 'matched', 'ambiguous', 'no_match')",
+            name="ck_portfolio_position_association_state",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("portfolio_position_associations")
+    op.drop_table("tracked_candidates")

--- a/tests/asa/test_portfolio_lifecycle.py
+++ b/tests/asa/test_portfolio_lifecycle.py
@@ -1,0 +1,160 @@
+from dataclasses import replace
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from asa.application.portfolio_lifecycle import (
+    CandidateNotFoundError,
+    PortfolioReconciliationService,
+    TrackCandidateService,
+)
+from asa.application.portfolio_use_cases import RunPortfolioIntelligence
+from asa.bootstrap import DependencyOverrides, build_application
+from asa.config import Settings
+from asa.contracts.portfolio_lifecycle import ReconciliationState
+from asa.integrations.providers.deterministic_fake_broker import (
+    DeterministicFakeBrokerPortfolioProvider,
+)
+from strategy_runtime.persistence import UniversalSignalRow
+from strategy_runtime.values import TypedValue
+from tests.asa.fakes import InMemoryLatestResultRepository, InMemoryObservationRepository
+
+NOW = datetime(2026, 8, 28, 12, tzinfo=UTC)
+
+
+class MemoryLifecycleRepository:
+    def __init__(self) -> None:
+        self.values = {}
+        self.associations = []
+
+    def add_candidate(self, candidate):
+        self.values.setdefault(candidate.id, candidate)
+        return self.values[candidate.id]
+
+    def candidates(self):
+        return tuple(self.values.values())
+
+    def candidate(self, candidate_id):
+        return self.values.get(candidate_id)
+
+    def append_association(self, association):
+        self.associations.append(association)
+
+
+def _row(observation_id: str = "observation-1") -> UniversalSignalRow:
+    return UniversalSignalRow(
+        signal_id="earnings_calendar",
+        signal_version="1.2.0",
+        symbol="AAPL",
+        observation_id=observation_id,
+        opportunity_id="opportunity-1",
+        row_type="result",
+        verdict="PASS",
+        evaluation_state="pass",
+        lifecycle_stage="candidate",
+        recommendation_state="monitor",
+        data_quality="complete",
+        metrics={
+            "decision.option_symbols": TypedValue.of_structured(
+                ["AAPL260918C00200000", "AAPL260918C00210000"]
+            )
+        },
+        economics={},
+        blockers=(),
+        warnings=(),
+        provenance=("snapshot-1",),
+        observed_at=NOW,
+    )
+
+
+def test_track_this_is_idempotent_and_bound_to_exact_latest_observation() -> None:
+    results = InMemoryLatestResultRepository()
+    results.upsert(_row())
+    lifecycle = MemoryLifecycleRepository()
+    service = TrackCandidateService(results, lifecycle)
+
+    first = service.track("earnings_calendar", "aapl", "observation-1", NOW)
+    second = service.track("earnings_calendar", "AAPL", "observation-1", NOW)
+
+    assert first == second
+    assert first.originating_observation_id == "observation-1"
+    assert first.opportunity_id == "opportunity-1"
+    assert first.exact_option_symbols == (
+        "AAPL260918C00200000",
+        "AAPL260918C00210000",
+    )
+
+
+def test_track_this_rejects_stale_or_invented_observation_identity() -> None:
+    results = InMemoryLatestResultRepository()
+    results.upsert(_row())
+
+    with pytest.raises(CandidateNotFoundError):
+        TrackCandidateService(results, MemoryLifecycleRepository()).track(
+            "earnings_calendar", "AAPL", "different-observation", NOW
+        )
+
+
+def test_exact_option_evidence_uniquely_associates_held_position() -> None:
+    results = InMemoryLatestResultRepository()
+    results.upsert(_row())
+    lifecycle = MemoryLifecycleRepository()
+    candidate = TrackCandidateService(results, lifecycle).track(
+        "earnings_calendar", "AAPL", "observation-1", NOW
+    )
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    snapshot = RunPortfolioIntelligence._normalize(
+        provider.fetch_accounts(), provider.fetch_positions()
+    )
+
+    associations = PortfolioReconciliationService().reconcile(snapshot, (candidate,))
+
+    assert len(associations) == 1
+    assert associations[0].tracked_candidate_id == candidate.id
+    assert associations[0].state is ReconciliationState.MATCHED
+
+
+def test_equity_symbol_alone_never_manufactures_provenance() -> None:
+    candidate = replace(_row(), metrics={})
+    results = InMemoryLatestResultRepository()
+    results.upsert(candidate)
+    lifecycle = MemoryLifecycleRepository()
+    tracked = TrackCandidateService(results, lifecycle).track(
+        "earnings_calendar", "AAPL", "observation-1", NOW
+    )
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    snapshot = RunPortfolioIntelligence._normalize(
+        provider.fetch_accounts(), provider.fetch_positions()
+    )
+
+    assert PortfolioReconciliationService().reconcile(snapshot, (tracked,)) == ()
+
+
+def test_track_this_api_uses_exact_persisted_observation() -> None:
+    results = InMemoryLatestResultRepository()
+    results.upsert(_row())
+    lifecycle = MemoryLifecycleRepository()
+    app = build_application(
+        Settings(agent_api_token="test-token", _env_file=None),
+        DependencyOverrides(
+            repository=InMemoryObservationRepository(),
+            latest_result_repository=results,
+            portfolio_lifecycle_repository=lifecycle,
+        ),
+    )
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/portfolio/tracked-candidates",
+        headers={"Authorization": "Bearer test-token"},
+        json={
+            "strategy_id": "earnings_calendar",
+            "symbol": "AAPL",
+            "observation_id": "observation-1",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["originating_observation_id"] == "observation-1"
+    assert response.json()["opportunity_id"] == "opportunity-1"


### PR DESCRIPTION
## Ticket
PL1-02 / Gate 3 — closes #371

Assigned Worker: `implementation-worker`
Manager stop status: **CLEAR**

## Outcome
`Track This` creates an idempotent durable candidate bound to the exact current screening observation. Later portfolio publication records a match only when explicit exact option identities uniquely support one candidate. Equity symbol alone never manufactures provenance.

## Architecture
- Consumes authoritative screening latest-state and broker snapshot owners.
- Adds no market acquisition or evaluation ownership.
- Provenance is optional and immutable.
- Association observations are append-only.
- Generic contracts are broker-neutral.
- No order/execution surface.

## Scope exclusions
No ambiguity-review UX, option grouping, valuation/P&L, lifecycle-history UI, exit logic, or strategy change.

## Validation
- Gate tests: **5 passed**
- Full repository: **3,265 passed / 48 skipped**
- Architecture: **577 passed**
- Ruff: pass
- strict mypy changed scope: pass
- Lean pre-push: **5/5 passed**
- `git diff --check`: pass

## Worker self-review
Complete. Gate 3 only. Gate 4 remains sequentially blocked until merge and exact-main verification.

## Auto-merge authority
Qualifying under active PORTFOLIO-LIFECYCLE-001 delegation after required CI. Branch protection will not be bypassed.
