### PR TITLE
PST-03: expose analytical completeness separately

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -120,6 +120,8 @@ class StrategyHealthFunnelResponse(BaseModel):
     strategy_id: str
     active_subjects: int
     evaluated: int
+    missing_data: int
+    no_signal: int
     evidence_sufficient: int
     structure_eligible_or_constructible: int
     gates_passed: int

--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -336,6 +336,8 @@ def build_screening_router(
                     strategy_id=item.strategy_id,
                     active_subjects=item.active_subjects,
                     evaluated=item.evaluated,
+                    missing_data=item.missing_data,
+                    no_signal=item.no_signal,
                     evidence_sufficient=item.evidence_sufficient,
                     structure_eligible_or_constructible=(item.structure_eligible_or_constructible),
                     gates_passed=item.gates_passed,

--- a/asa/ui/static/api-client.js
+++ b/asa/ui/static/api-client.js
@@ -45,6 +45,7 @@ export const api = Object.freeze({
   readiness: () => requestJson("/api/v1/readiness", false),
   version: () => requestJson("/api/v1/version", false),
   capabilities: () => requestJson("/api/v1/capabilities"),
+  strategyHealth: () => requestJson("/api/v1/screening-health"),
   results: () => collectCompleteScreeningState(
     (limit, offset) => requestJson(`/api/v1/screening?limit=${limit}&offset=${offset}`),
   ),

--- a/asa/ui/static/app.js
+++ b/asa/ui/static/app.js
@@ -77,9 +77,12 @@ async function loadPersistedState() {
     return;
   }
   try {
-    const [capabilities, results] = await Promise.all([api.capabilities(), api.results()]);
+    const [capabilities, results, strategyHealth] = await Promise.all([
+      api.capabilities(), api.results(), api.strategyHealth(),
+    ]);
     state.capabilities = capabilities.data;
     state.results = results.data.results;
+    state.strategyHealth = strategyHealth.data;
     state.apiVersion = results.apiVersion || capabilities.apiVersion;
     state.fetchedAt = new Date().toISOString();
     void loadExecutionReadiness();
@@ -102,6 +105,7 @@ const handlers = {
     clearToken();
     state.results = [];
     state.capabilities = null;
+    state.strategyHealth = null;
     state.error = null;
     render();
   },

--- a/asa/ui/static/render.js
+++ b/asa/ui/static/render.js
@@ -413,6 +413,29 @@ function healthView(model) {
   heading.append(element("h2", null, "Service state"));
   heading.append(element("p", null, "Infrastructure checks and exact counts from the latest persisted rows—not a single run."));
   fragment.append(heading);
+  const analyticalHeading = element("section", "page-heading");
+  analyticalHeading.append(element("p", "eyebrow", "ANALYTICAL COMPLETENESS"));
+  analyticalHeading.append(element("h2", null, "Strategy evaluation state"));
+  analyticalHeading.append(element("p", null, "Latest persisted state by strategy. This is separate from service health and data freshness."));
+  fragment.append(analyticalHeading);
+  const analyticalGrid = element("div", "health-grid");
+  for (const funnel of model.strategyHealth?.strategies || []) {
+    const value = {
+      subjects: funnel.active_subjects,
+      evaluated: funnel.evaluated,
+      missing_data: funnel.missing_data,
+      no_signal: funnel.no_signal,
+      watch: funnel.watch,
+      pass: funnel.passed,
+    };
+    const card = element("article", "health-card");
+    card.append(element("h3", null, funnel.strategy_id), element("code", null, JSON.stringify(value)));
+    analyticalGrid.append(card);
+  }
+  if (!(model.strategyHealth?.strategies || []).length) {
+    analyticalGrid.append(element("p", null, "Analytical state unavailable."));
+  }
+  fragment.append(analyticalGrid);
   const grid = element("div", "health-grid");
   const cards = [
     ["Health endpoint", JSON.stringify(model.health || "Unavailable")],

--- a/asa/ui/static/state.js
+++ b/asa/ui/static/state.js
@@ -3,6 +3,7 @@ export const state = {
   readiness: null,
   buildIdentity: null,
   capabilities: null,
+  strategyHealth: null,
   results: [],
   executionReadiness: {},
   apiVersion: null,

--- a/frontend/src/api/generated/models/StrategyHealthFunnelResponse.ts
+++ b/frontend/src/api/generated/models/StrategyHealthFunnelResponse.ts
@@ -7,6 +7,8 @@ export type StrategyHealthFunnelResponse = {
     strategy_id: string;
     active_subjects: number;
     evaluated: number;
+    missing_data: number;
+    no_signal: number;
     evidence_sufficient: number;
     structure_eligible_or_constructible: number;
     gates_passed: number;

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -4120,6 +4120,14 @@
             "type": "integer",
             "title": "Evaluated"
           },
+          "missing_data": {
+            "type": "integer",
+            "title": "Missing Data"
+          },
+          "no_signal": {
+            "type": "integer",
+            "title": "No Signal"
+          },
           "evidence_sufficient": {
             "type": "integer",
             "title": "Evidence Sufficient"
@@ -4160,6 +4168,8 @@
           "strategy_id",
           "active_subjects",
           "evaluated",
+          "missing_data",
+          "no_signal",
           "evidence_sufficient",
           "structure_eligible_or_constructible",
           "gates_passed",

--- a/strategy_runtime/health.py
+++ b/strategy_runtime/health.py
@@ -13,6 +13,8 @@ class StrategyHealthFunnel:
     strategy_id: str
     active_subjects: int
     evaluated: int
+    missing_data: int
+    no_signal: int
     evidence_sufficient: int
     structure_eligible_or_constructible: int
     gates_passed: int
@@ -45,6 +47,12 @@ def build_strategy_health(
         strategy_id=strategy_id,
         active_subjects=len(records),
         evaluated=len(evaluated_records),
+        missing_data=sum(
+            item.evaluation_state is EvaluationState.MISSING_DATA for item in records
+        ),
+        no_signal=sum(
+            item.evaluation_state is EvaluationState.NO_SIGNAL for item in records
+        ),
         evidence_sufficient=len(evaluated_records),
         structure_eligible_or_constructible=structure_eligible,
         gates_passed=watch + passed,

--- a/tests/asa/test_screening_routes.py
+++ b/tests/asa/test_screening_routes.py
@@ -30,7 +30,7 @@ def _record(
     lifecycle_stage: str | None = None,
     recommendation_state: str | None = None,
     score: Decimal = Decimal("75"),
-    verdict: str = "PASS",
+    verdict: str | None = "PASS",
 ) -> UniversalSignalRow:
     return UniversalSignalRow(
         signal_id=signal_id,
@@ -93,7 +93,29 @@ def test_strategy_health_exposes_all_registered_production_funnels() -> None:
     assert set(funnels) == {"forward_factor", "earnings_calendar", "skew_momentum"}
     assert all(item["active_subjects"] == 1 for item in funnels.values())
     assert all(item["evaluated"] == 1 for item in funnels.values())
+    assert all(item["missing_data"] == 0 for item in funnels.values())
+    assert all(item["no_signal"] == 0 for item in funnels.values())
     assert all(item["typed_rejection_counts"] for item in funnels.values())
+
+
+def test_strategy_health_distinguishes_missing_data_from_no_signal() -> None:
+    repository = InMemoryLatestResultRepository()
+    repository.upsert(
+        _record("forward_factor", "AAPL", outcome="missing_data", verdict=None)
+    )
+    repository.upsert(_record("forward_factor", "MSFT", outcome="no_signal"))
+
+    response = _client(repository).get("/api/v1/screening-health", headers=_auth())
+
+    funnel = next(
+        item
+        for item in response.json()["strategies"]
+        if item["strategy_id"] == "forward_factor"
+    )
+    assert funnel["active_subjects"] == 2
+    assert funnel["evaluated"] == 1
+    assert funnel["missing_data"] == 1
+    assert funnel["no_signal"] == 1
 
 
 class TestAuthentication:

--- a/tests/asa/test_ui_routes.py
+++ b/tests/asa/test_ui_routes.py
@@ -109,6 +109,18 @@ def test_ui_traverses_all_pages_and_rejects_incompatible_snapshots() -> None:
     assert "Duplicate screening identity across pages" in pagination_source
 
 
+def test_ui_separates_strategy_analytical_state_from_infrastructure_health() -> None:
+    static = files("asa.ui").joinpath("static")
+    client_source = static.joinpath("api-client.js").read_text(encoding="utf-8")
+    render_source = static.joinpath("render.js").read_text(encoding="utf-8")
+
+    assert "/api/v1/screening-health" in client_source
+    assert "ANALYTICAL COMPLETENESS" in render_source
+    assert "separate from service health and data freshness" in render_source
+    assert "missing_data: funnel.missing_data" in render_source
+    assert "no_signal: funnel.no_signal" in render_source
+
+
 def test_ui_exposes_exact_structure_and_explicit_modeled_pnl_assumptions() -> None:
     render_source = (
         files("asa.ui").joinpath("static", "render.js").read_text(encoding="utf-8")


### PR DESCRIPTION
Ticket: PST-03 / Gate 3

## Outcome
The existing strategy-health authority now exposes explicit `missing_data` and `no_signal` totals alongside subjects, evaluated, WATCH, and PASS. The Intelligence Console reads that existing endpoint and renders analytical completeness separately from infrastructure health and freshness.

## Boundaries
No new health ontology, thresholds, scheduler behavior, strategy semantics, provider acquisition, persistence change, or broker mutation. Additive API fields only.

## Proof
- explicit missing_data vs no_signal regression
- all three registered production funnels retained
- full repository: 3306 passed, 48 skipped
- architecture: 578 passed
- Ruff, mypy, frontend lint/type/build, Lean: green

Worker self-review complete; Manager stop status CLEAR. Delegated merge authority: PRODUCT-STATE-TRUTH-001.