### PR TITLE
AC-03: isolate competing provider evidence

### DIFF
--- a/market_data/fulfillment.py
+++ b/market_data/fulfillment.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
-from domain import FreshnessStatus, MarketObservation
+from domain import FreshnessStatus, MarketCapability, MarketObservation
 from domain.values import DomainInvariantError
 from market_data.budget import (
     BudgetExhaustedError,
@@ -264,6 +264,23 @@ class CapabilityFulfillmentService:
         request: CapabilityRequest,
         observations: tuple[MarketObservation, ...],
     ) -> NormalizedProviderError | None:
+        # Resolution compares one canonical value from each provider. Reject
+        # competing values from the same provider/subject here so audited
+        # fallback can proceed instead of crashing the shared subject seal.
+        provider_subjects = tuple(
+            (value.provenance.provider_id, value.subject.subject_identity)
+            for value in observations
+        )
+        if (
+            request.capability is MarketCapability.EARNINGS_CALENDAR_V1
+            and len(provider_subjects) != len(set(provider_subjects))
+        ):
+            return normalized_provider_error(
+                ProviderErrorCode.SCHEMA_MISMATCH,
+                "provider returned multiple canonical values for one subject and capability",
+                provider_id,
+                request.capability,
+            )
         usable_freshness = {
             FreshnessStatus.FRESH,
             FreshnessStatus.DELAYED,

--- a/project/reports/ANALYTICAL-COMPLETENESS-001-AC-03.md
+++ b/project/reports/ANALYTICAL-COMPLETENESS-001-AC-03.md
@@ -1,0 +1,49 @@
+# ANALYTICAL-COMPLETENESS-001 — AC-03 root-cause repair
+
+## AC02-D01
+
+**Symptom:** CPRT and FDS persisted `subject_preparation_failed` for all three
+production strategies (six active identities).
+
+**Reproduction:** Railway logs for the CPRT cohort at
+`2026-09-03T17:31:19Z` contain the production stack from
+`run_scheduled_refresh` through `run_subject_plan`, `_seal`, and
+`seal_subject_snapshot` to:
+
+```text
+DomainInvariantError: Observation resolution requires one value per provider
+```
+
+A bounded, sanitized reproduction against the production provider configuration
+identified the conflicting capability as `earnings_calendar_v1`: Finnhub
+returned two `EarningsEvent` observations for the same subject/provider. CPRT's
+reported candidate dates were 2026-09-09 and 2026-09-10. No provider payload or
+credential was retained.
+
+**Owning layer:** `market_data/fulfillment.py`, the provider-neutral acquisition
+quality boundary immediately after adapter output and before fallback/sealing.
+
+**Root cause:** fulfillment validated freshness and field completeness but did
+not enforce the resolver's existing one-canonical-value-per-provider-and-subject
+contract. Competing same-provider values passed as successful acquisition and
+later raised during the shared subject seal. That one optional earnings defect
+therefore destroyed otherwise usable Forward Factor and Skew evidence.
+
+**Correction:** fulfillment now rejects competing canonical values for the same
+provider/subject as a normalized `schema_mismatch`. Existing audited fallback is
+then allowed to proceed. If no provider can supply one unambiguous value, the
+capability remains explicitly unavailable; ASA does not choose an earnings date
+heuristically.
+
+**Before:** one ambiguous Finnhub response aborted shared preparation and wrote
+three generic missing-data results per affected subject.
+
+**After:** the provider attempt is typed and isolated at acquisition. Valid
+sibling strategies continue from the same sealed evidence boundary; Earnings
+Calendar receives `missing_earnings_date` when no fallback supplies an
+unambiguous event. No strategy semantics, provider routing, or acquisition
+authority changed.
+
+**Sprint effect:** AC02-D01 is repaired at its owner. Active preparation no
+longer converts a competing optional earnings observation into cross-strategy
+failure amplification.

--- a/tests/asa/_fixture_market_data_access.py
+++ b/tests/asa/_fixture_market_data_access.py
@@ -35,8 +35,11 @@ from domain import (
 from domain.references import EvidenceReference
 from market_data import (
     CapabilityFulfillmentService,
+    CapabilityRequest,
     FixtureScenario,
     ProviderDependencies,
+    ProviderFetchResult,
+    RequestBudgetAuthorization,
     load_market_data_config,
 )
 from market_data.attempts import InMemoryAcquisitionAttemptRepository
@@ -112,6 +115,23 @@ class WatchEarningsFixtureProvider(MultiExpirationFixtureProvider):
             for contract in value.contracts
         )
         return dataclasses.replace(value, contracts=contracts)
+
+
+class DuplicateEarningsFixtureProvider(MultiExpirationFixtureProvider):
+    """Reproduces Finnhub returning competing events for one subject."""
+
+    def fetch(
+        self, request: CapabilityRequest, budget: RequestBudgetAuthorization
+    ) -> ProviderFetchResult:
+        fetched: ProviderFetchResult = super().fetch(  # type: ignore[no-untyped-call]
+            request, budget
+        )
+        if request.capability.value != "earnings_calendar_v1" or fetched.error is not None:
+            return fetched
+        return dataclasses.replace(
+            fetched,
+            observations=(fetched.observations[0], fetched.observations[0]),
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/asa/test_scheduled_screening.py
+++ b/tests/asa/test_scheduled_screening.py
@@ -24,6 +24,7 @@ from market_data.transport import ReadOnlyHttpResponse
 from screening import APPROVED_LIVE_UNIVERSE, EARNINGS_CALENDAR_UNIVERSE
 from strategy_runtime.orchestration import ShadowParityDiagnostic
 from tests.asa._fixture_market_data_access import (
+    DuplicateEarningsFixtureProvider,
     WatchEarningsFixtureProvider,
     build_fixture_market_data_access_factory,
     capturing_market_data_access_factory,
@@ -1477,6 +1478,50 @@ def test_production_root_prepares_all_three_strategies_from_one_subject_snapshot
     assert len(outcomes) == 3
     assert all(item.error is None for item in outcomes)
     assert all(item.outcome != "missing_data" for item in outcomes)
+    assert not any(
+        record.message == "shadow_subject_preparation_failed" for record in caplog.records
+    )
+
+
+def test_duplicate_provider_earnings_cannot_destroy_sibling_strategy_preparation(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """AC02-D01: competing same-provider earnings fail at acquisition."""
+    import asa.scheduled_screening as scheduled_screening_module
+
+    monkeypatch.setattr(
+        scheduled_screening_module,
+        "build_shared_market_data_access",
+        build_fixture_market_data_access_factory(
+            provider_cls_by_symbol={"CPRT": DuplicateEarningsFixtureProvider}
+        ),
+    )
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    repository = InMemoryLatestResultRepository()
+    caplog.set_level(logging.WARNING)
+
+    outcomes = run_scheduled_refresh(
+        (
+            ("forward_factor", "CPRT"),
+            ("skew_momentum", "CPRT"),
+            ("earnings_calendar", "CPRT"),
+        ),
+        repository=repository,
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        historical_skew_repository=_RecordingHistoricalSkewRepository(),
+    )
+
+    assert len(outcomes) == 3
+    assert all(item.error is None for item in outcomes)
+    forward = repository.get_one("forward_factor", "CPRT")
+    skew = repository.get_one("skew_momentum", "CPRT")
+    assert forward is not None and forward.evaluation_state != "missing_data"
+    assert skew is not None and skew.evaluation_state != "missing_data"
+    earnings = repository.get_one("earnings_calendar", "CPRT")
+    assert earnings is not None
+    assert earnings.evaluation_state == "missing_data"
+    assert earnings.blockers == ("typed unknown evidence gap: missing_earnings_date",)
     assert not any(
         record.message == "shadow_subject_preparation_failed" for record in caplog.records
     )

--- a/tests/market_data/test_fulfillment.py
+++ b/tests/market_data/test_fulfillment.py
@@ -159,6 +159,20 @@ class ScriptedProvider:
         return ProviderShutdownReport(self.provider_id, NOW)
 
 
+class DuplicateValueProvider(ScriptedProvider):
+    """Adapter defect: two canonical values for one provider/subject."""
+
+    def fetch(
+        self, capability_request: CapabilityRequest, budget: RequestBudgetAuthorization
+    ) -> ProviderFetchResult:
+        fetched = super().fetch(capability_request, budget)
+        assert fetched.error is None
+        return dataclasses.replace(
+            fetched,
+            observations=(fetched.observations[0], fetched.observations[0]),
+        )
+
+
 def fixture_provider(scenario: FixtureScenario) -> DeterministicFixtureProvider:
     base = next(
         item
@@ -220,6 +234,30 @@ def test_primary_failure_secondary_success_is_explicitly_degraded() -> None:
     assert result.attempts[0].error.code is ProviderErrorCode.TIMEOUT
     assert result.attempts[1].observations
     assert len(budgets.accounting) == 2
+
+
+def test_duplicate_earnings_values_fail_at_provider_quality_boundary() -> None:
+    fetched = DuplicateValueProvider("primary", FixtureScenario()).fetch(
+        request(), RequestBudgetAuthorization("auth", "primary", 1, 1)
+    )
+    base_request = request()
+    earnings_subject = dataclasses.replace(
+        base_request.subjects[0],
+        requested_capability=MarketCapability.EARNINGS_CALENDAR_V1,
+        subject_type=MarketDataSubjectType.EARNINGS_SECURITY,
+    )
+    earnings_request = dataclasses.replace(
+        base_request,
+        capability=MarketCapability.EARNINGS_CALENDAR_V1,
+        subjects=(earnings_subject,),
+    )
+
+    error = CapabilityFulfillmentService._quality_error(
+        "primary", earnings_request, fetched.observations
+    )
+
+    assert error is not None
+    assert error.code is ProviderErrorCode.SCHEMA_MISMATCH
 
 
 def test_all_providers_fail_closed_with_aggregated_evidence() -> None:


### PR DESCRIPTION
## Ticket
AC-03 / AC02-D01 — Enumerated Root-Cause Repair

## Symptom
CPRT and FDS persisted `subject_preparation_failed` across all three strategies.

## Root cause
Finnhub returned two earnings observations for one subject/provider. Fulfillment accepted both, then snapshot resolution raised `Observation resolution requires one value per provider`, amplifying one optional earnings ambiguity across sibling consumers.

## Correction
At the provider-neutral fulfillment quality boundary, competing `earnings_calendar_v1` values for one provider/subject become normalized `schema_mismatch`, allowing audited fallback. No earnings date is chosen heuristically.

## Before / After
Before: shared sealing aborted; six generic missing-data identities.
After: FF/Skew continue from sealed evidence; Earnings receives typed `missing_earnings_date` if no unambiguous fallback exists.

## Validation
- Production-stack reproduction captured and sanitized
- Production-config bounded reproduction no longer raises
- Targeted production-shaped tests: 88 passed
- Full repository: 3315 passed, 48 skipped
- Architecture: 578 passed
- Ruff/mypy: pass
- Lean pre-push: pass

## Boundaries
No strategy semantics, provider routing, acquisition authority, broker behavior, or fabricated evidence.

## Authority
ANALYTICAL-COMPLETENESS-001 delegated Worker merge authority; AC-03 limited to merged AC02-D01.