### PR TITLE
STK-04: mask broker account numbers, add per-account holdings status

### DIFF
--- a/asa/api/models.py
+++ b/asa/api/models.py
@@ -8,6 +8,7 @@ from asa.application.portfolio_structures import project_option_structures
 from asa.application.portfolio_use_cases import PublishedPortfolioView
 from asa.application.portfolio_valuation import project_portfolio_valuation
 from asa.contracts.market import MarketObservation
+from asa.contracts.portfolio import mask_account_identifier
 from asa.contracts.runs import PublicationRecord, RunRecord
 
 
@@ -139,6 +140,8 @@ class AccountResponse(BaseModel):
     buying_power: Decimal | None
     account_value: Decimal | None
     observed_at: datetime
+    holdings_status: str
+    holdings_as_of: datetime
 
 
 class EquityPositionResponse(BaseModel):
@@ -241,7 +244,23 @@ class PortfolioEnvelope(BaseModel):
                 equity_position_count=view.equity_position_count,
                 option_leg_count=view.option_leg_count,
                 accounts=[
-                    AccountResponse.model_validate(account, from_attributes=True)
+                    AccountResponse(
+                        id=account.id,
+                        external_account_id=mask_account_identifier(
+                            account.external_account_id
+                        ),
+                        provider=account.provider,
+                        account_type=account.account_type,
+                        display_name=account.display_name,
+                        currency=account.currency,
+                        cash_balance=account.cash_balance,
+                        cash_available_for_withdrawal=account.cash_available_for_withdrawal,
+                        buying_power=account.buying_power,
+                        account_value=account.account_value,
+                        observed_at=account.observed_at,
+                        holdings_status=view.account_holdings[account.id].status.value,
+                        holdings_as_of=view.account_holdings[account.id].as_of,
+                    )
                     for account in snapshot.accounts
                 ],
             ),

