### PR TITLE
fix: B001/B002 BUY direction wasn't surfacing on the public API

### DIFF
--- a/strategy_runtime/adapters/stock_benchmarks_subject_first.py
+++ b/strategy_runtime/adapters/stock_benchmarks_subject_first.py
@@ -159,7 +159,13 @@ def build_b001_subject_first_adapter(
             data_quality=None,
             metrics={
                 "price": TypedValue.of_decimal(knowledge.payload.price),
-                "direction": TypedValue.of_string("BUY"),
+                # "decision.direction" is the established wire-vocabulary key
+                # every migrated strategy's own direction surfaces through
+                # (strategy_runtime/adapters/_screening_bridge.py's own
+                # explanation_metrics()) -- a bare "direction" key would
+                # populate the generic metrics dict but never the API's
+                # own top-level ScreeningResultResponse.direction field.
+                "decision.direction": TypedValue.of_string("BUY"),
             },
             economics={},
             blockers=(),
@@ -186,7 +192,7 @@ def build_b002_subject_first_adapter(
             "sma_10m_completed_months": TypedValue.of_decimal(payload.sma_10m),
         }
         if successful_pass:
-            metrics["direction"] = TypedValue.of_string("BUY")
+            metrics["decision.direction"] = TypedValue.of_string("BUY")
         return UniversalScreeningResult(
             strategy_id=_B002_STRATEGY_ID,
             strategy_version=B002_CONTRACT.version,

--- a/tests/strategy_runtime/adapters/test_stock_benchmarks_subject_first.py
+++ b/tests/strategy_runtime/adapters/test_stock_benchmarks_subject_first.py
@@ -212,7 +212,7 @@ class TestB001PrepareAndAdapter:
         assert result.opportunity_id is None
         assert result.lifecycle_stage is None
         assert result.metrics["price"].native() == Decimal("560.25")
-        assert result.metrics["direction"].native() == "BUY"
+        assert result.metrics["decision.direction"].native() == "BUY"
 
     def test_unusable_quote_is_a_typed_unknown_not_a_fabricated_result(self) -> None:
         snapshot = _b001_snapshot(price=None)
@@ -244,7 +244,7 @@ class TestB002PrepareAndAdapter:
         assert result.verdict == "PASS"
         assert result.evaluation_state is EvaluationState.PASS
         assert result.metrics["sma_10m_completed_months"].native() == Decimal("405.5")
-        assert result.metrics["direction"].native() == "BUY"
+        assert result.metrics["decision.direction"].native() == "BUY"
 
     def test_price_at_or_below_sma_is_no_signal_without_direction(self) -> None:
         bars = _ten_completed_months(price_above_sma=False)
@@ -259,7 +259,7 @@ class TestB002PrepareAndAdapter:
 
         assert result.verdict == "NO_SIGNAL"
         assert result.evaluation_state is EvaluationState.NO_SIGNAL
-        assert "direction" not in result.metrics
+        assert "decision.direction" not in result.metrics
 
     def test_insufficient_adjusted_history_is_a_typed_unknown_never_a_raw_close_fallback(
         self,


### PR DESCRIPTION
## Summary

Found while wiring the frontend Stocks tab (STK-05), which needs the public API's `direction` field to show "BUY" for a PASS verdict.

`asa/api/screening_models.py`'s `ScreeningResultResponse.direction` is derived only from a `result.metrics["decision.direction"]` key — the same wire-vocabulary key every other migrated strategy's `explanation_metrics()` populates. STK-03's B001/B002 adapters set a bare `"direction"` key instead, which landed in the generic `metrics` dict but never the top-level `direction` field — so `GET /api/v1/screening` always showed `direction: null` for B001/B002 regardless of verdict.

Fix: use `"decision.direction"` directly (matching the established convention), no manifest/graph-explanation machinery needed since B001/B002 don't use one.

## Test plan

- [x] Updated `tests/strategy_runtime/adapters/test_stock_benchmarks_subject_first.py` to assert on `metrics["decision.direction"]`
- [x] `ruff check` / `mypy` clean
- [x] `tests/strategy_runtime/adapters/test_stock_benchmarks_subject_first.py` (7/7) and `tests/asa/test_scheduled_stock_benchmark_refresh.py` (1/1) pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)