### PR TITLE
EXVIS-06: persist tracked option symbols as JSONB

### DIFF
--- a/asa/integrations/portfolio_lifecycle_postgres.py
+++ b/asa/integrations/portfolio_lifecycle_postgres.py
@@ -1,3 +1,4 @@
+import json
 from uuid import UUID
 
 from sqlalchemy import Engine, text
@@ -33,20 +34,7 @@ class PostgresPortfolioLifecycleRepository:
                         :resolved_proposal_identity, :resolved_proposal_json
                     ) ON CONFLICT (originating_observation_id) DO NOTHING
                 """),
-                {
-                    "id": candidate.id,
-                    "originating_observation_id": candidate.originating_observation_id,
-                    "opportunity_id": candidate.opportunity_id,
-                    "signal_id": candidate.strategy_id,
-                    "signal_version": candidate.strategy_version,
-                    "symbol": candidate.symbol,
-                    "tracked_at": candidate.tracked_at,
-                    "originating_observed_at": candidate.originating_observed_at,
-                    "evidence_observed_at": candidate.evidence_observed_at,
-                    "exact_option_symbols": list(candidate.exact_option_symbols),
-                    "resolved_proposal_identity": candidate.resolved_proposal_identity,
-                    "resolved_proposal_json": candidate.resolved_proposal_json,
-                },
+                _candidate_params(candidate),
             )
         stored = self.candidate(candidate.id)
         if stored is None:
@@ -203,6 +191,29 @@ class PostgresPortfolioLifecycleRepository:
                 )
                 for row in rows
             )
+
+
+def _candidate_params(candidate: TrackedCandidate) -> dict[str, object]:
+    """Encode JSONB explicitly for raw ``text()`` SQL.
+
+    psycopg cannot infer that a plain Python list targets JSONB when SQLAlchemy
+    has no column metadata, so passing the list directly is interpreted as a
+    PostgreSQL array and rejected as invalid JSON.
+    """
+    return {
+        "id": candidate.id,
+        "originating_observation_id": candidate.originating_observation_id,
+        "opportunity_id": candidate.opportunity_id,
+        "signal_id": candidate.strategy_id,
+        "signal_version": candidate.strategy_version,
+        "symbol": candidate.symbol,
+        "tracked_at": candidate.tracked_at,
+        "originating_observed_at": candidate.originating_observed_at,
+        "evidence_observed_at": candidate.evidence_observed_at,
+        "exact_option_symbols": json.dumps(candidate.exact_option_symbols),
+        "resolved_proposal_identity": candidate.resolved_proposal_identity,
+        "resolved_proposal_json": candidate.resolved_proposal_json,
+    }
 
 
 def _candidate(row: RowMapping) -> TrackedCandidate:

--- a/tests/asa/test_portfolio_lifecycle.py
+++ b/tests/asa/test_portfolio_lifecycle.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
@@ -17,7 +18,9 @@ from asa.contracts.portfolio_lifecycle import (
     ExecutionReadinessArtifact,
     PositionLifecycleState,
     ReconciliationState,
+    TrackedCandidate,
 )
+from asa.integrations.portfolio_lifecycle_postgres import _candidate_params
 from asa.integrations.providers.deterministic_fake_broker import (
     DeterministicFakeBrokerPortfolioProvider,
 )
@@ -26,6 +29,26 @@ from strategy_runtime.values import TypedValue
 from tests.asa.fakes import InMemoryLatestResultRepository, InMemoryObservationRepository
 
 NOW = datetime(2026, 8, 28, 12, tzinfo=UTC)
+
+
+def test_postgres_candidate_params_encode_exact_symbols_as_jsonb_text() -> None:
+    candidate = TrackedCandidate(
+        id=uuid4(),
+        originating_observation_id="observation-1",
+        opportunity_id=None,
+        strategy_id="forward_factor",
+        strategy_version="1.3.0",
+        symbol="BKNG",
+        tracked_at=NOW,
+        originating_observed_at=NOW,
+        evidence_observed_at=NOW,
+        exact_option_symbols=("BKNG261120C00200000", "BKNG261218C00200000"),
+    )
+
+    encoded = _candidate_params(candidate)["exact_option_symbols"]
+
+    assert isinstance(encoded, str)
+    assert json.loads(encoded) == list(candidate.exact_option_symbols)
 
 
 class MemoryLifecycleRepository:


### PR DESCRIPTION
Ticket: EXVIS-06 / Gate 6 corrective

## Symptom
Founder-authorized production proof reached a live constructible BKNG calendar and modeled P&L, but Track This returned 500.

## Root cause
The raw SQL repository passed `exact_option_symbols` as a Python list without SQLAlchemy column metadata. psycopg adapted it as a PostgreSQL array; the JSONB column rejected the array text.

## Correction
Encode the immutable tuple explicitly as canonical JSON text at the Postgres boundary, matching this repository family’s established raw-SQL JSON policy.

## Before / after
Before: exact OCC symbols caused `InvalidTextRepresentation` and no candidate was written. After: the JSONB parameter decodes to the exact ordered symbols and Track This can persist its immutable proposal.

## Sprint effect
Makes Gate 6 lifecycle attachment operational without changing strategy signals, acquisition, option resolution, valuation, or broker authority.

## Validation
- focused regression: 2 passed
- full suite: 3302 passed, 48 skipped
- architecture: 578 passed
- Ruff/mypy changed scope: green
- Lean pre-push: 5/5 green
- live readiness: constructible intended BKNG calendar with two exact legs
- live modeled P&L API: green with explicit proof assumptions
- no secrets or broker mutation

Worker self-review complete. Manager stop status CLEAR. Active Founder Sprint Delegation applies.