### PR TITLE
EXVIS-02: resolve exact intended option structures

### DIFF
--- a/strategy_runtime/__init__.py
+++ b/strategy_runtime/__init__.py
@@ -98,6 +98,11 @@ from strategy_runtime.market_data_planning import (
     build_shared_market_data_access,
     declared_rolling_window_policies,
 )
+from strategy_runtime.option_structure_resolver import (
+    OptionLegIntent,
+    OptionStructureIntent,
+    resolve_option_structure,
+)
 from strategy_runtime.registry import (
     StrategyAdapter,
     StrategyRegistry,
@@ -127,6 +132,8 @@ __all__ = [
     "LifecycleDeclaration",
     "LifecycleModel",
     "ModeledEntryEconomics",
+    "OptionLegIntent",
+    "OptionStructureIntent",
     "OutputKind",
     "RequirementCategory",
     "ResolvedOptionLeg",
@@ -154,6 +161,7 @@ __all__ = [
     "describe_contract",
     "describe_registry",
     "register",
+    "resolve_option_structure",
     "run_strategies",
     "validate_result",
 ]

--- a/strategy_runtime/option_structure_resolver.py
+++ b/strategy_runtime/option_structure_resolver.py
@@ -1,0 +1,209 @@
+"""Deterministic exact-option resolver over one canonical sealed chain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+
+from domain import OptionChain, OptionContract, OptionLeg, OptionLegPosition, OptionType
+from strategy_runtime.contract import StructureKind
+from strategy_runtime.executable_structures import (
+    ExecutableStructureAssessment,
+    ExecutableStructureStatus,
+    ModeledEntryEconomics,
+    ResolvedOptionLeg,
+    SelectionDiagnostic,
+)
+
+_MIDPOINT_MODEL_VERSION = "midpoint-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class OptionLegIntent:
+    role: str
+    option_type: OptionType
+    expiration: date
+    position: OptionLegPosition
+    quantity: Decimal
+    selected_contract_identity: str | None = None
+    selected_strike: Decimal | None = None
+    target_delta: Decimal | None = None
+
+    def __post_init__(self) -> None:
+        if not self.role or self.role != self.role.strip():
+            raise ValueError("OptionLegIntent.role must be normalized non-empty text")
+        selectors = tuple(
+            item is not None
+            for item in (
+                self.selected_contract_identity,
+                self.selected_strike,
+                self.target_delta,
+            )
+        )
+        if sum(selectors) != 1:
+            raise ValueError("OptionLegIntent requires exactly one selection authority")
+        if self.quantity <= 0:
+            raise ValueError("OptionLegIntent.quantity must be positive")
+        if self.target_delta is not None and not Decimal("-1") <= self.target_delta <= Decimal("1"):
+            raise ValueError("OptionLegIntent.target_delta must be within [-1, 1]")
+
+
+@dataclass(frozen=True, slots=True)
+class OptionStructureIntent:
+    subject: str
+    intended_structure_kind: StructureKind
+    legs: tuple[OptionLegIntent, ...]
+
+    def __post_init__(self) -> None:
+        if not self.subject or self.subject != self.subject.strip():
+            raise ValueError("OptionStructureIntent.subject must be normalized non-empty text")
+        if self.intended_structure_kind not in {StructureKind.CALENDAR, StructureKind.VERTICAL}:
+            raise ValueError("OptionStructureIntent supports active v1 structures only")
+        if len(self.legs) != 2:
+            raise ValueError("OptionStructureIntent v1 structures require exactly two legs")
+        roles = tuple(item.role for item in self.legs)
+        if len(roles) != len(set(roles)):
+            raise ValueError("OptionStructureIntent roles must be unique")
+
+
+def _matching_contracts(chain: OptionChain, intent: OptionLegIntent) -> tuple[OptionContract, ...]:
+    candidates = tuple(
+        contract
+        for contract in chain.contracts
+        if contract.expiration == intent.expiration and contract.option_type is intent.option_type
+    )
+    if intent.selected_contract_identity is not None:
+        return tuple(
+            item for item in candidates if item.identity == intent.selected_contract_identity
+        )
+    if intent.selected_strike is not None:
+        return tuple(item for item in candidates if item.strike == intent.selected_strike)
+    with_delta = tuple(item for item in candidates if item.delta is not None)
+    if not with_delta:
+        return ()
+    assert intent.target_delta is not None
+    return tuple(
+        sorted(
+            with_delta,
+            key=lambda item: (
+                abs(abs(item.delta) - abs(intent.target_delta)),  # type: ignore[arg-type]
+                item.identity,
+            ),
+        )
+    )
+
+
+def _resolve_leg(chain: OptionChain, intent: OptionLegIntent) -> ResolvedOptionLeg | None:
+    candidates = _matching_contracts(chain, intent)
+    if not candidates:
+        return None
+    contract = (
+        min(candidates, key=lambda item: item.identity)
+        if intent.target_delta is None
+        else candidates[0]
+    )
+    return ResolvedOptionLeg(
+        OptionLeg(contract, intent.position, intent.quantity, intent.role),
+        intent.target_delta,
+    )
+
+
+def _midpoint_entry(
+    legs: tuple[ResolvedOptionLeg, ...], assessed_at: datetime
+) -> ModeledEntryEconomics | None:
+    values = tuple(item.midpoint for item in legs)
+    if any(value is None for value in values):
+        return None
+    typed = tuple(value for value in values if value is not None)
+    total = Decimal(0)
+    per_leg: list[tuple[str, Decimal]] = []
+    for resolved, midpoint in zip(legs, typed, strict=True):
+        sign = Decimal(1) if resolved.leg.position is OptionLegPosition.LONG else Decimal(-1)
+        total += midpoint * resolved.leg.quantity * sign
+        per_leg.append((resolved.leg.identity, midpoint))
+    return ModeledEntryEconomics(tuple(per_leg), total, _MIDPOINT_MODEL_VERSION, assessed_at)
+
+
+def _shape(legs: tuple[ResolvedOptionLeg, ...]) -> StructureKind:
+    first, second = (item.leg.contract for item in legs)
+    same_expiration = first.expiration == second.expiration
+    same_strike = first.strike == second.strike
+    same_type = first.option_type is second.option_type
+    if same_strike and same_type and not same_expiration:
+        return StructureKind.CALENDAR
+    if same_expiration and same_type and not same_strike:
+        return StructureKind.VERTICAL
+    return StructureKind.CUSTOM
+
+
+def resolve_option_structure(
+    *,
+    intent: OptionStructureIntent,
+    chain: OptionChain,
+    originating_result_identity: str,
+    evidence_snapshot_identity: str,
+    assessed_at: datetime,
+) -> ExecutableStructureAssessment:
+    """Resolve an intent without acquisition, inference, or structure substitution."""
+
+    resolved = tuple(_resolve_leg(chain, item) for item in intent.legs)
+    if any(item is None for item in resolved):
+        missing_delta = any(
+            leg.target_delta is not None
+            and not any(
+                contract.delta is not None
+                for contract in chain.contracts
+                if contract.expiration == leg.expiration
+                and contract.option_type is leg.option_type
+            )
+            for leg, item in zip(intent.legs, resolved, strict=True)
+            if item is None
+        )
+        return ExecutableStructureAssessment(
+            originating_result_identity,
+            intent.subject,
+            intent.intended_structure_kind,
+            ExecutableStructureStatus.UNKNOWN
+            if missing_delta
+            else ExecutableStructureStatus.NOT_CONSTRUCTIBLE,
+            (),
+            (),
+            None,
+            evidence_snapshot_identity,
+            assessed_at,
+            reason_code="missing_actual_delta" if missing_delta else "no_compatible_contract",
+        )
+
+    exact = tuple(item for item in resolved if item is not None)
+    actual_shape = _shape(exact)
+    diagnostics = tuple(
+        SelectionDiagnostic(item.leg.role, item.target_delta, item.leg.contract.delta)
+        for item in exact
+    )
+    if actual_shape is not intent.intended_structure_kind:
+        return ExecutableStructureAssessment(
+            originating_result_identity,
+            intent.subject,
+            intent.intended_structure_kind,
+            ExecutableStructureStatus.DIFFERENT_STRUCTURE_AVAILABLE,
+            exact,
+            diagnostics,
+            _midpoint_entry(exact, assessed_at),
+            evidence_snapshot_identity,
+            assessed_at,
+            reason_code="resolved_legs_form_different_structure",
+            available_structure_kind=actual_shape,
+        )
+    return ExecutableStructureAssessment(
+        originating_result_identity,
+        intent.subject,
+        intent.intended_structure_kind,
+        ExecutableStructureStatus.CONSTRUCTIBLE_AS_INTENDED,
+        exact,
+        diagnostics,
+        _midpoint_entry(exact, assessed_at),
+        evidence_snapshot_identity,
+        assessed_at,
+        available_structure_kind=actual_shape,
+    )

--- a/tests/asa/test_option_structure_resolver.py
+++ b/tests/asa/test_option_structure_resolver.py
@@ -1,0 +1,204 @@
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from domain import (
+    CanonicalInstrumentIdentity,
+    EvidenceKind,
+    EvidenceReference,
+    Instrument,
+    InstrumentKind,
+    OptionChain,
+    OptionContract,
+    OptionLegPosition,
+    OptionType,
+    Security,
+    SecurityAssetType,
+)
+from strategy_runtime.contract import StructureKind
+from strategy_runtime.executable_structures import ExecutableStructureStatus
+from strategy_runtime.option_structure_resolver import (
+    OptionLegIntent,
+    OptionStructureIntent,
+    resolve_option_structure,
+)
+
+NOW = datetime(2026, 9, 1, 15, tzinfo=UTC)
+FRONT = date(2026, 9, 18)
+BACK = date(2026, 10, 16)
+EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "chain-observation", 1),)
+INSTRUMENT = Instrument(
+    CanonicalInstrumentIdentity("symbol", "AAPL"), InstrumentKind.EQUITY, "AAPL", "USD"
+)
+SECURITY = Security(INSTRUMENT, "AAPL", SecurityAssetType.EQUITY, "NASDAQ")
+
+
+def _contract(expiration: date, strike: str, delta: str | None = "0.50") -> OptionContract:
+    return OptionContract(
+        CanonicalInstrumentIdentity("occ", f"AAPL-{expiration}-{strike}-C"),
+        SECURITY,
+        expiration,
+        Decimal(strike),
+        OptionType.CALL,
+        Decimal("2.00"),
+        Decimal("2.20"),
+        Decimal("2.10"),
+        10,
+        100,
+        None if delta is None else Decimal(delta),
+        None,
+        None,
+        None,
+        None,
+        Decimal("0.30"),
+        NOW,
+        EVIDENCE,
+    )
+
+
+def _chain(*contracts: OptionContract) -> OptionChain:
+    return OptionChain("AAPL-chain", SECURITY, NOW, contracts, EVIDENCE)
+
+
+def _calendar(front_strike: str, back_strike: str) -> OptionStructureIntent:
+    return OptionStructureIntent(
+        "AAPL",
+        StructureKind.CALENDAR,
+        (
+            OptionLegIntent(
+                "front",
+                OptionType.CALL,
+                FRONT,
+                OptionLegPosition.SHORT,
+                Decimal(1),
+                selected_strike=Decimal(front_strike),
+            ),
+            OptionLegIntent(
+                "back",
+                OptionType.CALL,
+                BACK,
+                OptionLegPosition.LONG,
+                Decimal(1),
+                selected_strike=Decimal(back_strike),
+            ),
+        ),
+    )
+
+
+def _resolve(intent: OptionStructureIntent, chain: OptionChain):  # type: ignore[no-untyped-def]
+    return resolve_option_structure(
+        intent=intent,
+        chain=chain,
+        originating_result_identity="result-1",
+        evidence_snapshot_identity="snapshot-1",
+        assessed_at=NOW,
+    )
+
+
+def test_same_strike_calendar_resolves_exact_contracts_and_midpoint_entry() -> None:
+    result = _resolve(
+        _calendar("200", "200"),
+        _chain(_contract(FRONT, "200"), _contract(BACK, "200")),
+    )
+
+    assert result.status is ExecutableStructureStatus.CONSTRUCTIBLE_AS_INTENDED
+    assert result.available_structure_kind is StructureKind.CALENDAR
+    assert tuple(item.leg.contract.strike for item in result.exact_legs) == (
+        Decimal("200"),
+        Decimal("200"),
+    )
+    assert result.modeled_entry_economics is not None
+    assert result.modeled_entry_economics.modeled_net_debit_or_credit == Decimal("0.00")
+
+
+def test_diagonal_only_counterexample_is_not_substituted_for_calendar() -> None:
+    result = _resolve(
+        _calendar("200", "205"),
+        _chain(_contract(FRONT, "200"), _contract(BACK, "205")),
+    )
+
+    assert result.status is ExecutableStructureStatus.DIFFERENT_STRUCTURE_AVAILABLE
+    assert result.available_structure_kind is StructureKind.CUSTOM
+    assert result.reason_code == "resolved_legs_form_different_structure"
+
+
+def test_no_compatible_contract_is_typed_not_constructible() -> None:
+    result = _resolve(_calendar("200", "200"), _chain(_contract(FRONT, "205")))
+
+    assert result.status is ExecutableStructureStatus.NOT_CONSTRUCTIBLE
+    assert result.reason_code == "no_compatible_contract"
+    assert result.exact_legs == ()
+
+
+def test_delta_selection_is_deterministic_and_records_target_vs_actual() -> None:
+    intent = OptionStructureIntent(
+        "AAPL",
+        StructureKind.VERTICAL,
+        (
+            OptionLegIntent(
+                "long",
+                OptionType.CALL,
+                FRONT,
+                OptionLegPosition.LONG,
+                Decimal(1),
+                target_delta=Decimal("0.50"),
+            ),
+            OptionLegIntent(
+                "short",
+                OptionType.CALL,
+                FRONT,
+                OptionLegPosition.SHORT,
+                Decimal(1),
+                target_delta=Decimal("0.25"),
+            ),
+        ),
+    )
+    chain = _chain(
+        _contract(FRONT, "200", "0.48"),
+        _contract(FRONT, "205", "0.27"),
+        _contract(FRONT, "210", "0.20"),
+    )
+
+    result = _resolve(intent, chain)
+
+    assert result.status is ExecutableStructureStatus.CONSTRUCTIBLE_AS_INTENDED
+    assert tuple(item.leg.contract.strike for item in result.exact_legs) == (
+        Decimal("200"),
+        Decimal("205"),
+    )
+    assert tuple(item.actual_delta for item in result.selection_diagnostics) == (
+        Decimal("0.48"),
+        Decimal("0.27"),
+    )
+
+
+def test_missing_delta_is_typed_unknown() -> None:
+    intent = OptionStructureIntent(
+        "AAPL",
+        StructureKind.VERTICAL,
+        (
+            OptionLegIntent(
+                "long",
+                OptionType.CALL,
+                FRONT,
+                OptionLegPosition.LONG,
+                Decimal(1),
+                target_delta=Decimal("0.50"),
+            ),
+            OptionLegIntent(
+                "short",
+                OptionType.CALL,
+                FRONT,
+                OptionLegPosition.SHORT,
+                Decimal(1),
+                selected_strike=Decimal("205"),
+            ),
+        ),
+    )
+
+    result = _resolve(
+        intent,
+        _chain(_contract(FRONT, "200", None), _contract(FRONT, "205", None)),
+    )
+
+    assert result.status is ExecutableStructureStatus.UNKNOWN
+    assert result.reason_code == "missing_actual_delta"


### PR DESCRIPTION
## Ticket / gate
EXVIS-02 / Gate 2. Assigned Worker: implementation-worker (Codex). Manager stop status: CLEAR. Closes #390.

## Outcome
Adds a provider-neutral deterministic resolver from an explicit strategy-owned structure intent and one canonical `OptionChain` to the Gate 1 assessment artifact.

## Truth constraints
- Calendar requires same strike, same option type, and different expirations.
- Vertical requires same expiration/type and different strikes.
- Selected contract identity, selected strike, or target delta is explicit and mutually exclusive.
- Diagonal/other resolved legs are `different_structure_available`; never substituted.
- Missing compatible contracts are typed `not_constructible`; missing required delta evidence is typed `unknown`.
- Target versus actual delta remains visible.
- Midpoint entry is modeled-reference-only and omitted if quotes are incomplete.

## Boundaries
No provider/acquisition imports, strategy ID branches, signal changes, generalized builder, persistence/UI, or broker mutation.

## Validation
- Resolver/artifact/boundary: 14 passed.
- ASA package: 227 passed, 46 skipped.
- Architecture: 578 passed.
- Ruff, changed-scope mypy, Lean pre-push: pass.
