### PR TITLE
EXVIS-05: present exact structures and modeled P&L

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -17,6 +17,7 @@ from asa.api.agent_models import TimestampedResource
 from strategy_runtime.catalog import SignalCatalogEntry
 from strategy_runtime.executable_structures import ExecutableStructureAssessment
 from strategy_runtime.lifecycle import OpportunityHistory, OpportunityObservation
+from strategy_runtime.modeled_pnl import ModeledPnLSurface
 from strategy_runtime.result import EvaluationState, UniversalScreeningResult
 
 # SPRINT-009R/EPIC-R5: the public wire vocabulary predates strategy_runtime and must not
@@ -429,11 +430,56 @@ class ExecutableStructureAssessmentResponse(BaseModel):
         )
 
 
+class ModeledPnLPointResponse(BaseModel):
+    underlying_price: str
+    modeled_pnl: str
+
+
+class ModeledPnLSurfaceResponse(BaseModel):
+    surface_identity: str
+    structure_assessment_identity: str
+    valuation_model_and_version: str
+    valuation_time: datetime
+    spot_reference: str
+    points: list[ModeledPnLPointResponse]
+    entry_fill_assumption: str
+    volatility_assumptions: dict[str, str]
+    annual_risk_free_rate: str
+    annual_dividend_yield: str
+    contract_multiplier: str
+    semantics: str = "modeled_PnL_not_guaranteed_payoff"
+
+    @classmethod
+    def from_surface(cls, surface: ModeledPnLSurface) -> ModeledPnLSurfaceResponse:
+        return cls(
+            surface_identity=surface.identity,
+            structure_assessment_identity=surface.structure_assessment_identity,
+            valuation_model_and_version=surface.valuation_model_and_version,
+            valuation_time=surface.valuation_time,
+            spot_reference=str(surface.spot_reference),
+            points=[
+                ModeledPnLPointResponse(
+                    underlying_price=str(item.underlying_price),
+                    modeled_pnl=str(item.modeled_pnl),
+                )
+                for item in surface.points
+            ],
+            entry_fill_assumption=surface.entry_fill_assumption,
+            volatility_assumptions={
+                identity: str(value) for identity, value in surface.volatility_assumptions
+            },
+            annual_risk_free_rate=str(surface.annual_risk_free_rate),
+            annual_dividend_yield=str(surface.annual_dividend_yield),
+            contract_multiplier=str(surface.contract_multiplier),
+        )
+
+
 class ScreeningExecutionReadinessResponse(BaseModel):
     """Additive composition; the signal and assessment remain independent."""
 
     signal: ScreeningResultResponse
     execution_assessment: ExecutableStructureAssessmentResponse
+    modeled_pnl: ModeledPnLSurfaceResponse | None = None
 
 
 class RefreshResultResponse(ScreeningResultResponse):

--- a/asa/ui/static/render.js
+++ b/asa/ui/static/render.js
@@ -284,6 +284,57 @@ function detailView(item) {
     ["Structure", exactValue(item, "structure").text, exactValue(item, "structure").kind],
   ]));
   fragment.append(decision);
+  const readiness = item.execution_assessment;
+  if (readiness) {
+    const section = element("section", "audit-section execution-readiness");
+    section.append(element("h3", null, "Execution readiness — analytical only"));
+    section.append(definitionList([
+      ["Signal verdict (unchanged)", exactValue(item, "verdict").text],
+      ["Intended structure", readiness.intended_structure_kind],
+      ["Constructibility", readiness.status],
+      ["Available structure", readiness.available_structure_kind || "Unknown"],
+      ["Reason", readiness.reason_code || "None"],
+    ]));
+    for (const leg of readiness.exact_legs || []) {
+      section.append(element("h4", null, `Exact leg — ${leg.role}`));
+      section.append(definitionList([
+        ["Contract identity", leg.canonical_contract_identity],
+        ["Contract", `${leg.call_or_put} ${leg.expiration} ${leg.strike}`],
+        ["Position / quantity", `${leg.long_or_short} / ${leg.quantity}`],
+        ["Bid / ask / midpoint", `${leg.bid ?? "Unknown"} / ${leg.ask ?? "Unknown"} / ${leg.midpoint ?? "Unknown"}`],
+        ["Target / actual delta", `${leg.target_delta ?? "Not declared"} / ${leg.actual_delta ?? "Unknown"}`],
+      ]));
+    }
+    const entry = readiness.modeled_entry;
+    if (entry) section.append(definitionList([
+      ["Modeled entry", entry.modeled_net_debit_or_credit],
+      ["Fill assumption", `${entry.reference}; ${entry.semantics}`],
+    ]));
+    const surface = item.modeled_pnl;
+    if (surface) {
+      section.append(element("h4", null, "Modeled P&L at front expiration"));
+      section.append(definitionList([
+        ["Spot reference", surface.spot_reference],
+        ["Model", surface.valuation_model_and_version],
+        ["Fill assumption", surface.entry_fill_assumption],
+        ["Rate / dividend", `${surface.annual_risk_free_rate} / ${surface.annual_dividend_yield}`],
+        ["Disclosure", surface.semantics],
+      ]));
+      const graph = element("div", "pnl-graph");
+      const values = surface.points.map((point) => Number(point.modeled_pnl));
+      const maximum = Math.max(1, ...values.map((value) => Math.abs(value)));
+      for (const point of surface.points) {
+        const row = element("div", "pnl-point");
+        const value = Number(point.modeled_pnl);
+        const bar = element("span", value >= 0 ? "pnl-bar pnl-bar--gain" : "pnl-bar pnl-bar--loss");
+        bar.style.width = `${Math.max(1, Math.abs(value) / maximum * 100)}%`;
+        row.append(element("code", null, point.underlying_price), bar, element("code", null, point.modeled_pnl));
+        graph.append(row);
+      }
+      section.append(graph);
+    }
+    fragment.append(section);
+  }
   fragment.append(gateSection(item.gate_results));
   fragment.append(objectSection("Canonical facts", item.canonical_facts));
   fragment.append(objectSection("Named derived facts", item.named_derived_facts, item.formula_versions));

