### PR TITLE
PL1-04 Gate 6: append truthful lifecycle observations

### DIFF
--- a/asa/api/portfolio_lifecycle_routes.py
+++ b/asa/api/portfolio_lifecycle_routes.py
@@ -24,6 +24,7 @@ class TrackedCandidateResponse(BaseModel):
     symbol: str
     tracked_at: datetime
     originating_observed_at: datetime
+    evidence_observed_at: datetime
     exact_option_symbols: list[str]
 
     @classmethod
@@ -37,6 +38,7 @@ class TrackedCandidateResponse(BaseModel):
             symbol=candidate.symbol,
             tracked_at=candidate.tracked_at,
             originating_observed_at=candidate.originating_observed_at,
+            evidence_observed_at=candidate.evidence_observed_at,
             exact_option_symbols=list(candidate.exact_option_symbols),
         )
 

--- a/asa/application/portfolio_lifecycle.py
+++ b/asa/application/portfolio_lifecycle.py
@@ -5,6 +5,8 @@ from asa.application.ports.portfolio_lifecycle import PortfolioLifecycleReposito
 from asa.contracts.portfolio import PortfolioSnapshot
 from asa.contracts.portfolio_lifecycle import (
     PositionAssociation,
+    PositionLifecycleObservation,
+    PositionLifecycleState,
     ReconciliationState,
     TrackedCandidate,
 )
@@ -43,6 +45,36 @@ class PortfolioReconciliationService:
         associations = self.reconcile(snapshot, repository.candidates())
         for association in associations:
             repository.append_association(association)
