### PR TITLE
STK-04: derive equity market value/P&L from canonical ASA pricing

### DIFF
--- a/asa/api/models.py
+++ b/asa/api/models.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from datetime import date, datetime
 from decimal import Decimal
 from uuid import UUID
@@ -273,7 +274,11 @@ class PositionsEnvelope(BaseModel):
     data: PositionsDataResponse
 
     @classmethod
-    def from_view(cls, view: PublishedPortfolioView) -> "PositionsEnvelope":
+    def from_view(
+        cls,
+        view: PublishedPortfolioView,
+        quotes_by_symbol: Mapping[str, MarketObservation] | None = None,
+    ) -> "PositionsEnvelope":
         publication = view.publication
         snapshot = publication.snapshot
         run_response = RunResponse.from_domain(
@@ -291,7 +296,7 @@ class PositionsEnvelope(BaseModel):
             serving_last_success=view.serving_last_success,
         )
         structures = project_option_structures(snapshot.option_legs)
-        valuation = project_portfolio_valuation(snapshot)
+        valuation = project_portfolio_valuation(snapshot, quotes_by_symbol)
         return cls(
             run=run_response,
             freshness=freshness,

--- a/asa/api/routes.py
+++ b/asa/api/routes.py
@@ -120,6 +120,15 @@ def build_router(
         view = portfolio_query.current()
         if view is None:
             raise HTTPException(status_code=404, detail="positions unavailable")
-        return PositionsEnvelope.from_view(view)
+        # A pure read against the already-persisted canonical quote store,
+        # per equity symbol held -- never a new acquisition/provider call.
+        # Option legs have no canonical quote lookup and are unaffected.
+        symbols = {position.symbol for position in view.publication.snapshot.equity_positions}
+        quotes_by_symbol = {
+            symbol: observation
+            for symbol in symbols
+            if (observation := quote_service.get_latest_quote(symbol)) is not None
+        }
+        return PositionsEnvelope.from_view(view, quotes_by_symbol)
 
     return router

--- a/asa/application/portfolio_valuation.py
+++ b/asa/application/portfolio_valuation.py
@@ -1,6 +1,8 @@
+from collections.abc import Mapping
 from datetime import datetime
 
-from asa.contracts.portfolio import PortfolioSnapshot
+from asa.contracts.market import MarketObservation
+from asa.contracts.portfolio import EquityPosition, PortfolioSnapshot
 from asa.contracts.portfolio_valuation import (
     AccountValuation,
     DeclaredExitState,
@@ -13,7 +15,25 @@ from asa.contracts.portfolio_valuation import (
 )
 
 
-def project_portfolio_valuation(snapshot: PortfolioSnapshot) -> PortfolioValuationProjection:
+def project_portfolio_valuation(
+    snapshot: PortfolioSnapshot,
+    quotes_by_symbol: Mapping[str, MarketObservation] | None = None,
+) -> PortfolioValuationProjection:
+    """Broker (asa/integrations/providers/robinhood.py) remains the sole
+    authority for account identity, quantity, and cost basis -- nothing
+    here acquires a quote. ``quotes_by_symbol`` is a caller-supplied,
+    already-read lookup from ASA's own existing canonical market-data
+    authority (asa.application.use_cases.MarketQuoteService.get_latest_quote,
+    a pure read against the persisted market_observations table -- never a
+    new acquisition/provider call issued by this module or its caller).
+    Equity market value/P&L are DERIVED from that canonical price where
+    one is available for the position's own symbol and currency; option
+    legs are unaffected (no options capability exists in that lookup) and
+    stay exactly as before. Account-level total_value/profit_and_loss are
+    also unaffected -- Robinhood's own broker-computed account equity
+    remains BROKER_OBSERVED, never silently blended with canonical pricing.
+    """
+    quotes = quotes_by_symbol or {}
     account_currency = {account.id: account.currency for account in snapshot.accounts}
     accounts = tuple(
         AccountValuation(
@@ -35,18 +55,8 @@ def project_portfolio_valuation(snapshot: PortfolioSnapshot) -> PortfolioValuati
         for account in snapshot.accounts
     )
     equities = tuple(
-        PositionValuation(
-            position_key=f"{position.account_id}:equity:{position.symbol}",
-            market_value=_unknown(
-                account_currency[position.account_id],
-                position.observed_at,
-                "broker_position_value_unavailable",
-            ),
-            profit_and_loss=_unknown(
-                account_currency[position.account_id],
-                position.observed_at,
-                "broker_position_pnl_unavailable",
-            ),
+        _equity_valuation(
+            position, account_currency[position.account_id], quotes.get(position.symbol)
         )
         for position in snapshot.equity_positions
     )
@@ -67,6 +77,42 @@ def project_portfolio_valuation(snapshot: PortfolioSnapshot) -> PortfolioValuati
         for leg in snapshot.option_legs
     )
     return PortfolioValuationProjection(accounts, equities, option_legs)
+
+
+def _equity_valuation(
+    position: EquityPosition, currency: str, quote: MarketObservation | None
+) -> PositionValuation:
+    key = f"{position.account_id}:equity:{position.symbol}"
+    if quote is None:
+        return PositionValuation(
+            key,
+            _unknown(currency, position.observed_at, "canonical_price_unavailable"),
+            _unknown(currency, position.observed_at, "canonical_price_unavailable"),
+        )
+    if quote.currency != currency:
+        return PositionValuation(
+            key,
+            _unknown(currency, position.observed_at, "canonical_price_currency_mismatch"),
+            _unknown(currency, position.observed_at, "canonical_price_currency_mismatch"),
+        )
+    market_value = MonetaryValue(
+        amount=position.quantity * quote.price,
+        currency=currency,
+        authority=ValueAuthority.DERIVED,
+        observed_at=quote.observed_at,
+    )
+    if position.average_cost is None:
+        profit_and_loss = _unknown(
+            currency, position.observed_at, "broker_cost_basis_unavailable"
+        )
+    else:
+        profit_and_loss = MonetaryValue(
+            amount=(quote.price - position.average_cost) * position.quantity,
+            currency=currency,
+            authority=ValueAuthority.DERIVED,
+            observed_at=quote.observed_at,
+        )
+    return PositionValuation(key, market_value, profit_and_loss)
 
 
 def project_exit_state(

--- a/project/reports/STOCK-RUNTIME-001-STK-04-pricing.md
+++ b/project/reports/STOCK-RUNTIME-001-STK-04-pricing.md
@@ -1,0 +1,77 @@
+# STOCK-RUNTIME-001 — STK-04 pricing-authority follow-up
+
+Founder-authorized narrow exception to PORTFOLIO-LIFECYCLE-001's
+`duplicate_live_market_data_pipeline: prohibited` invariant: portfolio
+valuation may read (never fetch) from ASA's existing canonical market-data
+authority.
+
+## What "existing canonical market-data authority" means here
+
+`asa.application.use_cases.MarketQuoteService.get_latest_quote(symbol)` —
+already-shipped, already used by `GET /api/v1/market/quotes/{symbol}`. It
+is a pure read against the persisted `market_observations` table
+(`asa.application.ports.repositories.MarketObservationRepository.latest_quote`)
+and issues no provider/network call itself; only `ingest_quotes()` (a
+different method, never called from this delta) does that. This is the
+only existing, symbol-agnostic, acquisition-free "current price" read
+capability anywhere in the codebase — confirmed by inspection during the
+STK-04 audit.
+
+## What was implemented
+
+- `asa/application/portfolio_valuation.py` — `project_portfolio_valuation`
+  gained an optional `quotes_by_symbol: Mapping[str, MarketObservation]`
+  parameter (default `None`, fully backward compatible). For each equity
+  position with a matching, same-currency canonical quote: `market_value =
+  quantity * price` (`ValueAuthority.DERIVED`), and `profit_and_loss =
+  (price - average_cost) * quantity` (`ValueAuthority.DERIVED`) — or
+  explicitly `UNKNOWN` with a typed reason (`canonical_price_unavailable`,
+  `canonical_price_currency_mismatch`, or `broker_cost_basis_unavailable`
+  when the broker never reported a cost basis) when any input is missing
+  or inconsistent. Never silently substitutes, converts currency, or
+  invents a cost basis.
+- `asa/api/routes.py`'s `get_positions()` — the only caller. Looks up each
+  unique held equity symbol via the already-injected `quote_service`
+  (already a parameter of this same router-building function, used
+  elsewhere for the `/market/quotes/*` routes) and passes the result
+  straight through. No new dependency wiring, no new acquisition path.
+- `asa/api/models.py`'s `PositionsEnvelope.from_view` — threads the
+  optional quotes mapping through to the projection.
+
+**Deliberately unaffected** (smallest generic delta, not a redesign):
+- Option legs: no change. `MarketObservationRepository` has no options
+  capability at all — extending pricing there would require a genuinely
+  new capability, out of scope for this delta.
+- Account-level `total_value`/`profit_and_loss`: unchanged, still
+  Robinhood's own broker-reported account equity, still explicitly
+  `BROKER_OBSERVED`. Never blended with canonical position-level pricing.
+- No strategy-ID branching anywhere in this change — it operates on
+  symbols generically.
+- No broker mutation, no new acquisition/provider pipeline, no schema
+  change, no OpenAPI schema change (`MonetaryValueResponse.authority` was
+  already a plain `str`, not an enum — `"derived"` is simply a new value
+  within the same existing field).
+
+## Verification
+
+- `tests/asa/test_portfolio_valuation.py` — updated the pre-existing
+  no-quote-supplied test (now asserts the more specific
+  `canonical_price_unavailable` reason for equities, matching what the
+  code actually does when nothing is supplied, distinct from option
+  legs' unaffected `broker_position_value_unavailable`) and added three
+  new tests: canonical-quote-present derives market value and P&L
+  correctly (verified against the fake broker's known AAPL position:
+  quantity 12, cost basis 172.50, quote 200.00 → market value 2400.00,
+  P&L 330.00); a missing cost basis keeps P&L (but not market value)
+  explicitly unknown; a currency mismatch refuses to compute rather than
+  silently convert. 5/5 passed.
+- `ruff check asa tests/asa` and `mypy asa`: clean.
+- `tests/asa/test_portfolio_acceptance.py`'s existing pinned assertion
+  (`equity_valuations[0]["market_value"]["authority"] == "unknown"`)
+  remains correct by inspection: that fixture's injected
+  `MarketObservationRepository` (`InMemoryObservationRepository`) starts
+  and stays empty for that test, so `get_latest_quote` returns `None` and
+  the position stays `UNKNOWN` exactly as before — could not run this
+  Postgres-backed suite locally (pre-existing Windows-environment gap,
+  documented in earlier STK reports); will be confirmed by CI's real
+  Postgres job.

--- a/tests/asa/test_portfolio_valuation.py
+++ b/tests/asa/test_portfolio_valuation.py
@@ -1,10 +1,13 @@
+from dataclasses import replace
 from datetime import UTC, datetime
+from decimal import Decimal
 
 from asa.application.portfolio_use_cases import RunPortfolioIntelligence
 from asa.application.portfolio_valuation import (
     project_exit_state,
     project_portfolio_valuation,
 )
+from asa.contracts.market import CacheStatus, FreshnessStatus, MarketObservation, QuoteProvenance
 from asa.contracts.portfolio_valuation import (
     DeclaredExitState,
     ExitPolicyStatus,
@@ -24,16 +27,75 @@ def _snapshot():
     )
 
 
+def _quote(symbol: str, price: str, currency: str = "USD") -> MarketObservation:
+    return MarketObservation(
+        symbol=symbol,
+        price=Decimal(price),
+        currency=currency,
+        observed_at=NOW,
+        received_at=NOW,
+        provenance=QuoteProvenance(
+            selected_provider="test_provider",
+            original_provider="test_provider",
+            cache_status=CacheStatus.PERSISTED,
+            freshness_status=FreshnessStatus.FRESH,
+            fallback_reason=None,
+            provider_request_id="test-request",
+        ),
+    )
+
+
 def test_uses_broker_account_value_and_keeps_unavailable_position_values_unknown() -> None:
     projection = project_portfolio_valuation(_snapshot())
 
     assert projection.accounts[0].total_value.authority is ValueAuthority.BROKER_OBSERVED
     assert str(projection.accounts[0].total_value.amount) == "50000.00"
     assert projection.accounts[0].profit_and_loss.authority is ValueAuthority.UNKNOWN
+    # No canonical quote was supplied at all -- every equity reads the
+    # canonical-price-specific reason, never the broker one (Robinhood's
+    # own integration never fetches a per-position price to begin with).
+    assert all(
+        item.market_value.unknown_reason == "canonical_price_unavailable"
+        for item in projection.equity_positions
+    )
+    # Option legs have no canonical quote lookup at all -- unaffected.
     assert all(
         item.market_value.unknown_reason == "broker_position_value_unavailable"
-        for item in (*projection.equity_positions, *projection.option_legs)
+        for item in projection.option_legs
     )
+
+
+def test_equity_market_value_and_pnl_are_derived_from_the_canonical_quote() -> None:
+    snapshot = _snapshot()
+    (position,) = snapshot.equity_positions  # AAPL, quantity=12, average_cost=172.50
+    projection = project_portfolio_valuation(snapshot, {"AAPL": _quote("AAPL", "200.00")})
+
+    (valuation,) = projection.equity_positions
+    assert valuation.market_value.authority is ValueAuthority.DERIVED
+    assert valuation.market_value.amount == Decimal("2400.00")
+    assert valuation.profit_and_loss.authority is ValueAuthority.DERIVED
+    assert valuation.profit_and_loss.amount == Decimal("330.00")
+
+
+def test_equity_pnl_stays_unknown_without_a_broker_cost_basis() -> None:
+    snapshot = _snapshot()
+    no_cost_basis = replace(snapshot.equity_positions[0], average_cost=None)
+    snapshot = replace(snapshot, equity_positions=(no_cost_basis,))
+    projection = project_portfolio_valuation(snapshot, {"AAPL": _quote("AAPL", "200.00")})
+
+    (valuation,) = projection.equity_positions
+    assert valuation.market_value.authority is ValueAuthority.DERIVED
+    assert valuation.profit_and_loss.authority is ValueAuthority.UNKNOWN
+    assert valuation.profit_and_loss.unknown_reason == "broker_cost_basis_unavailable"
+
+
+def test_equity_valuation_refuses_a_currency_mismatch_rather_than_silently_convert() -> None:
+    snapshot = _snapshot()
+    projection = project_portfolio_valuation(snapshot, {"AAPL": _quote("AAPL", "200.00", "EUR")})
+
+    (valuation,) = projection.equity_positions
+    assert valuation.market_value.authority is ValueAuthority.UNKNOWN
+    assert valuation.market_value.unknown_reason == "canonical_price_currency_mismatch"
 
 
 def test_missing_exit_policy_is_not_defined_and_declared_state_is_only_passed_through() -> None:


### PR DESCRIPTION
## Summary

Founder-authorized narrow exception to PORTFOLIO-LIFECYCLE-001's `duplicate_live_market_data_pipeline: prohibited` invariant: portfolio valuation may **read** (never fetch) from ASA's existing canonical market-data authority. Full rationale in `project/reports/STOCK-RUNTIME-001-STK-04-pricing.md`.

- `project_portfolio_valuation()` gains an optional `quotes_by_symbol` lookup. For each equity position with a matching, same-currency canonical quote it derives `market_value`/`profit_and_loss` (`ValueAuthority.DERIVED`) — or an explicit typed `UNKNOWN` (`canonical_price_unavailable`, `canonical_price_currency_mismatch`, `broker_cost_basis_unavailable`) when a quote, cost basis, or matching currency is missing. Never silently substitutes or converts.
- The only caller, `GET /api/v1/positions`, sources the lookup via `MarketQuoteService.get_latest_quote()` — a pure read against the already-persisted `market_observations` table, already injected into that same router. No new acquisition/provider pipeline.
- Deliberately unaffected: option legs (no canonical quote capability exists for them yet), account-level `total_value`/P&L (stays broker-observed, never blended with canonical pricing), no strategy-ID branching, no schema change.

## Test plan

- [x] `tests/asa/test_portfolio_valuation.py`: 5/5 passed — updated the pre-existing no-quote test, added coverage for canonical-quote-present derivation (verified against the fake broker's known AAPL position), missing-cost-basis handling, and currency-mismatch refusal.
- [x] `ruff check asa tests/asa` / `mypy asa`: clean.
- [x] `test_portfolio_acceptance.py`'s existing pinned "market_value authority == unknown" assertion verified correct by inspection (its injected quote repository starts and stays empty) — will be confirmed by CI's real Postgres job.
- [x] No migration, no schema change, no broker mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)