### PR TITLE
STK-01: freeze stock benchmark contracts and evidence authorities

### DIFF
--- a/project/reports/STOCK-RUNTIME-001-STK-01.md
+++ b/project/reports/STOCK-RUNTIME-001-STK-01.md
@@ -1,0 +1,61 @@
+# STOCK-RUNTIME-001 — STK-01 contract and capability audit
+
+## Frozen benchmark contracts
+
+| Contract | Subject | Canonical requirements | Structure | Lifecycle |
+| --- | --- | --- | --- | --- |
+| `B001@1.0.0` | SPY | `real_time_quote_v1` | `NONE` | `NONE` |
+| `B002@1.0.0` | SPY | `real_time_quote_v1`, `historical_bars_v1` | `NONE` | `NONE` |
+
+The existing `StrategyContract` expresses both benchmarks without a schema
+change. Neither declares `OPTION_STRUCTURES`, economics, recommendations, or
+lifecycle authority. Generic runtime behavior therefore remains declaration
+driven and needs no benchmark-ID branch.
+
+## Input authorities
+
+- B001 current eligible price: selected canonical `Quote.last` from the sealed
+  `REAL_TIME_QUOTE_V1` resolution.
+- B002 current eligible price: the same canonical quote authority.
+- B002 monthly source: canonical daily `OHLCVSeries` from
+  `HISTORICAL_BARS_V1`, reduced before sealing by the existing generic
+  historical-series reducer.
+- B002 derived value: new registered/versioned
+  `sma_10m_completed_months@1.0.0`, materialized through the existing
+  `AnalyticsRegistry` and `DerivedFact` identity boundary.
+- Replay: persisted sealed evidence and materialized fact identity; never a
+  provider call.
+
+## Authorized historical-price clarification
+
+Issue #415 proved that the existing canonical bar carries raw-as-traded
+`close` only. Founder authorization permits the narrow backward-compatible
+addition required by B002:
+
+- raw OHLCV fields retain their existing meaning and serialization;
+- a bar may additionally carry an optional adjusted close;
+- adjusted evidence carries a typed adjustment basis;
+- the selected observation's existing provider provenance remains the source
+  provenance for both values;
+- adjusted close and basis are present together or absent together;
+- old serialized bars remain readable as raw bars with no adjusted value;
+- B002 returns typed missing data when ten qualifying completed-month adjusted
+  closes are unavailable; raw close is never substituted.
+
+The adjustment basis is descriptive evidence, not provider selection policy.
+Both split-adjusted and split-and-dividend-adjusted observations may be
+represented truthfully; the fact records the basis actually consumed.
+
+## Provider path
+
+The existing providers already own `HISTORICAL_BARS_V1`. Alpha Vantage's
+current implementation and metadata explicitly use raw `TIME_SERIES_DAILY`.
+Its official adjusted endpoint exposes a distinct adjusted-close field and may
+require premium entitlement. Finnhub documents daily candles as split-adjusted.
+STK-02 may populate the new field only where the provider contract is explicit
+and the account is entitled. Provider-specific semantics do not escape the
+adapter.
+
+No new canonical capability, provider subsystem, materialization subsystem, or
+strategy-local SMA is required. External entitlement remains a production
+proof question, not permission to fabricate adjusted history.

