### PR TITLE
STK-03: implement B001/B002 stock benchmarks through the universal runtime

### DIFF
--- a/analytics/derived_facts.py
+++ b/analytics/derived_facts.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from collections.abc import Sequence
 from datetime import UTC, date, datetime
 from decimal import ROUND_HALF_EVEN, Context, Decimal, localcontext
+from typing import Protocol
 
 from analytics.registry import AnalyticsFeatureDefinition, AnalyticsRegistry
 from domain import (
+    AdjustedCloseBasis,
     ComparisonUniverseReturns,
     HistoricalSkewObservations,
     MarketCapability,
-    OHLCVBar,
     SectorReferenceReturns,
 )
 
@@ -42,8 +43,32 @@ OPEN_INTEREST_QUALITY = "open_interest_quality"
 SMA_10M_COMPLETED_MONTHS = "sma_10m_completed_months"
 
 
+class AdjustedCloseBarLike(Protocol):
+    """The exact three fields SMA10M reads off a bar -- deliberately a
+    Protocol, not the concrete ``domain.market_data.OHLCVBar``, so a
+    caller carrying month-end evidence through a normalized canonical-fact
+    projection (which cannot hold a raw OHLCVBar -- CanonicalFact.value
+    must be an immutable normalized scalar/tuple, per domain/values.py's
+    own require_normalized) can pass a lightweight reconstruction of just
+    these three real fields instead of fabricating a full, mostly-unused
+    OHLCVBar. Every real OHLCVBar already satisfies this structurally.
+
+    Declared as read-only properties, not plain attributes: mypy treats a
+    plain Protocol attribute as requiring a *settable* member, which a
+    frozen dataclass (every real OHLCVBar, and the lightweight
+    reconstruction below) never has.
+    """
+
+    @property
+    def end_at(self) -> datetime: ...
+    @property
+    def adjusted_close(self) -> Decimal | None: ...
+    @property
+    def adjusted_close_basis(self) -> AdjustedCloseBasis | None: ...
+
+
 def compute_sma_10m_completed_months(
-    bars: Sequence[OHLCVBar], as_of: datetime
+    bars: Sequence[AdjustedCloseBarLike], as_of: datetime
 ) -> Decimal:
     """Mean of the last ten completed month-end adjusted closes.
 
@@ -60,7 +85,7 @@ def compute_sma_10m_completed_months(
         if (bar.end_at.astimezone(UTC).year, bar.end_at.astimezone(UTC).month)
         < (as_of_utc.year, as_of_utc.month)
     )
-    month_ends: dict[tuple[int, int], OHLCVBar] = {}
+    month_ends: dict[tuple[int, int], AdjustedCloseBarLike] = {}
     for bar in eligible:
         end_at = bar.end_at.astimezone(UTC)
         key = (end_at.year, end_at.month)

--- a/asa/scheduled_screening.py
+++ b/asa/scheduled_screening.py
@@ -131,6 +131,20 @@ PRODUCTION_SCREENING_UNIVERSE: tuple[tuple[str, str], ...] = tuple(
     for symbol in APPROVED_LIVE_UNIVERSE
 ) + tuple(("earnings_calendar", symbol) for symbol in EARNINGS_CALENDAR_UNIVERSE)
 
+# STOCK-RUNTIME-001 STK-03: B001/B002 are frozen, SPY-only, no-lifecycle
+# benchmarks (project/reports/STOCK-RUNTIME-001-STK-01.md) with their own
+# independent scheduling need -- always evaluate, every invocation, never
+# subject to the SP500 options universe's cohort rotation/claiming. Kept
+# deliberately OUT of PRODUCTION_SCREENING_UNIVERSE and the scheduled
+# cohort-claim branch below: both are pinned by existing fixture-driven
+# tests (tests/asa/_fixture_market_data_access.py's MultiExpirationFixture
+# Provider) built around a single-bar-per-request HISTORICAL_BARS_V1
+# fixture with no adjusted-close evidence at all, which can never satisfy
+# B002's ten-completed-month requirement -- run via
+# run_scheduled_stock_benchmark_refresh() below instead, a separate
+# invocation the production scheduler (Railway cron) calls independently.
+STOCK_BENCHMARK_UNIVERSE: tuple[tuple[str, str], ...] = (("B001", "SPY"), ("B002", "SPY"))
+
 # UNI-01's current proven live capacity. Increasing this is a measured
 # capacity decision, never a CLI/environment override.
 SP500_COHORT_MAXIMUM_SUBJECTS = 30
@@ -836,6 +850,38 @@ def run_scheduled_refresh(
             ),
         )
     return tuple(outcomes)
+
+
+def run_scheduled_stock_benchmark_refresh(
+    *,
+    repository: LatestResultRepository | None = None,
+    history_repository: ObservationHistoryRepository | None = None,
+    acquisition_attempt_repository: AcquisitionAttemptRepository | None = None,
+    historical_skew_repository: HistoricalSkewRepository | None = None,
+    portfolio_lifecycle_repository: PortfolioLifecycleRepository | None = None,
+    transport_factory: Callable[[str], object] = build_live_transport,
+    now: datetime | None = None,
+) -> tuple[PairOutcome, ...]:
+    """B001/B002's own independent scheduled entry point (STOCK-RUNTIME-001
+    STK-03): always evaluates the fixed two-pair STOCK_BENCHMARK_UNIVERSE,
+    unconditionally, every invocation -- a benchmark has no "stale subject"
+    queue to wait its turn in, so this deliberately never routes through
+    run_scheduled_refresh's own enforce_schedule=True SP500 cohort-claim
+    path. The production scheduler (Railway cron) invokes this as its own
+    separate trigger, independent of the options universe's scheduled
+    refresh.
+    """
+    return run_scheduled_refresh(
+        STOCK_BENCHMARK_UNIVERSE,
+        repository=repository,
+        history_repository=history_repository,
+        acquisition_attempt_repository=acquisition_attempt_repository,
+        historical_skew_repository=historical_skew_repository,
+        portfolio_lifecycle_repository=portfolio_lifecycle_repository,
+        transport_factory=transport_factory,
+        enforce_schedule=False,
+        now=now,
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/project/reports/STOCK-RUNTIME-001-STK-03.md
+++ b/project/reports/STOCK-RUNTIME-001-STK-03.md
@@ -1,0 +1,123 @@
+# STOCK-RUNTIME-001 — STK-03 evidence
+
+## Outcome
+
+B001 and B002 execute through the existing universal strategy runtime as
+ordinary, provider-blind subject-first strategies:
+
+- `strategies/stock_benchmark_planning.py` — bootstrap demands
+  (`REAL_TIME_QUOTE_V1` for B001; plus `HISTORICAL_BARS_V1` for B002) and a
+  no-op phase-two expansion (neither benchmark selects an expiration or any
+  other second-phase evidence).
+- `strategies/stock_benchmark_knowledge.py` — `KnowledgeMapping` bindings.
+  B002's ten completed-month bars are flattened to a normalized
+  `(end_at, adjusted_close, basis)` tuple before canonical-fact projection
+  (`CanonicalFact.value` must be an immutable normalized scalar/tuple —
+  a raw `OHLCVBar` cannot be projected directly) and reconstructed via a
+  lightweight `AdjustedCloseBarLike`-satisfying object before calling
+  STK-02's own `compute_sma_10m_completed_months` — the same real values,
+  never fabricated ones, and the SMA formula itself stays exactly where
+  STK-02 put it (`analytics/derived_facts.py`).
+- `strategies/stock_benchmark_evaluation.py` — pure verdict logic: B001 is
+  always PASS once reached (an unusable quote never reaches it — it is a
+  typed `UnknownReason` from preparation, surfaced generically as
+  MISSING_DATA); B002 is PASS only strictly above SMA10M, NO_SIGNAL at or
+  below.
+- `strategy_runtime/adapters/stock_benchmarks_subject_first.py` — the
+  preparation callbacks and runtime adapters, mirroring the smallest
+  existing subject-first shape in the repo
+  (`tests/strategy_runtime/strat_proof_plugin.py`): no manifest, no graph
+  evaluation, no option resolver invocation, no lifecycle.
+- `strategy_runtime/adapters/__init__.py` — B001/B002 joined the shared
+  composition root (`build_migrated_strategy_registry`,
+  `build_migrated_shadow_registry`, `migrated_shadow_resolution_policy`,
+  `build_migrated_signal_catalog`, `build_migrated_cutover_policy`) beside
+  the three existing migrated strategies, with `subject_first_by_strategy_id`
+  cutover `True` from the start (there is no legacy adapter for either
+  benchmark to shadow against).
+- `strategy_runtime/adapters/stock_benchmarks.py` — `B002_CONTRACT` gained
+  a second, `RequirementCategory.CUSTOM` requirement documenting its
+  `sma_10m_completed_months@1.0.0` dependency, following this repo's own
+  established convention for a non-capability-backed requirement.
+
+## Scheduling: a deliberately separate entry point
+
+B001/B002 are **not** added to `PRODUCTION_SCREENING_UNIVERSE` or the
+SP500 cohort-claim branch inside `asa/scheduled_screening.py`. Both paths
+are pinned by existing fixture-driven tests
+(`tests/asa/_fixture_market_data_access.py`'s `MultiExpirationFixtureProvider`)
+built around a single-bar-per-request `HISTORICAL_BARS_V1` fixture with no
+adjusted-close evidence at all — structurally incapable of ever satisfying
+B002's ten-completed-month requirement. Forcing B001/B002 through that
+shared fixture would have produced permanent, spurious `missing_data` for
+B002 in `test_production_universe_topology_has_no_universal_preparation_failure`
+and `test_default_scheduled_cycle_uses_bounded_sp500_cohort`, and required
+inflating a 500-name-equity fixture just to serve two SPY-only benchmarks.
+
+Instead, `asa/scheduled_screening.py` gained:
+
+- `STOCK_BENCHMARK_UNIVERSE = (("B001", "SPY"), ("B002", "SPY"))`
+- `run_scheduled_stock_benchmark_refresh(...)` — a thin wrapper calling
+  `run_scheduled_refresh(STOCK_BENCHMARK_UNIVERSE, ..., enforce_schedule=False)`.
+  Both benchmarks evaluate unconditionally on every invocation; there is no
+  "stale subject" queue for a benchmark to wait its turn in, so this never
+  routes through the SP500 cohort-claim machinery. The production scheduler
+  (Railway cron) is expected to invoke this as its own separate trigger,
+  independent of the options universe's own scheduled refresh — a Founder/
+  deployment decision for STK-06, not implemented here.
+
+## Verification
+
+- `tests/strategies/test_stock_benchmark_planning.py`,
+  `test_stock_benchmark_evaluation.py`,
+  `test_stock_benchmark_knowledge.py` — unit-level demand/verdict/
+  knowledge-mapping pins, including B002's insufficient-history and
+  missing-adjusted-close typed-unknown paths.
+- `tests/strategy_runtime/adapters/test_stock_benchmarks_subject_first.py`
+  — sealed-snapshot integration tests through the real
+  `compose_strategy_knowledge` orchestrator: B001 PASS/BUY, B001 unusable-
+  quote typed unknown, B002 PASS/BUY, B002 NO_SIGNAL at the SMA boundary,
+  B002 insufficient-adjusted-history typed unknown, and a deterministic-
+  replay pin (composing the same sealed snapshot twice yields byte-
+  identical facts).
+- `tests/asa/test_scheduled_stock_benchmark_refresh.py` — a genuine
+  end-to-end proof of `run_scheduled_stock_benchmark_refresh` through real
+  acquisition → resolution → sealed snapshot → generic knowledge
+  composition → subject-first adapter → persistence, against a
+  purpose-built fixture provider that (unlike the shared
+  `MultiExpirationFixtureProvider`) returns a genuine multi-month adjusted-
+  close `OHLCVSeries`.
+- `tests/strategy_runtime/adapters/test_registry.py` and
+  `tests/architecture/test_migrated_strategy_acquisition_blindness.py`
+  updated to expect five registered/shadow-bound strategy IDs instead of
+  three; both pinned assertions confirmed the original three strategies'
+  own identities and ordering are otherwise unchanged.
+- Full `ruff check` and `mypy` clean on every new/modified file.
+- Full local regression sweep (`tests/strategies`, `tests/strategy_runtime`,
+  `tests/architecture`, `tests/analytics`, relevant `tests/market_data`
+  and `tests/domain` suites): 824 passed. The only local failures are a
+  pre-existing, unrelated Windows-locale (cp1252) `UnicodeDecodeError`
+  reading a UTF-8 markdown fixture in
+  `tests/architecture/test_market_data_platform_contract.py`, confirmed
+  identical on a clean `main` checkout — not present on Linux CI.
+
+## Compatibility
+
+- No change to `asa/scheduled_screening.py`'s existing scheduled/manual
+  universes, cohort-claim behavior, or any of their pinned test
+  assertions.
+- No change to `RequirementCategory`, `StrategyContract`, or any other
+  shared contract primitive beyond the additive B002 requirement entry.
+- `analytics/derived_facts.py`'s `compute_sma_10m_completed_months` now
+  accepts `Sequence[AdjustedCloseBarLike]` (a structural Protocol) instead
+  of `Sequence[OHLCVBar]` — every real `OHLCVBar` still satisfies it
+  (confirmed against the full existing `tests/analytics/test_derived_facts.py`
+  and `tests/market_data/test_finnhub.py` STK-02 suites, unchanged), widening
+  the accepted input rather than narrowing it.
+- No migration, no schema change, no broker access, no lifecycle, no
+  option resolver invocation for either benchmark.
+
+## Verdict
+
+**COMPLETE.** STK-03 is done. Continuing to STK-04 (Robinhood portfolio
+reuse-gap audit) next, per the sprint's uninterrupted execution model.

--- a/strategies/stock_benchmark_evaluation.py
+++ b/strategies/stock_benchmark_evaluation.py
@@ -1,0 +1,28 @@
+"""Pure, deterministic verdict logic for the stock benchmarks (B001/B002).
+
+Both benchmarks reach this function only once their required evidence has
+already resolved and (for B002) SMA10M has already been materialized --
+an unusable-evidence or insufficient-history gap is a typed UnknownReason
+raised earlier in preparation, surfaced generically as MISSING_DATA, and
+never reaches these functions at all.
+"""
+
+from __future__ import annotations
+
+from strategies.stock_benchmark_knowledge import B001Payload, B002Payload
+
+VERDICT_PASS = "PASS"
+VERDICT_NO_SIGNAL = "NO_SIGNAL"
+
+
+def evaluate_b001(payload: B001Payload) -> str:
+    """SPY buy-and-hold: usable current price is always a PASS/BUY."""
+
+    del payload
+    return VERDICT_PASS
+
+
+def evaluate_b002(payload: B002Payload) -> str:
+    """SPY 10-month trend: PASS/BUY only strictly above the SMA10M."""
+
+    return VERDICT_PASS if payload.price > payload.sma_10m else VERDICT_NO_SIGNAL

--- a/strategies/stock_benchmark_knowledge.py
+++ b/strategies/stock_benchmark_knowledge.py
@@ -1,0 +1,185 @@
+"""Stock benchmark (B001/B002) mapping from sealed evidence to immutable
+facts. Both benchmarks are StructureKind.NONE/NO_LIFECYCLE: there is no
+option chain, no structural selection, and (unlike Skew Momentum/Forward
+Factor/Earnings Calendar) no manifest-graph evaluation -- their payloads
+are consumed directly by strategy_runtime/adapters/stock_benchmarks_subject_first.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from analytics.derived_facts import (
+    SMA_10M_COMPLETED_MONTHS,
+    AdjustedCloseBarLike,
+    compute_sma_10m_completed_months,
+)
+from analytics.features import DerivedFactQualityStatus, DerivedFactRequest, DerivedFactSet
+from domain import (
+    AdjustedCloseBasis,
+    CanonicalFact,
+    EvidenceKind,
+    EvidenceReference,
+    MarketCapability,
+    OHLCVBar,
+    UnknownReason,
+)
+from facts.canonical_projection import CanonicalFactRequest, canonical_fact_id
+from strategies.knowledge_contracts import KnowledgeMapping
+
+FACT_CURRENT_PRICE = "stock_benchmark_current_price"
+FACT_MONTHLY_HISTORY_BARS = "stock_benchmark_monthly_history_bars"
+_EVIDENCE_VERSION = 1
+
+# A CanonicalFact's value must be an immutable normalized scalar/tuple
+# (domain/values.py's own require_normalized) -- a raw OHLCVBar cannot be
+# projected directly. Each bar is flattened to exactly the three fields
+# compute_sma_10m_completed_months reads (end_at, adjusted_close,
+# adjusted_close_basis-as-str), reconstructed as an AdjustedCloseBarLike
+# below -- the same real values, never fabricated ones.
+_NormalizedBar = tuple[datetime, Decimal | None, str | None]
+
+
+@dataclass(frozen=True, slots=True)
+class _MonthEndObservation:
+    end_at: datetime
+    adjusted_close: Decimal | None
+    adjusted_close_basis: AdjustedCloseBasis | None
+
+
+def _normalize_bars(bars: tuple[OHLCVBar, ...]) -> tuple[_NormalizedBar, ...]:
+    return tuple(
+        (
+            bar.end_at,
+            bar.adjusted_close,
+            bar.adjusted_close_basis.value if bar.adjusted_close_basis is not None else None,
+        )
+        for bar in bars
+    )
+
+
+def _denormalize_bars(value: object) -> tuple[AdjustedCloseBarLike, ...]:
+    if not isinstance(value, tuple):
+        raise TypeError("B002 monthly history bars canonical fact must be a tuple")
+    observations = []
+    for entry in value:
+        end_at, adjusted_close, basis = entry
+        observations.append(
+            _MonthEndObservation(
+                end_at=end_at,
+                adjusted_close=adjusted_close,
+                adjusted_close_basis=(AdjustedCloseBasis(basis) if basis is not None else None),
+            )
+        )
+    return tuple(observations)
+
+
+@dataclass(frozen=True, slots=True)
+class B001Payload:
+    price: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class B002Payload:
+    price: Decimal
+    sma_10m: Decimal
+
+
+def build_b001_knowledge_mapping(
+    *,
+    subject: str,
+    quote_observation_id: str,
+    price: Decimal,
+) -> KnowledgeMapping[B001Payload]:
+    price_request = CanonicalFactRequest(
+        MarketCapability.REAL_TIME_QUOTE_V1,
+        quote_observation_id,
+        price,
+        subject,
+        FACT_CURRENT_PRICE,
+    )
+
+    def _compute(facts: tuple[CanonicalFact, ...]) -> tuple[DerivedFactRequest, ...]:
+        del facts
+        return ()
+
+    def _payload(facts: tuple[CanonicalFact, ...], derived: DerivedFactSet) -> B001Payload:
+        del derived
+        (price_fact,) = facts
+        if not isinstance(price_fact.value, Decimal):
+            raise TypeError("B001 current price canonical fact must be decimal")
+        return B001Payload(price_fact.value)
+
+    return KnowledgeMapping((price_request,), _compute, _payload)
+
+
+def build_b002_knowledge_mapping(
+    *,
+    subject: str,
+    snapshot_digest: str,
+    quote_observation_id: str,
+    price: Decimal,
+    bars_observation_id: str,
+    bars: tuple[OHLCVBar, ...],
+    as_of: datetime,
+) -> KnowledgeMapping[B002Payload]:
+    price_request = CanonicalFactRequest(
+        MarketCapability.REAL_TIME_QUOTE_V1,
+        quote_observation_id,
+        price,
+        subject,
+        FACT_CURRENT_PRICE,
+    )
+    bars_request = CanonicalFactRequest(
+        MarketCapability.HISTORICAL_BARS_V1,
+        bars_observation_id,
+        _normalize_bars(bars),
+        subject,
+        FACT_MONTHLY_HISTORY_BARS,
+    )
+    price_fact_id = canonical_fact_id(FACT_CURRENT_PRICE, subject, snapshot_digest)
+    bars_fact_id = canonical_fact_id(FACT_MONTHLY_HISTORY_BARS, subject, snapshot_digest)
+
+    def _compute(
+        facts: tuple[CanonicalFact, ...],
+    ) -> tuple[DerivedFactRequest, ...] | UnknownReason:
+        fact_by_id = {fact.fact_id: fact for fact in facts}
+        observations = _denormalize_bars(fact_by_id[bars_fact_id].value)
+        try:
+            sma = compute_sma_10m_completed_months(observations, as_of)
+        except ValueError:
+            # A genuine, expected data gap (fewer than ten completed
+            # months of adjusted-close history) -- never a raw-close
+            # fallback, per STOCK-RUNTIME-001 STK-01/STK-02.
+            return UnknownReason("insufficient_adjusted_history")
+        evidence = (
+            EvidenceReference(EvidenceKind.CANONICAL_FACT, bars_fact_id, _EVIDENCE_VERSION),
+        )
+        return (
+            DerivedFactRequest(
+                SMA_10M_COMPLETED_MONTHS,
+                subject,
+                sma,
+                "decimal",
+                evidence,
+                DerivedFactQualityStatus.VALID,
+            ),
+        )
+
+    def _payload(facts: tuple[CanonicalFact, ...], derived: DerivedFactSet) -> B002Payload:
+        fact_by_id = {fact.fact_id: fact for fact in facts}
+        price_value = fact_by_id[price_fact_id].value
+        if not isinstance(price_value, Decimal):
+            raise TypeError("B002 current price canonical fact must be decimal")
+        sma_fact = next(
+            item
+            for item in derived.facts
+            if item.derived_fact_id.startswith(f"{SMA_10M_COMPLETED_MONTHS}:")
+        )
+        if not isinstance(sma_fact.value, Decimal):
+            raise TypeError("sma_10m_completed_months derived fact must be decimal")
+        return B002Payload(price_value, sma_fact.value)
+
+    return KnowledgeMapping((price_request, bars_request), _compute, _payload)

