### PR TITLE
AC-01: establish canonical active-universe projection

### DIFF
--- a/asa/api/screening_models.py
+++ b/asa/api/screening_models.py
@@ -10,6 +10,7 @@ timestamped").
 from __future__ import annotations
 
 from datetime import date, datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -122,6 +123,7 @@ class StrategyHealthFunnelResponse(BaseModel):
     evaluated: int
     missing_data: int
     no_signal: int
+    retained_nonactive: int
     evidence_sufficient: int
     structure_eligible_or_constructible: int
     gates_passed: int
@@ -306,6 +308,8 @@ class ScreeningResultsEnvelope(BaseModel):
     limit: int
     offset: int
     snapshot_identity: str
+    scope: Literal["all_latest", "active_universe"]
+    retained_nonactive_total: int
 
 
 class ExactOptionLegResponse(BaseModel):

--- a/asa/api/screening_routes.py
+++ b/asa/api/screening_routes.py
@@ -263,6 +263,7 @@ def build_screening_router(
     history_repository: ObservationHistoryRepository,
     acquisition_attempt_repository: AcquisitionAttemptRepository,
     operational_health: Callable[[], dict[str, object]],
+    active_symbols: frozenset[str],
     portfolio_lifecycle_repository: PortfolioLifecycleRepository | None = None,
 ) -> APIRouter:
     router = APIRouter(prefix="/api/v1", dependencies=[Depends(authorize)])
@@ -299,8 +300,9 @@ def build_screening_router(
         status: str | None = None,
         sort_by: str | None = None,
         sort_order: Literal["asc", "desc"] = "desc",
+        active_only: bool = False,
     ) -> ScreeningResultsEnvelope:
-        records = _filter_and_sort(
+        all_records = _filter_and_sort(
             get_state(repository),
             signal=signal,
             symbol=symbol,
@@ -311,6 +313,14 @@ def build_screening_router(
             sort_by=sort_by,
             sort_order=sort_order,
         )
+        retained_nonactive_total = sum(
+            item.symbol not in active_symbols for item in all_records
+        )
+        records = (
+            tuple(item for item in all_records if item.symbol in active_symbols)
+            if active_only
+            else all_records
+        )
         page, total = _paginate(records, limit, offset)
         return ScreeningResultsEnvelope(
             results=[ScreeningResultResponse.from_universal_result(item) for item in page],
@@ -318,15 +328,18 @@ def build_screening_router(
             limit=limit,
             offset=offset,
             snapshot_identity=_latest_state_identity(records),
+            scope="active_universe" if active_only else "all_latest",
+            retained_nonactive_total=retained_nonactive_total,
         )
 
     @router.get("/screening-health", response_model=StrategyHealthResponse)
     def strategy_health() -> StrategyHealthResponse:
         state = get_state(repository)
+        active_state = tuple(item for item in state if item.symbol in active_symbols)
         funnels = [
             build_strategy_health(
                 strategy_id,
-                tuple(item for item in state if item.strategy_id == strategy_id),
+                tuple(item for item in active_state if item.strategy_id == strategy_id),
             )
             for strategy_id in registry.strategy_ids()
         ]
@@ -338,6 +351,11 @@ def build_screening_router(
                     evaluated=item.evaluated,
                     missing_data=item.missing_data,
                     no_signal=item.no_signal,
+                    retained_nonactive=sum(
+                        record.strategy_id == item.strategy_id
+                        and record.symbol not in active_symbols
+                        for record in state
+                    ),
                     evidence_sufficient=item.evidence_sufficient,
                     structure_eligible_or_constructible=(item.structure_eligible_or_constructible),
                     gates_passed=item.gates_passed,
@@ -386,9 +404,10 @@ def build_screening_router(
         status: str | None = None,
         sort_by: str | None = None,
         sort_order: Literal["asc", "desc"] = "desc",
+        active_only: bool = False,
     ) -> ScreeningResultsEnvelope:
         _require_registered_signal(signal)
-        records = _filter_and_sort(
+        all_records = _filter_and_sort(
             get_state(repository, strategy_id=signal),
             signal=None,
             symbol=symbol,
@@ -399,6 +418,14 @@ def build_screening_router(
             sort_by=sort_by,
             sort_order=sort_order,
         )
+        retained_nonactive_total = sum(
+            item.symbol not in active_symbols for item in all_records
+        )
+        records = (
+            tuple(item for item in all_records if item.symbol in active_symbols)
+            if active_only
+            else all_records
+        )
         page, total = _paginate(records, limit, offset)
         return ScreeningResultsEnvelope(
             results=[ScreeningResultResponse.from_universal_result(item) for item in page],
@@ -406,6 +433,8 @@ def build_screening_router(
             limit=limit,
             offset=offset,
             snapshot_identity=_latest_state_identity(records),
+            scope="active_universe" if active_only else "all_latest",
+            retained_nonactive_total=retained_nonactive_total,
         )
 
     @router.get("/screening/{signal}/{symbol}", response_model=ScreeningResultResponse)

--- a/asa/bootstrap.py
+++ b/asa/bootstrap.py
@@ -45,6 +45,7 @@ from asa.market_data_ops.routes import build_operations_router
 from asa.ui import mount_ui
 from market_data.attempts import AcquisitionAttemptRepository
 from market_data.live_transport import build_live_transport as build_transport_for_provider
+from screening.universe_membership import SP500_MEMBERSHIP
 from strategy_runtime.adapters import (
     build_migrated_signal_catalog,
     build_migrated_strategy_registry,
@@ -180,6 +181,7 @@ def build_application(
             history_repository=observation_history_repository,
             acquisition_attempt_repository=acquisition_attempt_repository,
             operational_health=screening_operational_health,
+            active_symbols=frozenset(SP500_MEMBERSHIP.symbols),
             portfolio_lifecycle_repository=portfolio_lifecycle_repository,
         )
     )

--- a/asa/ui/static/api-client.js
+++ b/asa/ui/static/api-client.js
@@ -47,7 +47,7 @@ export const api = Object.freeze({
   capabilities: () => requestJson("/api/v1/capabilities"),
   strategyHealth: () => requestJson("/api/v1/screening-health"),
   results: () => collectCompleteScreeningState(
-    (limit, offset) => requestJson(`/api/v1/screening?limit=${limit}&offset=${offset}`),
+    (limit, offset) => requestJson(`/api/v1/screening?limit=${limit}&offset=${offset}&active_only=true`),
   ),
   result: (signalId, symbol) =>
     requestJson(

--- a/asa/ui/static/app.js
+++ b/asa/ui/static/app.js
@@ -84,6 +84,7 @@ async function loadPersistedState() {
     state.results = results.data.results;
     state.resultsTotal = results.data.total;
     state.resultsSnapshotIdentity = results.data.snapshot_identity;
+    state.retainedNonactiveTotal = results.data.retained_nonactive_total;
     state.strategyHealth = strategyHealth.data;
     state.apiVersion = results.apiVersion || capabilities.apiVersion;
     state.fetchedAt = new Date().toISOString();
@@ -108,6 +109,7 @@ const handlers = {
     state.results = [];
     state.resultsTotal = 0;
     state.resultsSnapshotIdentity = null;
+    state.retainedNonactiveTotal = 0;
     state.capabilities = null;
     state.strategyHealth = null;
     state.error = null;

--- a/asa/ui/static/pagination.js
+++ b/asa/ui/static/pagination.js
@@ -3,6 +3,8 @@ export async function collectCompleteScreeningState(fetchPage, pageLimit = 500) 
   const identities = new Set();
   let authoritativeTotal = null;
   let snapshotIdentity = null;
+  let scope = null;
+  let retainedNonactiveTotal = null;
   let apiVersion = null;
 
   while (authoritativeTotal === null || results.length < authoritativeTotal) {
@@ -15,10 +17,14 @@ export async function collectCompleteScreeningState(fetchPage, pageLimit = 500) 
     if (authoritativeTotal === null) {
       authoritativeTotal = page.total;
       snapshotIdentity = page.snapshot_identity;
+      scope = page.scope;
+      retainedNonactiveTotal = page.retained_nonactive_total;
       apiVersion = response.apiVersion;
     } else if (
       page.total !== authoritativeTotal ||
-      page.snapshot_identity !== snapshotIdentity
+      page.snapshot_identity !== snapshotIdentity ||
+      page.scope !== scope ||
+      page.retained_nonactive_total !== retainedNonactiveTotal
     ) {
       throw new Error("Screening state changed during pagination; retry required");
     }
@@ -44,6 +50,8 @@ export async function collectCompleteScreeningState(fetchPage, pageLimit = 500) 
       limit: pageLimit,
       offset: 0,
       snapshot_identity: snapshotIdentity,
+      scope,
+      retained_nonactive_total: retainedNonactiveTotal,
     },
     apiVersion,
   };

--- a/asa/ui/static/render.js
+++ b/asa/ui/static/render.js
@@ -176,6 +176,7 @@ function resultsView(model, handlers) {
     ["Visible rows", String(model.visible.length)],
     ["Loaded rows", String(model.results.length)],
     ["Persisted rows", String(model.resultsTotal)],
+    ["Retained non-active rows", String(model.retainedNonactiveTotal)],
     ["Last fetched", model.fetchedAt || "Not fetched"],
     ["Revision", model.buildIdentity?.release_sha || "Unavailable"],
   ];
@@ -447,6 +448,7 @@ function healthView(model) {
     ["Release revision", model.buildIdentity?.release_sha || "Unavailable"],
     ["Loaded rows", String(model.results.length)],
     ["Persisted rows", String(model.resultsTotal)],
+    ["Retained non-active rows", String(model.retainedNonactiveTotal)],
     ["Latest-state identity", model.resultsSnapshotIdentity || "Unavailable"],
     ["Earliest evaluated", model.evaluatedRange.earliest],
     ["Latest evaluated", model.evaluatedRange.latest],

--- a/asa/ui/static/state.js
+++ b/asa/ui/static/state.js
@@ -7,6 +7,7 @@ export const state = {
   results: [],
   resultsTotal: 0,
   resultsSnapshotIdentity: null,
+  retainedNonactiveTotal: 0,
   executionReadiness: {},
   apiVersion: null,
   fetchedAt: null,

--- a/frontend/src/api/generated/index.ts
+++ b/frontend/src/api/generated/index.ts
@@ -47,7 +47,7 @@ export type { RunStepResponse } from './models/RunStepResponse';
 export type { ScreeningExecutionReadinessResponse } from './models/ScreeningExecutionReadinessResponse';
 export type { ScreeningOperationalHealthResponse } from './models/ScreeningOperationalHealthResponse';
 export type { ScreeningResultResponse } from './models/ScreeningResultResponse';
-export type { ScreeningResultsEnvelope } from './models/ScreeningResultsEnvelope';
+export { ScreeningResultsEnvelope } from './models/ScreeningResultsEnvelope';
 export type { SelectionDiagnosticResponse } from './models/SelectionDiagnosticResponse';
 export type { SignalCapabilityResponse } from './models/SignalCapabilityResponse';
 export type { StartRunRequest } from './models/StartRunRequest';

--- a/frontend/src/api/generated/models/ScreeningResultsEnvelope.ts
+++ b/frontend/src/api/generated/models/ScreeningResultsEnvelope.ts
@@ -9,4 +9,12 @@ export type ScreeningResultsEnvelope = {
     limit: number;
     offset: number;
     snapshot_identity: string;
+    scope: ScreeningResultsEnvelope.scope;
+    retained_nonactive_total: number;
 };
+export namespace ScreeningResultsEnvelope {
+    export enum scope {
+        ALL_LATEST = 'all_latest',
+        ACTIVE_UNIVERSE = 'active_universe',
+    }
+}

--- a/frontend/src/api/generated/models/StrategyHealthFunnelResponse.ts
+++ b/frontend/src/api/generated/models/StrategyHealthFunnelResponse.ts
@@ -9,6 +9,7 @@ export type StrategyHealthFunnelResponse = {
     evaluated: number;
     missing_data: number;
     no_signal: number;
+    retained_nonactive: number;
     evidence_sufficient: number;
     structure_eligible_or_constructible: number;
     gates_passed: number;

--- a/frontend/src/api/generated/services/DefaultService.ts
+++ b/frontend/src/api/generated/services/DefaultService.ts
@@ -307,6 +307,7 @@ export class DefaultService {
      * @param status
      * @param sortBy
      * @param sortOrder
+     * @param activeOnly
      * @returns ScreeningResultsEnvelope Successful Response
      * @throws ApiError
      */
@@ -321,6 +322,7 @@ export class DefaultService {
         status?: (string | null),
         sortBy?: (string | null),
         sortOrder: 'asc' | 'desc' = 'desc',
+        activeOnly: boolean = false,
     ): CancelablePromise<ScreeningResultsEnvelope> {
         return __request(OpenAPI, {
             method: 'GET',
@@ -336,6 +338,7 @@ export class DefaultService {
                 'status': status,
                 'sort_by': sortBy,
                 'sort_order': sortOrder,
+                'active_only': activeOnly,
             },
             errors: {
                 422: `Validation Error`,
@@ -393,6 +396,7 @@ export class DefaultService {
      * @param status
      * @param sortBy
      * @param sortOrder
+     * @param activeOnly
      * @returns ScreeningResultsEnvelope Successful Response
      * @throws ApiError
      */
@@ -407,6 +411,7 @@ export class DefaultService {
         status?: (string | null),
         sortBy?: (string | null),
         sortOrder: 'asc' | 'desc' = 'desc',
+        activeOnly: boolean = false,
     ): CancelablePromise<ScreeningResultsEnvelope> {
         return __request(OpenAPI, {
             method: 'GET',
@@ -424,6 +429,7 @@ export class DefaultService {
                 'status': status,
                 'sort_by': sortBy,
                 'sort_order': sortOrder,
+                'active_only': activeOnly,
             },
             errors: {
                 422: `Validation Error`,

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -790,6 +790,16 @@
               "default": "desc",
               "title": "Sort Order"
             }
+          },
+          {
+            "name": "active_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Active Only"
+            }
           }
         ],
         "responses": {
@@ -1045,6 +1055,16 @@
               "type": "string",
               "default": "desc",
               "title": "Sort Order"
+            }
+          },
+          {
+            "name": "active_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Active Only"
             }
           }
         ],
@@ -3986,6 +4006,18 @@
           "snapshot_identity": {
             "type": "string",
             "title": "Snapshot Identity"
+          },
+          "scope": {
+            "type": "string",
+            "enum": [
+              "all_latest",
+              "active_universe"
+            ],
+            "title": "Scope"
+          },
+          "retained_nonactive_total": {
+            "type": "integer",
+            "title": "Retained Nonactive Total"
           }
         },
         "type": "object",
@@ -3994,7 +4026,9 @@
           "total",
           "limit",
           "offset",
-          "snapshot_identity"
+          "snapshot_identity",
+          "scope",
+          "retained_nonactive_total"
         ],
         "title": "ScreeningResultsEnvelope"
       },
@@ -4128,6 +4162,10 @@
             "type": "integer",
             "title": "No Signal"
           },
+          "retained_nonactive": {
+            "type": "integer",
+            "title": "Retained Nonactive"
+          },
           "evidence_sufficient": {
             "type": "integer",
             "title": "Evidence Sufficient"
@@ -4170,6 +4208,7 @@
           "evaluated",
           "missing_data",
           "no_signal",
+          "retained_nonactive",
           "evidence_sufficient",
           "structure_eligible_or_constructible",
           "gates_passed",

--- a/frontend/tests/intelligence-console-pagination.test.ts
+++ b/frontend/tests/intelligence-console-pagination.test.ts
@@ -14,7 +14,7 @@ function pages(rows: Row[], snapshots: string[] = ['snapshot-a']) {
     return {
       data: {
         results: rows.slice(offset, offset + limit), total: rows.length,
-        limit, offset, snapshot_identity,
+        limit, offset, snapshot_identity, scope: 'active_universe', retained_nonactive_total: 16,
       },
       apiVersion: 'v1',
     }
@@ -34,6 +34,8 @@ describe('Intelligence Console complete latest-state pagination', () => {
 
     expect(result.data.results).toEqual(source)
     expect(result.data.total).toBe(total)
+    expect(result.data.scope).toBe('active_universe')
+    expect(result.data.retained_nonactive_total).toBe(16)
     expect(new Set(result.data.results.map((item: Row) => item.signal_id))).toContain('signal-2')
   })
 

--- a/project/reports/ANALYTICAL-COMPLETENESS-001-AC-01.md
+++ b/project/reports/ANALYTICAL-COMPLETENESS-001-AC-01.md
@@ -1,0 +1,44 @@
+# ANALYTICAL-COMPLETENESS-001 — AC-01 active-universe reconciliation
+
+Captured at `2026-09-03T19:20:00.326157Z` against production
+`1fe9dae2cc29ccddeeaa29d18b0322691fb60b7f`.
+
+## Authorities and counts
+
+The effective-dated `sp500` membership snapshot dated `2026-08-13` is the
+current membership authority. It contains 503 symbols, therefore three active
+production strategies produce 1,509 canonical active identities.
+
+| Set | Count | SHA-256 |
+|---|---:|---|
+| canonical active identities | 1,509 | `8c97453675f859e2012528feeb4864cef25364e4f93d6fa1cdd80e236ee2f771` |
+| persisted identities | 1,525 | `979a09c52b51811058a4dfd3f6a891a3112497fc5c236f63efb526ca900c9feb` |
+| active intersection | 1,509 | `8c97453675f859e2012528feeb4864cef25364e4f93d6fa1cdd80e236ee2f771` |
+
+Persistence contains all 1,509 active identities. Counts by strategy are 503
+active identities each. Persisted counts are 503 Earnings Calendar, 511
+Forward Factor, and 511 Skew Momentum.
+
+## Retained non-active evidence
+
+The 16 retained identities are Forward Factor and Skew Momentum rows for each
+of `DIA`, `GLD`, `IWM`, `QQQ`, `SPY`, `XLE`, `XLF`, and `XLK`. These symbols
+are the eight ETF members of the earlier bounded production universe declared
+in `screening/live_acquisition.py`; they are not members of the effective-dated
+S&P 500 snapshot. They are retained latest results, not active membership and
+not corrupt rows.
+
+No deletion or historical rewrite is required. Exact result reads continue to
+support retained rows.
+
+## Generic projection rule
+
+The canonical membership symbol set is injected at the production composition
+root. The generic screening surface can project `active_universe` without any
+strategy-ID branch, while its existing default `all_latest` behavior remains
+compatible. Envelopes state their scope and retained non-active count. Strategy
+health and the Intelligence Console use active membership for current totals
+and report retained rows separately.
+
+This makes membership an input from the canonical universe owner; the latest
+result repository remains storage authority and learns no universe semantics.

--- a/tests/asa/test_bootstrap_first_run.py
+++ b/tests/asa/test_bootstrap_first_run.py
@@ -104,8 +104,10 @@ def test_bootstrap_first_run_from_a_genuinely_empty_deployment(
         "total": 0,
         "limit": 100,
         "offset": 0,
-        "snapshot_identity": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-    }
+            "snapshot_identity": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+            "scope": "all_latest",
+            "retained_nonactive_total": 0,
+        }
 
     # A specific pair that has never been refreshed still 404s, distinguishably.
     no_result_yet = client.get("/api/v1/screening/skew_momentum/AAPL", headers=_auth())

--- a/tests/asa/test_screening_routes.py
+++ b/tests/asa/test_screening_routes.py
@@ -190,6 +190,8 @@ class TestListScreening:
             "snapshot_identity": (
                 "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
             ),
+            "scope": "all_latest",
+            "retained_nonactive_total": 0,
         }
 
     def test_returns_every_result_deterministically_ordered(self) -> None:
@@ -228,6 +230,41 @@ class TestListScreening:
             "/api/v1/screening?limit=500&offset=500", headers=_auth()
         ).json()
         assert changed["snapshot_identity"] != first["snapshot_identity"]
+
+    def test_active_projection_uses_membership_without_deleting_retained_rows(self) -> None:
+        repository = InMemoryLatestResultRepository()
+        repository.upsert(_record("forward_factor", "AAPL"))
+        repository.upsert(_record("forward_factor", "SPY"))
+        client = _client(repository)
+
+        current = client.get(
+            "/api/v1/screening?active_only=true", headers=_auth()
+        ).json()
+        retained = client.get("/api/v1/screening", headers=_auth()).json()
+
+        assert current["scope"] == "active_universe"
+        assert current["total"] == 1
+        assert current["results"][0]["symbol"] == "AAPL"
+        assert current["retained_nonactive_total"] == 1
+        assert retained["scope"] == "all_latest"
+        assert retained["total"] == 2
+        assert {item["symbol"] for item in retained["results"]} == {"AAPL", "SPY"}
+
+
+    def test_strategy_health_uses_active_membership_and_reports_retained_rows(self) -> None:
+        repository = InMemoryLatestResultRepository()
+        repository.upsert(_record("forward_factor", "AAPL"))
+        repository.upsert(_record("forward_factor", "SPY"))
+
+        response = _client(repository).get("/api/v1/screening-health", headers=_auth())
+
+        funnel = next(
+            item
+            for item in response.json()["strategies"]
+            if item["strategy_id"] == "forward_factor"
+        )
+        assert funnel["active_subjects"] == 1
+        assert funnel["retained_nonactive"] == 1
 
     def test_every_result_exposes_updated_at_and_age_seconds(self) -> None:
         repository = InMemoryLatestResultRepository()

--- a/tests/asa/test_ui_routes.py
+++ b/tests/asa/test_ui_routes.py
@@ -102,11 +102,13 @@ def test_ui_traverses_all_pages_and_rejects_incompatible_snapshots() -> None:
     pagination_source = static.joinpath("pagination.js").read_text(encoding="utf-8")
 
     assert "collectCompleteScreeningState" in client_source
+    assert "active_only=true" in client_source
     assert "while (authoritativeTotal === null || results.length < authoritativeTotal)" in (
         pagination_source
     )
     assert "page.snapshot_identity !== snapshotIdentity" in pagination_source
     assert "Duplicate screening identity across pages" in pagination_source
+    assert "page.retained_nonactive_total !== retainedNonactiveTotal" in pagination_source
 
 
 def test_ui_separates_strategy_analytical_state_from_infrastructure_health() -> None:


### PR DESCRIPTION
Ticket: AC-01 / Gate 1

## Production reconciliation
- canonical S&P membership: 503 symbols / 1,509 strategy identities
- persisted identities: 1,525
- active intersection: all 1,509
- retained non-active: 16
- retained identities are FF/Skew rows for DIA, GLD, IWM, QQQ, SPY, XLE, XLF, XLK from the prior ETF-inclusive bounded universe

## Correction
Canonical membership is injected at the production composition root. Generic API projection supports `active_universe` while preserving default `all_latest` compatibility and exact retained-row reads. Strategy health and Console current totals use active membership and expose retained counts separately. No strategy-ID branch and no persistence deletion.

Artifact: `project/reports/ANALYTICAL-COMPLETENESS-001-AC-01.md`

## Validation
- full repository: 3,312 passed / 48 skipped
- architecture: 578 passed
- frontend test/lint/type/build, Ruff, mypy, Lean: green

No strategy semantics, acquisition, broker, history rewrite, or destructive cleanup. Worker self-review complete; Manager stop CLEAR. Delegated authority: ANALYTICAL-COMPLETENESS-001.