### PR TITLE
PL1-03 Gate 5: derive truthful option structures

### DIFF
--- a/asa/application/portfolio_structures.py
+++ b/asa/application/portfolio_structures.py
@@ -1,0 +1,114 @@
+from collections import defaultdict
+from collections.abc import Iterable
+from decimal import Decimal
+
+from asa.contracts.portfolio import OptionPositionLeg, PositionSide
+from asa.contracts.portfolio_structures import (
+    OptionStructure,
+    OptionStructureKind,
+    OptionStructureProjection,
+    UnmatchedLegReason,
+    UnmatchedOptionLeg,
+)
+
+
+def project_option_structures(
+    legs: Iterable[OptionPositionLeg],
+) -> OptionStructureProjection:
+    """Derive only unambiguous structures without modifying canonical legs."""
+    grouped: dict[tuple[str, str], list[OptionPositionLeg]] = defaultdict(list)
+    for leg in legs:
+        grouped[(str(leg.account_id), leg.underlying_symbol)].append(leg)
+
+    structures: list[OptionStructure] = []
+    unmatched: list[UnmatchedOptionLeg] = []
+    for key in sorted(grouped):
+        group = tuple(sorted(grouped[key], key=_leg_order))
+        structure, reason = _recognize_exact_group(group)
+        if structure is not None:
+            structures.append(structure)
+        else:
+            unmatched.extend(UnmatchedOptionLeg(leg=leg, reason=reason) for leg in group)
+    return OptionStructureProjection(
+        structures=tuple(structures),
+        unmatched_legs=tuple(unmatched),
+    )
+
+
+def _recognize_exact_group(
+    legs: tuple[OptionPositionLeg, ...],
+) -> tuple[OptionStructure | None, UnmatchedLegReason]:
+    quantities = {abs(leg.quantity) for leg in legs}
+    if len(quantities) != 1 or quantities == {Decimal("0")}:
+        return None, UnmatchedLegReason.UNEQUAL_QUANTITIES
+    if len(legs) == 2:
+        if _is_calendar(legs):
+            return OptionStructure(
+                OptionStructureKind.CALENDAR, legs
+            ), UnmatchedLegReason.NO_SUPPORTED_STRUCTURE
+        if _is_vertical(legs):
+            return OptionStructure(
+                OptionStructureKind.VERTICAL, legs
+            ), UnmatchedLegReason.NO_SUPPORTED_STRUCTURE
+        return None, UnmatchedLegReason.NO_SUPPORTED_STRUCTURE
+    if len(legs) == 4 and _is_double_calendar(legs):
+        return OptionStructure(
+            OptionStructureKind.DOUBLE_CALENDAR, legs
+        ), UnmatchedLegReason.NO_SUPPORTED_STRUCTURE
+    if len(legs) > 2:
+        return None, UnmatchedLegReason.AMBIGUOUS_GROUPING
+    return None, UnmatchedLegReason.NO_SUPPORTED_STRUCTURE
+
+
+def _opposite_sides(legs: tuple[OptionPositionLeg, ...]) -> bool:
+    return {leg.side for leg in legs} == {PositionSide.LONG, PositionSide.SHORT}
+
+
+def _is_calendar(legs: tuple[OptionPositionLeg, ...]) -> bool:
+    if len(legs) != 2 or not _opposite_sides(legs):
+        return False
+    short = next(leg for leg in legs if leg.side == PositionSide.SHORT)
+    long = next(leg for leg in legs if leg.side == PositionSide.LONG)
+    return (
+        short.option_type == long.option_type
+        and short.strike == long.strike
+        and short.expiration < long.expiration
+    )
+
+
+def _is_vertical(legs: tuple[OptionPositionLeg, ...]) -> bool:
+    return (
+        len(legs) == 2
+        and _opposite_sides(legs)
+        and len({leg.option_type for leg in legs}) == 1
+        and len({leg.expiration for leg in legs}) == 1
+        and len({leg.strike for leg in legs}) == 2
+    )
+
+
+def _is_double_calendar(legs: tuple[OptionPositionLeg, ...]) -> bool:
+    if {leg.option_type.value for leg in legs} != {"call", "put"}:
+        return False
+    calendars = []
+    for option_type in sorted({leg.option_type for leg in legs}, key=lambda item: item.value):
+        pair = tuple(leg for leg in legs if leg.option_type == option_type)
+        if not _is_calendar(pair):
+            return False
+        calendars.append(pair)
+    front_back = {
+        (
+            next(leg.expiration for leg in pair if leg.side == PositionSide.SHORT),
+            next(leg.expiration for leg in pair if leg.side == PositionSide.LONG),
+        )
+        for pair in calendars
+    }
+    return len(front_back) == 1
+
+
+def _leg_order(leg: OptionPositionLeg) -> tuple[str, str, str, str]:
+    return (
+        leg.option_type.value,
+        leg.expiration.isoformat(),
+        str(leg.strike),
+        leg.side.value,
+    )

