### PR TITLE
STK-02: add adjusted-close SMA10M derived fact

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -32,6 +32,7 @@ from analytics.derived_facts import (
     compute_option_volume_band,
     compute_sector_relative_momentum,
     compute_skew_stretch_distributions,
+    compute_sma_10m_completed_months,
 )
 from analytics.engine import FeatureComputation, compute_feature
 from analytics.errors import (
@@ -80,6 +81,7 @@ __all__ = [
     "DerivedFactQualityStatus",
     "DerivedFactSet",
     "DerivedFactValue",
+    "compute_sma_10m_completed_months",
     "DuplicateFeatureRegistrationError",
     "ExpirationCandidate",
     "FeatureComputation",

--- a/analytics/derived_facts.py
+++ b/analytics/derived_facts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import ROUND_HALF_EVEN, Context, Decimal, localcontext
 
 from analytics.registry import AnalyticsFeatureDefinition, AnalyticsRegistry
@@ -11,6 +11,7 @@ from domain import (
     ComparisonUniverseReturns,
     HistoricalSkewObservations,
     MarketCapability,
+    OHLCVBar,
     SectorReferenceReturns,
 )
 
@@ -38,6 +39,47 @@ SECTOR_RELATIVE_MOMENTUM = "sector_relative_momentum"
 OPTION_VOLUME_BAND = "option_volume_band"
 SPREAD_QUALITY = "spread_quality"
 OPEN_INTEREST_QUALITY = "open_interest_quality"
+SMA_10M_COMPLETED_MONTHS = "sma_10m_completed_months"
+
+
+def compute_sma_10m_completed_months(
+    bars: Sequence[OHLCVBar], as_of: datetime
+) -> Decimal:
+    """Mean of the last ten completed month-end adjusted closes.
+
+    A month is completed only when it precedes ``as_of``'s calendar month.
+    The latest bar in each completed month is its month-end observation.
+    """
+
+    if as_of.tzinfo is None or as_of.utcoffset() is None:
+        raise ValueError("as_of must be timezone-aware")
+    as_of_utc = as_of.astimezone(UTC)
+    eligible = tuple(
+        bar
+        for bar in bars
+        if (bar.end_at.astimezone(UTC).year, bar.end_at.astimezone(UTC).month)
+        < (as_of_utc.year, as_of_utc.month)
+    )
+    month_ends: dict[tuple[int, int], OHLCVBar] = {}
+    for bar in eligible:
+        end_at = bar.end_at.astimezone(UTC)
+        key = (end_at.year, end_at.month)
+        current = month_ends.get(key)
+        if current is None or bar.end_at > current.end_at:
+            month_ends[key] = bar
+    selected = tuple(month_ends[key] for key in sorted(month_ends)[-10:])
+    if len(selected) != 10:
+        raise ValueError("ten completed months of adjusted-close history are required")
+    if any(bar.adjusted_close is None for bar in selected):
+        raise ValueError("adjusted close is required for every selected month end")
+    bases = {bar.adjusted_close_basis for bar in selected}
+    if len(bases) != 1:
+        raise ValueError("selected adjusted closes must use one adjustment basis")
+    with localcontext(DERIVED_FACT_DECIMAL_CONTEXT):
+        return sum(
+            (bar.adjusted_close for bar in selected if bar.adjusted_close is not None),
+            Decimal(0),
+        ) / Decimal(10)
 
 
 def compute_implied_forward_volatility(
@@ -270,6 +312,11 @@ def _definition(
 
 
 DERIVED_FACT_DEFINITIONS = (
+    _definition(
+        SMA_10M_COMPLETED_MONTHS,
+        "Arithmetic mean of the previous ten completed month-end adjusted closes.",
+        MarketCapability.HISTORICAL_BARS_V1,
+    ),
     _definition(
         REALIZED_VOLATILITY,
         "Annualized population volatility of canonical daily log returns.",

--- a/domain/__init__.py
+++ b/domain/__init__.py
@@ -61,6 +61,7 @@ from domain.guardrail import GuardrailOutcome
 from domain.indicator import Indicator
 from domain.market_data import (
     MARKET_DATA_CONTRACT_VERSION,
+    AdjustedCloseBasis,
     CompletenessMetadata,
     CorporateActionPlaceholder,
     CorporateActionStatus,
@@ -176,6 +177,7 @@ __all__ = [
     "MarketDataSubjectType",
     "MarketObservation",
     "Quote",
+    "AdjustedCloseBasis",
     "OHLCVBar",
     "OHLCVSeries",
     "TradingCalendarEvent",

--- a/domain/market_data.py
+++ b/domain/market_data.py
@@ -88,6 +88,13 @@ class FreshnessStatus(str, Enum):
     UNAVAILABLE = "unavailable"
 
 
+class AdjustedCloseBasis(str, Enum):  # noqa: UP042 -- preserve sibling contract enum style
+    """Corporate-action basis of an explicitly supplied adjusted close."""
+
+    SPLIT_ADJUSTED = "split_adjusted"
+    SPLIT_AND_DIVIDEND_ADJUSTED = "split_and_dividend_adjusted"
+
+
 class ProviderErrorKind(str, Enum):
     AUTHENTICATION = "authentication"
     AUTHORIZATION = "authorization"
@@ -278,6 +285,8 @@ class OHLCVBar:
     low: Decimal
     close: Decimal
     volume: Decimal
+    adjusted_close: Decimal | None = None
+    adjusted_close_basis: AdjustedCloseBasis | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.instrument, Instrument):
@@ -294,6 +303,11 @@ class OHLCVBar:
             raise DomainInvariantError("OHLCVBar interval must match its time window")
         for name in ("open", "high", "low", "close", "volume"):
             _decimal(getattr(self, name), "OHLCVBar", name)
+        _decimal(self.adjusted_close, "OHLCVBar", "adjusted_close", positive=True)
+        if (self.adjusted_close is None) != (self.adjusted_close_basis is None):
+            raise DomainInvariantError(
+                "OHLCVBar adjusted_close and adjusted_close_basis must be supplied together"
+            )
         if self.high < max(self.open, self.close, self.low):
             raise DomainInvariantError("OHLCVBar high is incoherent")
         if self.low > min(self.open, self.close, self.high):
@@ -569,6 +583,7 @@ _ENUM_TYPES = {
     value.__name__: value
     for value in (
         MarketCapability,
+        AdjustedCloseBasis,
         FreshnessStatus,
         ProviderErrorKind,
         TradingCalendarEventType,

--- a/market_data/finnhub.py
+++ b/market_data/finnhub.py
@@ -9,6 +9,7 @@ from decimal import Decimal, InvalidOperation
 from typing import cast
 
 from domain import (
+    AdjustedCloseBasis,
     AnnouncementTime,
     CompletenessMetadata,
     EarningsEvent,
@@ -322,6 +323,8 @@ class FinnhubProvider:
                     _decimal(arrays[2][index]),
                     _decimal(arrays[3][index]),
                     _decimal(arrays[4][index]),
+                    _decimal(arrays[3][index]),
+                    AdjustedCloseBasis.SPLIT_ADJUSTED,
                 )
                 for index in range(len(arrays[0]))
             )

--- a/project/reports/STOCK-RUNTIME-001-STK-02.md
+++ b/project/reports/STOCK-RUNTIME-001-STK-02.md
@@ -1,0 +1,30 @@
+# STOCK-RUNTIME-001 — STK-02 evidence
+
+## Outcome
+
+The canonical historical-bar contract now carries optional adjusted close plus an
+explicit adjustment basis. Raw OHLC semantics remain unchanged, old serialized
+bars remain readable, and absence is preserved rather than replaced with raw close.
+
+`sma_10m_completed_months@1.0.0` is registered as a provider-neutral derived fact.
+It selects the latest adjusted observation from each of the ten UTC calendar months
+strictly before `as_of`, requires one consistent declared adjustment basis, and is
+deterministic over sealed evidence.
+
+Finnhub daily candles populate `split_adjusted` because that provider documents its
+daily candle series as split-adjusted. Other adapters remain absent/unknown until an
+authoritative adjusted value is available. Provider provenance remains on the owning
+market observation; no provider identity enters the derived fact.
+
+## Compatibility and scope
+
+- Existing raw close values and constructors are preserved.
+- Legacy v1 payloads without the new optional fields deserialize unchanged.
+- No strategy, acquisition, broker, or execution behavior changed.
+- No raw-close fallback is permitted for B002.
+
+## Verification
+
+Contract round-trip/backward-read, provider normalization, completed-month selection,
+insufficient-history, registry-version, Ruff import, and mypy checks are pinned in the
+corresponding domain, analytics, and Finnhub tests.

--- a/tests/analytics/test_derived_facts.py
+++ b/tests/analytics/test_derived_facts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -24,8 +24,16 @@ from analytics.derived_facts import (
     compute_normalized_skew,
     compute_open_interest_quality,
     compute_option_volume_band,
+    compute_sma_10m_completed_months,
 )
 from analytics.realized_volatility import compute_realized_volatility
+from domain import (
+    AdjustedCloseBasis,
+    CanonicalInstrumentIdentity,
+    Instrument,
+    InstrumentKind,
+    OHLCVBar,
+)
 
 
 def test_forward_variance_and_factor_independent_vector() -> None:
@@ -34,6 +42,53 @@ def test_forward_variance_and_factor_independent_vector() -> None:
     assert compute_forward_factor(Decimal("0.40"), forward) == (
         Decimal("0.371988681140070699029212441775431")
     )
+
+
+def test_sma10m_uses_previous_ten_completed_month_ends() -> None:
+    instrument = Instrument(
+        CanonicalInstrumentIdentity("ticker", "SPY"), InstrumentKind.EQUITY, "SPY", "USD"
+    )
+    bars = []
+    for index, month in enumerate(range(1, 12), start=1):
+        start = datetime(2025, month, 27, tzinfo=UTC)
+        bars.append(
+            OHLCVBar(
+                instrument,
+                86400,
+                start,
+                start + timedelta(days=1),
+                Decimal(index),
+                Decimal(index),
+                Decimal(index),
+                Decimal(index),
+                Decimal("100"),
+                Decimal(index),
+                AdjustedCloseBasis.SPLIT_AND_DIVIDEND_ADJUSTED,
+            )
+        )
+    assert compute_sma_10m_completed_months(
+        bars, datetime(2025, 11, 15, tzinfo=UTC)
+    ) == Decimal("5.5")
+
+
+def test_sma10m_rejects_insufficient_history() -> None:
+    instrument = Instrument(
+        CanonicalInstrumentIdentity("ticker", "SPY"), InstrumentKind.EQUITY, "SPY", "USD"
+    )
+    start = datetime(2025, 1, 30, tzinfo=UTC)
+    raw = OHLCVBar(
+        instrument,
+        86400,
+        start,
+        start + timedelta(days=1),
+        Decimal("1"),
+        Decimal("1"),
+        Decimal("1"),
+        Decimal("1"),
+        Decimal("100"),
+    )
+    with pytest.raises(ValueError, match="ten completed months"):
+        compute_sma_10m_completed_months((raw,), datetime(2026, 1, 1, tzinfo=UTC))
 
 
 def test_earnings_and_expiration_temporal_facts() -> None:
@@ -88,9 +143,10 @@ def test_named_momentum_dimensions_are_replay_stable() -> None:
 
 
 def test_initial_registry_is_closed_versioned_and_complete() -> None:
-    assert len(DERIVED_FACT_REGISTRY.registered_ids()) == 22
+    assert len(DERIVED_FACT_REGISTRY.registered_ids()) == 23
     assert DERIVED_FACT_REGISTRY.get("forward_factor").feature_version == "1.0.0"
     assert DERIVED_FACT_REGISTRY.get("iv_term_structure_spread").feature_version == "1.0.0"
+    assert DERIVED_FACT_REGISTRY.get("sma_10m_completed_months").feature_version == "1.0.0"
 
 
 def test_confirmed_earnings_through_back_expiration_is_ineligible() -> None:

--- a/tests/domain/test_market_data_contracts.py
+++ b/tests/domain/test_market_data_contracts.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 import pytest
 
 from domain import (
+    AdjustedCloseBasis,
     CanonicalInstrumentIdentity,
     CompletenessMetadata,
     CorporateActionPlaceholder,
@@ -30,8 +31,8 @@ from domain import (
     NormalizedProviderErrorMetadata,
     OHLCVBar,
     OHLCVSeries,
-    ProviderErrorKind,
     ProviderAddressProjection,
+    ProviderErrorKind,
     ProviderProvenance,
     Quote,
     TradingCalendarEvent,
@@ -173,6 +174,24 @@ def test_bar_requires_utc_aware_coherent_window_and_prices() -> None:
         dataclasses.replace(bar(), start_at=NOW.replace(tzinfo=None))
     with pytest.raises(DomainInvariantError, match="high is incoherent"):
         dataclasses.replace(bar(), high=Decimal("200"))
+
+
+def test_adjusted_close_is_typed_optional_and_backward_compatible() -> None:
+    adjusted = dataclasses.replace(
+        bar(),
+        adjusted_close=Decimal("208.50"),
+        adjusted_close_basis=AdjustedCloseBasis.SPLIT_AND_DIVIDEND_ADJUSTED,
+    )
+    assert deserialize_market_data(serialize_market_data(adjusted)) == adjusted
+    with pytest.raises(DomainInvariantError, match="supplied together"):
+        dataclasses.replace(bar(), adjusted_close=Decimal("208.50"))
+
+    legacy = json.loads(serialize_market_data(bar()))
+    del legacy["fields"]["adjusted_close"]
+    del legacy["fields"]["adjusted_close_basis"]
+    assert deserialize_market_data(
+        json.dumps(legacy, sort_keys=True, separators=(",", ":")).encode()
+    ) == bar()
 
 
 def test_stale_evidence_can_never_report_fresh() -> None:

--- a/tests/market_data/test_finnhub.py
+++ b/tests/market_data/test_finnhub.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 import pytest
 
 from domain import (
+    AdjustedCloseBasis,
     CanonicalInstrumentIdentity,
     EarningsEvent,
     EvidenceKind,
@@ -191,6 +193,11 @@ def test_candle_success_validates_status_arrays_and_utc_timestamps() -> None:
     assert result.error is None and isinstance(result.observations[0].value, OHLCVSeries)
     assert len(result.observations) == 1
     assert result.observations[0].value.bars[0].start_at.tzinfo is UTC
+    assert result.observations[0].value.bars[0].adjusted_close == Decimal("210")
+    assert (
+        result.observations[0].value.bars[0].adjusted_close_basis
+        is AdjustedCloseBasis.SPLIT_ADJUSTED
+    )
     assert dict(transport.requests[0].query)["resolution"] == "D"
 
 


### PR DESCRIPTION
## Ticket
STK-02 / Gate 2

## Summary
Adds the Founder-authorized backward-compatible adjusted-close evidence fields and typed basis, populates authoritative Finnhub split-adjusted evidence, and registers deterministic `sma_10m_completed_months@1.0.0`.

## Architecture
Raw OHLC semantics remain unchanged. Legacy v1 payloads remain readable. Missing adjusted evidence stays missing; no raw fallback. Derived fact is provider-neutral and replay deterministic.

## Validation
- 164 focused domain/analytics/provider tests passed
- mypy passed
- Ruff import checks passed
- Lean pre-push 5/5 passed

## Authority
Issue #415 Option 1 Founder authorization. Delegated auto-merge active.