### PR TITLE
AC-02: bind typed active missing-data census

### DIFF
--- a/project/reports/ANALYTICAL-COMPLETENESS-001-AC-02.md
+++ b/project/reports/ANALYTICAL-COMPLETENESS-001-AC-02.md
@@ -1,0 +1,52 @@
+# ANALYTICAL-COMPLETENESS-001 — AC-02 typed missing-data census
+
+Captured at `2026-09-03T19:29:01.675506Z` from production
+`508eab2d733c140e7d97bee67f8cb5f3ba515470`, API snapshot
+`6e75a1db8259f2a82c6520ac0c400958e9889e1f5cbab7521bff2fd909205231`.
+Only the 1,509 canonical active identities established by AC-01 are included.
+
+## Exact census
+
+| Strategy | Stable reason | Count | Examples | Classification |
+|---|---|---:|---|---|
+| earnings_calendar | `missing_earnings_date` | 38 | A, ADI, ADSK, AVGO, BBY | unresolved external dependency |
+| earnings_calendar | `no_valid_expiration_pair` | 374 | AAPL, ABBV, ABNB, ACGL, ADBE | legitimate domain/policy absence |
+| earnings_calendar | `subject_preparation_failed` | 2 | CPRT, FDS | proven software defect AC02-D01 |
+| forward_factor | `missing_implied_volatility` | 5 | APTV, FITB, HONA, Q, SPGI | unresolved external dependency |
+| forward_factor | `no_valid_expiration_pair` | 131 | AEE, ALL, ALLE, AMCR, APD | legitimate domain/policy absence |
+| forward_factor | `non_positive_forward_variance` | 11 | BAX, CCL, HAL, IP, KIM | legitimate derived-domain absence |
+| forward_factor | `subject_preparation_failed` | 2 | CPRT, FDS | proven software defect AC02-D01 |
+| skew_momentum | `missing_implied_volatility` | 4 | BDX, HONA, Q, VICI | unresolved external dependency |
+| skew_momentum | `no_future_expiration` | 3 | BF.B, BRK.B, NVR | unresolved external dependency |
+| skew_momentum | `subject_preparation_failed` | 2 | CPRT, FDS | proven software defect AC02-D01 |
+| skew_momentum | `unusable_quote` | 2 | AVB, EQR | unresolved external dependency |
+
+Totals: 574 active `missing_data` rows; 574 stable primary typed reasons;
+zero untyped rows. Strategy totals are Earnings Calendar 414, Forward Factor
+149, and Skew Momentum 11.
+
+`missing_data` remains unchanged. The classification does not convert evidence
+absence into `no_signal` and does not assert that unresolved provider evidence
+is legitimate absence without proof.
+
+## AC-03 defect inventory
+
+### AC02-D01 — shared subject preparation fails for CPRT and FDS
+
+- Scope: six active identities, both subjects across all three strategies.
+- Evidence: stable `subject_preparation_failed` blocker and unavailable temporal
+  metadata for every sibling strategy on each subject.
+- Owning boundary to reproduce: shared subject preparation before independent
+  strategy knowledge projection.
+- Required correction: identify the exact exception and repair it at its owner;
+  do not add strategy-specific fallback or hide the failure.
+
+No other software defect is authorized for AC-03 by this census. A new proven
+defect must first amend this artifact within AC-02 scope.
+
+## Stable diagnostic projection
+
+The existing blocker prefix already owns stable reason IDs. Strategy health now
+projects one normalized primary reason per incomplete result and retains verbose
+detail only on the underlying result. Therefore reason totals reconcile exactly
+without inventing a second diagnostic taxonomy.