--- a/strategies/stock_benchmark_planning.py
+++ b/strategies/stock_benchmark_planning.py
@@ -1,0 +1,63 @@
+"""Provider-blind subject demands for the stock benchmarks (B001/B002)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Mapping  # noqa: UP035
+
+from domain import (
+    CapabilityDemand,
+    DemandExpansion,
+    MarketCapability,
+    ResolvedCapabilityEvidence,
+)
+
+# Ten completed calendar months back from any as_of date reaches at most
+# ~310 days into the past; this adds a full extra quarter of buffer for
+# month-boundary/weekend/holiday alignment without inventing a second,
+# hand-tuned constant elsewhere.
+HISTORICAL_LOOKBACK_DAYS = 400
+
+
+def quote_demand(now: datetime) -> CapabilityDemand:
+    return CapabilityDemand(MarketCapability.REAL_TIME_QUOTE_V1, ("last",), now, now)
+
+
+def bars_demand(now: datetime) -> CapabilityDemand:
+    return CapabilityDemand(
+        MarketCapability.HISTORICAL_BARS_V1,
+        ("close",),
+        now - timedelta(days=HISTORICAL_LOOKBACK_DAYS),
+        now,
+        maximum_age_seconds=int(timedelta(days=HISTORICAL_LOOKBACK_DAYS + 1).total_seconds()),
+    )
+
+
+def b001_bootstrap_demands(now: datetime) -> tuple[CapabilityDemand, ...]:
+    return (quote_demand(now),)
+
+
+def b002_bootstrap_demands(now: datetime) -> tuple[CapabilityDemand, ...]:
+    return quote_demand(now), bars_demand(now)
+
+
+def no_op_expand(evidence: Mapping[str, ResolvedCapabilityEvidence]) -> DemandExpansion:
+    """Neither benchmark selects an expiration or any other phase-two
+    evidence -- both are single-phase acquisitions."""
+
+    del evidence
+    return DemandExpansion()
+
+
+def b001_resolved_field_requirements() -> dict[MarketCapability, tuple[tuple[str, ...], int]]:
+    return {MarketCapability.REAL_TIME_QUOTE_V1: (("last",), 3600)}
+
+
+def b002_resolved_field_requirements() -> dict[MarketCapability, tuple[tuple[str, ...], int]]:
+    return {
+        MarketCapability.REAL_TIME_QUOTE_V1: (("last",), 3600),
+        MarketCapability.HISTORICAL_BARS_V1: (
+            ("close",),
+            int(timedelta(days=HISTORICAL_LOOKBACK_DAYS + 1).total_seconds()),
+        ),
+    }

--- a/strategy_runtime/adapters/__init__.py
+++ b/strategy_runtime/adapters/__init__.py
@@ -30,6 +30,10 @@ from strategies.forward_factor_planning import (
 from strategies.skew_momentum_planning import (
     resolved_field_requirements as skew_momentum_resolved_field_requirements,
 )
+from strategies.stock_benchmark_planning import (
+    b001_resolved_field_requirements,
+    b002_resolved_field_requirements,
+)
 from strategy_runtime.adapters.earnings_calendar import (
     EARNINGS_CALENDAR_CONTRACT,
 )
@@ -47,6 +51,11 @@ from strategy_runtime.adapters.skew_momentum_subject_first import (
 )
 from strategy_runtime.adapters.skew_momentum_vertical import (
     SKEW_MOMENTUM_VERTICAL_CONTRACT,
+)
+from strategy_runtime.adapters.stock_benchmarks import B001_CONTRACT, B002_CONTRACT
+from strategy_runtime.adapters.stock_benchmarks_subject_first import (
+    build_b001_subject_preparation_binding,
+    build_b002_subject_preparation_binding,
 )
 from strategy_runtime.catalog import SignalCatalogEntry
 from strategy_runtime.context import RuntimeContext
@@ -86,6 +95,12 @@ def build_migrated_strategy_registry() -> StrategyRegistry[UniversalScreeningRes
             (FORWARD_FACTOR_CONTRACT, _subject_first_only),
             (SKEW_MOMENTUM_VERTICAL_CONTRACT, _subject_first_only),
             (EARNINGS_CALENDAR_CONTRACT, _subject_first_only),
+            # B001/B002 (STOCK-RUNTIME-001 STK-03): StructureKind.NONE,
+            # NO_LIFECYCLE, no manifest-graph -- there is no legacy adapter
+            # for either benchmark at all, so validate_manifest_contract
+            # never applies to them (nothing to validate against).
+            (B001_CONTRACT, _subject_first_only),
+            (B002_CONTRACT, _subject_first_only),
         )
     )
 
@@ -120,6 +135,8 @@ def build_migrated_shadow_registry(
                 EARNINGS_CALENDAR_CONTRACT.strategy_id,
                 build_earnings_calendar_subject_preparation_binding(now),
             ),
+            (B001_CONTRACT.strategy_id, build_b001_subject_preparation_binding(now)),
+            (B002_CONTRACT.strategy_id, build_b002_subject_preparation_binding(now)),
         )
     )
 
@@ -157,6 +174,8 @@ def migrated_shadow_resolution_policy(
             EARNINGS_CALENDAR_CONTRACT.strategy_id,
             FORWARD_FACTOR_CONTRACT.strategy_id,
             SKEW_MOMENTUM_VERTICAL_CONTRACT.strategy_id,
+            B001_CONTRACT.strategy_id,
+            B002_CONTRACT.strategy_id,
         )
     )
     requirements: dict[MarketCapability, tuple[tuple[str, ...], int]] = {}
@@ -166,7 +185,20 @@ def migrated_shadow_resolution_policy(
         requirements.update(forward_factor_resolved_field_requirements())
     if SKEW_MOMENTUM_VERTICAL_CONTRACT.strategy_id in selected:
         requirements.update(skew_momentum_resolved_field_requirements())
+    if B001_CONTRACT.strategy_id in selected:
+        requirements.update(b001_resolved_field_requirements())
+    if B002_CONTRACT.strategy_id in selected:
+        requirements.update(b002_resolved_field_requirements())
     return resolution_policy_for_capabilities(capability_registry, requirements)
+
+
+
+# B001/B002 have no StrategyManifest -- StructureKind.NONE strategies with
+# no option structure never compile/execute a graph, so there is nothing
+# for a manifest_id to identify. SignalCatalogEntry.manifest_id has no
+# default, so this stable sentinel documents "no manifest" explicitly
+# rather than fabricating a fake manifest identity.
+_NO_MANIFEST = "none"
 
 
 def build_migrated_signal_catalog() -> tuple[SignalCatalogEntry, ...]:
@@ -184,6 +216,8 @@ def build_migrated_signal_catalog() -> tuple[SignalCatalogEntry, ...]:
             SKEW_MOMENTUM_VERTICAL_CONTRACT,
             manifest_id=SKEW_MOMENTUM_VERTICAL_MANIFEST.manifest_id,
         ),
+        SignalCatalogEntry.from_contract(B001_CONTRACT, manifest_id=_NO_MANIFEST),
+        SignalCatalogEntry.from_contract(B002_CONTRACT, manifest_id=_NO_MANIFEST),
     )
     return tuple(sorted(entries, key=lambda item: item.signal_id))
 
@@ -201,5 +235,10 @@ def build_migrated_cutover_policy(values: Mapping[str, str]) -> CutoverPolicy:
             FORWARD_FACTOR_CONTRACT.strategy_id: True,
             SKEW_MOMENTUM_VERTICAL_CONTRACT.strategy_id: True,
             EARNINGS_CALENDAR_CONTRACT.strategy_id: True,
+            # B001/B002 have no legacy adapter at all (their production
+            # registry entry is _subject_first_only, which raises) -- the
+            # subject-first path must be authoritative from day one.
+            B001_CONTRACT.strategy_id: True,
+            B002_CONTRACT.strategy_id: True,
         }
     )

--- a/strategy_runtime/adapters/stock_benchmarks.py
+++ b/strategy_runtime/adapters/stock_benchmarks.py
@@ -41,6 +41,10 @@ B002_CONTRACT = StrategyContract(
                 MarketCapability.HISTORICAL_BARS_V1,
             ),
         ),
+        DataRequirement(
+            RequirementCategory.CUSTOM,
+            identifier="sma_10m_completed_months@1.0.0",
+        ),
     ),
     lifecycle=NO_LIFECYCLE,
     structure=StructureKind.NONE,

--- a/strategy_runtime/adapters/stock_benchmarks_subject_first.py
+++ b/strategy_runtime/adapters/stock_benchmarks_subject_first.py
@@ -1,0 +1,214 @@
+"""B001/B002 preparation and read-only runtime binding (STOCK-RUNTIME-001
+STK-03). Both benchmarks are StructureKind.NONE/NO_LIFECYCLE with a single
+acquisition phase (no expiration selection, no option structure) -- the
+smallest subject-first shape the runtime supports, mirroring
+tests/strategy_runtime/strat_proof_plugin.py's own minimal adapter rather
+than the option-structure strategies' manifest-graph pattern.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from types import MappingProxyType
+from typing import Any
+
+from domain import MarketCapability, OHLCVSeries, Quote, UnknownReason
+from market_data.snapshot import MarketSnapshot
+from screening.subject_fact_projection import resolution_for
+from screening.subject_planning import ResolvedEvidenceView, SubjectPlanConsumer
+from strategies.knowledge_contracts import KnowledgeMapping
+from strategies.stock_benchmark_evaluation import evaluate_b001, evaluate_b002
+from strategies.stock_benchmark_knowledge import (
+    B001Payload,
+    B002Payload,
+    build_b001_knowledge_mapping,
+    build_b002_knowledge_mapping,
+)
+from strategies.stock_benchmark_planning import (
+    b001_bootstrap_demands,
+    b002_bootstrap_demands,
+    no_op_expand,
+)
+from strategy_runtime.adapters.stock_benchmarks import B001_CONTRACT, B002_CONTRACT
+from strategy_runtime.context import RuntimeContext
+from strategy_runtime.knowledge import ReadOnlyStrategyInput
+from strategy_runtime.registry import StrategyAdapter
+from strategy_runtime.result import (
+    EvaluationState,
+    RowType,
+    UniversalScreeningResult,
+    compute_observation_id,
+)
+from strategy_runtime.subject_preparation import SubjectPreparationBinding
+from strategy_runtime.values import TypedValue
+
+_B001_STRATEGY_ID = "B001"
+_B002_STRATEGY_ID = "B002"
+
+
+def _prepare_b001(
+    snapshot: MarketSnapshot,
+    projected_evidence: ResolvedEvidenceView,
+    selections: tuple[tuple[str, object], ...],
+    subject: str,
+) -> KnowledgeMapping[B001Payload] | UnknownReason:
+    del projected_evidence, selections
+    quote_resolution = resolution_for(snapshot, MarketCapability.REAL_TIME_QUOTE_V1)
+    quote_observation = quote_resolution.selected_observation
+    if quote_observation is None or not isinstance(quote_observation.value, Quote):
+        return UnknownReason("unusable_quote")
+    quote = quote_observation.value
+    if quote.last is None:
+        return UnknownReason("unusable_quote")
+    return build_b001_knowledge_mapping(
+        subject=subject,
+        quote_observation_id=quote_observation.observation_id,
+        price=quote.last,
+    )
+
+
+def _prepare_b002(
+    snapshot: MarketSnapshot,
+    projected_evidence: ResolvedEvidenceView,
+    selections: tuple[tuple[str, object], ...],
+    subject: str,
+) -> KnowledgeMapping[B002Payload] | UnknownReason:
+    del projected_evidence, selections
+    quote_resolution = resolution_for(snapshot, MarketCapability.REAL_TIME_QUOTE_V1)
+    quote_observation = quote_resolution.selected_observation
+    if quote_observation is None or not isinstance(quote_observation.value, Quote):
+        return UnknownReason("unusable_quote")
+    quote = quote_observation.value
+    if quote.last is None:
+        return UnknownReason("unusable_quote")
+    bars_resolution = resolution_for(snapshot, MarketCapability.HISTORICAL_BARS_V1)
+    bars_observation = bars_resolution.selected_observation
+    if bars_observation is None or not isinstance(bars_observation.value, OHLCVSeries):
+        return UnknownReason("unusable_historical_bars")
+    return build_b002_knowledge_mapping(
+        subject=subject,
+        snapshot_digest=snapshot.snapshot_digest,
+        quote_observation_id=quote_observation.observation_id,
+        price=quote.last,
+        bars_observation_id=bars_observation.observation_id,
+        bars=bars_observation.value.bars,
+        as_of=snapshot.as_of,
+    )
+
+
+def build_b001_subject_preparation_binding(now: datetime) -> SubjectPreparationBinding[B001Payload]:
+    consumer = SubjectPlanConsumer(
+        consumer_id=_B001_STRATEGY_ID,
+        bootstrap_demands=b001_bootstrap_demands(now),
+        expand=no_op_expand,
+    )
+    return SubjectPreparationBinding(
+        consumer=consumer,
+        prepare_knowledge_mapping=_prepare_b001,
+        build_shadow_adapter=build_b001_subject_first_adapter,
+    )
+
+
+def build_b002_subject_preparation_binding(now: datetime) -> SubjectPreparationBinding[B002Payload]:
+    consumer = SubjectPlanConsumer(
+        consumer_id=_B002_STRATEGY_ID,
+        bootstrap_demands=b002_bootstrap_demands(now),
+        expand=no_op_expand,
+    )
+    return SubjectPreparationBinding(
+        consumer=consumer,
+        prepare_knowledge_mapping=_prepare_b002,
+        build_shadow_adapter=build_b002_subject_first_adapter,
+    )
+
+
+def _provenance(knowledge: ReadOnlyStrategyInput[Any]) -> tuple[str, ...]:
+    return (
+        f"snapshot_id:{knowledge.snapshot_id}",
+        f"snapshot_digest:{knowledge.snapshot_digest}",
+        *(f"canonical_fact:{fact.fact_id}@{fact.version}" for fact in knowledge.canonical_facts),
+        *(
+            f"derived_fact:{fact.derived_fact_id}@{fact.formula_version}"
+            for fact in knowledge.derived_facts.facts
+        ),
+    )
+
+
+def build_b001_subject_first_adapter(
+    knowledge_by_subject: Mapping[str, ReadOnlyStrategyInput[B001Payload]],
+) -> StrategyAdapter[UniversalScreeningResult]:
+    frozen = MappingProxyType(dict(knowledge_by_subject))
+
+    def _adapter(context: RuntimeContext) -> UniversalScreeningResult:
+        knowledge = frozen[context.subject]
+        verdict = evaluate_b001(knowledge.payload)
+        return UniversalScreeningResult(
+            strategy_id=_B001_STRATEGY_ID,
+            strategy_version=B001_CONTRACT.version,
+            symbol=context.subject,
+            observation_id=compute_observation_id(
+                context.run_id, _B001_STRATEGY_ID, context.subject
+            ),
+            opportunity_id=None,
+            row_type=RowType.RESULT,
+            verdict=verdict,
+            evaluation_state=EvaluationState.PASS,
+            lifecycle_stage=None,
+            recommendation_state=None,
+            data_quality=None,
+            metrics={
+                "price": TypedValue.of_decimal(knowledge.payload.price),
+                "direction": TypedValue.of_string("BUY"),
+            },
+            economics={},
+            blockers=(),
+            warnings=(),
+            provenance=_provenance(knowledge),
+            observed_at=knowledge.effective_time,
+        )
+
+    return _adapter
+
+
+def build_b002_subject_first_adapter(
+    knowledge_by_subject: Mapping[str, ReadOnlyStrategyInput[B002Payload]],
+) -> StrategyAdapter[UniversalScreeningResult]:
+    frozen = MappingProxyType(dict(knowledge_by_subject))
+
+    def _adapter(context: RuntimeContext) -> UniversalScreeningResult:
+        knowledge = frozen[context.subject]
+        payload = knowledge.payload
+        verdict = evaluate_b002(payload)
+        successful_pass = verdict == "PASS"
+        metrics = {
+            "price": TypedValue.of_decimal(payload.price),
+            "sma_10m_completed_months": TypedValue.of_decimal(payload.sma_10m),
+        }
+        if successful_pass:
+            metrics["direction"] = TypedValue.of_string("BUY")
+        return UniversalScreeningResult(
+            strategy_id=_B002_STRATEGY_ID,
+            strategy_version=B002_CONTRACT.version,
+            symbol=context.subject,
+            observation_id=compute_observation_id(
+                context.run_id, _B002_STRATEGY_ID, context.subject
+            ),
+            opportunity_id=None,
+            row_type=RowType.RESULT,
+            verdict=verdict,
+            evaluation_state=(
+                EvaluationState.PASS if successful_pass else EvaluationState.NO_SIGNAL
+            ),
+            lifecycle_stage=None,
+            recommendation_state=None,
+            data_quality=None,
+            metrics=metrics,
+            economics={},
+            blockers=(),
+            warnings=(),
+            provenance=_provenance(knowledge),
+            observed_at=knowledge.effective_time,
+        )
+
+    return _adapter