+        matched = {
+            item.tracked_candidate_id: item
+            for item in associations
+            if item.state is ReconciliationState.MATCHED
+        }
+        for candidate in repository.candidates():
+            matched_association = matched.get(candidate.id)
+            prior = repository.lifecycle_observations(candidate.id)
+            previously_open = any(item.state is PositionLifecycleState.OPEN for item in prior)
+            state = (
+                PositionLifecycleState.OPEN
+                if matched_association is not None
+                else PositionLifecycleState.CLOSED
+                if previously_open
+                else PositionLifecycleState.TRACKED
+            )
+            repository.append_lifecycle_observation(
+                PositionLifecycleObservation(
+                    tracked_candidate_id=candidate.id,
+                    state=state,
+                    broker_position_key=(
+                        None
+                        if matched_association is None
+                        else matched_association.broker_position_key
+                    ),
+                    broker_observed_at=snapshot.observed_at,
+                    strategy_result_observed_at=candidate.originating_observed_at,
+                    evidence_observed_at=candidate.evidence_observed_at,
+                )
+            )
         return associations
 
     def reconcile(
@@ -86,9 +118,7 @@ def _candidate_from_row(row: UniversalSignalRow, tracked_at: datetime) -> Tracke
     option_symbols = row.metrics.get("decision.option_symbols")
     native = None if option_symbols is None else option_symbols.native()
     exact_symbols = (
-        tuple(sorted(str(item).upper() for item in native))
-        if isinstance(native, list)
-        else ()
+        tuple(sorted(str(item).upper() for item in native)) if isinstance(native, list) else ()
     )
     return TrackedCandidate(
         id=uuid5(NAMESPACE_URL, f"asa:tracked:{row.observation_id}"),
@@ -99,5 +129,10 @@ def _candidate_from_row(row: UniversalSignalRow, tracked_at: datetime) -> Tracke
         symbol=row.symbol,
         tracked_at=tracked_at.astimezone(UTC),
         originating_observed_at=row.observed_at.astimezone(UTC),
+        evidence_observed_at=(
+            row.temporal.observed_at.astimezone(UTC)
+            if row.temporal is not None
+            else row.observed_at.astimezone(UTC)
+        ),
         exact_option_symbols=exact_symbols,
     )

--- a/asa/application/ports/portfolio_lifecycle.py
+++ b/asa/application/ports/portfolio_lifecycle.py
@@ -1,7 +1,11 @@
 from typing import Protocol
 from uuid import UUID
 
-from asa.contracts.portfolio_lifecycle import PositionAssociation, TrackedCandidate
+from asa.contracts.portfolio_lifecycle import (
+    PositionAssociation,
+    PositionLifecycleObservation,
+    TrackedCandidate,
+)
 
 
 class PortfolioLifecycleRepository(Protocol):
@@ -13,3 +17,8 @@ class PortfolioLifecycleRepository(Protocol):
 
     def append_association(self, association: PositionAssociation) -> None: ...
 
+    def append_lifecycle_observation(self, observation: PositionLifecycleObservation) -> None: ...
+
+    def lifecycle_observations(
+        self, candidate_id: UUID
+    ) -> tuple[PositionLifecycleObservation, ...]: ...

--- a/asa/contracts/portfolio_lifecycle.py
+++ b/asa/contracts/portfolio_lifecycle.py
@@ -11,6 +11,12 @@ class ReconciliationState(StrEnum):
     NO_MATCH = "no_match"
 
 
+class PositionLifecycleState(StrEnum):
+    TRACKED = "tracked"
+    OPEN = "open"
+    CLOSED = "closed"
+
+
 @dataclass(frozen=True, slots=True)
 class TrackedCandidate:
     id: UUID
@@ -21,6 +27,7 @@ class TrackedCandidate:
     symbol: str
     tracked_at: datetime
     originating_observed_at: datetime
+    evidence_observed_at: datetime
     exact_option_symbols: tuple[str, ...]
 
 
@@ -35,3 +42,13 @@ class PositionAssociation:
     def is_associated(self) -> bool:
         """Only a unique match confers provenance; ambiguity is evidence, not association."""
         return self.state is ReconciliationState.MATCHED
+
+
+@dataclass(frozen=True, slots=True)
+class PositionLifecycleObservation:
+    tracked_candidate_id: UUID
+    state: PositionLifecycleState
+    broker_position_key: str | None
+    broker_observed_at: datetime
+    strategy_result_observed_at: datetime
+    evidence_observed_at: datetime

--- a/asa/integrations/portfolio_lifecycle_postgres.py
+++ b/asa/integrations/portfolio_lifecycle_postgres.py
@@ -5,6 +5,8 @@ from sqlalchemy.engine import RowMapping
 
 from asa.contracts.portfolio_lifecycle import (
     PositionAssociation,
+    PositionLifecycleObservation,
+    PositionLifecycleState,
     TrackedCandidate,
 )
 
@@ -20,11 +22,11 @@ class PostgresPortfolioLifecycleRepository:
                     INSERT INTO tracked_candidates (
                         id, originating_observation_id, opportunity_id, signal_id,
                         signal_version, symbol, tracked_at, originating_observed_at,
-                        exact_option_symbols
+                        evidence_observed_at, exact_option_symbols
                     ) VALUES (
                         :id, :originating_observation_id, :opportunity_id, :signal_id,
                         :signal_version, :symbol, :tracked_at, :originating_observed_at,
-                        :exact_option_symbols
+                        :evidence_observed_at, :exact_option_symbols
                     ) ON CONFLICT (originating_observation_id) DO NOTHING
                 """),
                 {
@@ -36,6 +38,7 @@ class PostgresPortfolioLifecycleRepository:
                     "symbol": candidate.symbol,
                     "tracked_at": candidate.tracked_at,
                     "originating_observed_at": candidate.originating_observed_at,
+                    "evidence_observed_at": candidate.evidence_observed_at,
                     "exact_option_symbols": list(candidate.exact_option_symbols),
                 },
             )
@@ -53,10 +56,14 @@ class PostgresPortfolioLifecycleRepository:
 
     def candidate(self, candidate_id: UUID) -> TrackedCandidate | None:
         with self._engine.connect() as connection:
-            row = connection.execute(
-                text("SELECT * FROM tracked_candidates WHERE id = :id"),
-                {"id": candidate_id},
-            ).mappings().first()
+            row = (
+                connection.execute(
+                    text("SELECT * FROM tracked_candidates WHERE id = :id"),
+                    {"id": candidate_id},
+                )
+                .mappings()
+                .first()
+            )
             return None if row is None else _candidate(row)
 
     def append_association(self, association: PositionAssociation) -> None:
@@ -77,6 +84,44 @@ class PostgresPortfolioLifecycleRepository:
                 },
             )
 
+    def append_lifecycle_observation(self, observation: PositionLifecycleObservation) -> None:
+        with self._engine.begin() as connection:
+            connection.execute(
+                text("""
+                    INSERT INTO portfolio_lifecycle_observations (
+                        tracked_candidate_id, state, broker_position_key,
+                        broker_observed_at, strategy_result_observed_at,
+                        evidence_observed_at
+                    ) VALUES (
+                        :tracked_candidate_id, :state, :broker_position_key,
+                        :broker_observed_at, :strategy_result_observed_at,
+                        :evidence_observed_at
+                    ) ON CONFLICT DO NOTHING
+                """),
+                {
+                    "tracked_candidate_id": observation.tracked_candidate_id,
+                    "state": observation.state.value,
+                    "broker_position_key": observation.broker_position_key,
+                    "broker_observed_at": observation.broker_observed_at,
+                    "strategy_result_observed_at": observation.strategy_result_observed_at,
+                    "evidence_observed_at": observation.evidence_observed_at,
+                },
+            )
+
+    def lifecycle_observations(
+        self, candidate_id: UUID
+    ) -> tuple[PositionLifecycleObservation, ...]:
+        with self._engine.connect() as connection:
+            rows = connection.execute(
+                text("""
+                    SELECT * FROM portfolio_lifecycle_observations
+                    WHERE tracked_candidate_id = :candidate_id
+                    ORDER BY broker_observed_at, id
+                """),
+                {"candidate_id": candidate_id},
+            ).mappings()
+            return tuple(_lifecycle_observation(row) for row in rows)
+
 
 def _candidate(row: RowMapping) -> TrackedCandidate:
     return TrackedCandidate(
@@ -88,5 +133,17 @@ def _candidate(row: RowMapping) -> TrackedCandidate:
         symbol=row["symbol"],
         tracked_at=row["tracked_at"],
         originating_observed_at=row["originating_observed_at"],
+        evidence_observed_at=row["evidence_observed_at"],
         exact_option_symbols=tuple(row["exact_option_symbols"]),
+    )
+
+
+def _lifecycle_observation(row: RowMapping) -> PositionLifecycleObservation:
+    return PositionLifecycleObservation(
+        tracked_candidate_id=row["tracked_candidate_id"],
+        state=PositionLifecycleState(row["state"]),
+        broker_position_key=row["broker_position_key"],
+        broker_observed_at=row["broker_observed_at"],
+        strategy_result_observed_at=row["strategy_result_observed_at"],
+        evidence_observed_at=row["evidence_observed_at"],
     )

--- a/migrations/versions/0017_portfolio_lifecycle_observations.py
+++ b/migrations/versions/0017_portfolio_lifecycle_observations.py
@@ -1,0 +1,53 @@
+"""Add append-only lifecycle observations and evidence time.
+
+Revision ID: 0017
+Revises: 0016
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0017"
+down_revision: str | None = "0016"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tracked_candidates",
+        sa.Column("evidence_observed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.execute("UPDATE tracked_candidates SET evidence_observed_at = originating_observed_at")
+    op.alter_column("tracked_candidates", "evidence_observed_at", nullable=False)
+    op.create_table(
+        "portfolio_lifecycle_observations",
+        sa.Column("id", sa.BigInteger(), sa.Identity(), primary_key=True),
+        sa.Column(
+            "tracked_candidate_id",
+            sa.Uuid(),
+            sa.ForeignKey("tracked_candidates.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("state", sa.String(16), nullable=False),
+        sa.Column("broker_position_key", sa.String(512), nullable=True),
+        sa.Column("broker_observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("strategy_result_observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("evidence_observed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "state IN ('tracked', 'open', 'closed')",
+            name="ck_portfolio_lifecycle_observation_state",
+        ),
+        sa.UniqueConstraint(
+            "tracked_candidate_id",
+            "broker_observed_at",
+            name="uq_portfolio_lifecycle_candidate_broker_time",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("portfolio_lifecycle_observations")
+    op.drop_column("tracked_candidates", "evidence_observed_at")

--- a/tests/asa/test_portfolio_lifecycle.py
+++ b/tests/asa/test_portfolio_lifecycle.py
@@ -1,5 +1,5 @@
 from dataclasses import replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
@@ -13,7 +13,10 @@ from asa.application.portfolio_lifecycle import (
 from asa.application.portfolio_use_cases import RunPortfolioIntelligence
 from asa.bootstrap import DependencyOverrides, build_application
 from asa.config import Settings
-from asa.contracts.portfolio_lifecycle import ReconciliationState
+from asa.contracts.portfolio_lifecycle import (
+    PositionLifecycleState,
+    ReconciliationState,
+)
 from asa.integrations.providers.deterministic_fake_broker import (
     DeterministicFakeBrokerPortfolioProvider,
 )
@@ -28,6 +31,7 @@ class MemoryLifecycleRepository:
     def __init__(self) -> None:
         self.values = {}
         self.associations = []
+        self.observations = []
 
     def add_candidate(self, candidate):
         self.values.setdefault(candidate.id, candidate)
@@ -41,6 +45,15 @@ class MemoryLifecycleRepository:
 
     def append_association(self, association):
         self.associations.append(association)
+
+    def append_lifecycle_observation(self, observation):
+        if observation not in self.observations:
+            self.observations.append(observation)
+
+    def lifecycle_observations(self, candidate_id):
+        return tuple(
+            item for item in self.observations if item.tracked_candidate_id == candidate_id
+        )
 
 
 def _row(observation_id: str = "observation-1") -> UniversalSignalRow:
@@ -85,6 +98,7 @@ def test_track_this_is_idempotent_and_bound_to_exact_latest_observation() -> Non
         "AAPL260918C00200000",
         "AAPL260918C00210000",
     )
+    assert first.evidence_observed_at == NOW
 
 
 def test_track_this_rejects_stale_or_invented_observation_identity() -> None:
@@ -187,3 +201,37 @@ def test_track_this_api_uses_exact_persisted_observation() -> None:
     assert response.status_code == 200
     assert response.json()["originating_observation_id"] == "observation-1"
     assert response.json()["opportunity_id"] == "opportunity-1"
+
+
+def test_lifecycle_observations_append_open_then_closed_with_separate_clocks() -> None:
+    results = InMemoryLatestResultRepository()
+    results.upsert(_row())
+    lifecycle = MemoryLifecycleRepository()
+    candidate = TrackCandidateService(results, lifecycle).track(
+        "earnings_calendar", "AAPL", "observation-1", NOW
+    )
+    candidate = replace(candidate, evidence_observed_at=NOW - timedelta(minutes=5))
+    lifecycle.values[candidate.id] = candidate
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    open_snapshot = RunPortfolioIntelligence._normalize(
+        provider.fetch_accounts(), provider.fetch_positions()
+    )
+    service = PortfolioReconciliationService()
+
+    service.reconcile_and_record(open_snapshot, lifecycle)
+    closed_snapshot = replace(
+        open_snapshot,
+        observed_at=open_snapshot.observed_at + timedelta(hours=1),
+        option_legs=(),
+    )
+    service.reconcile_and_record(closed_snapshot, lifecycle)
+
+    observations = lifecycle.lifecycle_observations(candidate.id)
+    assert [item.state for item in observations] == [
+        PositionLifecycleState.OPEN,
+        PositionLifecycleState.CLOSED,
+    ]
+    assert observations[0].broker_observed_at == open_snapshot.observed_at
+    assert observations[0].strategy_result_observed_at == NOW
+    assert observations[0].evidence_observed_at == NOW - timedelta(minutes=5)
+    assert lifecycle.candidate(candidate.id) == candidate


### PR DESCRIPTION
Ticket: PL1-04 / Gate 6
Assigned Worker: Codex Worker
Manager stop status: CLEAR

## Outcome
Each tracked candidate now receives append-only TRACKED/OPEN/CLOSED observations from coherent broker snapshots. The immutable originating candidate remains unchanged. Broker observation, strategy-result observation, and underlying evidence timestamps are persisted independently.

## Behavior
A unique exact-leg match observes OPEN. A later broker snapshot without those legs observes CLOSED. Never-open candidates remain TRACKED. No execution behavior exists.

## Boundary
No valuation, exit policy, UI, provider acquisition, or broker action.

## Validation
- OPEN to CLOSED regression and immutable origin proof
- 590 architecture/portfolio tests passed, 4 skipped
- Ruff and mypy passed
- Lean pre-push 5/5

Closes #377