--- a/asa/ui/static/styles.css
+++ b/asa/ui/static/styles.css
@@ -74,6 +74,11 @@ input:focus, select:focus, button:focus, a:focus { outline: 2px solid var(--cyan
 .mobile-results { display: none; }
 .result-card { padding: 1rem; border: 1px solid var(--line); background: var(--panel); }
 .result-card + .result-card { margin-top: .75rem; }
+.pnl-graph { display: grid; gap: .45rem; margin-top: 1rem; }
+.pnl-point { display: grid; grid-template-columns: 5rem 1fr 6rem; gap: .65rem; align-items: center; }
+.pnl-bar { display: block; min-height: .65rem; border-radius: 2px; }
+.pnl-bar--gain { background: var(--acid); }
+.pnl-bar--loss { background: #ee6a5f; }
 .result-card .badge-row { margin: .8rem 0; }
 .definition-list { display: grid; grid-template-columns: minmax(10rem, .35fr) 1fr; margin: 0; }
 .definition-list dt, .definition-list dd { margin: 0; padding: .65rem 0; border-top: 1px solid var(--line); }

--- a/tests/asa/test_execution_readiness_projection.py
+++ b/tests/asa/test_execution_readiness_projection.py
@@ -1,8 +1,9 @@
-from datetime import UTC, date, datetime
+from datetime import UTC, datetime
 from decimal import Decimal
 
 from asa.api.screening_models import (
     ExecutableStructureAssessmentResponse,
+    ModeledPnLSurfaceResponse,
     ScreeningResultResponse,
 )
 from strategy_runtime.contract import StructureKind
@@ -10,6 +11,7 @@ from strategy_runtime.executable_structures import (
     ExecutableStructureAssessment,
     ExecutableStructureStatus,
 )
+from strategy_runtime.modeled_pnl import MODEL_VERSION, ModeledPnLPoint, ModeledPnLSurface
 from strategy_runtime.result import EvaluationState, RowType, UniversalScreeningResult
 
 NOW = datetime(2026, 9, 1, 15, tzinfo=UTC)
@@ -69,5 +71,23 @@ def test_execution_assessment_schema_uses_exact_decimal_strings() -> None:
     assert "exact_legs" in schema["properties"]
     assert "modeled_entry" in schema["properties"]
     assert "status" in schema["properties"]
-    assert date(2026, 9, 1).isoformat() == "2026-09-01"
-    assert str(Decimal("2.10")) == "2.10"
+    surface = ModeledPnLSurface(
+        "assessment-1",
+        MODEL_VERSION,
+        NOW,
+        Decimal("200.00"),
+        (
+            ModeledPnLPoint(Decimal("190.00"), Decimal("-12.34")),
+            ModeledPnLPoint(Decimal("200.00"), Decimal("45.60")),
+        ),
+        "midpoint",
+        (("contract-1", Decimal("0.30")),),
+        Decimal("0.04"),
+        Decimal("0.01"),
+        Decimal("100"),
+    )
+    projected = ModeledPnLSurfaceResponse.from_surface(surface)
+
+    assert projected.spot_reference == "200.00"
+    assert projected.points[0].modeled_pnl == "-12.34"
+    assert projected.semantics == "modeled_PnL_not_guaranteed_payoff"


### PR DESCRIPTION
## Ticket / gate
EXVIS-05 / Gate 5. Assigned Worker: implementation-worker (Codex). Manager stop status: CLEAR. Closes #396.

## Outcome
Adds the complete additive API and read-only audit UI presentation for signal-versus-constructibility, exact legs, intended-versus-available structure, target/actual delta, bid/ask/midpoint, modeled entry, and modeled front-expiration P&L with visible assumptions and disclosure.

## Truth / safety
- Signal verdict is shown separately and explicitly unchanged.
- Typed non-constructible reason remains visible.
- P&L wording is `modeled_PnL_not_guaranteed_payoff`.
- Financial decimals remain exact strings on the wire.
- Graph is a transparent rendering of supplied deterministic points; it performs no pricing.
- No strategy, acquisition, persistence, execution, or broker mutation behavior.

## Validation
- API projection: 2 passed.
- ASA package: 232 passed, 46 skipped.
- Architecture: 578 passed.
- Ruff/mypy/Lean: pass.
- Static UI JavaScript syntax: pass.
- Frontend tests, lint, typecheck, build: pass.