--- a/strategy_runtime/adapters/stock_benchmarks.py
+++ b/strategy_runtime/adapters/stock_benchmarks.py
@@ -1,0 +1,50 @@
+"""Provider-blind stock benchmark contracts for STOCK-RUNTIME-001."""
+
+from __future__ import annotations
+
+from domain import MarketCapability
+from strategy_runtime.contract import (
+    NO_LIFECYCLE,
+    DataRequirement,
+    OutputKind,
+    RequirementCategory,
+    StrategyContract,
+    StructureKind,
+)
+
+B001_CONTRACT = StrategyContract(
+    strategy_id="B001",
+    version="1.0.0",
+    category="stock_benchmark",
+    description="SPY buy-and-hold benchmark over usable current price evidence.",
+    requirements=(
+        DataRequirement(
+            RequirementCategory.MARKET_DATA,
+            capabilities=(MarketCapability.REAL_TIME_QUOTE_V1,),
+        ),
+    ),
+    lifecycle=NO_LIFECYCLE,
+    structure=StructureKind.NONE,
+    outputs=(OutputKind.METRICS,),
+)
+
+B002_CONTRACT = StrategyContract(
+    strategy_id="B002",
+    version="1.0.0",
+    category="stock_benchmark",
+    description="SPY 10-month trend benchmark over completed-month adjusted closes.",
+    requirements=(
+        DataRequirement(
+            RequirementCategory.MARKET_DATA,
+            capabilities=(
+                MarketCapability.REAL_TIME_QUOTE_V1,
+                MarketCapability.HISTORICAL_BARS_V1,
+            ),
+        ),
+    ),
+    lifecycle=NO_LIFECYCLE,
+    structure=StructureKind.NONE,
+    outputs=(OutputKind.METRICS,),
+)
+
+STOCK_BENCHMARK_CONTRACTS = (B001_CONTRACT, B002_CONTRACT)

--- a/tests/strategy_runtime/test_stock_benchmark_contracts.py
+++ b/tests/strategy_runtime/test_stock_benchmark_contracts.py
@@ -1,0 +1,26 @@
+from domain import MarketCapability
+from strategy_runtime.adapters.stock_benchmarks import B001_CONTRACT, B002_CONTRACT
+from strategy_runtime.contract import LifecycleModel, StrategyCapability, StructureKind
+
+
+def test_b001_contract_uses_only_current_quote_without_option_or_lifecycle_authority() -> None:
+    assert B001_CONTRACT.strategy_id == "B001"
+    assert B001_CONTRACT.version == "1.0.0"
+    assert B001_CONTRACT.required_capabilities() == (
+        MarketCapability.REAL_TIME_QUOTE_V1,
+    )
+    assert B001_CONTRACT.structure is StructureKind.NONE
+    assert B001_CONTRACT.lifecycle.lifecycle_model is LifecycleModel.NONE
+    assert StrategyCapability.OPTION_STRUCTURES not in B001_CONTRACT.capabilities
+
+
+def test_b002_contract_declares_generic_quote_and_history_only() -> None:
+    assert B002_CONTRACT.strategy_id == "B002"
+    assert B002_CONTRACT.version == "1.0.0"
+    assert B002_CONTRACT.required_capabilities() == (
+        MarketCapability.HISTORICAL_BARS_V1,
+        MarketCapability.REAL_TIME_QUOTE_V1,
+    )
+    assert B002_CONTRACT.structure is StructureKind.NONE
+    assert B002_CONTRACT.lifecycle.lifecycle_model is LifecycleModel.NONE
+    assert StrategyCapability.OPTION_STRUCTURES not in B002_CONTRACT.capabilities


### PR DESCRIPTION
## Ticket
STK-01 — Contract and Capability Audit

## Summary
Freezes B001/B002 as ordinary provider-blind StrategyContracts using StructureKind.NONE and maps their inputs to existing quote/history/fact owners. Records the Founder-authorized narrow adjusted-close boundary from Issue #415 for STK-02.

## Acceptance
- current contract expresses both benchmarks without schema change
- no OPTION_STRUCTURES or lifecycle authority
- no strategy-ID runtime branch
- exact quote/history/fact/replay authorities mapped
- adjusted history ambiguity resolved by Founder authorization

## Validation
- focused contracts/planning: 46 passed
- Ruff: passed
- Lean pre-push: 5/5 passed

## Worker self-review
Complete. Gate 1 is bounded and Manager stop status is CLEAR. No provider, runtime execution, or strategy semantic behavior added.