### PR TITLE
AC-05: project active completeness and typed missing reasons

### DIFF
--- a/asa/ui/static/render.js
+++ b/asa/ui/static/render.js
@@ -175,7 +175,7 @@ function resultsView(model, handlers) {
   const summaries = [
     ["Visible rows", String(model.visible.length)],
     ["Loaded rows", String(model.results.length)],
-    ["Persisted rows", String(model.resultsTotal)],
+    ["Active latest-state rows", String(model.resultsTotal)],
     ["Retained non-active rows", String(model.retainedNonactiveTotal)],
     ["Last fetched", model.fetchedAt || "Not fetched"],
     ["Revision", model.buildIdentity?.release_sha || "Unavailable"],
@@ -430,6 +430,9 @@ function healthView(model) {
       no_signal: funnel.no_signal,
       watch: funnel.watch,
       pass: funnel.passed,
+      missing_data_reasons: Object.fromEntries(
+        (funnel.typed_unknown_counts || []).map((item) => [item.reason, item.count]),
+      ),
     };
     const card = element("article", "health-card");
     card.append(element("h3", null, funnel.strategy_id), element("code", null, JSON.stringify(value)));
@@ -447,7 +450,7 @@ function healthView(model) {
     ["Application version", model.buildIdentity?.application_version || "Unavailable"],
     ["Release revision", model.buildIdentity?.release_sha || "Unavailable"],
     ["Loaded rows", String(model.results.length)],
-    ["Persisted rows", String(model.resultsTotal)],
+    ["Active latest-state rows", String(model.resultsTotal)],
     ["Retained non-active rows", String(model.retainedNonactiveTotal)],
     ["Latest-state identity", model.resultsSnapshotIdentity || "Unavailable"],
     ["Earliest evaluated", model.evaluatedRange.earliest],

--- a/tests/asa/test_ui_routes.py
+++ b/tests/asa/test_ui_routes.py
@@ -121,6 +121,8 @@ def test_ui_separates_strategy_analytical_state_from_infrastructure_health() -> 
     assert "separate from service health and data freshness" in render_source
     assert "missing_data: funnel.missing_data" in render_source
     assert "no_signal: funnel.no_signal" in render_source
+    assert "missing_data_reasons: Object.fromEntries" in render_source
+    assert "funnel.typed_unknown_counts || []" in render_source
     assert "Fresh missing-data rows remain analytically incomplete" in render_source
 
 
@@ -135,7 +137,7 @@ def test_ui_distinguishes_visible_loaded_and_authoritative_total_and_build() -> 
     )
     assert '["Visible rows", String(model.visible.length)]' in render_source
     assert '["Loaded rows", String(model.results.length)]' in render_source
-    assert '["Persisted rows", String(model.resultsTotal)]' in render_source
+    assert '["Active latest-state rows", String(model.resultsTotal)]' in render_source
     assert 'model.buildIdentity?.release_sha || "Unavailable"' in render_source
 
 


### PR DESCRIPTION
## Ticket
AC-05 — Minimal Product Projection + Production Proof

## Summary
Projects the existing authoritative active-universe strategy health into the Intelligence Console. Each strategy now shows exact typed missing-data reason counts, and the active-only latest-state total is labeled truthfully instead of as all persisted rows. Retained non-active rows remain separate.

## Root cause
The API already provided canonical active totals and stable typed unknown counts, but the UI discarded the reason distribution and mislabeled its active-only total.

## Validation
- full repository: 3315 passed, 48 skipped
- focused API/UI/backend: 45 passed
- frontend tests: 7 passed
- frontend lint/typecheck/build: passed
- Ruff `asa tests/asa`: passed
- mypy `asa`: passed
- Lean pre-push: 5/5 passed

## Boundaries
No strategy semantics, persistence, acquisition, provider, broker, or API contract changes. Additive product projection only. Production deployment/proof remains Founder-only.

## Worker self-review
Complete. AC-05 implementation scope satisfied; Manager stop status CLEAR.