### PR TITLE
STK-05: add a Stocks tab (Portfolio + Stock Strategies) to the console

### DIFF
--- a/asa/ui/static/api-client.js
+++ b/asa/ui/static/api-client.js
@@ -46,6 +46,8 @@ export const api = Object.freeze({
   version: () => requestJson("/api/v1/version", false),
   capabilities: () => requestJson("/api/v1/capabilities"),
   strategyHealth: () => requestJson("/api/v1/screening-health"),
+  portfolio: () => requestJson("/api/v1/portfolio"),
+  positions: () => requestJson("/api/v1/positions"),
   results: () => collectCompleteScreeningState(
     (limit, offset) => requestJson(`/api/v1/screening?limit=${limit}&offset=${offset}&active_only=true`),
   ),

--- a/asa/ui/static/app.js
+++ b/asa/ui/static/app.js
@@ -76,6 +76,11 @@ async function loadPersistedState() {
     render();
     return;
   }
+  // Portfolio/positions run alongside the main screening fetch, not inside
+  // its own try/catch: an absent published portfolio (404, e.g. no
+  // successful broker run has ever completed) is a normal, distinguishable
+  // state -- never conflated with a broken screening fetch below.
+  const portfolioAndPositions = Promise.allSettled([api.portfolio(), api.positions()]);
   try {
     const [capabilities, results, strategyHealth] = await Promise.all([
       api.capabilities(), api.results(), api.strategyHealth(),
@@ -94,6 +99,9 @@ async function loadPersistedState() {
       ? "The token is missing, invalid, or the protected API is unavailable."
       : String(error.message || error);
   } finally {
+    const [portfolio, positions] = await portfolioAndPositions;
+    state.portfolio = portfolio.status === "fulfilled" ? portfolio.value.data : null;
+    state.positions = positions.status === "fulfilled" ? positions.value.data : null;
     state.loading = false;
     render();
   }
@@ -112,6 +120,8 @@ const handlers = {
     state.retainedNonactiveTotal = 0;
     state.capabilities = null;
     state.strategyHealth = null;
+    state.portfolio = null;
+    state.positions = null;
     state.error = null;
     render();
   },

--- a/asa/ui/static/render.js
+++ b/asa/ui/static/render.js
@@ -104,8 +104,13 @@ function shellHeader(model, handlers) {
 
   const nav = element("nav", "primary-nav");
   nav.setAttribute("aria-label", "Primary navigation");
-  for (const [href, label] of [["#/results", "Latest results"], ["#/health", "Runtime health"]]) {
-    const link = element("a", model.route.name === (href.includes("health") ? "health" : "results") ? "active" : "", label);
+  const primaryLinks = [
+    { href: "#/results", label: "Latest results", routeName: "results" },
+    { href: "#/stocks", label: "Stocks", routeName: "stocks" },
+    { href: "#/health", label: "Runtime health", routeName: "health" },
+  ];
+  for (const { href, label, routeName } of primaryLinks) {
+    const link = element("a", model.route.name === routeName ? "active" : "", label);
     link.href = href;
     nav.append(link);
   }
@@ -409,6 +414,157 @@ function detailView(item, handlers) {
   return fragment;
 }
 
+const STOCK_STRATEGY_SIGNAL_IDS = new Set(["B001", "B002"]);
+
+function stockPortfolioView(model) {
+  const fragment = document.createDocumentFragment();
+  const portfolio = model.portfolio;
+  if (!portfolio) {
+    fragment.append(
+      element("p", "empty-state empty-state--large", "No published portfolio is available."),
+    );
+    return fragment;
+  }
+
+  const summary = element("section", "summary-grid");
+  const summaries = [
+    ["Accounts", String(portfolio.data.account_count)],
+    ["Equity positions", String(portfolio.data.equity_position_count)],
+    ["Option legs", String(portfolio.data.option_leg_count)],
+    ["Provider", portfolio.data.provider],
+    ["Freshness", portfolio.freshness.status],
+    ["Serving last success", String(portfolio.freshness.serving_last_success)],
+  ];
+  for (const [label, value] of summaries) {
+    const card = element("article", "summary-card");
+    card.append(element("span", null, label), element("strong", null, value));
+    summary.append(card);
+  }
+  fragment.append(summary);
+
+  const grid = element("div", "health-grid");
+  for (const account of portfolio.data.accounts) {
+    const card = element("article", "health-card");
+    card.append(element("h3", null, `${account.display_name} (${account.account_type})`));
+    const badges = element("div", "badge-row");
+    badges.append(badge(account.holdings_status, "holdings"));
+    card.append(badges);
+    card.append(
+      definitionList([
+        ["Identifier", account.external_account_id],
+        ["Provider", account.provider],
+        ["Currency", account.currency],
+        [
+          "Cash balance",
+          exactValue(account, "cash_balance").text,
+          exactValue(account, "cash_balance").kind,
+        ],
+        [
+          "Buying power",
+          exactValue(account, "buying_power").text,
+          exactValue(account, "buying_power").kind,
+        ],
+        [
+          "Account value",
+          exactValue(account, "account_value").text,
+          exactValue(account, "account_value").kind,
+        ],
+        ["Holdings as of", account.holdings_as_of],
+        ["Observed", account.observed_at],
+      ]),
+    );
+    grid.append(card);
+  }
+  if (!portfolio.data.accounts.length) {
+    grid.append(element("p", "empty-state", "No accounts in the published snapshot."));
+  }
+  fragment.append(grid);
+  return fragment;
+}
+
+function stockStrategiesView(model) {
+  const fragment = document.createDocumentFragment();
+  const items = model.results.filter((item) => STOCK_STRATEGY_SIGNAL_IDS.has(item.signal_id));
+
+  const tableWrap = element("div", "table-wrap");
+  const table = element("table", "results-table");
+  const head = element("thead");
+  const headRow = element("tr");
+  for (const title of [
+    "Benchmark",
+    "Symbol",
+    "Verdict",
+    "Direction",
+    "Price",
+    "SMA 10M",
+    "Evaluated",
+    "Freshness",
+    "Usability",
+  ]) {
+    headRow.append(element("th", null, title));
+  }
+  head.append(headRow);
+  table.append(head);
+  const body = element("tbody");
+  for (const item of items) {
+    const row = element("tr");
+    const identity = element("td");
+    identity.append(resultLink(item), element("small", null, `v${item.signal_version}`));
+    row.append(identity);
+    row.append(element("td", null, item.symbol));
+    const verdict = element("td");
+    verdict.append(badge(item.verdict, "verdict"));
+    row.append(verdict);
+    row.append(element("td", null, exactValue(item, "direction").text));
+    row.append(element("td", null, exactValue(item.metrics, "price").text));
+    row.append(element("td", null, exactValue(item.metrics, "sma_10m_completed_months").text));
+    row.append(element("td", "timestamp", String(item.evaluated_at)));
+    const freshness = element("td");
+    freshness.append(badge(item.freshness_status, "freshness"));
+    row.append(freshness);
+    const usability = element("td");
+    usability.append(badge(item.usability_status, "usability"));
+    row.append(usability);
+    body.append(row);
+  }
+  table.append(body);
+  tableWrap.append(table);
+  fragment.append(tableWrap);
+  if (!items.length) {
+    fragment.append(
+      element("p", "empty-state empty-state--large", "No persisted stock-benchmark results yet."),
+    );
+  }
+  return fragment;
+}
+
+function stocksView(model) {
+  const fragment = document.createDocumentFragment();
+  const heading = element("section", "page-heading");
+  heading.append(element("p", "eyebrow", "STOCK BENCHMARKS AND HOLDINGS"));
+  heading.append(element("h2", null, "Stocks"));
+  heading.append(element("p", null, "Portfolio holdings and SPY benchmark results, read-only."));
+  fragment.append(heading);
+
+  const subnav = element("nav", "secondary-nav");
+  subnav.setAttribute("aria-label", "Stocks sections");
+  const subLinks = [
+    { href: "#/stocks/portfolio", label: "Portfolio", subview: "portfolio" },
+    { href: "#/stocks/strategies", label: "Stock strategies", subview: "strategies" },
+  ];
+  for (const { href, label, subview } of subLinks) {
+    const link = element("a", model.route.subview === subview ? "active" : "", label);
+    link.href = href;
+    subnav.append(link);
+  }
+  fragment.append(subnav);
+
+  fragment.append(
+    model.route.subview === "strategies" ? stockStrategiesView(model) : stockPortfolioView(model),
+  );
+  return fragment;
+}
+
 function healthView(model) {
   const fragment = document.createDocumentFragment();
   const heading = element("section", "page-heading");
@@ -485,6 +641,8 @@ export function renderApp(root, model, handlers) {
     else main.append(element("p", "empty-state empty-state--large", "Result not found in the persisted snapshot."));
   } else if (model.route.name === "health") {
     main.append(healthView(model));
+  } else if (model.route.name === "stocks") {
+    main.append(stocksView(model));
   } else {
     main.append(resultsView(model, handlers));
   }

--- a/asa/ui/static/state.js
+++ b/asa/ui/static/state.js
@@ -9,6 +9,8 @@ export const state = {
   resultsSnapshotIdentity: null,
   retainedNonactiveTotal: 0,
   executionReadiness: {},
+  portfolio: null,
+  positions: null,
   apiVersion: null,
   fetchedAt: null,
   loading: false,
@@ -48,6 +50,9 @@ export function routeFromHash(hash) {
   const route = (hash || "#/results").replace(/^#/, "");
   const parts = route.split("/").filter(Boolean).map(decodeURIComponent);
   if (parts[0] === "health") return { name: "health" };
+  if (parts[0] === "stocks") {
+    return { name: "stocks", subview: parts[1] === "strategies" ? "strategies" : "portfolio" };
+  }
   if (parts[0] === "results" && parts.length === 3) {
     return { name: "detail", signalId: parts[1], symbol: parts[2] };
   }

--- a/asa/ui/static/styles.css
+++ b/asa/ui/static/styles.css
@@ -37,6 +37,9 @@ h3 { font-size: 1.05rem; }
 .primary-nav a { padding: .9rem 1rem; color: var(--muted); text-decoration: none; border-bottom: 2px solid transparent; white-space: nowrap; }
 .primary-nav a.active, .primary-nav a:hover { color: var(--ink); border-color: var(--acid); }
 .primary-nav .button { margin-left: auto; }
+.secondary-nav { display: flex; gap: .25rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+.secondary-nav a { padding: .55rem .85rem; color: var(--muted); text-decoration: none; border: 1px solid var(--line); }
+.secondary-nav a.active, .secondary-nav a:hover { color: var(--ink); border-color: var(--acid); }
 .main-content { width: min(1480px, 100%); margin: 0 auto; padding: 2rem clamp(1rem, 4vw, 4.5rem) 5rem; }
 .connection-panel { display: flex; gap: 1rem; align-items: center; justify-content: space-between; padding: 1rem 1.2rem; margin-bottom: 3rem; border: 1px solid var(--line); background: color-mix(in srgb, var(--panel), transparent 10%); }
 .connection-panel h2, .connection-panel p { margin: 0; font-size: .9rem; }
@@ -67,9 +70,10 @@ input:focus, select:focus, button:focus, a:focus { outline: 2px solid var(--cyan
 .result-link:hover { text-decoration: underline; }
 .timestamp, code, pre { font-family: var(--mono); }
 .badge { display: inline-flex; align-items: center; min-height: 1.65rem; padding: .25rem .5rem; border: 1px solid var(--line); color: var(--muted); font: 700 .68rem/1 var(--mono); text-transform: uppercase; white-space: nowrap; }
-.badge--pass, .badge--pass, .badge--true, .badge--live, .badge--fresh, .badge--usable, .badge--health\:ok, .badge--readiness\:ready { border-color: #547b30; color: var(--acid); background: #192512; }
-.badge--watch, .badge--prior_session, .badge--usable_with_warning { border-color: #7b6330; color: var(--amber); background: #241f13; }
+.badge--pass, .badge--pass, .badge--true, .badge--live, .badge--fresh, .badge--usable, .badge--health\:ok, .badge--readiness\:ready, .badge--success { border-color: #547b30; color: var(--acid); background: #192512; }
+.badge--watch, .badge--prior_session, .badge--usable_with_warning, .badge--stale_fallback { border-color: #7b6330; color: var(--amber); background: #241f13; }
 .badge--fail, .badge--false, .badge--missing_data, .badge--malformed_output, .badge--strategy_exception, .badge--stale, .badge--rejected { border-color: #7e3932; color: var(--red); background: #251513; }
+.badge--success_empty { border-color: #3a4a63; color: var(--cyan); background: #101c22; }
 .badge--unknown, .badge--absent, .badge--null { border-color: #5b4b88; color: var(--unknown); background: #1d1928; }
 .mobile-results { display: none; }
 .result-card { padding: 1rem; border: 1px solid var(--line); background: var(--panel); }
@@ -129,7 +133,7 @@ input:focus, select:focus, button:focus, a:focus { outline: 2px solid var(--cyan
 @media (max-width: 560px) {
   .masthead { padding-top: 1.2rem; }
   h1 { font-size: 3.2rem; }
-  .primary-nav { display: grid; grid-template-columns: 1fr 1fr; margin-inline: 0; overflow: visible; }
+  .primary-nav { display: grid; grid-template-columns: repeat(3, 1fr); margin-inline: 0; overflow: visible; }
   .primary-nav a { padding-inline: .5rem; text-align: center; }
   .primary-nav .button { grid-column: 1 / -1; width: 100%; margin-left: 0; }
   .summary-grid, .filter-bar, .fact-grid, .gate-grid, .health-grid { grid-template-columns: 1fr; }

--- a/project/reports/STOCK-RUNTIME-001-STK-05.md
+++ b/project/reports/STOCK-RUNTIME-001-STK-05.md
@@ -1,0 +1,107 @@
+# STOCK-RUNTIME-001 — STK-05 evidence
+
+## Where "Options"/"Health" tabs actually live
+
+The ticket's premise ("add a Stocks tab alongside Options and Health") maps
+to a specific, real surface once located: `asa/ui/static/` — a
+framework-free vanilla-JS "Intelligence Console" served as static files by
+FastAPI, with its own hash router (`#/results` = the actual Options/
+strategy-results view, `#/health` = Runtime health). This is distinct from
+`frontend/` (a separate, minimal React app with no tabs at all today — just
+a single portfolio dashboard, unrelated to this ticket). All STK-05 work
+below is in `asa/ui/static/`.
+
+`asa/ui/static/`'s own automated test suite, `ui-tests/` (Node's built-in
+`node:test` + `happy-dom`), is not invoked by any GitHub Actions workflow —
+confirmed by grepping every `.github/workflows/*.yml` file. It was run
+manually for this change (`cd ui-tests && npm install && npm test`); CI
+will not catch a regression here on its own. Flagged as a follow-up, not
+fixed in this PR (out of STK-05's own scope).
+
+## What was implemented
+
+A third top-level tab, "Stocks" (`#/stocks`), with two sub-views selected
+by an explicit second hash segment:
+
+- `#/stocks/portfolio` (default) — `stockPortfolioView()`: renders
+  `GET /api/v1/portfolio`'s already-truthful per-account data (STK-04):
+  masked identifier, provider, currency, cash/buying-power/account-value
+  (typed `null` shown as an explicit `null`, never blank or fabricated
+  zero), and the per-account `holdings_status`/`holdings_as_of` STK-04
+  added. An absent publication renders "No published portfolio is
+  available." — never an empty-looking table.
+- `#/stocks/strategies` — `stockStrategiesView()`: filters the already-
+  loaded screening results to `signal_id` in `{B001, B002}` and renders
+  benchmark/version, symbol, verdict, direction, price, SMA10M, evaluated
+  timestamp, and freshness/usability — reusing the exact same `badge()`/
+  `exactValue()`/`resultLink()` helpers the existing Options results table
+  already uses, so an absent field (e.g. B001 has no SMA10M metric) reads
+  as an explicit `ABSENT`, identical to how every other strategy's gaps
+  are already shown.
+
+Generic StructureKind.NONE suppression comes for free, not from a new
+branch: clicking into a B001/B002 result reuses the existing, unmodified
+`detailView()`, whose execution-readiness section is already gated on
+`if (item.execution_assessment)` — B001/B002 simply never populate that
+field, so the option-structure/execution-readiness UI is already absent
+by construction. No `if (signal_id === "B001")` anywhere in this change.
+
+Supporting plumbing:
+- `state.js` — `routeFromHash` parses `#/stocks[/portfolio|/strategies]`;
+  `state.portfolio`/`state.positions` added.
+- `api-client.js` — `portfolio()`/`positions()` calls added (same
+  `requestJson` pattern as every other endpoint).
+- `app.js` — `loadPersistedState()` fetches portfolio/positions in
+  parallel with (not nested inside) the existing screening fetch, via its
+  own `Promise.allSettled`: an absent portfolio (404, no successful broker
+  run yet) is a normal, distinguishable state and must never be conflated
+  with a broken screening fetch by sharing one try/catch.
+- `render.js` — third primary-nav link ("Stocks"); its active-state check
+  was rewritten from a fragile `href.includes("health")` string trick to
+  an explicit `{href, label, routeName}` list (still functionally
+  equivalent for the two existing links, just no longer coincidentally
+  correct).
+- `styles.css` — `.secondary-nav` (the Portfolio/Stock strategies sub-tabs)
+  added; `.primary-nav`'s mobile grid widened from a hard-coded two-column
+  layout (which would have silently broken with a third tab) to three;
+  badge colors added for the three new `holdings_status` values not
+  already covered by an existing wire vocabulary (`success`,
+  `success_empty`; `stale_fallback` reuses the existing warning color,
+  plain `stale` reuses the existing one).
+
+## A bug found and fixed along the way (shipped separately, PR #420)
+
+Wiring this view surfaced that B001/B002's PASS verdict never actually
+produced a visible "BUY" over the API: `asa/api/screening_models.py`'s
+top-level `direction` field is derived only from a `"decision.direction"`
+metrics key (the same wire-vocabulary key every other migrated strategy's
+`explanation_metrics()` populates); STK-03's adapters had set a bare
+`"direction"` key instead, which landed in the generic metrics dict but
+never the field this UI (and any other API consumer) actually reads.
+Fixed and merged ahead of this PR.
+
+## Verification
+
+- `cd ui-tests && npm test`: 13/13 passed (7 pre-existing + 6 new —
+  hash-route parsing, nav active-state, strategies-subview row content and
+  empty state, portfolio-subview account rendering and empty state).
+- `npm run lint` (`node --check` on every touched file): clean.
+- Manual smoke test: served `asa/ui/static/` as static files, navigated to
+  `#/stocks`, `#/stocks/portfolio`, `#/stocks/strategies` with no token
+  (matching real first-load behavior) — confirmed the Stocks nav link,
+  sub-nav, and both truthful empty states render correctly; confirmed via
+  `document.querySelectorAll` that `active` classes land on the correct
+  links for the current route.
+
+## Compatibility
+
+- No backend change. No new endpoint. Existing `#/results` and `#/health`
+  routes, their rendering, and all 7 pre-existing `ui-tests` are unchanged
+  and still pass.
+- No scope beyond the two named sub-views; no broader redesign.
+
+## Follow-up flagged, not actioned here
+
+`ui-tests/` has no CI job. Recommend a follow-up ticket to add an
+`asa/ui/static` job to a GitHub Actions workflow (`cd ui-tests && npm ci
+&& npm test`) so a future regression here is actually caught.

--- a/ui-tests/ui.test.js
+++ b/ui-tests/ui.test.js
@@ -43,6 +43,8 @@ function model(overrides = {}) {
     results: [fixture],
     visible: [fixture],
     detail: null,
+    portfolio: null,
+    positions: null,
     fetchedAt: "2026-07-29T13:46:00Z",
     filters: { signal: "", symbol: "", verdict: "", evaluationState: "" },
     loading: false,
@@ -57,6 +59,82 @@ function model(overrides = {}) {
     ...overrides,
   };
 }
+
+const b001Result = {
+  ...fixture,
+  signal_id: "B001",
+  signal_version: "1.0.0",
+  symbol: "SPY",
+  outcome: "pass",
+  evaluation_state: "pass",
+  verdict: "PASS",
+  direction: "BUY",
+  structure: null,
+  lifecycle_stage: null,
+  opportunity_id: null,
+  opportunity_history_url: null,
+  metrics: { price: "560.25" },
+  metric_types: { price: "decimal" },
+  canonical_facts: {},
+  named_derived_facts: {},
+  formula_versions: {},
+  gate_results: {},
+  reason_codes: [],
+  assumptions: [],
+  blockers: [],
+  warnings: [],
+};
+
+const b002Result = {
+  ...b001Result,
+  signal_id: "B002",
+  metrics: { price: "560.25", sma_10m_completed_months: "540.10" },
+  metric_types: { price: "decimal", sma_10m_completed_months: "decimal" },
+};
+
+const portfolioFixture = {
+  freshness: { as_of: "2026-09-05T12:00:00Z", status: "fresh", serving_last_success: false },
+  data: {
+    publication_id: "pub-1",
+    snapshot_id: "snap-1",
+    provider: "robinhood",
+    account_count: 2,
+    equity_position_count: 1,
+    option_leg_count: 0,
+    accounts: [
+      {
+        id: "acct-1",
+        external_account_id: "***********1234",
+        provider: "robinhood",
+        account_type: "individual",
+        display_name: "Individual",
+        currency: "USD",
+        cash_balance: "1250.00",
+        cash_available_for_withdrawal: "1000.00",
+        buying_power: "2500.00",
+        account_value: "50000.00",
+        observed_at: "2026-09-05T12:00:00Z",
+        holdings_status: "success",
+        holdings_as_of: "2026-09-05T12:00:00Z",
+      },
+      {
+        id: "acct-2",
+        external_account_id: "***********5678",
+        provider: "robinhood",
+        account_type: "roth_ira",
+        display_name: "Roth IRA",
+        currency: "USD",
+        cash_balance: null,
+        cash_available_for_withdrawal: null,
+        buying_power: null,
+        account_value: null,
+        observed_at: "2026-09-05T12:00:00Z",
+        holdings_status: "success_empty",
+        holdings_as_of: "2026-09-05T12:00:00Z",
+      },
+    ],
+  },
+};
 
 test("shared public fixture renders exact audit identity, decision, evidence, and time", () => {
   const root = document.createElement("div");
@@ -158,6 +236,99 @@ test("responsive contract declares desktop table and narrow card modes", () => {
   assert.match(styles, /@media \(max-width: 900px\)/);
   assert.match(styles, /\.desktop-results\s*\{\s*display:\s*none/);
   assert.match(styles, /\.mobile-results\s*\{\s*display:\s*block/);
+});
+
+test("stocks hash routes carry an explicit portfolio/strategies subview", () => {
+  assert.deepEqual(routeFromHash("#/stocks"), { name: "stocks", subview: "portfolio" });
+  assert.deepEqual(routeFromHash("#/stocks/portfolio"), {
+    name: "stocks",
+    subview: "portfolio",
+  });
+  assert.deepEqual(routeFromHash("#/stocks/strategies"), {
+    name: "stocks",
+    subview: "strategies",
+  });
+});
+
+test("primary nav includes a Stocks link, active only on the stocks route", () => {
+  const root = document.createElement("div");
+  renderApp(root, model({ route: { name: "stocks", subview: "portfolio" } }), noOpHandlers);
+  const links = [...root.querySelectorAll(".primary-nav a")];
+  const stocksLink = links.find((link) => link.textContent === "Stocks");
+  assert.ok(stocksLink, "expected a Stocks link in the primary nav");
+  assert.ok(stocksLink.classList.contains("active"));
+
+  renderApp(root, model({ route: { name: "results" } }), noOpHandlers);
+  const stocksLinkOnResults = [...root.querySelectorAll(".primary-nav a")].find(
+    (link) => link.textContent === "Stocks",
+  );
+  assert.ok(!stocksLinkOnResults.classList.contains("active"));
+});
+
+test("stock strategies subview renders only B001/B002 rows with truthful BUY direction and SMA10M", () => {
+  const root = document.createElement("div");
+  renderApp(
+    root,
+    model({
+      route: { name: "stocks", subview: "strategies" },
+      results: [fixture, b001Result, b002Result],
+    }),
+    noOpHandlers,
+  );
+
+  const text = root.textContent;
+  assert.match(text, /B001 \/ SPY/);
+  assert.match(text, /B002 \/ SPY/);
+  assert.doesNotMatch(text, /skew_momentum \/ AAPL/);
+  // B001 has no SMA10M metric at all -- must read ABSENT, never a fabricated
+  // or silently blank cell (this codebase's own exact-value convention).
+  const rows = [...root.querySelectorAll(".results-table tbody tr")];
+  const b001Row = rows.find((row) => row.textContent.includes("B001"));
+  const b002Row = rows.find((row) => row.textContent.includes("B002"));
+  assert.match(b001Row.textContent, /BUY/);
+  assert.match(b001Row.textContent, /ABSENT/);
+  assert.match(b002Row.textContent, /BUY/);
+  assert.match(b002Row.textContent, /540\.10/);
+});
+
+test("stock strategies subview declares an explicit empty state with no rows", () => {
+  const root = document.createElement("div");
+  renderApp(
+    root,
+    model({ route: { name: "stocks", subview: "strategies" }, results: [fixture] }),
+    noOpHandlers,
+  );
+  assert.match(root.textContent, /No persisted stock-benchmark results yet\./);
+});
+
+test("stock portfolio subview renders masked identifiers and per-account holdings status", () => {
+  const root = document.createElement("div");
+  renderApp(
+    root,
+    model({ route: { name: "stocks", subview: "portfolio" }, portfolio: portfolioFixture }),
+    noOpHandlers,
+  );
+
+  const text = root.textContent;
+  assert.match(text, /Individual/);
+  assert.match(text, /\*{11}1234/);
+  assert.match(text, /Roth IRA/);
+  assert.match(text, /\*{11}5678/);
+  assert.ok(root.querySelector(".badge--success"));
+  assert.ok(root.querySelector(".badge--success_empty"));
+  // A genuinely absent cash balance for the empty account must read as an
+  // explicit null, never "0" or a blank cell.
+  assert.match(text, /null/);
+});
+
+test("stock portfolio subview declares an explicit unavailable state, never a fabricated empty portfolio", () => {
+  const root = document.createElement("div");
+  renderApp(
+    root,
+    model({ route: { name: "stocks", subview: "portfolio" }, portfolio: null }),
+    noOpHandlers,
+  );
+  assert.match(root.textContent, /No published portfolio is available\./);
 });
 
 test.after(() => window.close());


### PR DESCRIPTION
## Summary

Full context in `project/reports/STOCK-RUNTIME-001-STK-05.md`. The important finding first: the ticket's "Options"/"Health" tabs live in the vanilla-JS Intelligence Console (`asa/ui/static/`, hash-routed, no build step), not the separate `frontend/` React app (which has no tabs at all today). This PR adds the Stocks tab there.

- New primary tab `#/stocks` with two sub-views: `#/stocks/portfolio` (default, renders `GET /api/v1/portfolio`'s STK-04 per-account status/freshness/holdings) and `#/stocks/strategies` (filters already-loaded screening results to B001/B002, renders benchmark/version, verdict, direction, price, SMA10M, freshness/usability).
- Reuses the existing `badge()`/`exactValue()`/`resultLink()` row-rendering helpers verbatim — an absent field (B001 has no SMA10M) reads as explicit `ABSENT`, same as every other strategy's gaps today.
- StructureKind.NONE suppression of option-structure/execution-readiness UI is generic by construction: clicking into a B001/B002 result reuses the unmodified `detailView()`, whose readiness section is already gated on `if (item.execution_assessment)` — no `if (signal_id === "B001")` anywhere.
- Portfolio/positions fetch runs in its own `Promise.allSettled`, independent of the screening fetch's try/catch — an absent portfolio (no successful broker run yet) is a normal state, never conflated with a broken screening fetch.

Pure UI addition: no backend change, no new endpoint, no change to `#/results`/`#/health`.

**Flagged, not actioned here**: `ui-tests/` (this console's own test suite) has no CI job in any workflow — confirmed by grepping all `.github/workflows/*.yml`. Filed as a separate follow-up task rather than expanding this PR's scope.

## Test plan

- [x] `cd ui-tests && npm test`: 13/13 passed (7 pre-existing + 6 new: hash-route parsing, nav active-state, strategies-subview content/empty-state, portfolio-subview content/empty-state)
- [x] `npm run lint` (`node --check` on every touched file): clean
- [x] Manual smoke test: served `asa/ui/static/` statically, navigated `#/stocks`, `#/stocks/portfolio`, `#/stocks/strategies` with no token, confirmed nav/sub-nav/empty-states render and `active` classes land correctly
- [x] All 7 pre-existing `ui-tests` still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)