### PR TITLE
PL1 Gate 10: persist trusted Robinhood session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 .venv/
 venv/
 node_modules/
+robinhood*.pickle

--- a/asa/bootstrap.py
+++ b/asa/bootstrap.py
@@ -250,5 +250,6 @@ def _build_broker_provider(settings: Settings) -> BrokerPortfolioProvider:
                 else settings.robinhood_totp_secret.get_secret_value()
             ),
             account_numbers=settings.selected_robinhood_accounts,
+            session_path=settings.robinhood_session_path,
         )
     raise ValueError(f"unsupported broker portfolio provider: {settings.broker_portfolio_provider}")

--- a/asa/config.py
+++ b/asa/config.py
@@ -1,5 +1,6 @@
 from hashlib import sha256
 from json import dumps
+from pathlib import Path
 
 from pydantic import AliasChoices, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -27,6 +28,7 @@ class Settings(BaseSettings):
     robinhood_password: SecretStr | None = None
     robinhood_totp_secret: SecretStr | None = None
     robinhood_account_numbers: str | None = None
+    robinhood_session_path: str = "/data/asa-robinhood"
     operations_token: SecretStr | None = None
     agent_api_token: SecretStr | None = None
     fresh_for_seconds: int = Field(default=300, ge=1)
@@ -46,6 +48,14 @@ class Settings(BaseSettings):
             stripped = value.strip()
             return stripped or None
         return value
+
+    @field_validator("robinhood_session_path")
+    @classmethod
+    def validate_robinhood_session_path(cls, value: str) -> str:
+        path = Path(value.strip())
+        if not path.is_absolute():
+            raise ValueError("Robinhood session path must be absolute")
+        return str(path)
 
     @field_validator("database_url")
     @classmethod

--- a/asa/integrations/providers/robinhood.py
+++ b/asa/integrations/providers/robinhood.py
@@ -1,8 +1,10 @@
 import io
+import os
 from collections.abc import Callable, Mapping
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import UTC, date, datetime
 from decimal import Decimal, InvalidOperation
+from pathlib import Path
 from typing import Any, Protocol, TypeVar
 from uuid import uuid4
 
@@ -21,6 +23,7 @@ from asa.application.ports.brokers import (
 
 T = TypeVar("T")
 RawRecord = Mapping[str, Any]
+_SESSION_PICKLE_NAME = "asa_trusted_session"
 
 _BROKERAGE_ACCOUNT_TYPE_MAP = {
     "individual": "individual",
@@ -69,39 +72,70 @@ class RobinStocksReadClient:
         password: str,
         totp_secret: str | None,
         account_numbers: tuple[str, ...],
+        session_path: str,
     ) -> None:
         self._username = username
         self._password = password
         self._totp_secret = totp_secret
         self._account_numbers = account_numbers
+        self._session_path = Path(session_path)
         self._authenticated = False
 
     def authenticate(self) -> None:
         if self._authenticated:
             return
         mfa_code = None if self._totp_secret is None else pyotp.TOTP(self._totp_secret).now()
+        self._prepare_session_directory()
         try:
             self._quiet_call(
                 robinhood.login,
                 username=self._username,
                 password=self._password,
                 mfa_code=mfa_code,
-                store_session=False,
-                pickle_path="/tmp/asa-robinhood-no-session",
+                store_session=True,
+                pickle_path=str(self._session_path),
+                pickle_name=_SESSION_PICKLE_NAME,
             )
-        except RobinhoodProviderError:
+        except RobinhoodProviderError as exc:
+            if exc.code == "broker_provider_unavailable":
+                raise
             raise RobinhoodProviderError(
                 "broker_authentication_failed", "Robinhood authentication failed"
             ) from None
-        finally:
-            self._username = ""
-            self._password = ""
-            self._totp_secret = None
         if not robinhood_helper.LOGGED_IN:
             raise RobinhoodProviderError(
-                "broker_authentication_failed", "Robinhood authentication failed"
+                "broker_manual_approval_required",
+                "Robinhood manual approval or trusted-session renewal is required",
             )
+        self._secure_session_file()
         self._authenticated = True
+        # Secrets remain available only until a trusted session has been established.
+        # A failed approval must remain retryable without reconstructing the provider.
+        self._username = ""
+        self._password = ""
+        self._totp_secret = None
+
+    def _prepare_session_directory(self) -> None:
+        try:
+            self._session_path.mkdir(mode=0o700, parents=True, exist_ok=True)
+            os.chmod(self._session_path, 0o700)
+        except OSError:
+            raise RobinhoodProviderError(
+                "broker_session_storage_unavailable",
+                "Robinhood trusted-session storage is unavailable",
+            ) from None
+
+    def _secure_session_file(self) -> None:
+        session_file = self._session_path / f"robinhood{_SESSION_PICKLE_NAME}.pickle"
+        if not session_file.exists():
+            return
+        try:
+            os.chmod(session_file, 0o600)
+        except OSError:
+            raise RobinhoodProviderError(
+                "broker_session_storage_unavailable",
+                "Robinhood trusted-session storage is unavailable",
+            ) from None
 
     def accounts(self) -> list[RawRecord]:
         if self._account_numbers:
@@ -194,11 +228,12 @@ class RobinhoodPortfolioProvider:
         password: str,
         totp_secret: str | None = None,
         account_numbers: tuple[str, ...] = (),
+        session_path: str = "/data/asa-robinhood",
         client: RobinhoodReadClient | None = None,
         clock: Callable[[], datetime] = lambda: datetime.now(UTC),
     ) -> None:
         self._client = client or RobinStocksReadClient(
-            username, password, totp_secret, account_numbers
+            username, password, totp_secret, account_numbers, session_path
         )
         self._account_numbers = set(account_numbers)
         self._clock = clock

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -112,11 +112,20 @@ After deployment:
 1. Confirm the pre-deploy migration completed.
 2. Confirm `/api/v1/health` returns 200 and `/api/v1/readiness` reports `ready`.
 3. In deterministic mode, POST one run and verify `/api/v1/portfolio` and `/api/v1/positions`.