--- a/tests/architecture/test_migrated_strategy_acquisition_blindness.py
+++ b/tests/architecture/test_migrated_strategy_acquisition_blindness.py
@@ -10,6 +10,7 @@ ADAPTERS = (
     ROOT / "strategy_runtime/adapters/earnings_calendar_subject_first.py",
     ROOT / "strategy_runtime/adapters/forward_factor_subject_first.py",
     ROOT / "strategy_runtime/adapters/skew_momentum_subject_first.py",
+    ROOT / "strategy_runtime/adapters/stock_benchmarks_subject_first.py",
 )
 FORBIDDEN = {
     "CapabilityFulfiller",
@@ -39,6 +40,8 @@ def test_all_production_strategies_have_subject_first_bindings() -> None:
 
     registry = build_migrated_shadow_registry(datetime(2026, 8, 11, tzinfo=UTC))
     assert registry.strategy_ids() == (
+        "B001",
+        "B002",
         "earnings_calendar",
         "forward_factor",
         "skew_momentum",

--- a/tests/asa/test_ai_agent_workflow.py
+++ b/tests/asa/test_ai_agent_workflow.py
@@ -266,6 +266,8 @@ def test_ai_agent_workflow_discovers_reads_refreshes_and_briefs(
     assert capabilities_response.status_code == 200
     signals = capabilities_response.json()["signals"]
     assert {item["signal_id"] for item in signals} == {
+        "B001",
+        "B002",
         "earnings_calendar",
         "forward_factor",
         "skew_momentum",

--- a/tests/asa/test_bootstrap_first_run.py
+++ b/tests/asa/test_bootstrap_first_run.py
@@ -94,7 +94,13 @@ def test_bootstrap_first_run_from_a_genuinely_empty_deployment(
     capabilities = client.get("/api/v1/capabilities", headers=_auth())
     assert capabilities.status_code == 200
     signal_ids = {item["signal_id"] for item in capabilities.json()["signals"]}
-    assert signal_ids == {"earnings_calendar", "forward_factor", "skew_momentum"}
+    assert signal_ids == {
+        "B001",
+        "B002",
+        "earnings_calendar",
+        "forward_factor",
+        "skew_momentum",
+    }
 
     # Step 2: confirm the empty state is 200 + empty list, never 404.
     empty_list = client.get("/api/v1/screening", headers=_auth())

--- a/tests/asa/test_scheduled_stock_benchmark_refresh.py
+++ b/tests/asa/test_scheduled_stock_benchmark_refresh.py
@@ -1,0 +1,152 @@
+"""STOCK-RUNTIME-001 STK-03: proves B001/B02's own dedicated scheduled
+entry point (asa.scheduled_screening.run_scheduled_stock_benchmark_refresh)
+actually runs both benchmarks end to end through real acquisition ->
+resolution -> sealed snapshot -> generic knowledge composition -> subject-
+first adapter -> persistence -- not merely a hand-built sealed snapshot
+(tests/strategy_runtime/adapters/test_stock_benchmarks_subject_first.py
+already proves the composition/adapter layer directly; this proves the
+production entry point wires all of that together correctly).
+
+Deliberately does NOT reuse tests/asa/_fixture_market_data_access.py's
+MultiExpirationFixtureProvider: that fixture returns exactly one
+HISTORICAL_BARS_V1 bar per fetch with no adjusted-close evidence at all,
+which can never satisfy B002's ten-completed-month requirement -- this is
+precisely why B001/B002 are kept out of PRODUCTION_SCREENING_UNIVERSE and
+the SP500 cohort-claim path (see asa/scheduled_screening.py's own comment
+beside STOCK_BENCHMARK_UNIVERSE). This file's own fixture provider returns
+a genuine multi-month OHLCVSeries instead.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from asa.scheduled_screening import STOCK_BENCHMARK_UNIVERSE, run_scheduled_stock_benchmark_refresh
+from domain import (
+    AdjustedCloseBasis,
+    EvidenceKind,
+    EvidenceReference,
+    MarketCapability,
+    OHLCVBar,
+    OHLCVSeries,
+    Quote,
+)
+from market_data import CapabilityFulfillmentService, ProviderDependencies, load_market_data_config
+from market_data.attempts import InMemoryAcquisitionAttemptRepository
+from market_data.fixture import DeterministicFixtureProvider
+from market_data.registry import ProviderRegistry
+from screening.live_acquisition import build_capability_registry, build_request_budget_manager
+from strategy_runtime.market_data_planning import SubjectMarketDataAccess
+from tests.asa.fakes import InMemoryLatestResultRepository, InMemoryObservationHistoryRepository
+from tests.asa.test_scheduled_screening import _RecordingHistoricalSkewRepository
+
+NOW = datetime(2026, 9, 5, 15, 0, tzinfo=UTC)
+_EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "fixture:SPY"),)
+
+
+def _month_end_bar(instrument: object, months_back: int, adjusted_close: Decimal) -> OHLCVBar:
+    total_months = NOW.year * 12 + (NOW.month - 1) - months_back
+    year, month = divmod(total_months, 12)
+    end_at = datetime(year, month + 1, 15, 12, 0, tzinfo=UTC)
+    start_at = end_at - timedelta(days=1)
+    close = Decimal("400") + Decimal(months_back)
+    return OHLCVBar(
+        instrument,
+        86400,
+        start_at,
+        end_at,
+        close,
+        close + Decimal("2"),
+        close - Decimal("2"),
+        close,
+        Decimal("1000000"),
+        adjusted_close,
+        AdjustedCloseBasis.SPLIT_ADJUSTED,
+    )
+
+
+class StockBenchmarkFixtureProvider(DeterministicFixtureProvider):
+    """REAL_TIME_QUOTE_V1 above the SMA10M, plus a genuine ten-completed-
+    month adjusted-close OHLCVSeries for HISTORICAL_BARS_V1 -- SMA10M mean
+    of 401..410 == 405.5, quote last == 450 (> SMA10M, so B002 -> PASS).
+    """
+
+    def _value(self, subject, address, observed_at, evidence):  # noqa: ANN001
+        instrument = subject.canonical_instrument
+        capability = subject.requested_capability
+        if capability is MarketCapability.REAL_TIME_QUOTE_V1:
+            return Quote(
+                instrument, None, None, Decimal("450"), None, None, None, instrument.currency
+            )
+        if capability is MarketCapability.HISTORICAL_BARS_V1:
+            bars = tuple(
+                _month_end_bar(instrument, months_back, Decimal("400") + months_back)
+                for months_back in range(1, 11)
+            )
+            return OHLCVSeries(instrument, 86400, observed_at, bars)
+        return super()._value(subject, address, observed_at, evidence)  # type: ignore[no-untyped-call]
+
+
+def _build_stock_benchmark_access() -> dict[str, SubjectMarketDataAccess]:
+    config = load_market_data_config({})
+    (fixture_config,) = tuple(item for item in config.providers if item.enabled)
+
+    def _factory(  # noqa: ANN001
+        _config, _transport_factory, clock, subjects, *, budget_clock=None, rolling_window=None
+    ):
+        budget_manager = build_request_budget_manager((fixture_config,), clock)
+        provider = StockBenchmarkFixtureProvider(
+            fixture_config, ProviderDependencies(object(), clock, budget_manager)
+        )
+        provider_registry = ProviderRegistry((provider,))
+        capability_registry = build_capability_registry(provider_registry)
+        fulfillment = CapabilityFulfillmentService(
+            provider_registry, capability_registry, budget_manager
+        )
+        return {
+            symbol: SubjectMarketDataAccess(
+                fulfillment, budget_manager, capability_registry, provider_registry.metadata()
+            )
+            for symbol in subjects
+        }
+
+    return _factory
+
+
+def test_stock_benchmark_refresh_runs_both_pairs_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import asa.scheduled_screening as scheduled_screening_module
+
+    monkeypatch.setattr(
+        scheduled_screening_module,
+        "build_shared_market_data_access",
+        _build_stock_benchmark_access(),
+    )
+    monkeypatch.setenv("ASA_TRADIER_ENABLED", "true")
+    monkeypatch.setenv("ASA_TRADIER_ACCESS_TOKEN", "sandbox-secret-token")
+    repository = InMemoryLatestResultRepository()
+
+    outcomes = run_scheduled_stock_benchmark_refresh(
+        repository=repository,
+        history_repository=InMemoryObservationHistoryRepository(),
+        acquisition_attempt_repository=InMemoryAcquisitionAttemptRepository(),
+        historical_skew_repository=_RecordingHistoricalSkewRepository(),
+        now=NOW,
+    )
+
+    assert {(item.signal_id, item.symbol) for item in outcomes} == set(STOCK_BENCHMARK_UNIVERSE)
+    assert all(item.error is None for item in outcomes)
+    assert all(item.outcome != "missing_data" for item in outcomes)
+
+    b001 = repository.get_one("B001", "SPY")
+    assert b001 is not None
+    assert b001.verdict == "PASS"
+
+    b002 = repository.get_one("B002", "SPY")
+    assert b002 is not None
+    assert b002.verdict == "PASS"
+    assert b002.metrics["sma_10m_completed_months"].native() == Decimal("405.5")

--- a/tests/asa/test_screening_routes.py
+++ b/tests/asa/test_screening_routes.py
@@ -84,19 +84,27 @@ def _auth(token: str = "correct-token") -> dict[str, str]:
 
 def test_strategy_health_exposes_all_registered_production_funnels() -> None:
     repository = InMemoryLatestResultRepository()
-    for signal in ("forward_factor", "earnings_calendar", "skew_momentum"):
+    seeded_signals = ("forward_factor", "earnings_calendar", "skew_momentum")
+    for signal in seeded_signals:
         repository.upsert(_record(signal, "AAPL"))
 
     response = _client(repository).get("/api/v1/screening-health", headers=_auth())
 
     assert response.status_code == 200
     funnels = {item["strategy_id"]: item for item in response.json()["strategies"]}
-    assert set(funnels) == {"forward_factor", "earnings_calendar", "skew_momentum"}
-    assert all(item["active_subjects"] == 1 for item in funnels.values())
-    assert all(item["evaluated"] == 1 for item in funnels.values())
-    assert all(item["missing_data"] == 0 for item in funnels.values())
-    assert all(item["no_signal"] == 0 for item in funnels.values())
-    assert all(item["typed_rejection_counts"] for item in funnels.values())
+    assert set(funnels) == {
+        "B001",
+        "B002",
+        "earnings_calendar",
+        "forward_factor",
+        "skew_momentum",
+    }
+    seeded_funnels = {signal_id: funnels[signal_id] for signal_id in seeded_signals}
+    assert all(item["active_subjects"] == 1 for item in seeded_funnels.values())
+    assert all(item["evaluated"] == 1 for item in seeded_funnels.values())
+    assert all(item["missing_data"] == 0 for item in seeded_funnels.values())
+    assert all(item["no_signal"] == 0 for item in seeded_funnels.values())
+    assert all(item["typed_rejection_counts"] for item in seeded_funnels.values())
 
 
 def test_strategy_health_distinguishes_missing_data_from_no_signal() -> None:
@@ -179,7 +187,13 @@ class TestCapabilities:
         response = _client().get("/api/v1/capabilities", headers=_auth())
         assert response.status_code == 200
         signal_ids = {item["signal_id"] for item in response.json()["signals"]}
-        assert signal_ids == {"earnings_calendar", "forward_factor", "skew_momentum"}
+        assert signal_ids == {
+            "B001",
+            "B002",
+            "earnings_calendar",
+            "forward_factor",
+            "skew_momentum",
+        }
 
     def test_each_signal_declares_required_capabilities(self) -> None:
         response = _client().get("/api/v1/capabilities", headers=_auth())

--- a/tests/strategies/test_stock_benchmark_evaluation.py
+++ b/tests/strategies/test_stock_benchmark_evaluation.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from strategies.stock_benchmark_evaluation import evaluate_b001, evaluate_b002
+from strategies.stock_benchmark_knowledge import B001Payload, B002Payload
+
+
+def test_b001_is_always_pass_once_reached() -> None:
+    assert evaluate_b001(B001Payload(Decimal("560.25"))) == "PASS"
+
+
+def test_b002_is_pass_strictly_above_sma() -> None:
+    payload = B002Payload(price=Decimal("410"), sma_10m=Decimal("400"))
+    assert evaluate_b002(payload) == "PASS"
+
+
+def test_b002_is_no_signal_at_or_below_sma() -> None:
+    at_sma = B002Payload(price=Decimal("400"), sma_10m=Decimal("400"))
+    below_sma = B002Payload(price=Decimal("390"), sma_10m=Decimal("400"))
+    assert evaluate_b002(at_sma) == "NO_SIGNAL"
+    assert evaluate_b002(below_sma) == "NO_SIGNAL"

--- a/tests/strategies/test_stock_benchmark_knowledge.py
+++ b/tests/strategies/test_stock_benchmark_knowledge.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from domain import (
+    AdjustedCloseBasis,
+    CanonicalFact,
+    CanonicalInstrumentIdentity,
+    Confidence,
+    Instrument,
+    InstrumentKind,
+    OHLCVBar,
+    Provenance,
+    UnknownReason,
+)
+from facts.canonical_projection import canonical_fact_id
+from strategies.stock_benchmark_knowledge import (
+    B001Payload,
+    B002Payload,
+    build_b001_knowledge_mapping,
+    build_b002_knowledge_mapping,
+)
+
+NOW = datetime(2026, 9, 5, 15, 0, tzinfo=UTC)
+_INSTRUMENT = Instrument(
+    CanonicalInstrumentIdentity("figi", "figi-SPY"), InstrumentKind.EQUITY, "SPY", "USD"
+)
+
+
+def _fact(fact_id: str, fact_type: str, value: object) -> CanonicalFact:
+    return CanonicalFact(
+        fact_id,
+        1,
+        fact_type,
+        value,
+        Confidence(1.0),
+        Provenance(("observation",), ("provider",), "provider", (), NOW),
+        NOW,
+        NOW,
+    )
+
+
+def _month_end_bar(months_back: int, *, adjusted_close: Decimal | None) -> OHLCVBar:
+    total_months = NOW.year * 12 + (NOW.month - 1) - months_back
+    year, month = divmod(total_months, 12)
+    end_at = datetime(year, month + 1, 15, 12, 0, tzinfo=UTC)
+    start_at = end_at - timedelta(days=1)
+    close = Decimal("400") + Decimal(months_back)
+    basis = AdjustedCloseBasis.SPLIT_ADJUSTED if adjusted_close is not None else None
+    return OHLCVBar(
+        _INSTRUMENT,
+        86400,
+        start_at,
+        end_at,
+        close,
+        close + Decimal("2"),
+        close - Decimal("2"),
+        close,
+        Decimal("1000000"),
+        adjusted_close,
+        basis,
+    )
+
+
+def _ten_completed_months() -> tuple[OHLCVBar, ...]:
+    return tuple(
+        _month_end_bar(months_back, adjusted_close=Decimal("400") + months_back)
+        for months_back in range(1, 11)
+    )
+
+
+class TestB001KnowledgeMapping:
+    def test_payload_carries_the_projected_price(self) -> None:
+        digest = "snapshot-digest"
+        mapping = build_b001_knowledge_mapping(
+            subject="SPY", quote_observation_id="quote-1", price=Decimal("560.25")
+        )
+        (request,) = mapping.canonical_fact_requests
+        fact = _fact(
+            canonical_fact_id(request.fact_type, request.subject, digest),
+            request.fact_type,
+            request.value,
+        )
+
+        derived_requests = mapping.compute_derived_fact_requests((fact,))
+        assert derived_requests == ()
+
+        from analytics.features import DerivedFactSet
+
+        payload = mapping.build_payload((fact,), DerivedFactSet(()))
+        assert payload == B001Payload(Decimal("560.25"))
+
+
+class TestB002KnowledgeMapping:
+    def _facts(self, digest: str, bars: tuple[OHLCVBar, ...], price: Decimal = Decimal("560.25")):
+        mapping = build_b002_knowledge_mapping(
+            subject="SPY",
+            snapshot_digest=digest,
+            quote_observation_id="quote-1",
+            price=price,
+            bars_observation_id="bars-1",
+            bars=bars,
+            as_of=NOW,
+        )
+        facts = tuple(
+            _fact(
+                canonical_fact_id(request.fact_type, request.subject, digest),
+                request.fact_type,
+                request.value,
+            )
+            for request in mapping.canonical_fact_requests
+        )
+        return mapping, facts
+
+    def test_sufficient_history_materializes_sma_and_builds_payload(self) -> None:
+        digest = "snapshot-digest"
+        mapping, facts = self._facts(digest, _ten_completed_months())
+
+        derived_requests = mapping.compute_derived_fact_requests(facts)
+        assert not isinstance(derived_requests, UnknownReason)
+        assert len(derived_requests) == 1
+
+        from analytics.derived_fact_materialization import materialize_derived_fact
+        from analytics.derived_facts import DERIVED_FACT_REGISTRY
+        from analytics.features import DerivedFactSet
+
+        (request,) = derived_requests
+        derived = DerivedFactSet(
+            (
+                materialize_derived_fact(
+                    DERIVED_FACT_REGISTRY,
+                    request.feature_id,
+                    request.subject,
+                    digest,
+                    value=request.value,
+                    unit=request.unit,
+                    effective_time=NOW,
+                    input_evidence=request.input_evidence,
+                    quality_status=request.quality_status,
+                    parameters=request.parameters,
+                ),
+            )
+        )
+        payload = mapping.build_payload(facts, derived)
+        assert isinstance(payload, B002Payload)
+        assert payload.price == Decimal("560.25")
+        # Mean of 401..410 == 405.5
+        assert payload.sma_10m == Decimal("405.5")
+
+    def test_insufficient_history_is_a_typed_unknown_not_a_raw_close_fallback(self) -> None:
+        digest = "snapshot-digest"
+        nine_months = tuple(
+            _month_end_bar(months_back, adjusted_close=Decimal("400") + months_back)
+            for months_back in range(1, 10)
+        )
+        mapping, facts = self._facts(digest, nine_months)
+
+        result = mapping.compute_derived_fact_requests(facts)
+
+        assert result == UnknownReason("insufficient_adjusted_history")
+
+    def test_missing_adjusted_close_is_a_typed_unknown(self) -> None:
+        digest = "snapshot-digest"
+        bars = tuple(
+            _month_end_bar(months_back, adjusted_close=None) for months_back in range(1, 11)
+        )
+        mapping, facts = self._facts(digest, bars)
+
+        result = mapping.compute_derived_fact_requests(facts)
+
+        assert result == UnknownReason("insufficient_adjusted_history")

--- a/tests/strategies/test_stock_benchmark_planning.py
+++ b/tests/strategies/test_stock_benchmark_planning.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from domain import DemandExpansion, MarketCapability
+from strategies.stock_benchmark_planning import (
+    b001_bootstrap_demands,
+    b001_resolved_field_requirements,
+    b002_bootstrap_demands,
+    b002_resolved_field_requirements,
+    no_op_expand,
+)
+
+NOW = datetime(2026, 9, 5, 15, 0, tzinfo=UTC)
+
+
+def test_b001_bootstrap_demands_is_quote_only() -> None:
+    demands = b001_bootstrap_demands(NOW)
+    assert len(demands) == 1
+    assert demands[0].capability is MarketCapability.REAL_TIME_QUOTE_V1
+
+
+def test_b002_bootstrap_demands_is_quote_and_bars() -> None:
+    demands = b002_bootstrap_demands(NOW)
+    capabilities = {demand.capability for demand in demands}
+    assert capabilities == {
+        MarketCapability.REAL_TIME_QUOTE_V1,
+        MarketCapability.HISTORICAL_BARS_V1,
+    }
+
+
+def test_no_op_expand_never_adds_a_second_phase() -> None:
+    assert no_op_expand({}) == DemandExpansion()
+
+
+def test_resolved_field_requirements_declare_only_what_each_benchmark_needs() -> None:
+    assert set(b001_resolved_field_requirements()) == {MarketCapability.REAL_TIME_QUOTE_V1}
+    assert set(b002_resolved_field_requirements()) == {
+        MarketCapability.REAL_TIME_QUOTE_V1,
+        MarketCapability.HISTORICAL_BARS_V1,
+    }

--- a/tests/strategy_runtime/adapters/test_registry.py
+++ b/tests/strategy_runtime/adapters/test_registry.py
@@ -1,6 +1,8 @@
 """SPRINT-009/EPIC-9: all three EPIC-7 migration targets registered
 together -- directly checking this sprint's own "three production
-strategies execute through one shared runtime" success criterion.
+strategies execute through one shared runtime" success criterion. Extended
+by STOCK-RUNTIME-001 STK-03: B001/B002 join the same shared registry
+without disturbing the original three's own identities.
 """
 
 from __future__ import annotations
@@ -10,7 +12,13 @@ from strategy_runtime.adapters import build_migrated_strategy_registry
 
 def test_all_three_migration_targets_are_registered() -> None:
     registry = build_migrated_strategy_registry()
-    assert registry.strategy_ids() == ("earnings_calendar", "forward_factor", "skew_momentum")
+    assert registry.strategy_ids() == (
+        "B001",
+        "B002",
+        "earnings_calendar",
+        "forward_factor",
+        "skew_momentum",
+    )
 
 
 def test_each_registered_strategy_has_a_contract_and_an_adapter() -> None:

--- a/tests/strategy_runtime/adapters/test_stock_benchmarks_subject_first.py
+++ b/tests/strategy_runtime/adapters/test_stock_benchmarks_subject_first.py
@@ -1,0 +1,308 @@
+"""STOCK-RUNTIME-001 STK-03: proves B001/B002's own preparation callbacks
+(``_prepare_b001``/``_prepare_b002``), the generic
+``compose_strategy_knowledge`` orchestrator, and the subject-first runtime
+adapters actually produce the frozen benchmark semantics
+(project/reports/STOCK-RUNTIME-001-STK-01.md):
+
+- B001: usable quote -> PASS/BUY; unusable quote -> typed UnknownReason
+  (surfaced generically as MISSING_DATA, never reached by the adapter).
+- B002: price above SMA10M -> PASS/BUY; at or below -> NO_SIGNAL; fewer
+  than ten completed months of adjusted-close history -> typed
+  UnknownReason, never a raw-close fallback.
+- Deterministic replay: composing the same sealed snapshot twice produces
+  byte-identical facts, proving SMA10M is computed from sealed evidence,
+  never a fresh provider call.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from domain import (
+    AdjustedCloseBasis,
+    CompletenessMetadata,
+    EvidenceKind,
+    EvidenceReference,
+    FreshnessMetadata,
+    FreshnessStatus,
+    MarketCapability,
+    MarketDataRequestContext,
+    MarketDataSubject,
+    MarketDataSubjectType,
+    MarketObservation,
+    OHLCVBar,
+    OHLCVSeries,
+    ProviderProvenance,
+    Quote,
+    UnknownReason,
+    market_observation_identity,
+)
+from market_data.fulfillment import (
+    CapabilityFulfillmentResult,
+    FulfillmentStatus,
+    ProviderFulfillmentAttempt,
+)
+from market_data.providers import (
+    CapabilityRequest,
+    ProviderIdentity,
+    ProviderMetadata,
+    ProviderStatus,
+)
+from market_data.resolution import ResolutionPolicy
+from market_data.subject_snapshot import seal_subject_snapshot
+from strategy_runtime.adapters.stock_benchmarks import B001_CONTRACT, B002_CONTRACT
+from strategy_runtime.adapters.stock_benchmarks_subject_first import (
+    _prepare_b001,
+    _prepare_b002,
+    build_b001_subject_first_adapter,
+    build_b002_subject_first_adapter,
+)
+from strategy_runtime.context import RuntimeContext
+from strategy_runtime.knowledge_composition import compose_strategy_knowledge
+from strategy_runtime.knowledge_registry import KnowledgeCompositionRegistry
+from strategy_runtime.result import EvaluationState
+from tests.domain.test_financial_contracts import security
+
+NOW = datetime(2026, 9, 5, 15, 0, tzinfo=UTC)
+SYMBOL = "SPY"
+_INSTRUMENT = security(SYMBOL).instrument
+_EVIDENCE = (EvidenceReference(EvidenceKind.OBSERVATION, "instrument-reference:SPY"),)
+_RESOLUTION_POLICY = {
+    MarketCapability.REAL_TIME_QUOTE_V1: ResolutionPolicy("v1", ("tradier",), 3600, ("last",)),
+    MarketCapability.HISTORICAL_BARS_V1: ResolutionPolicy("v1", ("tradier",), 3600, ("close",)),
+}
+_PROVIDER_METADATA = tuple(
+    ProviderMetadata(
+        ProviderIdentity("tradier", "test_provider", "v1"), (capability,), (), (capability,), "v1"
+    )
+    for capability in _RESOLUTION_POLICY
+)
+
+
+def _quote(price: Decimal | None) -> Quote:
+    if price is None:
+        # Quote requires at least one of bid/ask/last -- an "unusable"
+        # quote for these benchmarks (which only ever read .last) is one
+        # with a bid/ask but no last trade, not an impossible all-None
+        # quote the domain model itself refuses to construct.
+        return Quote(_INSTRUMENT, Decimal("1"), Decimal("2"), None, None, None, None, "USD")
+    return Quote(_INSTRUMENT, None, None, price, None, None, None, "USD")
+
+
+def _month_end_bar(months_back: int, *, adjusted_close: Decimal | None) -> OHLCVBar:
+    total_months = NOW.year * 12 + (NOW.month - 1) - months_back
+    year, month = divmod(total_months, 12)
+    end_at = datetime(year, month + 1, 15, 12, 0, tzinfo=UTC)
+    start_at = end_at - timedelta(days=1)
+    close = Decimal("400") + Decimal(months_back)
+    basis = AdjustedCloseBasis.SPLIT_ADJUSTED if adjusted_close is not None else None
+    return OHLCVBar(
+        _INSTRUMENT,
+        86400,
+        start_at,
+        end_at,
+        close,
+        close + Decimal("2"),
+        close - Decimal("2"),
+        close,
+        Decimal("1000000"),
+        adjusted_close,
+        basis,
+    )
+
+
+def _ten_completed_months(*, price_above_sma: bool) -> tuple[OHLCVBar, ...]:
+    # Ascending adjusted closes 401..410 -> mean (SMA10M) == 405.5.
+    return tuple(
+        _month_end_bar(months_back, adjusted_close=Decimal("400") + months_back)
+        for months_back in range(1, 11)
+    )
+
+
+def _subject(capability: MarketCapability, required_fields: tuple[str, ...]) -> MarketDataSubject:
+    return MarketDataSubject(
+        _INSTRUMENT,
+        MarketDataSubjectType.INSTRUMENT,
+        capability,
+        MarketDataRequestContext(NOW, NOW, required_fields, (), _EVIDENCE),
+    )
+
+
+def _observation(
+    capability: MarketCapability, required_fields: tuple[str, ...], value: object
+) -> MarketObservation:
+    subject = _subject(capability, required_fields)
+    identity = market_observation_identity("tradier", capability, subject, NOW, value, "v1")
+    return MarketObservation(
+        identity,
+        capability,
+        subject,
+        NOW,
+        NOW,
+        value,
+        "v1",
+        ProviderProvenance("tradier", "tradier-request", _EVIDENCE),
+        FreshnessMetadata(NOW, NOW, 3600, 0, FreshnessStatus.FRESH),
+        CompletenessMetadata(required_fields, required_fields, ()),
+    )
+
+
+def _single_result(
+    capability: MarketCapability, required_fields: tuple[str, ...], value: object
+) -> CapabilityFulfillmentResult:
+    observation = _observation(capability, required_fields, value)
+    request = CapabilityRequest(capability, (observation.subject,), NOW, NOW, required_fields, 3600)
+    attempt = ProviderFulfillmentAttempt(
+        "tradier", 1, ProviderStatus.AVAILABLE, (observation,), None, ()
+    )
+    return CapabilityFulfillmentResult(
+        request, FulfillmentStatus.FULFILLED, "tradier", (observation,), (attempt,), True
+    )
+
+
+def _b001_snapshot(*, price: Decimal | None):
+    quote_result = _single_result(MarketCapability.REAL_TIME_QUOTE_V1, ("last",), _quote(price))
+    return seal_subject_snapshot(
+        (quote_result,),
+        as_of=NOW,
+        required_capabilities=(MarketCapability.REAL_TIME_QUOTE_V1,),
+        resolution_policy_by_capability=_RESOLUTION_POLICY,
+        provider_metadata=(_PROVIDER_METADATA[0],),
+    )
+
+
+def _b002_snapshot(*, price: Decimal | None, bars: tuple[OHLCVBar, ...]):
+    quote_result = _single_result(MarketCapability.REAL_TIME_QUOTE_V1, ("last",), _quote(price))
+    bars_result = _single_result(
+        MarketCapability.HISTORICAL_BARS_V1,
+        ("close",),
+        OHLCVSeries(_INSTRUMENT, 86400, NOW, bars),
+    )
+    return seal_subject_snapshot(
+        (quote_result, bars_result),
+        as_of=NOW,
+        required_capabilities=(
+            MarketCapability.REAL_TIME_QUOTE_V1,
+            MarketCapability.HISTORICAL_BARS_V1,
+        ),
+        resolution_policy_by_capability=_RESOLUTION_POLICY,
+        provider_metadata=_PROVIDER_METADATA,
+    )
+
+
+class TestB001PrepareAndAdapter:
+    def test_usable_quote_produces_pass_and_buy(self) -> None:
+        snapshot = _b001_snapshot(price=Decimal("560.25"))
+        mapping = _prepare_b001(snapshot, {}, (), SYMBOL)
+        assert not isinstance(mapping, UnknownReason)
+
+        registry = KnowledgeCompositionRegistry((("B001", mapping),))
+        knowledge = compose_strategy_knowledge(snapshot, registry, "B001", subject=SYMBOL)
+        assert not isinstance(knowledge, UnknownReason)
+
+        adapter = build_b001_subject_first_adapter({SYMBOL: knowledge})
+        context = RuntimeContext(
+            contract=B001_CONTRACT, subject=SYMBOL, clock=_Clock(), run_id="run-1"
+        )
+        result = adapter(context)
+
+        assert result.verdict == "PASS"
+        assert result.evaluation_state is EvaluationState.PASS
+        assert result.opportunity_id is None
+        assert result.lifecycle_stage is None
+        assert result.metrics["price"].native() == Decimal("560.25")
+        assert result.metrics["direction"].native() == "BUY"
+
+    def test_unusable_quote_is_a_typed_unknown_not_a_fabricated_result(self) -> None:
+        snapshot = _b001_snapshot(price=None)
+        mapping = _prepare_b001(snapshot, {}, (), SYMBOL)
+        assert isinstance(mapping, UnknownReason)
+        assert mapping.code == "unusable_quote"
+
+
+class TestB002PrepareAndAdapter:
+    def _knowledge(self, *, price: Decimal, bars: tuple[OHLCVBar, ...]):
+        snapshot = _b002_snapshot(price=price, bars=bars)
+        mapping = _prepare_b002(snapshot, {}, (), SYMBOL)
+        assert not isinstance(mapping, UnknownReason)
+        registry = KnowledgeCompositionRegistry((("B002", mapping),))
+        knowledge = compose_strategy_knowledge(snapshot, registry, "B002", subject=SYMBOL)
+        return snapshot, knowledge
+
+    def test_price_above_sma_is_pass_and_buy(self) -> None:
+        bars = _ten_completed_months(price_above_sma=True)
+        _snapshot, knowledge = self._knowledge(price=Decimal("450"), bars=bars)
+        assert not isinstance(knowledge, UnknownReason)
+
+        adapter = build_b002_subject_first_adapter({SYMBOL: knowledge})
+        context = RuntimeContext(
+            contract=B002_CONTRACT, subject=SYMBOL, clock=_Clock(), run_id="run-1"
+        )
+        result = adapter(context)
+
+        assert result.verdict == "PASS"
+        assert result.evaluation_state is EvaluationState.PASS
+        assert result.metrics["sma_10m_completed_months"].native() == Decimal("405.5")
+        assert result.metrics["direction"].native() == "BUY"
+
+    def test_price_at_or_below_sma_is_no_signal_without_direction(self) -> None:
+        bars = _ten_completed_months(price_above_sma=False)
+        _snapshot, knowledge = self._knowledge(price=Decimal("405.5"), bars=bars)
+        assert not isinstance(knowledge, UnknownReason)
+
+        adapter = build_b002_subject_first_adapter({SYMBOL: knowledge})
+        context = RuntimeContext(
+            contract=B002_CONTRACT, subject=SYMBOL, clock=_Clock(), run_id="run-1"
+        )
+        result = adapter(context)
+
+        assert result.verdict == "NO_SIGNAL"
+        assert result.evaluation_state is EvaluationState.NO_SIGNAL
+        assert "direction" not in result.metrics
+
+    def test_insufficient_adjusted_history_is_a_typed_unknown_never_a_raw_close_fallback(
+        self,
+    ) -> None:
+        nine_months = tuple(
+            _month_end_bar(months_back, adjusted_close=Decimal("400") + months_back)
+            for months_back in range(1, 10)
+        )
+        snapshot = _b002_snapshot(price=Decimal("450"), bars=nine_months)
+        mapping = _prepare_b002(snapshot, {}, (), SYMBOL)
+        assert not isinstance(mapping, UnknownReason)
+
+        registry = KnowledgeCompositionRegistry((("B002", mapping),))
+        result = compose_strategy_knowledge(snapshot, registry, "B002", subject=SYMBOL)
+
+        assert isinstance(result, UnknownReason)
+        assert result.code == "insufficient_adjusted_history"
+
+    def test_unusable_quote_is_a_typed_unknown(self) -> None:
+        bars = _ten_completed_months(price_above_sma=True)
+        snapshot = _b002_snapshot(price=None, bars=bars)
+        mapping = _prepare_b002(snapshot, {}, (), SYMBOL)
+        assert isinstance(mapping, UnknownReason)
+        assert mapping.code == "unusable_quote"
+
+    def test_replay_from_the_same_sealed_snapshot_is_deterministic(self) -> None:
+        bars = _ten_completed_months(price_above_sma=True)
+        snapshot, first = self._knowledge(price=Decimal("450"), bars=bars)
+        mapping = _prepare_b002(snapshot, {}, (), SYMBOL)
+        assert not isinstance(mapping, UnknownReason)
+        registry = KnowledgeCompositionRegistry((("B002", mapping),))
+        second = compose_strategy_knowledge(snapshot, registry, "B002", subject=SYMBOL)
+
+        assert not isinstance(first, UnknownReason)
+        assert not isinstance(second, UnknownReason)
+        assert first.payload == second.payload
+        assert (
+            first.derived_facts.facts[0].derived_fact_id
+            == second.derived_facts.facts[0].derived_fact_id
+        )
+        assert first.derived_facts.facts[0].value == second.derived_facts.facts[0].value
+
+
+class _Clock:
+    def now(self) -> datetime:
+        return NOW


### PR DESCRIPTION
## Summary

- Implements B001 (SPY buy-and-hold) and B002 (SPY 10-month SMA trend) through the existing subject-first universal strategy runtime: provider-blind demands, knowledge mapping, pure evaluation, and a `StructureKind.NONE`/`NO_LIFECYCLE` subject-first adapter — the smallest existing adapter shape in the repo (no manifest, no graph evaluation, no option resolver).
- Wires both into the shared composition root (`strategy_runtime/adapters/__init__.py`) alongside the three existing migrated strategies: registry, shadow registry, resolution policy, signal catalog, cutover policy (authoritative from day one — there is no legacy adapter to shadow against).
- Adds a dedicated `run_scheduled_stock_benchmark_refresh()` entry point and `STOCK_BENCHMARK_UNIVERSE` constant in `asa/scheduled_screening.py`, deliberately **not** folded into `PRODUCTION_SCREENING_UNIVERSE` or the SP500 cohort-claim path — both are pinned by existing fixture-driven tests built around a single-bar HISTORICAL_BARS_V1 fixture with no adjusted-close evidence, structurally unable to satisfy B002's ten-completed-month requirement.
- Widens `compute_sma_10m_completed_months`'s parameter from concrete `OHLCVBar` to a structural `AdjustedCloseBarLike` Protocol (a raw `OHLCVBar` cannot be projected through canonical-fact normalization directly — `CanonicalFact.value` must be an immutable normalized scalar/tuple). Every real `OHLCVBar` still satisfies it unchanged.
- Updates two pinned composition-root tests (`test_registry.py`, `test_migrated_strategy_acquisition_blindness.py`) to expect five registered strategies instead of three.

Full rationale and verification detail in `project/reports/STOCK-RUNTIME-001-STK-03.md`.

## Test plan

- [x] `ruff check` clean on every new/modified file
- [x] `mypy` clean on every new/modified production file
- [x] New unit tests: planning demands, evaluation verdicts, knowledge-mapping (including insufficient-history/missing-adjusted-close typed-unknown paths)
- [x] New integration tests: sealed-snapshot `compose_strategy_knowledge` proof for B001/B002 (PASS/BUY, NO_SIGNAL boundary, unusable-quote and insufficient-history typed unknowns, deterministic replay)
- [x] New end-to-end test: `run_scheduled_stock_benchmark_refresh` through real acquisition → resolution → sealed snapshot → composition → adapter → persistence, against a purpose-built adjusted-close fixture provider
- [x] Full local regression sweep: 824 passed (`tests/strategies`, `tests/strategy_runtime`, `tests/architecture`, `tests/analytics`, relevant `tests/market_data`/`tests/domain`) — only pre-existing, unrelated Windows-locale failures in `test_market_data_platform_contract.py` (confirmed identical on clean `main`)
- [x] No migration, no schema change, no scope beyond STK-03

🤖 Generated with [Claude Code](https://claude.com/claude-code)