### PR TITLE
EXVIS-06: keep readiness identity aligned with screening state

### DIFF
--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -672,11 +672,20 @@ def run_scheduled_refresh(
                 if shadow_registry.is_registered(signal_id)
                 else None
             )
+            # Latest-result persistence may correctly reject an out-of-order
+            # refresh (for example, a manual after-hours proof whose sealed
+            # evidence predates the current production row).  Execution
+            # readiness is a projection of the authoritative screening row,
+            # so it must not advance independently and make the API's two
+            # identities disagree.
+            authoritative_row = resolved_repository.get_one(signal_id, symbol)
             if (
                 isinstance(knowledge, ReadOnlyStrategyInput)
                 and binding is not None
                 and binding.build_execution_assessment is not None
                 and resolved_portfolio_lifecycle_repository is not None
+                and authoritative_row is not None
+                and authoritative_row.observation_id == result.observation_id
             ):
                 try:
                     assessment = binding.build_execution_assessment(
@@ -703,6 +712,15 @@ def run_scheduled_refresh(
                         extra={"signal_id": signal_id, "symbol": symbol},
                         exc_info=True,
                     )
+            elif (
+                resolved_portfolio_lifecycle_repository is not None
+                and authoritative_row is not None
+                and authoritative_row.observation_id != result.observation_id
+            ):
+                _LOGGER.info(
+                    "execution_readiness_projection_skipped_stale_result",
+                    extra={"signal_id": signal_id, "symbol": symbol},
+                )
             _tally_new_calls(symbol, call_log_start)
             if shadow_diagnostic is not None:
                 # Diagnostic-only (Architect checkpoint: sixteenth review,

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -1826,6 +1826,54 @@ def test_scheduled_subject_first_path_publishes_execution_readiness_without_new_
     assert '"intended_structure_kind":"calendar"' in artifact.canonical_json
 
 
+def test_scheduled_readiness_does_not_advance_past_authoritative_screening_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An out-of-order refresh rejected by latest-state persistence must not
+    overwrite readiness with an identity the read API will reject as stale.
+    """
+    import asa.scheduled_screening as scheduled_screening_module
+
+    monkeypatch.setattr(
+        scheduled_screening_module,
+        "build_shared_market_data_access",
+        build_fixture_market_data_access_factory(),
+    )
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+
+    class RejectOutOfOrderResult:
+        def __init__(self) -> None:
+            self.reads = 0
+
+        def get_one(self, signal_id: str, symbol: str) -> object | None:
+            self.reads += 1
+            if self.reads == 1:
+                return None
+            return type("CurrentRow", (), {"observation_id": "newer-current-row"})()
+
+        def upsert(self, row: object) -> None:
+            return None
+
+    class CaptureReadiness:
+        def __init__(self) -> None:
+            self.artifacts = []
+
+        def put_execution_readiness(self, artifact) -> None:
+            self.artifacts.append(artifact)
+
+    readiness = CaptureReadiness()
+    outcomes = run_scheduled_refresh(
+        (("forward_factor", "AAPL"),),
+        repository=RejectOutOfOrderResult(),  # type: ignore[arg-type]
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        portfolio_lifecycle_repository=readiness,  # type: ignore[arg-type]
+    )
+
+    assert outcomes[0].error is None
+    assert readiness.artifacts == []
+
+
 # -- SPRINT-014 S14-PR-05A: real Earnings PASS/WATCH/UNKNOWN evidence at
 # the scheduled production root (Architect checkpoint: eighteenth review,
 # "SPRINT-014 PR-05 requires exact output parity before Architect


### PR DESCRIPTION
Ticket: EXVIS-06 / Gate 6 corrective

## Symptom
Production proof could overwrite execution readiness from an out-of-order refresh even when latest screening persistence correctly rejected that older result. The API then returned `STALE_EXECUTION_READINESS`.

## Root cause
The scheduled composition root persisted readiness from the local refresh return value without first confirming that the same observation became the authoritative latest screening row.

## Correction
Publish readiness only when the persisted authoritative row has the same observation identity. Log a sanitized skip for rejected out-of-order results. No contract, strategy, acquisition, P&L, or broker behavior changes.

## Before / after
Before: a bounded after-hours production proof made readiness and screening identities diverge. After: rejected stale results cannot advance readiness; the existing current artifact remains intact.

## Sprint effect
Restores EX-I01, EX-I07, EX-I13, and Gate 6 API/lifecycle integrity under real out-of-order refresh conditions.

## Validation
- regression: 2 passed
- full suite: 3301 passed, 48 skipped
- architecture: 578 passed
- Ruff changed files: green
- mypy changed production module: green
- Lean pre-push: 5/5 green
- no secrets, provider calls, broker mutation, or signal changes

Worker self-review complete. Manager stop status CLEAR. Active Founder Sprint Delegation applies.