--- a/strategy_runtime/health.py
+++ b/strategy_runtime/health.py
@@ -34,12 +34,11 @@ def build_strategy_health(
     unknowns: Counter[str] = Counter()
     rejections: Counter[str] = Counter()
     for item in records:
-        reasons = _reasons(item)
-        destination = (
-            unknowns if item.evaluation_state not in SUCCESS_EVALUATION_STATES else rejections
-        )
-        for reason in reasons:
-            destination[reason] += 1
+        if item.evaluation_state not in SUCCESS_EVALUATION_STATES:
+            unknowns[_primary_unknown_reason(item)] += 1
+        else:
+            for reason in _reasons(item):
+                rejections[reason] += 1
     watch = sum(_verdict(item) == "WATCH" for item in evaluated_records)
     passed = sum(_verdict(item) == "PASS" for item in evaluated_records)
     structure_eligible = sum("decision.structure" in item.metrics for item in evaluated_records)
@@ -86,3 +85,13 @@ def _reasons(item: UniversalScreeningResult) -> tuple[str, ...]:
         if item.verdict
         else (f"evaluation_state:{item.evaluation_state.value}",)
     )
+
+
+def _primary_unknown_reason(item: UniversalScreeningResult) -> str:
+    """One stable reason per incomplete evaluation, preserving exact census totals."""
+    candidates = _reasons(item)
+    reason = candidates[0]
+    prefix = "typed unknown evidence gap: "
+    if reason.startswith(prefix):
+        return reason.removeprefix(prefix).partition(" (")[0]
+    return reason

--- a/tests/asa/test_screening_routes.py
+++ b/tests/asa/test_screening_routes.py
@@ -31,6 +31,7 @@ def _record(
     recommendation_state: str | None = None,
     score: Decimal = Decimal("75"),
     verdict: str | None = "PASS",
+    blockers: tuple[str, ...] = ("capital unavailable",),
 ) -> UniversalSignalRow:
     return UniversalSignalRow(
         signal_id=signal_id,
@@ -46,7 +47,7 @@ def _record(
         data_quality="complete",
         metrics={"strategy_native_score": TypedValue.of_decimal(score)},
         economics={"estimated_return": TypedValue.of_decimal(Decimal("0.12"))},
-        blockers=("capital unavailable",),
+        blockers=blockers,
         warnings=("monitor liquidity",),
         provenance=("fixture:screening",),
         observed_at=observed_at,
@@ -116,6 +117,35 @@ def test_strategy_health_distinguishes_missing_data_from_no_signal() -> None:
     assert funnel["evaluated"] == 1
     assert funnel["missing_data"] == 1
     assert funnel["no_signal"] == 1
+
+
+def test_strategy_health_collapses_detailed_unknown_to_stable_primary_reason() -> None:
+    repository = InMemoryLatestResultRepository()
+    detail = (
+        "typed unknown evidence gap: no_valid_expiration_pair "
+        "(listed=2026-09-18;target_gap=30)"
+    )
+    repository.upsert(
+        _record(
+            "earnings_calendar",
+            "AAPL",
+            outcome="missing_data",
+            verdict=None,
+            blockers=(detail,),
+        )
+    )
+
+    response = _client(repository).get("/api/v1/screening-health", headers=_auth())
+
+    funnel = next(
+        item
+        for item in response.json()["strategies"]
+        if item["strategy_id"] == "earnings_calendar"
+    )
+    assert funnel["typed_unknown_counts"] == [
+        {"reason": "no_valid_expiration_pair", "count": 1}
+    ]
+    assert sum(item["count"] for item in funnel["typed_unknown_counts"]) == 1
 
 
 class TestAuthentication:


### PR DESCRIPTION
## Ticket
AC-02 — Typed Missing-Data Census

## Outcome
Accounts for all 574 active missing-data rows with stable typed reasons. Unknown/untyped remainder is zero.

## Counts
- earnings_calendar: 414
- forward_factor: 149
- skew_momentum: 11

## Defect inventory
Only AC02-D01 is authorized for AC-03: shared `subject_preparation_failed` for CPRT and FDS across all three strategies (6 rows). Other reasons remain explicit domain/policy absence or unresolved external dependencies.

## Changes
- Collapse verbose blocker detail into one stable primary unknown reason per incomplete result.
- Preserve successful evaluation rejection semantics.
- Add deterministic production census evidence.

## Validation
- Full repository: 3313 passed, 48 skipped
- Architecture: 578 passed
- Ruff/mypy targeted: pass
- Lean pre-push: pass

## Authority
ANALYTICAL-COMPLETENESS-001 delegated Worker merge authority; AC-02 scope.