--- a/asa/application/portfolio_use_cases.py
+++ b/asa/application/portfolio_use_cases.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TypeVar
@@ -16,6 +16,7 @@ from asa.application.ports.portfolio_lifecycle import PortfolioLifecycleReposito
 from asa.application.ports.runs import RunPublicationRepository
 from asa.contracts.market import FreshnessStatus
 from asa.contracts.portfolio import (
+    AccountHoldingsSummary,
     BrokerAccount,
     EquityPosition,
     OptionPositionLeg,
@@ -23,6 +24,8 @@ from asa.contracts.portfolio import (
     PortfolioSnapshot,
     PositionSide,
     PublishedPortfolio,
+    account_holdings_status,
+    mask_account_identifier,
     validate_snapshot,
 )
 from asa.contracts.runs import PublicationRecord, RunRecord, RunStatus, RunStepName
@@ -48,6 +51,7 @@ class PublishedPortfolioView:
     account_count: int
     equity_position_count: int
     option_leg_count: int
+    account_holdings: Mapping[UUID, AccountHoldingsSummary]
 
 
 class RunPortfolioIntelligence:
@@ -127,7 +131,11 @@ class RunPortfolioIntelligence:
         if accounts.provider != positions.provider:
             raise ValueError("broker account and position providers must match")
         self._repository.complete_step(run_id, step, self._clock())
-        account_id = accounts.accounts[0].external_account_id if accounts.accounts else None
+        account_id = (
+            mask_account_identifier(accounts.accounts[0].external_account_id)
+            if accounts.accounts
+            else None
+        )
         self._log_step(run_id, step, accounts.provider, account_id)
         return accounts, positions
 
@@ -246,22 +254,41 @@ class PublishedPortfolioQuery:
         latest_run = self._repository.latest_run()
         if run is None or latest_run is None:
             raise RuntimeError("published portfolio has incomplete run provenance")
+        now = self._clock()
         freshness = (
             FreshnessStatus.FRESH
-            if publication.snapshot.observed_at >= self._clock() - self._fresh_for
+            if publication.snapshot.observed_at >= now - self._fresh_for
             else FreshnessStatus.STALE
         )
+        serving_last_success = (
+            latest_run.id != run.id and latest_run.status is RunStatus.FAILED
+        )
+        accounts_with_positions = {
+            position.account_id for position in publication.snapshot.equity_positions
+        } | {leg.account_id for leg in publication.snapshot.option_legs}
+        account_holdings = {
+            account.id: AccountHoldingsSummary(
+                status=account_holdings_status(
+                    account_observed_at=account.observed_at,
+                    has_positions=account.id in accounts_with_positions,
+                    now=now,
+                    fresh_for=self._fresh_for,
+                    serving_last_success=serving_last_success,
+                ),
+                as_of=account.observed_at,
+            )
+            for account in publication.snapshot.accounts
+        }
         return PublishedPortfolioView(
             publication=publication,
             run=run,
             latest_run=latest_run,
             freshness_status=freshness,
-            serving_last_success=(
-                latest_run.id != run.id and latest_run.status is RunStatus.FAILED
-            ),
+            serving_last_success=serving_last_success,
             account_count=len(publication.snapshot.accounts),
             equity_position_count=len(publication.snapshot.equity_positions),
             option_leg_count=len(publication.snapshot.option_legs),
+            account_holdings=account_holdings,
         )
 
 

--- a/asa/contracts/portfolio.py
+++ b/asa/contracts/portfolio.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from enum import StrEnum
 from uuid import UUID
@@ -13,6 +13,66 @@ class OptionType(StrEnum):
 class PositionSide(StrEnum):
     LONG = "long"
     SHORT = "short"
+
+
+class AccountHoldingsStatus(StrEnum):
+    """One account's own truthful fetch outcome (STOCK-RUNTIME-001 STK-04).
+
+    SUCCESS/SUCCESS_EMPTY are both genuine, current data -- the only
+    difference is whether this account happens to hold anything right now.
+    STALE_FALLBACK means the most recent refresh attempt failed and this is
+    the last known-good snapshot for this account; STALE means nobody has
+    refreshed recently but no refresh is known to have failed. A wholly
+    unseen portfolio (never any successful run) has no accounts to report
+    a per-account status for at all -- that case surfaces at the portfolio
+    level (no publication exists), never fabricated here.
+    """
+
+    SUCCESS = "success"
+    SUCCESS_EMPTY = "success_empty"
+    STALE_FALLBACK = "stale_fallback"
+    STALE = "stale"
+
+
+@dataclass(frozen=True, slots=True)
+class AccountHoldingsSummary:
+    status: AccountHoldingsStatus
+    as_of: datetime
+
+
+def account_holdings_status(
+    *,
+    account_observed_at: datetime,
+    has_positions: bool,
+    now: datetime,
+    fresh_for: timedelta,
+    serving_last_success: bool,
+) -> AccountHoldingsStatus:
+    """Pure derivation from already-known evidence -- no acquisition, no
+    clock read, no fabricated failure isolation the underlying single-call
+    broker fetch doesn't actually support (see project/reports/
+    STOCK-RUNTIME-001-STK-04.md).
+    """
+    if account_observed_at >= now - fresh_for:
+        if has_positions:
+            return AccountHoldingsStatus.SUCCESS
+        return AccountHoldingsStatus.SUCCESS_EMPTY
+    if serving_last_success:
+        return AccountHoldingsStatus.STALE_FALLBACK
+    return AccountHoldingsStatus.STALE
+
+
+def mask_account_identifier(value: str) -> str:
+    """Never expose a raw broker account identifier outside the system
+    boundary (API responses, application logs) -- at most the last four
+    characters survive, matching the masking convention brokerages
+    themselves use. Internal persistence keeps the real value: this is a
+    presentation/logging-boundary transform, not a storage change.
+    """
+    trimmed = value.strip()
+    if len(trimmed) <= 4:
+        return "*" * len(trimmed)
+    return f"{'*' * (len(trimmed) - 4)}{trimmed[-4:]}"
 
 
 @dataclass(frozen=True, slots=True)

--- a/project/reports/STOCK-RUNTIME-001-STK-04.md
+++ b/project/reports/STOCK-RUNTIME-001-STK-04.md
@@ -1,0 +1,123 @@
+# STOCK-RUNTIME-001 — STK-04 reuse-gap audit and bounded delta
+
+## Audit summary
+
+ASA already has a substantial, Founder-authorized portfolio subsystem from a
+prior sprint (`PORTFOLIO-LIFECYCLE-001`, `docs/sprints/PORTFOLIO-LIFECYCLE-001.yaml`,
+PRs #367-#384, all merged to main). Its own Gate 10 (production
+verification) is recorded as still open pending separate Founder-authorized
+deployment. Auditing against STK-04's desired semantics found:
+
+**Already present, no gap:**
+- Multi-account holdings (`PortfolioSnapshot.accounts: tuple[BrokerAccount, ...]`,
+  each position carrying its own `account_id`).
+- Normalized account type (`individual`, `roth_ira`, `traditional_ira`, ... —
+  `asa/integrations/providers/robinhood.py`'s `_BROKERAGE_ACCOUNT_TYPE_MAP`).
+- Per-position symbol, quantity, average cost basis.
+- A failed broker fetch never masquerades as an empty portfolio: an
+  exception anywhere in acquire/normalize/validate/publish always produces
+  `RunStatus.FAILED` and preserves the prior successful publication
+  (`RunPortfolioIntelligence.execute`, pinned by
+  `tests/asa/test_portfolio_acceptance.py`).
+- Latest-known-good fallback serving (`serving_last_success`) already
+  exists and is already wired through the API.
+
+**Real gaps, addressed by this ticket's bounded delta:**
+- Raw Robinhood account numbers were exposed verbatim in the
+  `/api/v1/portfolio` API response and in application logs
+  (`RunPortfolioIntelligence._log_step`'s `account_id` extra field) — a
+  genuine violation of "never expose raw account numbers... in API/UI."
+  Internal Postgres persistence of the real value is unchanged (needed for
+  cross-run account correlation; it is not an external-facing surface).
+- No explicit typed outcome distinguishing SUCCESS / SUCCESS_EMPTY /
+  stale-serving-last-known-good, and no *per-account* freshness at all —
+  `PublishedPortfolioQuery.current()` only ever produced one freshness
+  value for the entire portfolio, even though each `BrokerAccount` already
+  carries its own `observed_at`.
+
+**Explicitly not a gap — a different Founder-ratified boundary, flagged
+below rather than crossed:**
+- Current price, market value, and unrealized P&L (absolute or %) are
+  deliberately typed `UNKNOWN` for every position today
+  (`asa/application/portfolio_valuation.py`). This is not an oversight:
+  `PORTFOLIO-LIFECYCLE-001`'s own governing YAML states
+  `duplicate_live_market_data_pipeline: prohibited`, and its reuse-decision
+  doc explicitly lists "Live quote acquisition for portfolio rendering"
+  under behavior deliberately rejected. See **Blocker** below.
+
+## What was implemented
+
+- `asa/contracts/portfolio.py` — `mask_account_identifier()` (keeps at
+  most the last four characters of a broker account identifier),
+  `AccountHoldingsStatus` (`SUCCESS` / `SUCCESS_EMPTY` / `STALE_FALLBACK` /
+  `STALE`), `AccountHoldingsSummary`, and `account_holdings_status()` — a
+  pure derivation from already-known evidence (that account's own
+  `observed_at`, whether it currently holds any position, and the
+  portfolio-level `serving_last_success` flag), never a new acquisition
+  and never fabricated per-account failure isolation the underlying
+  single broker-call architecture doesn't actually support (Robinhood
+  fetch is one call returning every account at once — a genuinely
+  per-account-independent `FAILED` state does not exist prior to any
+  first success, at which point there are no accounts to enumerate a
+  status for at all; that case remains a portfolio-level 404, unchanged).
+- `asa/application/portfolio_use_cases.py` — `PublishedPortfolioQuery.current()`
+  now computes one `AccountHoldingsSummary` per account and exposes it via
+  a new `PublishedPortfolioView.account_holdings` mapping; `_acquire()`
+  masks the account identifier before it ever reaches `_log_step`'s log
+  line.
+- `asa/api/models.py` — `AccountResponse.external_account_id` is now
+  always the masked value; two new fields, `holdings_status` and
+  `holdings_as_of`, surface the per-account status and timestamp.
+  `PortfolioEnvelope.from_view` now builds each `AccountResponse`
+  explicitly (field by field) instead of a blind
+  `model_validate(account, from_attributes=True)`, since the response now
+  intentionally diverges from the domain object's own raw shape.
+
+## Verification
+
+- `tests/asa/test_portfolio_domain.py` — new tests for
+  `mask_account_identifier` (normal and short/exact-length inputs), all
+  four `account_holdings_status` branches, and a genuine two-account
+  scenario (one funded, one empty) proving `SUCCESS` and `SUCCESS_EMPTY`
+  are correctly distinguished per account. 13/13 passed (6 pre-existing +
+  7 new).
+- `ruff check asa tests/asa` and `mypy asa` (both run exactly as CI's
+  `backend` job does): clean.
+- Full local regression: `tests/asa/test_portfolio_domain.py`,
+  `test_portfolio_valuation.py`, `test_portfolio_structures.py`, and the
+  full `tests/architecture/` suite (579 passed; the only failures are the
+  pre-existing, unrelated Windows-locale `test_market_data_platform_contract.py`
+  encoding issue already documented in STK-03's own report).
+  `test_portfolio_acceptance.py` and `test_portfolio_lifecycle.py`
+  (Postgres-backed acceptance tests) and `test_robinhood_provider.py`
+  could not run locally on this Windows machine (pre-existing, unrelated
+  local-environment gaps: no local Postgres/`.env`, and a POSIX-only file
+  permission assertion) — unaffected by inspection, since neither test
+  asserts on `external_account_id`'s API-response value or constructs
+  `PublishedPortfolioView` directly, and `robinhood.py` itself was not
+  touched. These will run for real in CI (real Postgres, Linux).
+
+## Blocker — pricing authority requires explicit Founder re-authorization
+
+STK-04's own brief states: *"ASA canonical market-data authority owns
+current price where available."* Implementing that — computing real
+current price, market value, or unrealized P&L for portfolio positions —
+means wiring `market_data`/`strategy_runtime`'s canonical pricing into the
+portfolio valuation path. `PORTFOLIO-LIFECYCLE-001` (Founder-ratified,
+`AMD-013-PORTFOLIO-LIFECYCLE-001-V1.0`) explicitly prohibits exactly that:
+`duplicate_live_market_data_pipeline: prohibited`, with "Live quote
+acquisition for portfolio rendering" named as deliberately rejected
+behavior when that sprint considered and declined the same idea.
+
+This is a genuine cross-sprint governance conflict, not an implementation
+gap — proceeding either way without explicit sign-off risks either
+silently violating a standing Founder-ratified invariant, or silently
+dropping a semantic STK-04 explicitly asked for. Per STOCK-RUNTIME-001's
+own blocker criteria ("scope/governance/risk boundary must expand"),
+raising this for an explicit decision rather than choosing unilaterally.
+
+Everything else STK-04 asked for (account-aware holdings, normalized
+account type, quantity, average cost, SUCCESS/SUCCESS_EMPTY, latest-known-
+good fallback, per-account provenance with a timestamp, and never exposing
+raw account numbers) is complete above and does not depend on this
+decision.

--- a/tests/asa/test_portfolio_domain.py
+++ b/tests/asa/test_portfolio_domain.py
@@ -5,8 +5,15 @@ from uuid import uuid4
 import pytest
 
 from asa.application.portfolio_use_cases import PublishedPortfolioQuery, RunPortfolioIntelligence
+from asa.application.ports.brokers import ProviderAccount
 from asa.contracts.market import FreshnessStatus
-from asa.contracts.portfolio import PublishedPortfolio, validate_snapshot
+from asa.contracts.portfolio import (
+    AccountHoldingsStatus,
+    PublishedPortfolio,
+    account_holdings_status,
+    mask_account_identifier,
+    validate_snapshot,
+)
 from asa.contracts.runs import RunRecord, RunStatus
 from asa.integrations.providers.deterministic_fake_broker import (
     DeterministicFakeBrokerPortfolioProvider,
@@ -165,3 +172,93 @@ def test_publication_freshness_and_last_success_are_application_fields() -> None
     assert view is not None
     assert view.freshness_status is FreshnessStatus.STALE
     assert view.serving_last_success is True
+
+
+def test_mask_account_identifier_keeps_only_the_last_four_characters() -> None:
+    assert mask_account_identifier("RH-ACCOUNT-1234") == "***********1234"
+
+
+def test_mask_account_identifier_masks_entirely_when_four_characters_or_fewer() -> None:
+    assert mask_account_identifier("ab1") == "***"
+    assert mask_account_identifier("ab12") == "****"
+
+
+class TestAccountHoldingsStatus:
+    NOW = datetime(2026, 7, 19, 12, 30, tzinfo=UTC)
+    FRESH_FOR = timedelta(minutes=45)
+
+    def test_current_with_positions_is_success(self) -> None:
+        status = account_holdings_status(
+            account_observed_at=self.NOW,
+            has_positions=True,
+            now=self.NOW,
+            fresh_for=self.FRESH_FOR,
+            serving_last_success=False,
+        )
+        assert status is AccountHoldingsStatus.SUCCESS
+
+    def test_current_without_positions_is_success_empty(self) -> None:
+        status = account_holdings_status(
+            account_observed_at=self.NOW,
+            has_positions=False,
+            now=self.NOW,
+            fresh_for=self.FRESH_FOR,
+            serving_last_success=False,
+        )
+        assert status is AccountHoldingsStatus.SUCCESS_EMPTY
+
+    def test_outside_the_window_after_a_failed_refresh_is_stale_fallback(self) -> None:
+        status = account_holdings_status(
+            account_observed_at=self.NOW - timedelta(hours=2),
+            has_positions=True,
+            now=self.NOW,
+            fresh_for=self.FRESH_FOR,
+            serving_last_success=True,
+        )
+        assert status is AccountHoldingsStatus.STALE_FALLBACK
+
+    def test_outside_the_window_with_no_known_failure_is_plain_stale(self) -> None:
+        status = account_holdings_status(
+            account_observed_at=self.NOW - timedelta(hours=2),
+            has_positions=True,
+            now=self.NOW,
+            fresh_for=self.FRESH_FOR,
+            serving_last_success=False,
+        )
+        assert status is AccountHoldingsStatus.STALE
+
+
+def test_per_account_holdings_status_distinguishes_holdings_from_empty_accounts() -> None:
+    """A second, genuinely empty account (e.g. a Roth IRA with no positions
+    yet) must read SUCCESS_EMPTY, never be confused with the funded
+    taxable account's own SUCCESS -- and never with a fetch failure.
+    """
+    provider = DeterministicFakeBrokerPortfolioProvider()
+    accounts_result = provider.fetch_accounts()
+    empty_account = ProviderAccount(
+        external_account_id="roth-002",
+        connection_id="fake-connection-secondary",
+        provider=provider.name,
+        account_type="roth_ira",
+        display_name="Roth IRA",
+        currency="USD",
+        cash_balance=None,
+        cash_available_for_withdrawal=None,
+        buying_power=None,
+        account_value=None,
+        observed_at=provider.observed_at,
+    )
+    accounts_result = replace(
+        accounts_result, accounts=(*accounts_result.accounts, empty_account)
+    )
+    snapshot = RunPortfolioIntelligence._normalize(accounts_result, provider.fetch_positions())
+
+    view = publication_view_for_snapshot(snapshot, provider.observed_at)
+
+    assert view is not None
+    assert len(snapshot.accounts) == 2
+    funded = next(a for a in snapshot.accounts if a.external_account_id == "taxable-001")
+    empty = next(a for a in snapshot.accounts if a.external_account_id == "roth-002")
+    assert view.account_holdings[funded.id].status is AccountHoldingsStatus.SUCCESS
+    assert view.account_holdings[empty.id].status is AccountHoldingsStatus.SUCCESS_EMPTY
+    assert view.account_holdings[empty.id].as_of == empty.observed_at


### PR DESCRIPTION
## Summary

Reuse-gap audit against the existing `PORTFOLIO-LIFECYCLE-001` portfolio subsystem, full findings in `project/reports/STOCK-RUNTIME-001-STK-04.md`. This PR implements the bounded, uncontested delta:

- **Account-number masking**: raw Robinhood account numbers were exposed verbatim in the `/api/v1/portfolio` API response and in application logs. Now masked to at most the last four characters at both boundaries (`mask_account_identifier`). Internal Postgres persistence is unchanged (needed for cross-run correlation — this is a presentation/logging-boundary fix, not a storage change).
- **Per-account holdings provenance**: freshness was previously reported only in aggregate across the whole portfolio snapshot, even though every account already carries its own `observed_at`. `PublishedPortfolioQuery.current()` now derives a per-account `SUCCESS` / `SUCCESS_EMPTY` / `STALE_FALLBACK` / `STALE` status — pure derivation from already-known evidence, no new acquisition — surfaced via two new `AccountResponse` fields (`holdings_status`, `holdings_as_of`).

**Deliberately not touched**: current price / market value / unrealized P&L remain typed `UNKNOWN`, unchanged. `PORTFOLIO-LIFECYCLE-001`'s own Founder-ratified invariants (`duplicate_live_market_data_pipeline: prohibited`) directly conflict with this ticket's own "ASA canonical market-data authority owns current price" ask — flagged as a blocker in the report for explicit Founder resolution, not decided unilaterally.

## Test plan

- [x] New tests in `tests/asa/test_portfolio_domain.py`: `mask_account_identifier` (normal/short inputs), all four `account_holdings_status` branches, and a genuine two-account (funded + empty) scenario proving SUCCESS vs SUCCESS_EMPTY. 13/13 passed.
- [x] `ruff check asa tests/asa` and `mypy asa` (matching CI's `backend` job exactly): clean.
- [x] Full local regression: `tests/asa/test_portfolio_domain.py`, `test_portfolio_valuation.py`, `test_portfolio_structures.py`, full `tests/architecture/` (579 passed, only pre-existing unrelated Windows-locale failures already documented in STK-03).
- [x] No migration, no schema change, no broker mutation, no scope beyond the audited delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)