### PR TITLE
PST-05: label bounded operational cohort reports

### DIFF
--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -872,6 +872,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(
         json.dumps(
             {
+                "artifact_type": "bounded_run_cohort",
                 "total": len(outcomes),
                 "failed": len(failures),
                 # Never silently report complete acquisition accounting

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, date, datetime, timedelta
 
@@ -30,6 +31,28 @@ from tests.asa._fixture_market_data_access import (
 )
 from tests.asa.fakes import InMemoryLatestResultRepository, InMemoryObservationHistoryRepository
 from tests.asa.market_data_ops.fakes import ScriptedTransport, tradier_quote_response
+
+
+def test_operational_json_labels_bounded_cohort_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import asa.scheduled_screening as scheduled_screening_module
+
+    monkeypatch.setattr(
+        scheduled_screening_module,
+        "run_scheduled_refresh",
+        lambda **_kwargs: (
+            scheduled_screening_module.PairOutcome(
+                "forward_factor", "AAPL", "no_signal", 3, None, True
+            ),
+        ),
+    )
+
+    assert scheduled_screening_module.main(["--json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["artifact_type"] == "bounded_run_cohort"
+    assert report["total"] == 1
 
 
 def _tradier_option(


### PR DESCRIPTION
Ticket: PST-05 / Gate 5

## Outcome
Scheduled screening machine-readable output now identifies itself as `bounded_run_cohort`, preventing its pair count from being confused with the persistence/API latest-state snapshot.

## Proof
- deterministic operational JSON semantic-label regression
- full repository: 3310 passed, 48 skipped
- architecture: 578 passed
- frontend: 7 passed; lint/type/build green
- Ruff, mypy, Lean: green

## Production gate
Cross-surface production reconciliation remains Founder-authorized deployment/proof work after this PR merges and exact-main validation passes.

No strategy, provider, acquisition, persistence, broker, scheduler, or run topology change. Worker self-review complete; Manager stop status CLEAR. Delegated merge authority: PRODUCT-STATE-TRUTH-001.