### PR TITLE
PST-04: make product totals and build identity truthful

### DIFF
--- a/asa/config.py
+++ b/asa/config.py
@@ -21,7 +21,12 @@ class Settings(BaseSettings):
     )
     environment: str = "development"
     application_version: str = Field(default="0.1.0", min_length=1, max_length=64)
-    release_sha: str | None = Field(default=None, min_length=1, max_length=64)
+    release_sha: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=64,
+        validation_alias=AliasChoices("ASA_RELEASE_SHA", "RAILWAY_GIT_COMMIT_SHA"),
+    )
     quote_provider: str = "deterministic_fake"
     broker_portfolio_provider: str = "deterministic_fake_broker"
     robinhood_username: SecretStr | None = None

--- a/asa/ui/static/app.js
+++ b/asa/ui/static/app.js
@@ -82,6 +82,8 @@ async function loadPersistedState() {
     ]);
     state.capabilities = capabilities.data;
     state.results = results.data.results;
+    state.resultsTotal = results.data.total;
+    state.resultsSnapshotIdentity = results.data.snapshot_identity;
     state.strategyHealth = strategyHealth.data;
     state.apiVersion = results.apiVersion || capabilities.apiVersion;
     state.fetchedAt = new Date().toISOString();
@@ -104,6 +106,8 @@ const handlers = {
   clearToken() {
     clearToken();
     state.results = [];
+    state.resultsTotal = 0;
+    state.resultsSnapshotIdentity = null;
     state.capabilities = null;
     state.strategyHealth = null;
     state.error = null;

--- a/asa/ui/static/render.js
+++ b/asa/ui/static/render.js
@@ -168,14 +168,16 @@ function resultsView(model, handlers) {
   heading.append(element("p", "eyebrow", "LATEST PERSISTED SNAPSHOT"));
   heading.append(element("h2", null, "Strategy results"));
   heading.append(element("p", null, "Rows may span refresh times; the API exposes no cycle identifier."));
+  heading.append(element("p", null, "Freshness and usability describe evidence; evaluation state describes whether analysis completed. Fresh missing-data rows remain analytically incomplete."));
   fragment.append(heading);
 
   const summary = element("section", "summary-grid");
   const summaries = [
     ["Visible rows", String(model.visible.length)],
-    ["Persisted rows", String(model.results.length)],
+    ["Loaded rows", String(model.results.length)],
+    ["Persisted rows", String(model.resultsTotal)],
     ["Last fetched", model.fetchedAt || "Not fetched"],
-    ["Revision", "Unavailable from API"],
+    ["Revision", model.buildIdentity?.release_sha || "Unavailable"],
   ];
   for (const [label, value] of summaries) {
     const card = element("article", "summary-card");
@@ -443,7 +445,9 @@ function healthView(model) {
     ["API contract", model.apiVersion || "Revision unavailable"],
     ["Application version", model.buildIdentity?.application_version || "Unavailable"],
     ["Release revision", model.buildIdentity?.release_sha || "Unavailable"],
-    ["Persisted rows", String(model.results.length)],
+    ["Loaded rows", String(model.results.length)],
+    ["Persisted rows", String(model.resultsTotal)],
+    ["Latest-state identity", model.resultsSnapshotIdentity || "Unavailable"],
     ["Earliest evaluated", model.evaluatedRange.earliest],
     ["Latest evaluated", model.evaluatedRange.latest],
     ["Verdicts", JSON.stringify(model.counts.verdict)],

--- a/asa/ui/static/state.js
+++ b/asa/ui/static/state.js
@@ -5,6 +5,8 @@ export const state = {
   capabilities: null,
   strategyHealth: null,
   results: [],
+  resultsTotal: 0,
+  resultsSnapshotIdentity: null,
   executionReadiness: {},
   apiVersion: null,
   fetchedAt: null,

--- a/tests/asa/test_config.py
+++ b/tests/asa/test_config.py
@@ -132,6 +132,24 @@ def test_build_identity_strips_configuration_whitespace() -> None:
     assert settings.release_sha == "abc123"
 
 
+def test_build_identity_uses_railway_commit_when_asa_override_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ASA_RELEASE_SHA", raising=False)
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "railway-commit-123")
+
+    assert Settings(_env_file=None).release_sha == "railway-commit-123"
+
+
+def test_explicit_asa_release_sha_precedes_railway_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ASA_RELEASE_SHA", "asa-release")
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "railway-commit")
+
+    assert Settings(_env_file=None).release_sha == "asa-release"
+
+
 def test_robinhood_provider_is_selected_from_railway_variables(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/asa/test_ui_routes.py
+++ b/tests/asa/test_ui_routes.py
@@ -119,6 +119,22 @@ def test_ui_separates_strategy_analytical_state_from_infrastructure_health() -> 
     assert "separate from service health and data freshness" in render_source
     assert "missing_data: funnel.missing_data" in render_source
     assert "no_signal: funnel.no_signal" in render_source
+    assert "Fresh missing-data rows remain analytically incomplete" in render_source
+
+
+def test_ui_distinguishes_visible_loaded_and_authoritative_total_and_build() -> None:
+    static = files("asa.ui").joinpath("static")
+    application_source = static.joinpath("app.js").read_text(encoding="utf-8")
+    render_source = static.joinpath("render.js").read_text(encoding="utf-8")
+
+    assert "state.resultsTotal = results.data.total" in application_source
+    assert "state.resultsSnapshotIdentity = results.data.snapshot_identity" in (
+        application_source
+    )
+    assert '["Visible rows", String(model.visible.length)]' in render_source
+    assert '["Loaded rows", String(model.results.length)]' in render_source
+    assert '["Persisted rows", String(model.resultsTotal)]' in render_source
+    assert 'model.buildIdentity?.release_sha || "Unavailable"' in render_source
 
 
 def test_ui_exposes_exact_structure_and_explicit_modeled_pnl_assumptions() -> None:


### PR DESCRIPTION
Ticket: PST-04 / Gate 4

## Outcome
- Preserve authoritative API total and latest-state identity in Console state.
- Label visible, loaded, and persisted totals separately.
- Keep freshness/usability separate from evaluation completion, including explicit fresh+missing_data language.
- Render exact release SHA in results and health views.
- Use Railway commit SHA as the release identity only when the explicit ASA override is absent.

## Proof
- ASA override precedence and Railway fallback tests
- UI source contract tests for total/snapshot/build semantics
- full repository: 3309 passed, 48 skipped
- architecture: 578 passed
- Ruff, mypy, frontend lint/type/build, Lean: green

## Boundaries
No persistence migration, API break, strategy/provider behavior, scheduler change, broker mutation, or new health semantics. Worker self-review complete; Manager stop status CLEAR. Delegated merge authority: PRODUCT-STATE-TRUTH-001.