### PR TITLE
PST-02: retrieve complete screening product state

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -303,6 +303,7 @@ class ScreeningResultsEnvelope(BaseModel):
     total: int
     limit: int
     offset: int
+    snapshot_identity: str
 
 
 class ExactOptionLegResponse(BaseModel):

--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -29,6 +29,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
+from hashlib import sha256
 from typing import Literal
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -100,6 +101,16 @@ DEFAULT_LIMIT = 100
 MAX_LIMIT = 500
 FRESHNESS_THRESHOLD_SECONDS = 86_400
 _LOGGER = logging.getLogger(__name__)
+
+
+def _latest_state_identity(records: tuple[UniversalScreeningResult, ...]) -> str:
+    payload = [
+        (item.strategy_id, item.symbol, item.observation_id)
+        for item in sorted(records, key=lambda item: (item.strategy_id, item.symbol))
+    ]
+    return sha256(
+        json.dumps(payload, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    ).hexdigest()
 
 
 @dataclass(frozen=True, slots=True)
@@ -306,6 +317,7 @@ def build_screening_router(
             total=total,
             limit=limit,
             offset=offset,
+            snapshot_identity=_latest_state_identity(records),
         )
 
     @router.get("/screening-health", response_model=StrategyHealthResponse)
@@ -391,6 +403,7 @@ def build_screening_router(
             total=total,
             limit=limit,
             offset=offset,
+            snapshot_identity=_latest_state_identity(records),
         )
 
     @router.get("/screening/{signal}/{symbol}", response_model=ScreeningResultResponse)

--- a/asa/ui/static/api-client.js
+++ b/asa/ui/static/api-client.js
@@ -1,3 +1,5 @@
+import { collectCompleteScreeningState } from "./pagination.js";
+
 const TOKEN_KEY = "asa-agent-token";
 
 let memoryToken = sessionStorage.getItem(TOKEN_KEY) || "";
@@ -43,7 +45,9 @@ export const api = Object.freeze({
   readiness: () => requestJson("/api/v1/readiness", false),
   version: () => requestJson("/api/v1/version", false),
   capabilities: () => requestJson("/api/v1/capabilities"),
-  results: () => requestJson("/api/v1/screening?limit=500&offset=0"),
+  results: () => collectCompleteScreeningState(
+    (limit, offset) => requestJson(`/api/v1/screening?limit=${limit}&offset=${offset}`),
+  ),
   result: (signalId, symbol) =>
     requestJson(
       `/api/v1/screening/${encodeURIComponent(signalId)}/${encodeURIComponent(symbol)}`,

--- a/asa/ui/static/pagination.js
+++ b/asa/ui/static/pagination.js
@@ -1,0 +1,50 @@
+export async function collectCompleteScreeningState(fetchPage, pageLimit = 500) {
+  const results = [];
+  const identities = new Set();
+  let authoritativeTotal = null;
+  let snapshotIdentity = null;
+  let apiVersion = null;
+
+  while (authoritativeTotal === null || results.length < authoritativeTotal) {
+    const requestedOffset = results.length;
+    const response = await fetchPage(pageLimit, requestedOffset);
+    const page = response.data;
+    if (page.offset !== requestedOffset || page.limit !== pageLimit) {
+      throw new Error("Screening pagination contract mismatch");
+    }
+    if (authoritativeTotal === null) {
+      authoritativeTotal = page.total;
+      snapshotIdentity = page.snapshot_identity;
+      apiVersion = response.apiVersion;
+    } else if (
+      page.total !== authoritativeTotal ||
+      page.snapshot_identity !== snapshotIdentity
+    ) {
+      throw new Error("Screening state changed during pagination; retry required");
+    }
+    if (!page.results.length && results.length < authoritativeTotal) {
+      throw new Error("Screening pagination ended before authoritative total");
+    }
+    for (const item of page.results) {
+      const identity = `${item.signal_id}:${item.symbol}`;
+      if (identities.has(identity)) {
+        throw new Error(`Duplicate screening identity across pages: ${identity}`);
+      }
+      identities.add(identity);
+      results.push(item);
+    }
+  }
+  if (results.length !== authoritativeTotal) {
+    throw new Error("Screening page union exceeds authoritative total");
+  }
+  return {
+    data: {
+      results,
+      total: authoritativeTotal,
+      limit: pageLimit,
+      offset: 0,
+      snapshot_identity: snapshotIdentity,
+    },
+    apiVersion,
+  };
+}

--- a/frontend/src/api/generated/models/ScreeningResultsEnvelope.ts
+++ b/frontend/src/api/generated/models/ScreeningResultsEnvelope.ts
@@ -8,4 +8,5 @@ export type ScreeningResultsEnvelope = {
     total: number;
     limit: number;
     offset: number;
+    snapshot_identity: string;
 };

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -3982,6 +3982,10 @@
           "offset": {
             "type": "integer",
             "title": "Offset"
+          },
+          "snapshot_identity": {
+            "type": "string",
+            "title": "Snapshot Identity"
           }
         },
         "type": "object",
@@ -3989,7 +3993,8 @@
           "results",
           "total",
           "limit",
-          "offset"
+          "offset",
+          "snapshot_identity"
         ],
         "title": "ScreeningResultsEnvelope"
       },

--- a/frontend/tests/intelligence-console-pagination.test.ts
+++ b/frontend/tests/intelligence-console-pagination.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+// Static Intelligence Console code is packaged by the backend, outside this
+// TypeScript project's source root.
+// @ts-expect-error JavaScript module intentionally has no separate declaration file.
+import { collectCompleteScreeningState } from '../../asa/ui/static/pagination.js'
+
+type Row = { signal_id: string; symbol: string }
+
+function pages(rows: Row[], snapshots: string[] = ['snapshot-a']) {
+  let call = 0
+  return async (limit: number, offset: number) => {
+    const snapshot_identity = snapshots[Math.min(call++, snapshots.length - 1)]
+    return {
+      data: {
+        results: rows.slice(offset, offset + limit), total: rows.length,
+        limit, offset, snapshot_identity,
+      },
+      apiVersion: 'v1',
+    }
+  }
+}
+
+function rows(counts: number[]): Row[] {
+  return counts.flatMap((count, signal) =>
+    Array.from({ length: count }, (_, index) => ({ signal_id: `signal-${signal}`, symbol: `${index}` })),
+  )
+}
+
+describe('Intelligence Console complete latest-state pagination', () => {
+  it.each([501, 1000, 1001])('loads all %i rows without alphabetical starvation', async (total) => {
+    const source = rows([500, Math.max(0, total - 501), 1])
+    const result = await collectCompleteScreeningState(pages(source))
+
+    expect(result.data.results).toEqual(source)
+    expect(result.data.total).toBe(total)
+    expect(new Set(result.data.results.map((item: Row) => item.signal_id))).toContain('signal-2')
+  })
+
+  it('rejects duplicate identities across exact page boundaries', async () => {
+    const source = rows([501])
+    const fetchPage = pages(source)
+    await expect(collectCompleteScreeningState(async (limit: number, offset: number) => {
+      const response = await fetchPage(limit, offset)
+      if (offset === 500) response.data.results[0] = source[0]
+      return response
+    })).rejects.toThrow('Duplicate screening identity')
+  })
+
+  it('rejects a refresh that changes the snapshot between pages', async () => {
+    await expect(
+      collectCompleteScreeningState(pages(rows([501]), ['snapshot-a', 'snapshot-b'])),
+    ).rejects.toThrow('Screening state changed during pagination')
+  })
+})

--- a/tests/asa/test_bootstrap_first_run.py
+++ b/tests/asa/test_bootstrap_first_run.py
@@ -99,7 +99,13 @@ def test_bootstrap_first_run_from_a_genuinely_empty_deployment(
     # Step 2: confirm the empty state is 200 + empty list, never 404.
     empty_list = client.get("/api/v1/screening", headers=_auth())
     assert empty_list.status_code == 200
-    assert empty_list.json() == {"results": [], "total": 0, "limit": 100, "offset": 0}
+    assert empty_list.json() == {
+        "results": [],
+        "total": 0,
+        "limit": 100,
+        "offset": 0,
+        "snapshot_identity": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+    }
 
     # A specific pair that has never been refreshed still 404s, distinguishably.
     no_result_yet = client.get("/api/v1/screening/skew_momentum/AAPL", headers=_auth())

--- a/tests/asa/test_screening_routes.py
+++ b/tests/asa/test_screening_routes.py
@@ -160,7 +160,15 @@ class TestListScreening:
         response = _client().get("/api/v1/screening", headers=_auth())
         assert response.status_code == 200
         body = response.json()
-        assert body == {"results": [], "total": 0, "limit": 100, "offset": 0}
+        assert body == {
+            "results": [],
+            "total": 0,
+            "limit": 100,
+            "offset": 0,
+            "snapshot_identity": (
+                "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+            ),
+        }
 
     def test_returns_every_result_deterministically_ordered(self) -> None:
         repository = InMemoryLatestResultRepository()
@@ -173,6 +181,31 @@ class TestListScreening:
             ("skew_momentum", "MSFT"),
         ]
         assert body["total"] == 2
+
+    def test_snapshot_identity_fences_multi_page_latest_state(self) -> None:
+        repository = InMemoryLatestResultRepository()
+        for index in range(501):
+            repository.upsert(_record("earnings_calendar", f"E{index:04d}"))
+        repository.upsert(_record("forward_factor", "F0000"))
+        client = _client(repository)
+
+        first = client.get("/api/v1/screening?limit=500&offset=0", headers=_auth()).json()
+        second = client.get("/api/v1/screening?limit=500&offset=500", headers=_auth()).json()
+
+        identities = {
+            (item["signal_id"], item["symbol"])
+            for item in first["results"] + second["results"]
+        }
+        assert first["total"] == second["total"] == 502
+        assert first["snapshot_identity"] == second["snapshot_identity"]
+        assert len(identities) == 502
+        assert ("forward_factor", "F0000") in identities
+
+        repository.upsert(_record("skew_momentum", "S0000"))
+        changed = client.get(
+            "/api/v1/screening?limit=500&offset=500", headers=_auth()
+        ).json()
+        assert changed["snapshot_identity"] != first["snapshot_identity"]
 
     def test_every_result_exposes_updated_at_and_age_seconds(self) -> None:
         repository = InMemoryLatestResultRepository()

--- a/tests/asa/test_ui_routes.py
+++ b/tests/asa/test_ui_routes.py
@@ -34,7 +34,14 @@ def test_ui_shell_and_packaged_assets_return_200() -> None:
     assert shell.status_code == 200
     assert "ASA Intelligence Console" in shell.text
     assert "Content-Security-Policy" in shell.text
-    for asset in ("app.js", "api-client.js", "state.js", "render.js", "styles.css"):
+    for asset in (
+        "app.js",
+        "api-client.js",
+        "pagination.js",
+        "state.js",
+        "render.js",
+        "styles.css",
+    ):
         response = client.get(f"/ui/static/{asset}")
         assert response.status_code == 200
         assert response.content
@@ -87,6 +94,19 @@ def test_ui_client_is_get_only_and_never_persists_token_in_local_storage() -> No
     assert "refresh" not in client_source.lower()
     assert "localStorage" not in client_source + application_source
     assert "sessionStorage" in client_source
+
+
+def test_ui_traverses_all_pages_and_rejects_incompatible_snapshots() -> None:
+    static = files("asa.ui").joinpath("static")
+    client_source = static.joinpath("api-client.js").read_text(encoding="utf-8")
+    pagination_source = static.joinpath("pagination.js").read_text(encoding="utf-8")
+
+    assert "collectCompleteScreeningState" in client_source
+    assert "while (authoritativeTotal === null || results.length < authoritativeTotal)" in (
+        pagination_source
+    )
+    assert "page.snapshot_identity !== snapshotIdentity" in pagination_source
+    assert "Duplicate screening identity across pages" in pagination_source
 
 
 def test_ui_exposes_exact_structure_and_explicit_modeled_pnl_assumptions() -> None:


### PR DESCRIPTION
Ticket: PST-02 / Gate 2

## Root cause
The Intelligence Console requested only `/api/v1/screening?limit=500&offset=0`, discarded the authoritative envelope total, and treated that partial page as complete latest state. Strategy-first ordering could therefore hide later strategies.

## Correction
- Preserve the existing paginated API contract.
- Add an additive content-derived `snapshot_identity` to each screening envelope.
- Traverse every page in the static Intelligence Console.
- Fail closed on total/snapshot changes, duplicate identities, early termination, or pagination contract mismatch.
- Update the OpenAPI snapshot and generated frontend type.

## Proof
- 501, 1000, and 1001-row multi-strategy traversal
- exact boundary and duplicate rejection
- refresh-during-pagination rejection
- full repository: 3304 passed, 48 skipped
- architecture: 578 passed
- Ruff, mypy, frontend test/lint/typecheck/build, Lean checks: green

## Boundaries
No MAX_LIMIT increase, persistence migration, strategy/provider behavior, broker mutation, scheduler redesign, or API break. Worker self-review complete; Manager stop status CLEAR. Delegated merge authority: PRODUCT-STATE-TRUTH-001.