### PR TITLE
PL1-02 Gate 4: keep ambiguous matches unassociated

### DIFF
--- a/asa/contracts/portfolio_lifecycle.py
+++ b/asa/contracts/portfolio_lifecycle.py
@@ -31,3 +31,7 @@ class PositionAssociation:
     state: ReconciliationState
     observed_at: datetime
 
+    @property
+    def is_associated(self) -> bool:
+        """Only a unique match confers provenance; ambiguity is evidence, not association."""
+        return self.state is ReconciliationState.MATCHED

--- a/tests/asa/test_portfolio_lifecycle.py
+++ b/tests/asa/test_portfolio_lifecycle.py
@@ -1,5 +1,6 @@
 from dataclasses import replace
 from datetime import UTC, datetime
+from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
@@ -113,6 +114,31 @@ def test_exact_option_evidence_uniquely_associates_held_position() -> None:
     assert len(associations) == 1
     assert associations[0].tracked_candidate_id == candidate.id
     assert associations[0].state is ReconciliationState.MATCHED
+    assert associations[0].is_associated is True
+
+
+def test_duplicate_exact_candidates_remain_ambiguous_and_unassociated() -> None:
+    results = InMemoryLatestResultRepository()
+    results.upsert(_row())
+    lifecycle = MemoryLifecycleRepository()
+    first = TrackCandidateService(results, lifecycle).track(
+        "earnings_calendar", "AAPL", "observation-1", NOW
+    )
+    second = replace(
+        first,
+        id=uuid4(),
+        originating_observation_id="observation-2",
+    )
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    snapshot = RunPortfolioIntelligence._normalize(
+        provider.fetch_accounts(), provider.fetch_positions()
+    )
+
+    findings = PortfolioReconciliationService().reconcile(snapshot, (first, second))
+
+    assert len(findings) == 2
+    assert {item.state for item in findings} == {ReconciliationState.AMBIGUOUS}
+    assert not any(item.is_associated for item in findings)
 
 
 def test_equity_symbol_alone_never_manufactures_provenance() -> None:
@@ -128,7 +154,10 @@ def test_equity_symbol_alone_never_manufactures_provenance() -> None:
         provider.fetch_accounts(), provider.fetch_positions()
     )
 
+    before = snapshot
     assert PortfolioReconciliationService().reconcile(snapshot, (tracked,)) == ()
+    assert snapshot == before
+    assert snapshot.equity_positions[0].symbol == "AAPL"
 
 
 def test_track_this_api_uses_exact_persisted_observation() -> None:


### PR DESCRIPTION
## Ticket
PL1-02 / Gate 4 — closes #373

Assigned Worker: `implementation-worker`
Manager stop status: **CLEAR**

## Outcome
Makes association semantics explicit: only `matched` confers provenance. Duplicate exact candidates produce typed `ambiguous` findings whose `is_associated` is false. Symbol-only/no-match holdings remain unchanged in the canonical portfolio.

## Exclusions
No ambiguity-review UX, grouping, valuation, history UI, or strategy/provider behavior.

## Validation
- Focused lifecycle/domain: **12 passed**
- Architecture: **577 passed**
- Ruff: pass
- strict mypy: pass
- Lean pre-push: **5/5 passed**
- `git diff --check`: pass

## Worker self-review
Complete. Gate 4 only; no authority or architecture violation.

## Auto-merge authority
Qualifying under active PORTFOLIO-LIFECYCLE-001 delegation after required CI passes.
