### PR TITLE
PL1-06 Gate 9: expose auditable strategy health

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -54,9 +54,7 @@ def _wire_metrics(result: UniversalScreeningResult) -> dict[str, str]:
     }
 
 
-def _prefixed_values(
-    result: UniversalScreeningResult, prefix: str
-) -> dict[str, str]:
+def _prefixed_values(result: UniversalScreeningResult, prefix: str) -> dict[str, str]:
     return {
         key.removeprefix(prefix): str(value.native())
         for key, value in result.metrics.items()
@@ -109,6 +107,28 @@ class ScreeningOperationalHealthResponse(BaseModel):
     last_batch_pair_count: int
     last_batch_failure_count: int
     last_batch_incomplete_diagnostic_count: int
+
+
+class ReasonCountResponse(BaseModel):
+    reason: str
+    count: int
+
+
+class StrategyHealthFunnelResponse(BaseModel):
+    strategy_id: str
+    active_subjects: int
+    evaluated: int
+    evidence_sufficient: int
+    structure_eligible_or_constructible: int
+    gates_passed: int
+    watch: int
+    passed: int
+    typed_unknown_counts: list[ReasonCountResponse]
+    typed_rejection_counts: list[ReasonCountResponse]
+
+
+class StrategyHealthResponse(BaseModel):
+    strategies: list[StrategyHealthFunnelResponse]
 
 
 class ScreeningResultResponse(TimestampedResource):
@@ -207,16 +227,12 @@ class ScreeningResultResponse(TimestampedResource):
             status=result.recommendation_state,
             data_quality=result.data_quality,
             freshness=(
-                "fresh"
-                if freshness_status in {"fresh", "live", "prior_session"}
-                else "stale"
+                "fresh" if freshness_status in {"fresh", "live", "prior_session"} else "stale"
             ),
             economics=_wire_values(
                 {key: value.native() for key, value in result.economics.items()}
             ),
-            metric_types={
-                key: value.value_type.value for key, value in result.metrics.items()
-            },
+            metric_types={key: value.value_type.value for key, value in result.metrics.items()},
             economics_types={
                 key: value.value_type.value for key, value in result.economics.items()
             },
@@ -246,51 +262,33 @@ class ScreeningResultResponse(TimestampedResource):
             received_at=received_at,
             evaluated_at=evaluated_at,
             persisted_at=persisted_at,
-            market_session_date=(
-                temporal.market_session_date if temporal is not None else None
-            ),
+            market_session_date=(temporal.market_session_date if temporal is not None else None),
             market_session_status=(
                 temporal.market_session_status if temporal is not None else "unknown"
             ),
             last_refresh_attempt_at=(
-                temporal.last_refresh_attempt_at
-                if temporal is not None
-                else result.observed_at
+                temporal.last_refresh_attempt_at if temporal is not None else result.observed_at
             ),
             last_successful_refresh_at=(
-                temporal.last_successful_refresh_at
-                if temporal is not None
-                else result.observed_at
+                temporal.last_successful_refresh_at if temporal is not None else result.observed_at
             ),
-            next_refresh_at=(
-                temporal.next_refresh_at if temporal is not None else None
-            ),
+            next_refresh_at=(temporal.next_refresh_at if temporal is not None else None),
             data_advanced_on_last_refresh=(
-                temporal.data_advanced_on_last_refresh
-                if temporal is not None
-                else False
+                temporal.data_advanced_on_last_refresh if temporal is not None else False
             ),
             freshness_status=freshness_status,
-            usability_status=(
-                temporal.usability_status if temporal is not None else "unknown"
-            ),
+            usability_status=(temporal.usability_status if temporal is not None else "unknown"),
             usability_reason=(
                 temporal.usability_reason
                 if temporal is not None
                 else "temporal metadata unavailable"
             ),
-            warning_codes=(
-                list(temporal.warning_codes) if temporal is not None else []
-            ),
+            warning_codes=(list(temporal.warning_codes) if temporal is not None else []),
             acquisition_started_at=(
-                temporal.acquisition_started_at
-                if temporal is not None
-                else result.observed_at
+                temporal.acquisition_started_at if temporal is not None else result.observed_at
             ),
             acquisition_completed_at=(
-                temporal.acquisition_completed_at
-                if temporal is not None
-                else result.observed_at
+                temporal.acquisition_completed_at if temporal is not None else result.observed_at
             ),
             input_time_skew_seconds=(
                 temporal.input_time_skew_seconds if temporal is not None else 0

--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -36,11 +36,14 @@ from asa.api.agent_models import agent_api_error
 from asa.api.screening_models import (
     CapabilitiesResponse,
     OpportunityHistoryResponse,
+    ReasonCountResponse,
     RefreshResultResponse,
     ScreeningOperationalHealthResponse,
     ScreeningResultResponse,
     ScreeningResultsEnvelope,
     SignalCapabilityResponse,
+    StrategyHealthFunnelResponse,
+    StrategyHealthResponse,
 )
 from domain import MarketObservation, UnknownReason
 from market_data import load_market_data_config_from_environment
@@ -61,6 +64,7 @@ from strategy_runtime.adapters import (
     migrated_shadow_resolution_policy,
 )
 from strategy_runtime.catalog import SignalCatalogEntry
+from strategy_runtime.health import build_strategy_health
 from strategy_runtime.knowledge import ReadOnlyStrategyInput
 from strategy_runtime.lifecycle import RecommendedAction
 from strategy_runtime.market_data_planning import (
@@ -293,6 +297,40 @@ def build_screening_router(
             offset=offset,
         )
 
+    @router.get("/screening-health", response_model=StrategyHealthResponse)
+    def strategy_health() -> StrategyHealthResponse:
+        state = get_state(repository)
+        funnels = [
+            build_strategy_health(
+                strategy_id,
+                tuple(item for item in state if item.strategy_id == strategy_id),
+            )
+            for strategy_id in registry.strategy_ids()
+        ]
+        return StrategyHealthResponse(
+            strategies=[
+                StrategyHealthFunnelResponse(
+                    strategy_id=item.strategy_id,
+                    active_subjects=item.active_subjects,
+                    evaluated=item.evaluated,
+                    evidence_sufficient=item.evidence_sufficient,
+                    structure_eligible_or_constructible=(item.structure_eligible_or_constructible),
+                    gates_passed=item.gates_passed,
+                    watch=item.watch,
+                    passed=item.passed,
+                    typed_unknown_counts=[
+                        ReasonCountResponse(reason=reason, count=count)
+                        for reason, count in item.typed_unknown_counts
+                    ],
+                    typed_rejection_counts=[
+                        ReasonCountResponse(reason=reason, count=count)
+                        for reason, count in item.typed_rejection_counts
+                    ],
+                )
+                for item in funnels
+            ]
+        )
+
     @router.get(
         "/screening/opportunities/{opportunity_id}/history",
         response_model=OpportunityHistoryResponse,
@@ -425,9 +463,7 @@ def build_screening_router(
         shadow_knowledge_by_subject: (
             dict[str, ReadOnlyStrategyInput[object] | UnknownReason] | None
         ) = None
-        shadow_temporal_observations_by_strategy: dict[
-            str, tuple[MarketObservation, ...]
-        ] = {}
+        shadow_temporal_observations_by_strategy: dict[str, tuple[MarketObservation, ...]] = {}
         if signal in shadow_registry.strategy_ids():
             try:
                 prepared_subject = prepare_subject_shadow_knowledge_with_temporal(
@@ -442,9 +478,7 @@ def build_screening_router(
                     capability_reducer_by_capability=migrated_shadow_capability_reducers(),
                     strategy_ids=(signal,),
                 )
-                shadow_knowledge_by_subject = dict(
-                    prepared_subject.knowledge_by_strategy
-                )
+                shadow_knowledge_by_subject = dict(prepared_subject.knowledge_by_strategy)
                 shadow_temporal_observations_by_strategy = dict(
                     prepared_subject.temporal_observations_by_strategy
                 )

--- a/frontend/src/api/generated/index.ts
+++ b/frontend/src/api/generated/index.ts
@@ -35,6 +35,7 @@ export type { PositionValuationResponse } from './models/PositionValuationRespon
 export type { ProvenanceResponse } from './models/ProvenanceResponse';
 export type { ProviderResultResponse } from './models/ProviderResultResponse';
 export type { QuoteResponse } from './models/QuoteResponse';
+export type { ReasonCountResponse } from './models/ReasonCountResponse';
 export type { RefreshResultResponse } from './models/RefreshResultResponse';
 export type { RunResponse } from './models/RunResponse';
 export type { RunStepResponse } from './models/RunStepResponse';
@@ -43,6 +44,8 @@ export type { ScreeningResultResponse } from './models/ScreeningResultResponse';
 export type { ScreeningResultsEnvelope } from './models/ScreeningResultsEnvelope';
 export type { SignalCapabilityResponse } from './models/SignalCapabilityResponse';
 export type { StartRunRequest } from './models/StartRunRequest';
+export type { StrategyHealthFunnelResponse } from './models/StrategyHealthFunnelResponse';
+export type { StrategyHealthResponse } from './models/StrategyHealthResponse';
 export type { TrackCandidateRequest } from './models/TrackCandidateRequest';
 export type { TrackedCandidateDetailResponse } from './models/TrackedCandidateDetailResponse';
 export type { TrackedCandidateResponse } from './models/TrackedCandidateResponse';

--- a/frontend/src/api/generated/models/ReasonCountResponse.ts
+++ b/frontend/src/api/generated/models/ReasonCountResponse.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ReasonCountResponse = {
+    reason: string;
+    count: number;
+};

--- a/frontend/src/api/generated/models/StrategyHealthFunnelResponse.ts
+++ b/frontend/src/api/generated/models/StrategyHealthFunnelResponse.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ReasonCountResponse } from './ReasonCountResponse';
+export type StrategyHealthFunnelResponse = {
+    strategy_id: string;
+    active_subjects: number;
+    evaluated: number;
+    evidence_sufficient: number;
+    structure_eligible_or_constructible: number;
+    gates_passed: number;
+    watch: number;
+    passed: number;
+    typed_unknown_counts: Array<ReasonCountResponse>;
+    typed_rejection_counts: Array<ReasonCountResponse>;
+};

--- a/frontend/src/api/generated/models/StrategyHealthResponse.ts
+++ b/frontend/src/api/generated/models/StrategyHealthResponse.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { StrategyHealthFunnelResponse } from './StrategyHealthFunnelResponse';
+export type StrategyHealthResponse = {
+    strategies: Array<StrategyHealthFunnelResponse>;
+};

--- a/frontend/src/api/generated/services/DefaultService.ts
+++ b/frontend/src/api/generated/services/DefaultService.ts
@@ -19,6 +19,7 @@ import type { ScreeningOperationalHealthResponse } from '../models/ScreeningOper
 import type { ScreeningResultResponse } from '../models/ScreeningResultResponse';
 import type { ScreeningResultsEnvelope } from '../models/ScreeningResultsEnvelope';
 import type { StartRunRequest } from '../models/StartRunRequest';
+import type { StrategyHealthResponse } from '../models/StrategyHealthResponse';
 import type { TrackCandidateRequest } from '../models/TrackCandidateRequest';
 import type { TrackedCandidateDetailResponse } from '../models/TrackedCandidateDetailResponse';
 import type { TrackedCandidateResponse } from '../models/TrackedCandidateResponse';
@@ -337,6 +338,17 @@ export class DefaultService {
             errors: {
                 422: `Validation Error`,
             },
+        });
+    }
+    /**
+     * Strategy Health
+     * @returns StrategyHealthResponse Successful Response
+     * @throws ApiError
+     */
+    public static strategyHealthApiV1ScreeningHealthGet(): CancelablePromise<StrategyHealthResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/screening-health',
         });
     }
     /**

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -816,6 +816,24 @@
         }
       }
     },
+    "/api/v1/screening-health": {
+      "get": {
+        "summary": "Strategy Health",
+        "operationId": "strategy_health_api_v1_screening_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StrategyHealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/screening/opportunities/{opportunity_id}/history": {
       "get": {
         "summary": "Opportunity History",
@@ -2328,6 +2346,24 @@
         ],
         "title": "QuoteResponse"
       },
+      "ReasonCountResponse": {
+        "properties": {
+          "reason": {
+            "type": "string",
+            "title": "Reason"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "reason",
+          "count"
+        ],
+        "title": "ReasonCountResponse"
+      },
       "RefreshResultResponse": {
         "properties": {
           "updated_at": {
@@ -3439,6 +3475,86 @@
           "effective_config_hash"
         ],
         "title": "StartRunRequest"
+      },
+      "StrategyHealthFunnelResponse": {
+        "properties": {
+          "strategy_id": {
+            "type": "string",
+            "title": "Strategy Id"
+          },
+          "active_subjects": {
+            "type": "integer",
+            "title": "Active Subjects"
+          },
+          "evaluated": {
+            "type": "integer",
+            "title": "Evaluated"
+          },
+          "evidence_sufficient": {
+            "type": "integer",
+            "title": "Evidence Sufficient"
+          },
+          "structure_eligible_or_constructible": {
+            "type": "integer",
+            "title": "Structure Eligible Or Constructible"
+          },
+          "gates_passed": {
+            "type": "integer",
+            "title": "Gates Passed"
+          },
+          "watch": {
+            "type": "integer",
+            "title": "Watch"
+          },
+          "passed": {
+            "type": "integer",
+            "title": "Passed"
+          },
+          "typed_unknown_counts": {
+            "items": {
+              "$ref": "#/components/schemas/ReasonCountResponse"
+            },
+            "type": "array",
+            "title": "Typed Unknown Counts"
+          },
+          "typed_rejection_counts": {
+            "items": {
+              "$ref": "#/components/schemas/ReasonCountResponse"
+            },
+            "type": "array",
+            "title": "Typed Rejection Counts"
+          }
+        },
+        "type": "object",
+        "required": [
+          "strategy_id",
+          "active_subjects",
+          "evaluated",
+          "evidence_sufficient",
+          "structure_eligible_or_constructible",
+          "gates_passed",
+          "watch",
+          "passed",
+          "typed_unknown_counts",
+          "typed_rejection_counts"
+        ],
+        "title": "StrategyHealthFunnelResponse"
+      },
+      "StrategyHealthResponse": {
+        "properties": {
+          "strategies": {
+            "items": {
+              "$ref": "#/components/schemas/StrategyHealthFunnelResponse"
+            },
+            "type": "array",
+            "title": "Strategies"
+          }
+        },
+        "type": "object",
+        "required": [
+          "strategies"
+        ],
+        "title": "StrategyHealthResponse"
       },
       "TrackCandidateRequest": {
         "properties": {

--- a/strategy_runtime/health.py
+++ b/strategy_runtime/health.py
@@ -1,0 +1,80 @@
+from collections import Counter
+from dataclasses import dataclass
+
+from strategy_runtime.result import (
+    SUCCESS_EVALUATION_STATES,
+    EvaluationState,
+    UniversalScreeningResult,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyHealthFunnel:
+    strategy_id: str
+    active_subjects: int
+    evaluated: int
+    evidence_sufficient: int
+    structure_eligible_or_constructible: int
+    gates_passed: int
+    watch: int
+    passed: int
+    typed_unknown_counts: tuple[tuple[str, int], ...]
+    typed_rejection_counts: tuple[tuple[str, int], ...]
+
+
+def build_strategy_health(
+    strategy_id: str,
+    records: tuple[UniversalScreeningResult, ...],
+) -> StrategyHealthFunnel:
+    evaluated_records = tuple(
+        item for item in records if item.evaluation_state in SUCCESS_EVALUATION_STATES
+    )
+    unknowns: Counter[str] = Counter()
+    rejections: Counter[str] = Counter()
+    for item in records:
+        reasons = _reasons(item)
+        destination = (
+            unknowns if item.evaluation_state not in SUCCESS_EVALUATION_STATES else rejections
+        )
+        for reason in reasons:
+            destination[reason] += 1
+    watch = sum(_verdict(item) == "WATCH" for item in evaluated_records)
+    passed = sum(_verdict(item) == "PASS" for item in evaluated_records)
+    structure_eligible = sum("decision.structure" in item.metrics for item in evaluated_records)
+    return StrategyHealthFunnel(
+        strategy_id=strategy_id,
+        active_subjects=len(records),
+        evaluated=len(evaluated_records),
+        evidence_sufficient=len(evaluated_records),
+        structure_eligible_or_constructible=structure_eligible,
+        gates_passed=watch + passed,
+        watch=watch,
+        passed=passed,
+        typed_unknown_counts=tuple(sorted(unknowns.items())),
+        typed_rejection_counts=tuple(sorted(rejections.items())),
+    )
+
+
+def _verdict(item: UniversalScreeningResult) -> str:
+    return (item.verdict or "").upper()
+
+
+def _reasons(item: UniversalScreeningResult) -> tuple[str, ...]:
+    reason_metric = item.metrics.get("decision.reason_codes")
+    native = None if reason_metric is None else reason_metric.native()
+    metric_reasons = tuple(str(value) for value in native) if isinstance(native, list) else ()
+    temporal_reasons = (
+        (item.temporal.usability_reason,)
+        if item.temporal is not None and item.evaluation_state is EvaluationState.MISSING_DATA
+        else ()
+    )
+    explicit = tuple(item.blockers) + tuple(item.warnings) + metric_reasons + temporal_reasons
+    if explicit:
+        return explicit
+    if _verdict(item) == "PASS":
+        return ()
+    return (
+        (f"verdict:{_verdict(item).lower()}",)
+        if item.verdict
+        else (f"evaluation_state:{item.evaluation_state.value}",)
+    )

--- a/tests/asa/test_screening_routes.py
+++ b/tests/asa/test_screening_routes.py
@@ -81,6 +81,21 @@ def _auth(token: str = "correct-token") -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
+def test_strategy_health_exposes_all_registered_production_funnels() -> None:
+    repository = InMemoryLatestResultRepository()
+    for signal in ("forward_factor", "earnings_calendar", "skew_momentum"):
+        repository.upsert(_record(signal, "AAPL"))
+
+    response = _client(repository).get("/api/v1/screening-health", headers=_auth())
+
+    assert response.status_code == 200
+    funnels = {item["strategy_id"]: item for item in response.json()["strategies"]}
+    assert set(funnels) == {"forward_factor", "earnings_calendar", "skew_momentum"}
+    assert all(item["active_subjects"] == 1 for item in funnels.values())
+    assert all(item["evaluated"] == 1 for item in funnels.values())
+    assert all(item["typed_rejection_counts"] for item in funnels.values())
+
+
 class TestAuthentication:
     def test_capabilities_without_authorization_header_is_404(self) -> None:
         response = _client().get("/api/v1/capabilities")
@@ -177,12 +192,8 @@ class TestListScreening:
                 "gate.eligible": TypedValue.of_boolean(True),
                 "decision.direction": TypedValue.of_string("NEUTRAL"),
                 "decision.structure": TypedValue.of_string("structure-1"),
-                "decision.reason_codes": TypedValue.of_structured(
-                    ["verdict:watch"]
-                ),
-                "decision.assumptions": TypedValue.of_structured(
-                    ["threshold=0.20"]
-                ),
+                "decision.reason_codes": TypedValue.of_structured(["verdict:watch"]),
+                "decision.assumptions": TypedValue.of_structured(["threshold=0.20"]),
             }
         )
         repository.upsert(row)
@@ -214,9 +225,7 @@ class TestListScreening:
         assert [item["symbol"] for item in body["results"]] == ["MSFT"]
 
     def test_limit_above_maximum_is_rejected(self) -> None:
-        response = _client().get(
-            "/api/v1/screening", headers=_auth(), params={"limit": 501}
-        )
+        response = _client().get("/api/v1/screening", headers=_auth(), params={"limit": 501})
         assert response.status_code == 422
 
     def test_exposes_complete_generic_result_semantics_and_history_link(self) -> None:
@@ -230,14 +239,10 @@ class TestListScreening:
                 recommendation_state="monitor",
             )
         )
-        result = _client(repository).get("/api/v1/screening", headers=_auth()).json()[
-            "results"
-        ][0]
+        result = _client(repository).get("/api/v1/screening", headers=_auth()).json()["results"][0]
         assert result["observation_id"] == "earnings_calendar-AAPL-obs"
         assert result["opportunity_id"] == "opportunity-1"
-        assert result["opportunity_history_url"].endswith(
-            "/opportunities/opportunity-1/history"
-        )
+        assert result["opportunity_history_url"].endswith("/opportunities/opportunity-1/history")
         assert result["lifecycle_stage"] == "watching"
         assert result["status"] == "monitor"
         assert result["data_quality"] == "complete"
@@ -352,9 +357,7 @@ class TestGetScreeningResult:
     def test_returns_the_single_result(self) -> None:
         repository = InMemoryLatestResultRepository()
         repository.upsert(_record("forward_factor", "AAPL"))
-        response = _client(repository).get(
-            "/api/v1/screening/forward_factor/AAPL", headers=_auth()
-        )
+        response = _client(repository).get("/api/v1/screening/forward_factor/AAPL", headers=_auth())
         assert response.status_code == 200
         body = response.json()
         assert body["signal_id"] == "forward_factor"

--- a/tests/strategy_runtime/test_health.py
+++ b/tests/strategy_runtime/test_health.py
@@ -1,0 +1,42 @@
+from dataclasses import replace
+
+from strategy_runtime.health import build_strategy_health
+from strategy_runtime.result import EvaluationState
+from strategy_runtime.values import TypedValue
+from tests.strategy_runtime.test_result_migration_targets import _no_lifecycle_result
+
+
+def test_health_funnel_and_typed_attrition_are_derived_from_results() -> None:
+    passed = replace(
+        _no_lifecycle_result("forward_factor", "1.3.0"),
+        strategy_id="forward_factor",
+        verdict="PASS",
+        metrics={"decision.structure": TypedValue.of_string("calendar")},
+    )
+    watch = replace(
+        passed,
+        symbol="MSFT",
+        verdict="WATCH",
+        metrics={
+            "decision.structure": TypedValue.of_string("calendar"),
+            "decision.reason_codes": TypedValue.of_structured(["momentum_conflict"]),
+        },
+    )
+    missing = replace(
+        passed,
+        symbol="NVDA",
+        verdict=None,
+        evaluation_state=EvaluationState.MISSING_DATA,
+        metrics={},
+        blockers=("historical_bars_unavailable",),
+    )
+
+    health = build_strategy_health("forward_factor", (passed, watch, missing))
+
+    assert health.active_subjects == 3
+    assert health.evaluated == health.evidence_sufficient == 2
+    assert health.structure_eligible_or_constructible == 2
+    assert health.gates_passed == 2
+    assert health.watch == health.passed == 1
+    assert health.typed_unknown_counts == (("historical_bars_unavailable", 1),)
+    assert health.typed_rejection_counts == (("momentum_conflict", 1),)


### PR DESCRIPTION
Ticket: PL1-06 / Gate 9
Assigned Worker: Codex Worker
Manager stop status: CLEAR

## Outcome
Adds a read-only health funnel for every registered production strategy: active subjects, evaluated, evidence sufficient, structure eligible/constructible, gates passed, WATCH, PASS, typed unknowns, and typed rejection/attrition reasons. The aggregate reads authoritative persisted UniversalScreeningResults only.

## Safety
No strategy formula, threshold, gate, acquisition, verdict, or policy behavior changed.

## Validation
- all three registered strategies covered
- 608 architecture/health/screening tests passed
- frontend generation/typecheck/lint/tests green
- Ruff and mypy green
- Lean pre-push 5/5

Closes #383