--- a/asa/contracts/portfolio_structures.py
+++ b/asa/contracts/portfolio_structures.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from enum import StrEnum
+
+from asa.contracts.portfolio import OptionPositionLeg
+
+
+class OptionStructureKind(StrEnum):
+    CALENDAR = "calendar"
+    DOUBLE_CALENDAR = "double_calendar"
+    VERTICAL = "vertical"
+
+
+class UnmatchedLegReason(StrEnum):
+    NO_SUPPORTED_STRUCTURE = "no_supported_structure"
+    AMBIGUOUS_GROUPING = "ambiguous_grouping"
+    UNEQUAL_QUANTITIES = "unequal_quantities"
+
+
+@dataclass(frozen=True, slots=True)
+class OptionStructure:
+    kind: OptionStructureKind
+    legs: tuple[OptionPositionLeg, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class UnmatchedOptionLeg:
+    leg: OptionPositionLeg
+    reason: UnmatchedLegReason
+
+
+@dataclass(frozen=True, slots=True)
+class OptionStructureProjection:
+    structures: tuple[OptionStructure, ...]
+    unmatched_legs: tuple[UnmatchedOptionLeg, ...]

--- a/tests/asa/test_portfolio_structures.py
+++ b/tests/asa/test_portfolio_structures.py
@@ -1,0 +1,95 @@
+from dataclasses import replace
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import UUID
+
+from asa.application.portfolio_structures import project_option_structures
+from asa.contracts.portfolio import OptionPositionLeg, OptionType, PositionSide
+from asa.contracts.portfolio_structures import OptionStructureKind, UnmatchedLegReason
+
+
+def _leg(
+    *, kind: OptionType, strike: str, expiration: date, side: PositionSide
+) -> OptionPositionLeg:
+    return OptionPositionLeg(
+        account_id=UUID("00000000-0000-0000-0000-000000000001"),
+        underlying_symbol="AAPL",
+        option_symbol=f"{kind.value}-{strike}-{expiration}-{side.value}",
+        option_type=kind,
+        strike=Decimal(strike),
+        expiration=expiration,
+        quantity=Decimal("1"),
+        side=side,
+        average_price=None,
+        observed_at=datetime(2026, 8, 28, tzinfo=UTC),
+        original_provider="fixture",
+    )
+
+
+def test_recognizes_calendar_without_changing_raw_legs() -> None:
+    legs = (
+        _leg(
+            kind=OptionType.CALL,
+            strike="200",
+            expiration=date(2026, 9, 18),
+            side=PositionSide.SHORT,
+        ),
+        _leg(
+            kind=OptionType.CALL,
+            strike="200",
+            expiration=date(2026, 10, 16),
+            side=PositionSide.LONG,
+        ),
+    )
+    projection = project_option_structures(legs)
+    assert projection.structures[0].kind == OptionStructureKind.CALENDAR
+    assert set(projection.structures[0].legs) == set(legs)
+    assert projection.unmatched_legs == ()
+
+
+def test_recognizes_vertical() -> None:
+    expiration = date(2026, 9, 18)
+    projection = project_option_structures(
+        (
+            _leg(kind=OptionType.PUT, strike="180", expiration=expiration, side=PositionSide.LONG),
+            _leg(kind=OptionType.PUT, strike="170", expiration=expiration, side=PositionSide.SHORT),
+        )
+    )
+    assert projection.structures[0].kind == OptionStructureKind.VERTICAL
+
+
+def test_recognizes_call_and_put_calendars_as_double_calendar() -> None:
+    front, back = date(2026, 9, 18), date(2026, 10, 16)
+    legs = tuple(
+        _leg(kind=kind, strike=strike, expiration=expiration, side=side)
+        for kind, strike in ((OptionType.CALL, "210"), (OptionType.PUT, "190"))
+        for expiration, side in ((front, PositionSide.SHORT), (back, PositionSide.LONG))
+    )
+    projection = project_option_structures(reversed(legs))
+    assert projection.structures[0].kind == OptionStructureKind.DOUBLE_CALENDAR
+    assert set(projection.structures[0].legs) == set(legs)
+
+
+def test_ambiguous_group_and_unequal_quantities_remain_unmatched() -> None:
+    expiration = date(2026, 9, 18)
+    three_legs = tuple(
+        _leg(kind=OptionType.CALL, strike=strike, expiration=expiration, side=side)
+        for strike, side in (
+            ("190", PositionSide.LONG),
+            ("200", PositionSide.SHORT),
+            ("210", PositionSide.LONG),
+        )
+    )
+    ambiguous = project_option_structures(three_legs)
+    assert ambiguous.structures == ()
+    assert {item.reason for item in ambiguous.unmatched_legs} == {
+        UnmatchedLegReason.AMBIGUOUS_GROUPING
+    }
+
+    unequal = project_option_structures(
+        (three_legs[0], replace(three_legs[1], quantity=Decimal("2")))
+    )
+    assert unequal.structures == ()
+    assert {item.reason for item in unequal.unmatched_legs} == {
+        UnmatchedLegReason.UNEQUAL_QUANTITIES
+    }


### PR DESCRIPTION
Ticket: PL1-03 / Gate 5
Assigned Worker: Codex Worker
Manager stop status: CLEAR

## Outcome
Adds immutable broker-neutral projections for calendars, double calendars, and verticals while preserving exact canonical option legs. Unsupported, ambiguous, and unequal-quantity groups remain explicitly unmatched.

## Stonk reuse evidence
Inspected its calendar, vertical, and double-calendar recognition behavior first. Reused the proven exact-leg relationship semantics, not its provider-coupled architecture, pricing, exit signals, or lifecycle row model.

## Boundary
No valuation, exit policy, lifecycle UI, provider acquisition, or broker action.

## Validation
- 10 focused tests passed
- Ruff passed
- mypy passed
- Lean pre-push 5/5

Closes #375