-4. In Robinhood mode, POST one run, approve any Robinhood challenge if required, and verify the published account/equity/option facts through those same endpoints.
+4. In Robinhood mode, mount a persistent Railway volume at `/data`, leave
+   `ASA_ROBINHOOD_SESSION_PATH=/data/asa-robinhood` (the default), then POST one run.
+   Approve Robinhood's device challenge only when establishing or renewing trust; normal
+   refreshes reuse the sealed session. Verify the published account/equity/option facts through
+   those same endpoints. Never download, print, or attach the session pickle.
 5. Review structured logs only for request, run, step, provider, and account correlation fields. Stop if credential, token, cookie, or raw response material appears.
 6. With `ASA_AGENT_API_TOKEN` set, confirm `GET /api/v1/capabilities` with a correct bearer token returns 200 and lists the registered signals, and that an omitted or incorrect token returns 404.
 
-Robinhood authentication is an unofficial integration and may require interactive approval. ASA remains synchronous and preserves the prior successful publication if authentication or acquisition fails.
+Robinhood authentication is an unofficial integration and may require interactive approval. ASA
+persists the trusted session in the configured runtime-only directory, following the proven Stonk
+`store_session=True` behavior while retaining ASA's narrower read-only boundary. A missing or
+expired trusted session is reported as `broker_manual_approval_required`; ASA preserves the prior
+successful publication if authentication or acquisition fails. A TOTP seed is not required for
+this trusted-device flow.
 
 Run the bounded authenticated smoke without placing the token on the command line:
 

--- a/tests/asa/test_config.py
+++ b/tests/asa/test_config.py
@@ -17,6 +17,19 @@ def test_robinhood_mode_fails_closed_without_credentials() -> None:
         Settings(_env_file=None, broker_portfolio_provider="robinhood")
 
 
+def test_robinhood_session_path_is_centralized_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ASA_ROBINHOOD_SESSION_PATH", "/sealed/runtime/robinhood")
+
+    assert Settings(_env_file=None).robinhood_session_path == "/sealed/runtime/robinhood"
+
+
+def test_robinhood_session_path_cannot_write_relative_to_repository() -> None:
+    with pytest.raises(ValidationError, match="session path must be absolute"):
+        Settings(_env_file=None, robinhood_session_path="repository/session")
+
+
 def test_robinhood_secrets_are_redacted_and_excluded_from_config_hash() -> None:
     first = Settings(
         _env_file=None,

--- a/tests/asa/test_robinhood_provider.py
+++ b/tests/asa/test_robinhood_provider.py
@@ -1,10 +1,13 @@
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 
+from asa.integrations.providers import robinhood as robinhood_module
 from asa.integrations.providers.robinhood import (
     RobinhoodPortfolioProvider,
     RobinhoodProviderError,
+    RobinStocksReadClient,
 )
 
 
@@ -68,6 +71,52 @@ class FakeRobinhoodReadClient:
             "strike_price": "200.00",
             "expiration_date": "2026-09-18",
         }
+
+
+def test_robin_stocks_client_persists_and_reuses_trusted_session(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def login(**kwargs: object) -> dict[str, str]:
+        calls.append(kwargs)
+        session_file = tmp_path / "robinhoodasa_trusted_session.pickle"
+        if not session_file.exists():
+            session_file.write_bytes(b"opaque-test-session")
+        monkeypatch.setattr(robinhood_module.robinhood_helper, "LOGGED_IN", True)
+        return {"detail": "trusted session available"}
+
+    monkeypatch.setattr(robinhood_module.robinhood, "login", login)
+    first = RobinStocksReadClient("user", "password", None, (), str(tmp_path))
+    second = RobinStocksReadClient("user", "password", None, (), str(tmp_path))
+
+    first.authenticate()
+    second.authenticate()
+
+    assert len(calls) == 2
+    assert all(call["store_session"] is True for call in calls)
+    assert all(call["pickle_path"] == str(tmp_path) for call in calls)
+    assert all(call["pickle_name"] == "asa_trusted_session" for call in calls)
+    assert (tmp_path.stat().st_mode & 0o777) == 0o700
+    assert ((tmp_path / "robinhoodasa_trusted_session.pickle").stat().st_mode & 0o777) == 0o600
+
+
+@pytest.mark.parametrize("expired_session_exists", [False, True])
+def test_robin_stocks_client_reports_manual_approval_without_disclosure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, expired_session_exists: bool
+) -> None:
+    if expired_session_exists:
+        (tmp_path / "robinhoodasa_trusted_session.pickle").write_bytes(b"expired")
+    monkeypatch.setattr(robinhood_module.robinhood, "login", lambda **_: None)
+    monkeypatch.setattr(robinhood_module.robinhood_helper, "LOGGED_IN", False)
+    client = RobinStocksReadClient("private-user", "private-password", None, (), str(tmp_path))
+
+    with pytest.raises(RobinhoodProviderError) as captured:
+        client.authenticate()
+
+    assert captured.value.code == "broker_manual_approval_required"
+    assert str(captured.value) == "Robinhood manual approval or trusted-session renewal is required"
+    assert "private" not in str(captured.value)
 
 
 def test_robinhood_adapter_normalizes_read_only_account_equity_and_option() -> None:


### PR DESCRIPTION
## Ticket / gate
PORTFOLIO-LIFECYCLE-001 / Gate 10 corrective. Assigned Worker: Codex. Manager stop status: CLEAR.

## Symptom
Production Robinhood proof cannot establish reusable trust because ASA disables session storage and points robin_stocks at a disposable `/tmp` location.

## Root cause and correction
The read-only adapter called `login(store_session=False)`. It now uses the existing centralized configuration boundary and an absolute persistent runtime directory, enables robin_stocks trusted-session persistence, and restricts the directory/file to 0700/0600. Missing or expired trust returns sanitized `broker_manual_approval_required`; storage failure is separately typed.

## Stonk reuse audit
Inspected `jaiaFoster/Stonk` `app/providers/robinhood_provider.py` first. Recovered only its proven `store_session=True`/named-pickle behavior. Did not port Stonk retries, notifications, architecture, or any order-capable surface.

## Security / authority
- Session pickle is runtime-only, gitignored, never logged or serialized.
- Absolute-path validation prevents repository-relative storage.
- No credential, session, provider payload, or TOTP seed is added.
- Existing read-only facade remains unchanged; no broker mutation surface.
- No Gates 1–9, portfolio, lifecycle, reconciliation, valuation, or strategy-health semantics changed.

## Validation
- Focused Robinhood/config: 25 passed.
- Full repository: 3281 passed, 48 skipped.
- Architecture: 578 passed.
- Ruff: pass.
- mypy: pass.
- Lean integrity/entrypoints/pre-push: pass.
- Session persistence/reuse, 0700/0600 permissions, missing/expired typed failure, config boundary, and disclosure protections have regression coverage.

## Production boundary
After merge, production proof requires Founder-authorized deployment of the exact merge SHA, a Railway persistent volume mounted at `/data`, Robinhood provider selection, and manual device approval only if Robinhood requires trust establishment/renewal.

Relates to #385.
